### PR TITLE
refactor: Sort imports, exports, keys, etc alphabetically. Disallow trailing whitespace and dangling commas.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,14 @@
     "ecmaVersion": 12,
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint", "sort-imports-es6-autofix", "sort-exports", "sort-keys-fix"],
+  "plugins": [
+    "react",
+    "@typescript-eslint",
+    "sort-imports-es6-autofix",
+    "sort-exports",
+    "sort-keys-fix",
+    "typescript-sort-keys"
+  ],
   "settings": {
     "react": {
       "version": "17.0"
@@ -28,6 +35,7 @@
   "rules": {
     "complexity": "off",
     "sort-keys-fix/sort-keys-fix": "error",
+    "typescript-sort-keys/interface": "error",
     "sort-vars": "error",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,8 @@
   },
   "rules": {
     "complexity": "off",
+    "comma-dangle": ["error", "never"],
+    "no-trailing-spaces": "error",
     "sort-keys-fix/sort-keys-fix": "error",
     "typescript-sort-keys/interface": "error",
     "sort-vars": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@
     "ecmaVersion": 12,
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint"],
+  "plugins": ["react", "@typescript-eslint", "sort-imports-es6-autofix", "sort-exports"],
   "settings": {
     "react": {
       "version": "17.0"
@@ -27,8 +27,13 @@
   },
   "rules": {
     "complexity": "off",
+    "sort-vars": 2,
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "error",
-    "@typescript-eslint/no-unused-vars": "error"
+    "@typescript-eslint/no-unused-vars": "error",
+    "sort-imports-es6-autofix/sort-imports-es6": [
+      2, {}
+    ],
+    "sort-exports/sort-exports": ["error", {"sortDir": "asc"}]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@
     "ecmaVersion": 12,
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint", "sort-imports-es6-autofix", "sort-exports"],
+  "plugins": ["react", "@typescript-eslint", "sort-imports-es6-autofix", "sort-exports", "sort-keys-fix"],
   "settings": {
     "react": {
       "version": "17.0"
@@ -27,12 +27,13 @@
   },
   "rules": {
     "complexity": "off",
-    "sort-vars": 2,
+    "sort-keys-fix/sort-keys-fix": "error",
+    "sort-vars": "error",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-unused-vars": "error",
     "sort-imports-es6-autofix/sort-imports-es6": [
-      2, {}
+      "error", {}
     ],
     "sort-exports/sort-exports": ["error", {"sortDir": "asc"}]
   }

--- a/electron/legendary_utils/library.ts
+++ b/electron/legendary_utils/library.ts
@@ -22,7 +22,7 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
   const loggedIn = isLoggedIn()
 
   if (!isLoggedIn) {
-    return { user: { displayName: null }, library: [] }
+    return { library: [], user: { displayName: null } }
   }
 
   const files: {
@@ -31,12 +31,12 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
     config: string
     installed: Game[]
   } = {
-    user: getUserInfo(),
-    library: `${legendaryConfigPath}/metadata/`,
     config: heroicConfigPath,
     installed: await statAsync(installed)
       .then(() => JSON.parse(readFileSync(installed, 'utf-8')))
       .catch(() => []),
+    library: `${legendaryConfigPath}/metadata/`,
+    user: getUserInfo(),
   }
 
   if (file === 'user') {
@@ -117,24 +117,24 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
             `${byteSize(install_size).value}${byteSize(install_size).unit}`
 
           return {
-            isInstalled,
-            info,
-            title,
-            executable,
-            version,
-            install_size: convertedSize,
-            install_path,
             app_name,
-            developer,
-            description,
-            cloudSaveEnabled,
-            saveFolder,
-            folderName: installFolder,
             art_cover: art_cover || art_square,
-            art_square: art_square || art_cover,
             art_logo,
+            art_square: art_square || art_cover,
+            cloudSaveEnabled,
+            description,
+            developer,
+            executable,
+            folderName: installFolder,
+            info,
+            install_path,
+            install_size: convertedSize,
+            isInstalled,
             is_dlc,
-            namespace
+            namespace,
+            saveFolder,
+            title,
+            version
           }
         })
         .sort((a: { title: string }, b: { title: string }) => {
@@ -143,6 +143,6 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
           return gameA < gameB ? -1 : 1
         })
     }
-    return { user: null, library: [] }
+    return { library: [], user: null }
   }
 }

--- a/electron/legendary_utils/library.ts
+++ b/electron/legendary_utils/library.ts
@@ -26,10 +26,10 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
   }
 
   const files: {
+    config: string,
+    installed: Game[],
+    library: string,
     user: UserInfo
-    library: string
-    config: string
-    installed: Game[]
   } = {
     config: heroicConfigPath,
     installed: await statAsync(installed)

--- a/electron/legendary_utils/library.ts
+++ b/electron/legendary_utils/library.ts
@@ -10,7 +10,7 @@ import {
   heroicConfigPath,
   isLoggedIn,
   legendaryConfigPath,
-  writeDefaultconfig,
+  writeDefaultconfig
 } from '../utils'
 
 const statAsync = promisify(stat)
@@ -36,7 +36,7 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
       .then(() => JSON.parse(readFileSync(installed, 'utf-8')))
       .catch(() => []),
     library: `${legendaryConfigPath}/metadata/`,
-    user: getUserInfo(),
+    user: getUserInfo()
   }
 
   if (file === 'user') {
@@ -62,9 +62,9 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
             title,
             developer,
             dlcItemList,
-            customAttributes: { CloudSaveFolder, FolderName },
+            customAttributes: { CloudSaveFolder, FolderName }
           } = metadata
-          
+
           const {namespace} = asset_info
 
           if (dlcItemList) {
@@ -109,7 +109,7 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
             version = null,
             install_size = null,
             install_path = null,
-            is_dlc = dlc(),
+            is_dlc = dlc()
           } = info as InstalledInfo
 
           const convertedSize =

--- a/electron/legendary_utils/library.ts
+++ b/electron/legendary_utils/library.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
+import { existsSync, readFileSync, readdirSync, stat } from 'graceful-fs'
 import { promisify } from 'util'
-import { readFileSync, existsSync, stat, readdirSync } from 'graceful-fs'
 // @ts-ignore
 import byteSize from 'byte-size'
 
+import { Game, InstalledInfo, KeyImage, UserInfo } from '../types'
 import {
   getUserInfo,
   heroicConfigPath,
@@ -11,7 +12,6 @@ import {
   legendaryConfigPath,
   writeDefaultconfig,
 } from '../utils'
-import { Game, InstalledInfo, KeyImage, UserInfo } from '../types'
 
 const statAsync = promisify(stat)
 const dlcs: string[] = []

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -69,15 +69,15 @@ let mainWindow: BrowserWindow = null
 function createWindow(): BrowserWindow {
   // Create the browser window.
   mainWindow = new BrowserWindow({
-    width: isDev ? 1800 : 1280,
     height: isDev ? 1200 : 720,
     minHeight: 700,
     minWidth: 1200,
     webPreferences: {
-      nodeIntegration: true,
       contextIsolation: false,
       enableRemoteModule: true,
+      nodeIntegration: true,
     },
+    width: isDev ? 1800 : 1280,
   })
 
   setTimeout(() => {
@@ -134,41 +134,41 @@ const gotTheLock = app.requestSingleInstanceLock()
 const contextMenu = () =>
   Menu.buildFromTemplate([
     {
-      label: i18next.t('tray.show'),
       click: function () {
         mainWindow.show()
       },
+      label: i18next.t('tray.show'),
     },
     {
-      label: i18next.t('tray.about', 'About'),
       click: function () {
         showAboutWindow()
       },
+      label: i18next.t('tray.about', 'About'),
     },
     {
-      label: 'Github',
       click: function () {
         exec(`xdg-open ${heroicGithubURL}`)
       },
+      label: 'Github',
     },
     {
-      label: i18next.t('tray.support', 'Support Us'),
       click: function () {
         exec(`xdg-open ${supportURL}`)
       },
+      label: i18next.t('tray.support', 'Support Us'),
     },
     {
-      label: i18next.t('tray.reload', 'Reload'),
+      accelerator: 'ctrl + R',
       click: function () {
         mainWindow.reload()
       },
-      accelerator: 'ctrl + R',
+      label: i18next.t('tray.reload', 'Reload'),
     },
     {
-      label: i18next.t('tray.quit', 'Quit'),
       click: function () {
         handleExit()
       },
+      label: i18next.t('tray.quit', 'Quit'),
     },
   ])
 
@@ -185,8 +185,14 @@ if (!gotTheLock) {
     const { language, darkTrayIcon } = await getSettings('default')
 
     await i18next.use(Backend).init({
-      lng: language,
+      backend: {
+        addPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}'),
+        allowMultiLoading: false,
+        loadPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}.json'),
+      },
+      debug: false,
       fallbackLng: 'en',
+      lng: language,
       supportedLngs: [
         'de',
         'en',
@@ -199,12 +205,6 @@ if (!gotTheLock) {
         'tr',
         'hu',
       ],
-      debug: false,
-      backend: {
-        allowMultiLoading: false,
-        addPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}'),
-        loadPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}.json'),
-      },
     })
 
     createWindow()
@@ -225,8 +225,8 @@ if (!gotTheLock) {
 
 ipcMain.on('Notify', (event, args) => {
   const notify = new Notification({
-    title: args[0],
     body: args[1],
+    title: args[0],
   })
 
   notify.on('click', () => mainWindow.show())
@@ -287,9 +287,9 @@ const getProductSlug = async (namespace: string, game: string) => {
     variables: {},
   })
   const result = await axios('https://www.epicgames.com/graphql', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     data: graphql,
+    headers: { 'Content-Type': 'application/json' },
+    method: 'POST',
   })
   const res = result.data.data.Catalog.catalogOffers
   const slug = res.elements.find((e: { productSlug: string }) => e.productSlug)
@@ -319,8 +319,8 @@ ipcMain.handle('getGameInfo', async (event, game, namespace: string | null) => {
   }
   try {
     const response = await axios({
-      url: epicUrl,
       method: 'GET',
+      url: epicUrl,
     })
     delete response.data.pages[0].data.requirements.systems[0].details[0]
     const about = response.data.pages.find(
@@ -413,7 +413,7 @@ ipcMain.handle('requestGameProgress', async (event, appName) => {
   const [percent, eta] = progress_result.split(' ')
   const bytes = downloaded_result + 'MiB'
 
-  const progress = { percent, bytes, eta }
+  const progress = { bytes, eta, percent }
   console.log(
     `Progress: ${appName} ${progress.percent}/${progress.bytes}/${eta}`
   )
@@ -537,7 +537,7 @@ ipcMain.handle('egsSync', async (event, args) => {
 
 ipcMain.handle('getUserInfo', () => {
   const { account_id } = JSON.parse(readFileSync(userInfo, 'utf-8'))
-  return { user: user().username, epicId: account_id }
+  return { epicId: account_id, user: user().username }
 })
 
 ipcMain.on('removeFolder', async (e, args: string[]) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -431,10 +431,10 @@ ipcMain.handle('getAlternativeWine', () => getAlternativeWine())
 
 // Calls WineCFG or Winetricks. If is WineCFG, use the same binary as wine to launch it to dont update the prefix
 interface Tools {
-  tool: string
+  exe: string,
+  prefix: string,
+  tool: string,
   wine: string
-  prefix: string
-  exe: string
 }
 
 ipcMain.on('callTool', async (event, { tool, wine, prefix, exe }: Tools) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,18 +1,21 @@
-import axios from 'axios'
+import * as path from 'path'
+import {
+  BrowserWindow,
+  Menu,
+  Notification,
+  Tray,
+  app,
+  ipcMain,
+  powerSaveBlocker
+} from 'electron'
+import {
+  cpus,
+  userInfo as user
+} from 'os'
 import {
   exec,
   spawn
 } from 'child_process'
-import {
-  app,
-  BrowserWindow,
-  ipcMain,
-  Menu,
-  Notification,
-  powerSaveBlocker,
-  Tray
-} from 'electron'
-import isDev from 'electron-is-dev'
 import {
   existsSync,
   mkdirSync,
@@ -21,18 +24,15 @@ import {
   writeFile,
   writeFileSync
 } from 'graceful-fs'
-import i18next from 'i18next'
-import Backend from 'i18next-fs-backend'
-import isOnline from 'is-online'
-import {
-  cpus,
-  userInfo as user
-} from 'os'
-import * as path from 'path'
 import { promisify } from 'util'
+import Backend from 'i18next-fs-backend'
+import axios from 'axios'
+import i18next from 'i18next'
+import isDev from 'electron-is-dev'
+import isOnline from 'is-online'
 
-import { getLegendaryConfig } from './legendary_utils/library'
 import { Game } from './types.js'
+import { getLegendaryConfig } from './legendary_utils/library'
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
   checkForUpdates,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -75,9 +75,9 @@ function createWindow(): BrowserWindow {
     webPreferences: {
       contextIsolation: false,
       enableRemoteModule: true,
-      nodeIntegration: true,
+      nodeIntegration: true
     },
-    width: isDev ? 1800 : 1280,
+    width: isDev ? 1800 : 1280
   })
 
   setTimeout(() => {
@@ -137,39 +137,39 @@ const contextMenu = () =>
       click: function () {
         mainWindow.show()
       },
-      label: i18next.t('tray.show'),
+      label: i18next.t('tray.show')
     },
     {
       click: function () {
         showAboutWindow()
       },
-      label: i18next.t('tray.about', 'About'),
+      label: i18next.t('tray.about', 'About')
     },
     {
       click: function () {
         exec(`xdg-open ${heroicGithubURL}`)
       },
-      label: 'Github',
+      label: 'Github'
     },
     {
       click: function () {
         exec(`xdg-open ${supportURL}`)
       },
-      label: i18next.t('tray.support', 'Support Us'),
+      label: i18next.t('tray.support', 'Support Us')
     },
     {
       accelerator: 'ctrl + R',
       click: function () {
         mainWindow.reload()
       },
-      label: i18next.t('tray.reload', 'Reload'),
+      label: i18next.t('tray.reload', 'Reload')
     },
     {
       click: function () {
         handleExit()
       },
-      label: i18next.t('tray.quit', 'Quit'),
-    },
+      label: i18next.t('tray.quit', 'Quit')
+    }
   ])
 
 if (!gotTheLock) {
@@ -188,7 +188,7 @@ if (!gotTheLock) {
       backend: {
         addPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}'),
         allowMultiLoading: false,
-        loadPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}.json'),
+        loadPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}.json')
       },
       debug: false,
       fallbackLng: 'en',
@@ -203,8 +203,8 @@ if (!gotTheLock) {
         'pt',
         'ru',
         'tr',
-        'hu',
-      ],
+        'hu'
+      ]
     })
 
     createWindow()
@@ -226,7 +226,7 @@ if (!gotTheLock) {
 ipcMain.on('Notify', (event, args) => {
   const notify = new Notification({
     body: args[1],
-    title: args[0],
+    title: args[0]
   })
 
   notify.on('click', () => mainWindow.show())
@@ -284,12 +284,12 @@ ipcMain.on('quit', async () => handleExit())
 const getProductSlug = async (namespace: string, game: string) => {
   const graphql = JSON.stringify({
     query: `{Catalog{catalogOffers( namespace:"${namespace}"){elements {productSlug}}}}`,
-    variables: {},
+    variables: {}
   })
   const result = await axios('https://www.epicgames.com/graphql', {
     data: graphql,
     headers: { 'Content-Type': 'application/json' },
-    method: 'POST',
+    method: 'POST'
   })
   const res = result.data.data.Catalog.catalogOffers
   const slug = res.elements.find((e: { productSlug: string }) => e.productSlug)
@@ -320,7 +320,7 @@ ipcMain.handle('getGameInfo', async (event, game, namespace: string | null) => {
   try {
     const response = await axios({
       method: 'GET',
-      url: epicUrl,
+      url: epicUrl
     })
     delete response.data.pages[0].data.requirements.systems[0].details[0]
     const about = response.data.pages.find(
@@ -328,7 +328,7 @@ ipcMain.handle('getGameInfo', async (event, game, namespace: string | null) => {
     )
     return {
       about: about.data.about,
-      reqs: about.data.requirements.systems[0].details,
+      reqs: about.data.requirements.systems[0].details
     }
   } catch (error) {
     return {}

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -1,32 +1,3 @@
-export interface InstalledInfo {
-  executable: string | null
-  version: string | null
-  install_size: string | null
-  install_path: string | null
-  is_dlc: boolean
-}
-
-export interface KeyImage {
-  type: string
-}
-
-interface ExtraInfo {
-  description: string
-  shortDescription: string
-}
-
-export interface WineProps {
-  name: string
-  bin: string
-}
-
-export type UserInfo = {
-  name?: string
-  epicId?: string
-  account_id?: string
-  displayName?: string
-}
-
 export interface AppSettings {
   wineVersion: WineProps
   winePrefix: string
@@ -49,6 +20,24 @@ export interface AppSettings {
   autoInstallDxvk: boolean
   customWinePaths: Array<string>
 }
+export interface ContextType {
+  user: string
+  data: Game[]
+  filter: string
+  refreshing: boolean
+  error: boolean
+  libraryStatus: GameStatus[]
+  refresh: () => void
+  refreshLibrary: () => void
+  handleGameStatus: (game: GameStatus) => void
+  handleFilter: (value: string) => void
+  handleSearch: (input: string) => void
+}
+
+interface ExtraInfo {
+  description: string
+  shortDescription: string
+}
 
 export interface Game {
   art_cover: string
@@ -69,19 +58,6 @@ export interface Game {
   extraInfo: ExtraInfo
 }
 
-export interface InstallProgress {
-  percent: string
-  bytes: string
-  eta: string
-}
-
-export interface Path {
-  filePaths: string[]
-}
-export interface WineProps {
-  name: string
-  bin: string
-}
 
 export interface GameStatus {
   appName: string
@@ -97,18 +73,36 @@ export interface GameStatus {
   progress?: number | null
 }
 
+export interface InstallProgress {
+  percent: string
+  bytes: string
+  eta: string
+}
+export interface InstalledInfo {
+  executable: string | null
+  version: string | null
+  install_size: string | null
+  install_path: string | null
+  is_dlc: boolean
+}
+export interface KeyImage {
+  type: string
+}
+
+export interface Path {
+  filePaths: string[]
+}
+
 export type SyncType = 'Download' | 'Upload' | 'Force download' | 'Force upload'
 
-export interface ContextType {
-  user: string
-  data: Game[]
-  filter: string
-  refreshing: boolean
-  error: boolean
-  libraryStatus: GameStatus[]
-  refresh: () => void
-  refreshLibrary: () => void
-  handleGameStatus: (game: GameStatus) => void
-  handleFilter: (value: string) => void
-  handleSearch: (input: string) => void
+
+export type UserInfo = {
+  name?: string
+  epicId?: string
+  account_id?: string
+  displayName?: string
+}
+export interface WineProps {
+  name: string
+  bin: string
 }

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -1,37 +1,37 @@
 export interface AppSettings {
+  audioFix: boolean,
+  autoInstallDxvk: boolean,
+  autoSyncSaves: boolean,
+  customWinePaths: Array<string>,
+  darkTrayIcon: boolean,
+  defaultInstallPath: string,
+  egsLinkedPath: string,
+  exitToTray: boolean,
+  language: string,
+  launcherArgs: string,
+  maxWorkers: number,
+  offlineMode: boolean,
+  otherOptions: string,
+  savesPath: string,
+  showFps: boolean,
+  showMangohud: boolean,
+  useGameMode: boolean,
+  userInfo: UserInfo,
+  winePrefix: string,
   wineVersion: WineProps
-  winePrefix: string
-  otherOptions: string
-  useGameMode: boolean
-  showFps: boolean
-  egsLinkedPath: string
-  savesPath: string
-  autoSyncSaves: boolean
-  exitToTray: boolean
-  offlineMode: boolean
-  launcherArgs: string
-  audioFix: boolean
-  showMangohud: boolean
-  defaultInstallPath: string
-  language: string
-  maxWorkers: number
-  userInfo: UserInfo
-  darkTrayIcon: boolean
-  autoInstallDxvk: boolean
-  customWinePaths: Array<string>
 }
 export interface ContextType {
-  user: string
-  data: Game[]
+  data: Game[],
+  error: boolean,
   filter: string
-  refreshing: boolean
-  error: boolean
-  libraryStatus: GameStatus[]
-  refresh: () => void
-  refreshLibrary: () => void
-  handleGameStatus: (game: GameStatus) => void
-  handleFilter: (value: string) => void
-  handleSearch: (input: string) => void
+  handleFilter: (value: string) => void,
+  handleGameStatus: (game: GameStatus) => void,
+  handleSearch: (input: string) => void,
+  libraryStatus: GameStatus[],
+  refresh: () => void,
+  refreshLibrary: () => void,
+  refreshing: boolean,
+  user: string
 }
 
 interface ExtraInfo {
@@ -40,27 +40,28 @@ interface ExtraInfo {
 }
 
 export interface Game {
-  art_cover: string
-  art_square: string
-  app_name: string
-  art_logo: string
-  executable: string
-  title: string
+  app_name: string,
+  art_cover: string,
+  art_logo: string,
+  art_square: string,
+  cloudSaveEnabled: boolean,
+  developer: string,
+  executable: string,
+  extraInfo: ExtraInfo,
+  folderName: string,
+  install_path: string,
+  install_size: number,
+  isInstalled: boolean,
+  is_dlc: boolean,
+  saveFolder: string,
+  title: string,
   version: string
-  install_size: number
-  install_path: string
-  developer: string
-  isInstalled: boolean
-  cloudSaveEnabled: boolean
-  saveFolder: string
-  folderName: string
-  is_dlc: boolean
-  extraInfo: ExtraInfo
 }
 
 
 export interface GameStatus {
   appName: string
+  progress?: number | null,
   status:
     | 'installing'
     | 'updating'
@@ -70,20 +71,19 @@ export interface GameStatus {
     | 'done'
     | 'canceled'
     | 'moving'
-  progress?: number | null
 }
 
 export interface InstallProgress {
+  bytes: string,
+  eta: string,
   percent: string
-  bytes: string
-  eta: string
 }
 export interface InstalledInfo {
   executable: string | null
-  version: string | null
+  install_path: string | null,
   install_size: string | null
-  install_path: string | null
-  is_dlc: boolean
+  is_dlc: boolean,
+  version: string | null
 }
 export interface KeyImage {
   type: string
@@ -97,12 +97,12 @@ export type SyncType = 'Download' | 'Upload' | 'Force download' | 'Force upload'
 
 
 export type UserInfo = {
+  account_id?: string,
+  displayName?: string,
+  epicId?: string,
   name?: string
-  epicId?: string
-  account_id?: string
-  displayName?: string
 }
 export interface WineProps {
+  bin: string,
   name: string
-  bin: string
 }

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -1,21 +1,21 @@
 import * as axios from 'axios'
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { exec } from 'child_process'
 import { app, dialog } from 'electron'
-import { fixPathForAsarUnpack } from 'electron-util'
+import { exec } from 'child_process'
 import {
   existsSync,
   mkdir,
-  readdirSync,
   readFileSync,
+  readdirSync,
   writeFile,
   writeFileSync,
 } from 'graceful-fs'
-import i18next from 'i18next'
-import isOnline from 'is-online'
+import { fixPathForAsarUnpack } from 'electron-util'
 import { homedir, userInfo as user } from 'os'
 import { join } from 'path'
 import { promisify } from 'util'
+import i18next from 'i18next'
+import isOnline from 'is-online'
 
 import { AppSettings, UserInfo, WineProps } from './types'
 

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -86,9 +86,9 @@ async function getAlternativeWine(): Promise<WineProps[]> {
 
   const lutrisPath = `${home}/.local/share/lutris`
   const lutrisCompatPath = `${lutrisPath}/runners/wine/`
-  const proton: Set<{ name: string; bin: string }> = new Set()
-  const altWine: Set<{ name: string; bin: string }> = new Set()
-  const customPaths: Set<{ name: string; bin: string }> = new Set()
+  const proton: Set<{ bin: string, name: string; }> = new Set()
+  const altWine: Set<{ bin: string, name: string; }> = new Set()
+  const customPaths: Set<{ bin: string, name: string; }> = new Set()
 
   protonPaths.forEach((path) => {
     if (existsSync(path)) {

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -69,7 +69,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
   const protonPaths: string[] = [`${heroicToolsPath}/proton/`]
   const foundPaths = steamPaths.filter((path) => existsSync(path))
 
-  const defaultWine = { name: '', bin: '' }
+  const defaultWine = { bin: '', name: '' }
   await execAsync(`which wine`)
     .then(async ({ stdout }) => {
       defaultWine.bin = stdout.split('\n')[0]
@@ -95,8 +95,8 @@ async function getAlternativeWine(): Promise<WineProps[]> {
       readdirSync(path).forEach((version) => {
         if (version.toLowerCase().startsWith('proton')) {
           proton.add({
-            name: `Proton - ${version}`,
             bin: `'${path}${version}/proton'`,
+            name: `Proton - ${version}`,
           })
         }
       })
@@ -106,16 +106,16 @@ async function getAlternativeWine(): Promise<WineProps[]> {
   if (existsSync(lutrisCompatPath)) {
     readdirSync(lutrisCompatPath).forEach((version) => {
       altWine.add({
-        name: `Wine - ${version}`,
         bin: `'${lutrisCompatPath}${version}/bin/wine64'`,
+        name: `Wine - ${version}`,
       })
     })
   }
 
   readdirSync(`${heroicToolsPath}/wine/`).forEach((version) => {
     altWine.add({
-      name: `Wine - ${version}`,
       bin: `'${lutrisCompatPath}${version}/bin/wine64'`,
+      name: `Wine - ${version}`,
     })
   })
 
@@ -124,13 +124,13 @@ async function getAlternativeWine(): Promise<WineProps[]> {
       customWinePaths.forEach((path) => {
         if (path.endsWith('proton')) {
           return customPaths.add({
-            name: `Proton Custom - ${path}`,
             bin: `'${path}'`,
+            name: `Proton Custom - ${path}`,
           })
         }
         return customPaths.add({
-          name: `Wine Custom - ${path}`,
           bin: `'${path}'`,
+          name: `Wine Custom - ${path}`,
         })
       })
     }
@@ -215,15 +215,15 @@ const launchGame = async (appName: string) => {
   prefix = isProton ? '' : prefix
 
   const options = {
-    other: otherOptions ? otherOptions : '',
-    fps: showFps ? `DXVK_HUD=fps` : '',
     audio: audioFix ? `PULSE_LATENCY_MSEC=60` : '',
-    showMangohud: showMangohud ? `MANGOHUD=1` : '',
+    fps: showFps ? `DXVK_HUD=fps` : '',
+    other: otherOptions ? otherOptions : '',
     proton: isProton
       ? `STEAM_COMPAT_DATA_PATH='${winePrefix
           .replaceAll("'", '')
           .replace('~', home)}'`
       : '',
+    showMangohud: showMangohud ? `MANGOHUD=1` : '',
   }
 
   envVars = Object.values(options).join(' ')
@@ -383,19 +383,19 @@ const writeDefaultconfig = async () => {
 
     const config = {
       defaultSettings: {
-        defaultInstallPath: heroicInstallPath,
-        wineVersion: defaultWine,
-        winePrefix: `${home}/.wine`,
-        otherOptions: '',
-        useGameMode: false,
-        showFps: false,
-        maxWorkers: 0,
-        language: 'en',
         customWinePaths: [],
+        defaultInstallPath: heroicInstallPath,
+        language: 'en',
+        maxWorkers: 0,
+        otherOptions: '',
+        showFps: false,
+        useGameMode: false,
         userInfo: {
-          name: userName,
           epicId: account_id,
+          name: userName,
         },
+        winePrefix: `${home}/.wine`,
+        wineVersion: defaultWine,
       } as AppSettings,
     }
 
@@ -422,12 +422,12 @@ const writeGameconfig = async (game: string) => {
 
     const config = {
       [game]: {
-        wineVersion,
-        winePrefix,
         otherOptions,
-        useGameMode,
         showFps,
+        useGameMode,
         userInfo,
+        winePrefix,
+        wineVersion,
       },
     }
 
@@ -459,10 +459,10 @@ async function checkForUpdates() {
 const showAboutWindow = () => {
   app.setAboutPanelOptions({
     applicationName: 'Heroic Games Launcher',
-    copyright: 'GPL V3',
     applicationVersion: `${app.getVersion()} Magelan`,
-    website: 'https://github.com/flavioislima/HeroicGamesLauncher',
+    copyright: 'GPL V3',
     iconPath: icon,
+    website: 'https://github.com/flavioislima/HeroicGamesLauncher',
   })
   return app.showAboutPanel()
 }
@@ -483,12 +483,12 @@ const handleExit = async () => {
 
   if (isLocked) {
     const { response } = await showMessageBox({
-      title: i18next.t('box.quit.title', 'Exit'),
+      buttons: [i18next.t('box.no'), i18next.t('box.yes')],
       message: i18next.t(
         'box.quit.message',
         'There are pending operations, are you sure?'
       ),
-      buttons: [i18next.t('box.no'), i18next.t('box.yes')],
+      title: i18next.t('box.quit.title', 'Exit'),
     })
 
     if (response === 0) {

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -8,7 +8,7 @@ import {
   readFileSync,
   readdirSync,
   writeFile,
-  writeFileSync,
+  writeFileSync
 } from 'graceful-fs'
 import { fixPathForAsarUnpack } from 'electron-util'
 import { homedir, userInfo as user } from 'os'
@@ -51,7 +51,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
   const steamPaths: string[] = [
     `${home}/.local/share/Steam`,
     `${home}/.var/app/com.valvesoftware.Steam/.local/share/Steam`,
-    '/usr/share/steam',
+    '/usr/share/steam'
   ]
 
   if (!existsSync(`${heroicToolsPath}/wine`)) {
@@ -96,7 +96,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
         if (version.toLowerCase().startsWith('proton')) {
           proton.add({
             bin: `'${path}${version}/proton'`,
-            name: `Proton - ${version}`,
+            name: `Proton - ${version}`
           })
         }
       })
@@ -107,7 +107,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
     readdirSync(lutrisCompatPath).forEach((version) => {
       altWine.add({
         bin: `'${lutrisCompatPath}${version}/bin/wine64'`,
-        name: `Wine - ${version}`,
+        name: `Wine - ${version}`
       })
     })
   }
@@ -115,7 +115,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
   readdirSync(`${heroicToolsPath}/wine/`).forEach((version) => {
     altWine.add({
       bin: `'${lutrisCompatPath}${version}/bin/wine64'`,
-      name: `Wine - ${version}`,
+      name: `Wine - ${version}`
     })
   })
 
@@ -125,12 +125,12 @@ async function getAlternativeWine(): Promise<WineProps[]> {
         if (path.endsWith('proton')) {
           return customPaths.add({
             bin: `'${path}'`,
-            name: `Proton Custom - ${path}`,
+            name: `Proton Custom - ${path}`
           })
         }
         return customPaths.add({
           bin: `'${path}'`,
-          name: `Wine Custom - ${path}`,
+          name: `Wine Custom - ${path}`
         })
       })
     }
@@ -197,7 +197,7 @@ const launchGame = async (appName: string) => {
     launcherArgs = '',
     showMangohud,
     audioFix,
-    autoInstallDxvk,
+    autoInstallDxvk
   } = await getSettings(appName)
 
   const fixedWinePrefix = winePrefix.replace('~', home)
@@ -223,7 +223,7 @@ const launchGame = async (appName: string) => {
           .replaceAll("'", '')
           .replace('~', home)}'`
       : '',
-    showMangohud: showMangohud ? `MANGOHUD=1` : '',
+    showMangohud: showMangohud ? `MANGOHUD=1` : ''
   }
 
   envVars = Object.values(options).join(' ')
@@ -296,7 +296,7 @@ async function getLatestDxvk() {
     return
   }
   const {
-    data: { assets },
+    data: { assets }
   } = await axios.default.get(
     'https://api.github.com/repos/lutris/dxvk/releases/latest'
   )
@@ -392,11 +392,11 @@ const writeDefaultconfig = async () => {
         useGameMode: false,
         userInfo: {
           epicId: account_id,
-          name: userName,
+          name: userName
         },
         winePrefix: `${home}/.wine`,
-        wineVersion: defaultWine,
-      } as AppSettings,
+        wineVersion: defaultWine
+      } as AppSettings
     }
 
     writeFileSync(heroicConfigPath, JSON.stringify(config, null, 2))
@@ -417,7 +417,7 @@ const writeGameconfig = async (game: string) => {
       otherOptions,
       useGameMode,
       showFps,
-      userInfo,
+      userInfo
     } = await getSettings('default')
 
     const config = {
@@ -427,8 +427,8 @@ const writeGameconfig = async (game: string) => {
         useGameMode,
         userInfo,
         winePrefix,
-        wineVersion,
-      },
+        wineVersion
+      }
     }
 
     writeFileSync(
@@ -445,7 +445,7 @@ async function checkForUpdates() {
     return false
   }
   const {
-    data: { tag_name },
+    data: { tag_name }
   } = await axios.default.get(
     'https://api.github.com/repos/flavioislima/HeroicGamesLauncher/releases/latest'
   )
@@ -462,7 +462,7 @@ const showAboutWindow = () => {
     applicationVersion: `${app.getVersion()} Magelan`,
     copyright: 'GPL V3',
     iconPath: icon,
-    website: 'https://github.com/flavioislima/HeroicGamesLauncher',
+    website: 'https://github.com/flavioislima/HeroicGamesLauncher'
   })
   return app.showAboutPanel()
 }
@@ -488,7 +488,7 @@ const handleExit = async () => {
         'box.quit.message',
         'There are pending operations, are you sure?'
       ),
-      title: i18next.t('box.quit.title', 'Exit'),
+      title: i18next.t('box.quit.title', 'Exit')
     })
 
     if (response === 0) {
@@ -555,5 +555,5 @@ export {
   updateGame,
   userInfo,
   writeDefaultconfig,
-  writeGameconfig,
+  writeGameconfig
 }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "ci-build": "GH_TOKEN='${{ secrets.WORKFLOW_TOKEN }}' npm run build-electron && npm run build && electron-builder -c.extraMetadata.main=build/main.js --linux deb AppImage rpm pacman",
     "dist": "yarn build-electron && yarn build && electron-builder -c.extraMetadata.main=build/main.js --linux",
     "lint": "eslint -c .eslintrc --ext .tsx,ts ./src && eslint -c .eslintrc --ext .ts ./electron",
-    "lint-fix": "eslint -c .eslintrc --ext .tsx,ts ./src --fix && eslint -c .eslintrc --ext .ts ./electron --fix",
+    "lint-fix": "eslint --fix -c .eslintrc --ext .tsx,ts ./src && eslint --fix -c .eslintrc --ext .ts ./electron",
     "build-electron": "tsc --project electron/tsconfig.json",
     "watch-electron": "tsc --watch --project electron/tsconfig.json",
     "i18n": "i18next"
@@ -119,6 +119,7 @@
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-react": "^7.22.0",
+    "eslint-plugin-typescript-sort-keys": "^1.5.0",
     "foreman": "^3.0.1",
     "husky": "^4.3.8",
     "i18next-parser": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "classnames": "^2.2.6",
     "electron-is-dev": "^1.2.0",
     "electron-util": "^0.14.2",
+    "eslint-plugin-sort-exports": "^0.3.2",
+    "eslint-plugin-sort-imports-es6-autofix": "^0.5.0",
     "i18next": "^19.8.7",
     "i18next-browser-languagedetector": "^6.0.1",
     "i18next-fs-backend": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "ci-build": "GH_TOKEN='${{ secrets.WORKFLOW_TOKEN }}' npm run build-electron && npm run build && electron-builder -c.extraMetadata.main=build/main.js --linux deb AppImage rpm pacman",
     "dist": "yarn build-electron && yarn build && electron-builder -c.extraMetadata.main=build/main.js --linux",
     "lint": "eslint -c .eslintrc --ext .tsx,ts ./src && eslint -c .eslintrc --ext .ts ./electron",
+    "lint-fix": "eslint -c .eslintrc --ext .tsx,ts ./src --fix && eslint -c .eslintrc --ext .ts ./electron --fix",
     "build-electron": "tsc --project electron/tsconfig.json",
     "watch-electron": "tsc --watch --project electron/tsconfig.json",
     "i18n": "i18next"
@@ -129,7 +130,9 @@
     "hooks": {
       "post-checkout": "yarn",
       "post-merge": "yarn",
-      "pre-push": "yarn lint && pretty-quick --staged lint-staged"
+      "post-rebase": "yarn",
+      "pre-push": "yarn lint && pretty-quick --staged lint-staged",
+      "pre-commit": "yarn lint-fix"
     }
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "electron-util": "^0.14.2",
     "eslint-plugin-sort-exports": "^0.3.2",
     "eslint-plugin-sort-imports-es6-autofix": "^0.5.0",
+    "eslint-plugin-sort-keys-fix": "^1.1.1",
     "i18next": "^19.8.7",
     "i18next-browser-languagedetector": "^6.0.1",
     "i18next-fs-backend": "^1.0.8",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import App from './App'
+import React from 'react'
 
 test('renders learn react link', () => {
   render(<App />)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import React, { lazy, useContext } from 'react'
 
 import './App.css'
+import { HashRouter, Route, Switch } from 'react-router-dom'
 import { Library } from './components/Library'
-import { HashRouter, Switch, Route } from 'react-router-dom'
 import ContextProvider from './state/ContextProvider'
 
 const NavBar = lazy(() => import('./components/NavBar'))

--- a/src/components/GamePage/GamePage.tsx
+++ b/src/components/GamePage/GamePage.tsx
@@ -61,9 +61,9 @@ export default function GamePage(): JSX.Element | null {
 
   const [gameInfo, setGameInfo] = useState({} as Game)
   const [progress, setProgress] = useState({
-    percent: '0.00%',
     bytes: '0.00MiB',
     eta: '00:00:00',
+    percent: '0.00%',
   } as InstallProgress)
   const [installPath, setInstallPath] = useState('default')
   const [defaultPath, setDefaultPath] = useState('...')
@@ -125,8 +125,8 @@ export default function GamePage(): JSX.Element | null {
 
         handleGameStatus({
           appName,
-          status,
           progress: getProgress(progress),
+          status,
         })
       }
     }, 1500)
@@ -244,9 +244,9 @@ export default function GamePage(): JSX.Element | null {
                     )}
                     <p
                       style={{
-                        fontStyle: 'italic',
                         color:
                           isInstalled || isInstalling ? '#0BD58C' : '#BD0A0A',
+                        fontStyle: 'italic',
                       }}
                     >
                       {getInstallLabel(isInstalled)}
@@ -438,9 +438,9 @@ export default function GamePage(): JSX.Element | null {
             err.includes('ERROR: Game is out of date')
           ) {
             const { response } = await showMessageBox({
-              title: t('box.update.title'),
-              message: t('box.update.message'),
               buttons: [t('box.yes'), t('box.no')],
+              message: t('box.update.message'),
+              title: t('box.update.title'),
             })
 
             if (response === 0) {
@@ -493,9 +493,9 @@ export default function GamePage(): JSX.Element | null {
 
       if (installPath === 'import') {
         const { filePaths } = await showOpenDialog({
-          title: t('box.importpath'),
           buttonLabel: t('box.choose'),
           properties: ['openDirectory'],
+          title: t('box.importpath'),
         })
 
         if (filePaths[0]) {
@@ -508,9 +508,9 @@ export default function GamePage(): JSX.Element | null {
 
       if (installPath === 'another') {
         const { filePaths } = await showOpenDialog({
-          title: t('box.installpath'),
           buttonLabel: t('box.choose'),
           properties: ['openDirectory'],
+          title: t('box.installpath'),
         })
 
         if (filePaths[0]) {
@@ -529,10 +529,10 @@ export default function GamePage(): JSX.Element | null {
 
   async function handleUninstall() {
     const { response } = await showMessageBox({
-      type: 'warning',
-      title: t('box.uninstall.title'),
-      message: t('box.uninstall.message'),
       buttons: [t('box.yes'), t('box.no')],
+      message: t('box.uninstall.message'),
+      title: t('box.uninstall.title'),
+      type: 'warning',
     })
 
     if (response === 0) {

--- a/src/components/GamePage/GamePage.tsx
+++ b/src/components/GamePage/GamePage.tsx
@@ -4,11 +4,12 @@ import '../../App.css'
 import React, { Fragment, useContext, useEffect, useState } from 'react'
 
 import { IpcRenderer, Remote } from 'electron'
-import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 
 import Settings from '@material-ui/icons/Settings'
 
+import { AppSettings, Game, GameStatus, InstallProgress } from '../../types'
 import {
   fixSaveFolder,
   getGameInfo,
@@ -23,11 +24,10 @@ import {
   updateGame,
 } from '../../helper'
 import ContextProvider from '../../state/ContextProvider'
-import { AppSettings, Game, GameStatus, InstallProgress } from '../../types'
+import GamesSubmenu from './GamesSubmenu'
 import Header from '../UI/Header'
 import InfoBox from '../UI/InfoBox'
 import UpdateComponent from '../UI/UpdateComponent'
-import GamesSubmenu from './GamesSubmenu'
 
 const { ipcRenderer, remote } = window.require('electron') as {
   ipcRenderer: IpcRenderer

--- a/src/components/GamePage/GamePage.tsx
+++ b/src/components/GamePage/GamePage.tsx
@@ -21,7 +21,7 @@ import {
   legendary,
   sendKill,
   syncSaves,
-  updateGame,
+  updateGame
 } from '../../helper'
 import ContextProvider from '../../state/ContextProvider'
 import GamesSubmenu from './GamesSubmenu'
@@ -34,7 +34,7 @@ const { ipcRenderer, remote } = window.require('electron') as {
   remote: Remote
 }
 const {
-  dialog: { showOpenDialog, showMessageBox },
+  dialog: { showOpenDialog, showMessageBox }
 } = remote
 
 // This component is becoming really complex and it needs to be refactored in smaller ones
@@ -51,7 +51,7 @@ export default function GamePage(): JSX.Element | null {
     libraryStatus,
     handleGameStatus,
     data,
-    gameUpdates,
+    gameUpdates
   } = useContext(ContextProvider)
   const gameStatus: GameStatus = libraryStatus.filter(
     (game: GameStatus) => game.appName === appName
@@ -63,7 +63,7 @@ export default function GamePage(): JSX.Element | null {
   const [progress, setProgress] = useState({
     bytes: '0.00MiB',
     eta: '00:00:00',
-    percent: '0.00%',
+    percent: '0.00%'
   } as InstallProgress)
   const [installPath, setInstallPath] = useState('default')
   const [defaultPath, setDefaultPath] = useState('...')
@@ -87,7 +87,7 @@ export default function GamePage(): JSX.Element | null {
           autoSyncSaves,
           winePrefix,
           wineVersion,
-          savesPath,
+          savesPath
         }: AppSettings = await ipcRenderer.invoke('requestSettings', appName)
         const isProton = wineVersion?.name?.includes('Proton') || false
         setAutoSyncSaves(autoSyncSaves)
@@ -126,7 +126,7 @@ export default function GamePage(): JSX.Element | null {
         handleGameStatus({
           appName,
           progress: getProgress(progress),
-          status,
+          status
         })
       }
     }, 1500)
@@ -146,18 +146,18 @@ export default function GamePage(): JSX.Element | null {
       version,
       extraInfo,
       developer,
-      cloudSaveEnabled,
+      cloudSaveEnabled
     }: Game = gameInfo
 
     if (savesPath.includes('{InstallDir}')) {
       setSavesPath(savesPath.replace('{InstallDir}', install_path))
     }
 
-    /* 
+    /*
     Other Keys:
     t('box.stopInstall.title')
     t('box.stopInstall.message')
-    t('box.stopInstall.keepInstalling') 
+    t('box.stopInstall.keepInstalling')
     */
 
     return (
@@ -207,7 +207,7 @@ export default function GamePage(): JSX.Element | null {
                     {cloudSaveEnabled && (
                       <div
                         style={{
-                          color: autoSyncSaves ? '#07C5EF' : '',
+                          color: autoSyncSaves ? '#07C5EF' : ''
                         }}
                       >
                         {t('info.syncsaves')}:{' '}
@@ -246,7 +246,7 @@ export default function GamePage(): JSX.Element | null {
                       style={{
                         color:
                           isInstalled || isInstalling ? '#0BD58C' : '#BD0A0A',
-                        fontStyle: 'italic',
+                        fontStyle: 'italic'
                       }}
                     >
                       {getInstallLabel(isInstalled)}
@@ -440,7 +440,7 @@ export default function GamePage(): JSX.Element | null {
             const { response } = await showMessageBox({
               buttons: [t('box.yes'), t('box.no')],
               message: t('box.update.message'),
-              title: t('box.update.title'),
+              title: t('box.update.title')
             })
 
             if (response === 0) {
@@ -495,7 +495,7 @@ export default function GamePage(): JSX.Element | null {
         const { filePaths } = await showOpenDialog({
           buttonLabel: t('box.choose'),
           properties: ['openDirectory'],
-          title: t('box.importpath'),
+          title: t('box.importpath')
         })
 
         if (filePaths[0]) {
@@ -510,7 +510,7 @@ export default function GamePage(): JSX.Element | null {
         const { filePaths } = await showOpenDialog({
           buttonLabel: t('box.choose'),
           properties: ['openDirectory'],
-          title: t('box.installpath'),
+          title: t('box.installpath')
         })
 
         if (filePaths[0]) {
@@ -532,7 +532,7 @@ export default function GamePage(): JSX.Element | null {
       buttons: [t('box.yes'), t('box.no')],
       message: t('box.uninstall.message'),
       title: t('box.uninstall.title'),
-      type: 'warning',
+      type: 'warning'
     })
 
     if (response === 0) {

--- a/src/components/GamePage/GamesSubmenu.tsx
+++ b/src/components/GamePage/GamesSubmenu.tsx
@@ -43,15 +43,15 @@ export default function GamesSubmenu({
 
   async function handleMoveInstall() {
     const { response } = await showMessageBox({
-      title: t('box.move.title'),
-      message: t('box.move.message'),
       buttons: [t('box.yes'), t('box.no')],
+      message: t('box.move.message'),
+      title: t('box.move.title'),
     })
     if (response === 0) {
       const { filePaths } = await showOpenDialog({
-        title: t('box.move.path'),
         buttonLabel: t('box.choose'),
         properties: ['openDirectory'],
+        title: t('box.move.path'),
       })
       if (filePaths[0]) {
         const path = filePaths[0]
@@ -66,15 +66,15 @@ export default function GamesSubmenu({
 
   async function handleChangeInstall() {
     const { response } = await showMessageBox({
-      title: t('box.change.title'),
-      message: t('box.change.message'),
       buttons: [t('box.yes'), t('box.no')],
+      message: t('box.change.message'),
+      title: t('box.change.title'),
     })
     if (response === 0) {
       const { filePaths } = await showOpenDialog({
-        title: t('box.change.path'),
         buttonLabel: t('box.choose'),
         properties: ['openDirectory'],
+        title: t('box.change.path'),
       })
       if (filePaths[0]) {
         const path = filePaths[0]
@@ -88,9 +88,9 @@ export default function GamesSubmenu({
 
   async function handleUpdate() {
     const { response } = await showMessageBox({
-      title: t('box.update.title'),
-      message: t('box.update.message'),
       buttons: [t('box.yes'), t('box.no')],
+      message: t('box.update.message'),
+      title: t('box.update.title'),
     })
 
     if (response === 0) {
@@ -103,9 +103,9 @@ export default function GamesSubmenu({
 
   async function handleRepair(appName: string) {
     const { response } = await showMessageBox({
-      title: t('box.repair.title'),
-      message: t('box.repair.message'),
       buttons: [t('box.yes'), t('box.no')],
+      message: t('box.repair.message'),
+      title: t('box.repair.title'),
     })
 
     if (response === 1) {

--- a/src/components/GamePage/GamesSubmenu.tsx
+++ b/src/components/GamePage/GamesSubmenu.tsx
@@ -4,7 +4,7 @@ import {
   createNewWindow,
   formatStoreUrl,
   repair,
-  updateGame,
+  updateGame
 } from '../../helper'
 import { useTranslation } from 'react-i18next'
 import ContextProvider from '../../state/ContextProvider'
@@ -12,7 +12,7 @@ import React, { useContext } from 'react'
 
 const { ipcRenderer, remote } = window.require('electron')
 const {
-  dialog: { showMessageBox, showOpenDialog },
+  dialog: { showMessageBox, showOpenDialog }
 } = remote
 
 const renderer: IpcRenderer = ipcRenderer
@@ -28,7 +28,7 @@ export default function GamesSubmenu({
   appName,
   isInstalled,
   title,
-  clicked,
+  clicked
 }: Props) {
   const { handleGameStatus, refresh, gameUpdates } = useContext(ContextProvider)
 
@@ -45,13 +45,13 @@ export default function GamesSubmenu({
     const { response } = await showMessageBox({
       buttons: [t('box.yes'), t('box.no')],
       message: t('box.move.message'),
-      title: t('box.move.title'),
+      title: t('box.move.title')
     })
     if (response === 0) {
       const { filePaths } = await showOpenDialog({
         buttonLabel: t('box.choose'),
         properties: ['openDirectory'],
-        title: t('box.move.path'),
+        title: t('box.move.path')
       })
       if (filePaths[0]) {
         const path = filePaths[0]
@@ -68,13 +68,13 @@ export default function GamesSubmenu({
     const { response } = await showMessageBox({
       buttons: [t('box.yes'), t('box.no')],
       message: t('box.change.message'),
-      title: t('box.change.title'),
+      title: t('box.change.title')
     })
     if (response === 0) {
       const { filePaths } = await showOpenDialog({
         buttonLabel: t('box.choose'),
         properties: ['openDirectory'],
-        title: t('box.change.path'),
+        title: t('box.change.path')
       })
       if (filePaths[0]) {
         const path = filePaths[0]
@@ -90,7 +90,7 @@ export default function GamesSubmenu({
     const { response } = await showMessageBox({
       buttons: [t('box.yes'), t('box.no')],
       message: t('box.update.message'),
-      title: t('box.update.title'),
+      title: t('box.update.title')
     })
 
     if (response === 0) {
@@ -105,7 +105,7 @@ export default function GamesSubmenu({
     const { response } = await showMessageBox({
       buttons: [t('box.yes'), t('box.no')],
       message: t('box.repair.message'),
-      title: t('box.repair.title'),
+      title: t('box.repair.title')
     })
 
     if (response === 1) {
@@ -125,7 +125,7 @@ export default function GamesSubmenu({
             className="hidden link"
             to={{
               pathname: `/settings/${appName}/wine`,
-              state: { fromGameCard: false },
+              state: { fromGameCard: false }
             }}
           >
             {t('submenu.settings')}

--- a/src/components/GamePage/GamesSubmenu.tsx
+++ b/src/components/GamePage/GamesSubmenu.tsx
@@ -19,9 +19,9 @@ const renderer: IpcRenderer = ipcRenderer
 
 interface Props {
   appName: string
-  isInstalled: boolean
+  clicked: boolean,
+  isInstalled: boolean,
   title: string
-  clicked: boolean
 }
 
 export default function GamesSubmenu({

--- a/src/components/GamePage/GamesSubmenu.tsx
+++ b/src/components/GamePage/GamesSubmenu.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { IpcRenderer } from 'electron'
 import { Link } from 'react-router-dom'
 import {
   createNewWindow,
@@ -6,9 +6,9 @@ import {
   repair,
   updateGame,
 } from '../../helper'
-import ContextProvider from '../../state/ContextProvider'
 import { useTranslation } from 'react-i18next'
-import { IpcRenderer } from 'electron'
+import ContextProvider from '../../state/ContextProvider'
+import React, { useContext } from 'react'
 
 const { ipcRenderer, remote } = window.require('electron')
 const {

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -36,8 +36,8 @@ export const Library = ({ library }: Props) => {
       <div
         style={!library.length ? { backgroundColor: 'transparent' } : {}}
         className={cx({
-          gameListLayout: layout !== 'grid',
           gameList: layout === 'grid',
+          gameListLayout: layout !== 'grid',
         })}
       >
         {!!library.length &&

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -1,9 +1,15 @@
-import React, { lazy, useContext } from 'react'
+import React, {
+  lazy,
+  useContext
+} from 'react'
+
 import cx from 'classnames'
+
 import ArrowDropUp from '@material-ui/icons/ArrowDropUp'
-import ContextProvider from '../state/ContextProvider'
 
 import { Game } from '../types'
+import ContextProvider from '../state/ContextProvider'
+
 const GameCard = lazy(() => import('./UI/GameCard'))
 
 interface Props {
@@ -12,8 +18,8 @@ interface Props {
 
 window.onscroll = () => {
   const pageOffset =
-      document.documentElement.scrollTop || document.body.scrollTop,
-    btn = document.getElementById('backToTopBtn')
+      document.documentElement.scrollTop || document.body.scrollTop
+  const btn = document.getElementById('backToTopBtn')
   if (btn) btn.style.visibility = pageOffset > 450 ? 'visible' : 'hidden'
 }
 

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -37,7 +37,7 @@ export const Library = ({ library }: Props) => {
         style={!library.length ? { backgroundColor: 'transparent' } : {}}
         className={cx({
           gameList: layout === 'grid',
-          gameListLayout: layout !== 'grid',
+          gameListLayout: layout !== 'grid'
         })}
       >
         {!!library.length &&
@@ -51,7 +51,7 @@ export const Library = ({ library }: Props) => {
               isInstalled,
               version,
               install_size,
-              is_dlc,
+              is_dlc
             }: Game) => {
               if (is_dlc) {
                 return null

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -117,10 +117,10 @@ export default function Login({ refresh }: Props) {
           </div>
           <span
             style={{
-              paddingRight: '22px',
-              marginBottom: '22px',
               display: 'flex',
               justifyContent: 'flex-end',
+              marginBottom: '22px',
+              paddingRight: '22px',
               width: '100%',
             }}
           >

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -15,7 +15,7 @@ export default function Login({ refresh }: Props) {
   const [input, setInput] = useState('')
   const [status, setStatus] = useState({
     loading: false,
-    message: '',
+    message: ''
   })
   const { loading, message } = status
 
@@ -29,14 +29,14 @@ export default function Login({ refresh }: Props) {
   const handleLogin = async (sid: string) => {
     setStatus({
       loading: true,
-      message: t('status.logging', 'Logging In...'),
+      message: t('status.logging', 'Logging In...')
     })
 
     await legendary(`auth --sid ${sid}`).then(async (res) => {
       if (res !== 'error') {
         setStatus({
           loading: true,
-          message: t('status.loading', 'Loading Game list, please wait'),
+          message: t('status.loading', 'Loading Game list, please wait')
         })
 
         await legendary(`list-games`)
@@ -121,7 +121,7 @@ export default function Login({ refresh }: Props) {
               justifyContent: 'flex-end',
               marginBottom: '22px',
               paddingRight: '22px',
-              width: '100%',
+              width: '100%'
             }}
           >
             <LanguageSelector

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react'
-import { useTranslation } from 'react-i18next'
 import { legendary, loginPage, sidInfoPage } from '../helper'
+import { useTranslation } from 'react-i18next'
 import Autorenew from '@material-ui/icons/Autorenew'
 import Info from '@material-ui/icons/Info'
 import LanguageSelector, { FlagPosition } from './UI/LanguageSelector'
+import React, { useState } from 'react'
 const storage: Storage = window.localStorage
 interface Props {
   refresh: () => Promise<void>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,7 +1,7 @@
-import React, { lazy } from 'react'
-import { useTranslation } from 'react-i18next'
 import { NavLink } from 'react-router-dom'
 import { createNewWindow } from '../helper'
+import { useTranslation } from 'react-i18next'
+import React, { lazy } from 'react'
 const SearchBar = lazy(() => import('./UI/SearchBar'))
 const UserSelector = lazy(() => import('./UI/UserSelector'))
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -32,7 +32,7 @@ export default function NavBar() {
           activeStyle={{ color: '#FFA800', fontWeight: 500 }}
           isActive={(match, location) => location.pathname.includes('settings')}
           to={{
-            pathname: '/settings/default/general',
+            pathname: '/settings/default/general'
           }}
         >
           {t('Settings')}

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -71,8 +71,8 @@ export default function GeneralSettings({
     if (isLinked) {
       return await ipcRenderer.invoke('egsSync', 'unlink').then(async () => {
         await showMessageBox({
-          title: 'EGS Sync',
           message: t('message.unsync'),
+          title: 'EGS Sync',
         })
         setEgsLinkedPath('')
         setEgsPath('')
@@ -92,8 +92,8 @@ export default function GeneralSettings({
           return
         }
         await dialog.showMessageBox({
-          title: 'EGS Sync',
           message: t('message.sync'),
+          title: 'EGS Sync',
         })
 
         setIsSyncing(false)
@@ -130,9 +130,9 @@ export default function GeneralSettings({
             className="material-icons settings folder"
             onClick={() =>
               showOpenDialog({
-                title: t('box.default-install-path'),
                 buttonLabel: t('box.choose'),
                 properties: ['openDirectory'],
+                title: t('box.default-install-path'),
               }).then(({ filePaths }: Path) =>
                 setDefaultInstallPath(filePaths[0] ? `'${filePaths[0]}'` : '')
               )
@@ -160,9 +160,9 @@ export default function GeneralSettings({
                   ? ''
                   : dialog
                       .showOpenDialog({
-                        title: t('box.choose-egs-prefix'),
                         buttonLabel: t('box.choose'),
                         properties: ['openDirectory'],
+                        title: t('box.choose-egs-prefix'),
                       })
                       .then(({ filePaths }: Path) =>
                         setEgsPath(filePaths[0] ? `'${filePaths[0]}'` : '')
@@ -175,7 +175,7 @@ export default function GeneralSettings({
               onClick={() => (isLinked ? '' : setEgsPath(''))}
               style={
                 isLinked
-                  ? { pointerEvents: 'none', color: 'transparent' }
+                  ? { color: 'transparent', pointerEvents: 'none' }
                   : { color: '#B0ABB6' }
               }
             />

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -1,12 +1,12 @@
-import React, { useContext, useEffect, useState } from 'react'
+import { Path } from '../../types'
 import { useTranslation } from 'react-i18next'
+import Backspace from '@material-ui/icons/Backspace'
 import ContextProvider from '../../state/ContextProvider'
 import CreateNewFolder from '@material-ui/icons/CreateNewFolder'
-import Backspace from '@material-ui/icons/Backspace'
-import { Path } from '../../types'
 import InfoBox from '../UI/InfoBox'
-import ToggleSwitch from '../UI/ToggleSwitch'
 import LanguageSelector from '../UI/LanguageSelector'
+import React, { useContext, useEffect, useState } from 'react'
+import ToggleSwitch from '../UI/ToggleSwitch'
 const {
   ipcRenderer,
   remote: { dialog },

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -15,20 +15,20 @@ const { showErrorBox, showMessageBox, showOpenDialog } = dialog
 const storage: Storage = window.localStorage
 
 interface Props {
-  defaultInstallPath: string
-  setDefaultInstallPath: (value: string) => void
-  egsPath: string
-  setEgsPath: (value: string) => void
-  egsLinkedPath: string
-  setEgsLinkedPath: (value: string) => void
-  exitToTray: boolean
-  toggleTray: () => void
-  language: string
-  setLanguage: (value: string) => void
-  maxWorkers: number
+  darkTrayIcon: boolean,
+  defaultInstallPath: string,
+  egsLinkedPath: string,
+  egsPath: string,
+  exitToTray: boolean,
+  language: string,
+  maxWorkers: number,
+  setDefaultInstallPath: (value: string) => void,
+  setEgsLinkedPath: (value: string) => void,
+  setEgsPath: (value: string) => void,
+  setLanguage: (value: string) => void,
   setMaxWorkers: (value: number) => void
-  darkTrayIcon: boolean
-  toggleDarkTrayIcon: () => void
+  toggleDarkTrayIcon: () => void,
+  toggleTray: () => void
 }
 
 export default function GeneralSettings({

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -9,7 +9,7 @@ import React, { useContext, useEffect, useState } from 'react'
 import ToggleSwitch from '../UI/ToggleSwitch'
 const {
   ipcRenderer,
-  remote: { dialog },
+  remote: { dialog }
 } = window.require('electron')
 const { showErrorBox, showMessageBox, showOpenDialog } = dialog
 const storage: Storage = window.localStorage
@@ -45,7 +45,7 @@ export default function GeneralSettings({
   maxWorkers,
   setMaxWorkers,
   darkTrayIcon,
-  toggleDarkTrayIcon,
+  toggleDarkTrayIcon
 }: Props) {
   const [isSyncing, setIsSyncing] = useState(false)
   const [maxCpus, setMaxCpus] = useState(maxWorkers)
@@ -72,7 +72,7 @@ export default function GeneralSettings({
       return await ipcRenderer.invoke('egsSync', 'unlink').then(async () => {
         await showMessageBox({
           message: t('message.unsync'),
-          title: 'EGS Sync',
+          title: 'EGS Sync'
         })
         setEgsLinkedPath('')
         setEgsPath('')
@@ -93,7 +93,7 @@ export default function GeneralSettings({
         }
         await dialog.showMessageBox({
           message: t('message.sync'),
-          title: 'EGS Sync',
+          title: 'EGS Sync'
         })
 
         setIsSyncing(false)
@@ -132,7 +132,7 @@ export default function GeneralSettings({
               showOpenDialog({
                 buttonLabel: t('box.choose'),
                 properties: ['openDirectory'],
-                title: t('box.default-install-path'),
+                title: t('box.default-install-path')
               }).then(({ filePaths }: Path) =>
                 setDefaultInstallPath(filePaths[0] ? `'${filePaths[0]}'` : '')
               )
@@ -162,7 +162,7 @@ export default function GeneralSettings({
                       .showOpenDialog({
                         buttonLabel: t('box.choose'),
                         properties: ['openDirectory'],
-                        title: t('box.choose-egs-prefix'),
+                        title: t('box.choose-egs-prefix')
                       })
                       .then(({ filePaths }: Path) =>
                         setEgsPath(filePaths[0] ? `'${filePaths[0]}'` : '')

--- a/src/components/Settings/OtherSettings.tsx
+++ b/src/components/Settings/OtherSettings.tsx
@@ -6,21 +6,21 @@ import InfoBox from '../UI/InfoBox'
 import ToggleSwitch from '../UI/ToggleSwitch'
 
 interface Props {
-  otherOptions: string
-  setOtherOptions: (value: string) => void
+  audioFix: boolean,
+  isDefault: boolean,
+  launcherArgs: string,
+  offlineMode : boolean,
+  otherOptions: string,
+  setLauncherArgs: (value: string) => void,
+  setOtherOptions: (value: string) => void,
+  showFps: boolean,
+  showMangohud: boolean,
+  toggleAudioFix: () => void,
+  toggleFps: () => void,
+  toggleMangoHud: () => void,
+  toggleOffline : () => void,
+  toggleUseGameMode: () => void,
   useGameMode: boolean
-  toggleUseGameMode: () => void
-  showFps: boolean
-  toggleFps: () => void
-  offlineMode : boolean
-  toggleOffline : () => void
-  launcherArgs: string
-  setLauncherArgs: (value: string) => void
-  audioFix: boolean
-  toggleAudioFix: () => void
-  showMangohud: boolean
-  toggleMangoHud: () => void
-  isDefault: boolean
 }
 
 export default function OtherSettings({

--- a/src/components/Settings/OtherSettings.tsx
+++ b/src/components/Settings/OtherSettings.tsx
@@ -38,7 +38,7 @@ export default function OtherSettings({
   toggleAudioFix,
   showMangohud,
   toggleMangoHud,
-  isDefault,
+  isDefault
 }: Props) {
   const handleOtherOptions = (event: ChangeEvent<HTMLInputElement>) =>
     setOtherOptions(event.currentTarget.value)

--- a/src/components/Settings/SyncSaves.tsx
+++ b/src/components/Settings/SyncSaves.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import React, { useEffect, useState } from 'react'
 
-import { fixSaveFolder, getGameInfo, syncSaves } from '../../helper'
-import CreateNewFolder from '@material-ui/icons/CreateNewFolder';
-import Backspace from '@material-ui/icons/Backspace';
 import { Path, SyncType } from '../../types'
+import { fixSaveFolder, getGameInfo, syncSaves } from '../../helper'
+import Backspace from '@material-ui/icons/Backspace';
+import CreateNewFolder from '@material-ui/icons/CreateNewFolder';
 import InfoBox from '../UI/InfoBox'
 import ToggleSwitch from '../UI/ToggleSwitch'
 

--- a/src/components/Settings/SyncSaves.tsx
+++ b/src/components/Settings/SyncSaves.tsx
@@ -62,13 +62,13 @@ export default function SyncSaves({
     setIsSyncing(true)
     const command = {
       Download: '--skip-upload',
-      Upload: '--skip-download',
       'Force download': '--force-download',
       'Force upload': '--force-upload',
+      Upload: '--skip-download',
     }
 
     await syncSaves(savesPath, appName, command[syncType]).then((res: string) =>
-      dialog.showMessageBox({ title: 'Saves Sync', message: res })
+      dialog.showMessageBox({ message: res, title: 'Saves Sync' })
     )
     setIsSyncing(false)
   }
@@ -95,10 +95,10 @@ export default function SyncSaves({
                   ? ''
                   : dialog
                       .showOpenDialog({
-                        title: t('box.sync.title'),
                         buttonLabel: t('box.sync.button'),
                         defaultPath: defaultFolder,
                         properties: ['openDirectory'],
+                        title: t('box.sync.title'),
                       })
                       .then(({ filePaths }: Path) =>
                         setSavesPath(filePaths[0] ? `${filePaths[0]}` : '')

--- a/src/components/Settings/SyncSaves.tsx
+++ b/src/components/Settings/SyncSaves.tsx
@@ -13,13 +13,13 @@ const {
 } = window.require('electron')
 
 interface Props {
-  savesPath: string
-  setSavesPath: (value: string) => void
-  appName: string
-  autoSyncSaves: boolean
-  setAutoSyncSaves: (value: boolean) => void
-  defaultFolder: string
-  isProton: boolean
+  appName: string,
+  autoSyncSaves: boolean,
+  defaultFolder: string,
+  isProton: boolean,
+  savesPath: string,
+  setAutoSyncSaves: (value: boolean) => void,
+  setSavesPath: (value: string) => void,
   winePrefix: string
 }
 

--- a/src/components/Settings/SyncSaves.tsx
+++ b/src/components/Settings/SyncSaves.tsx
@@ -9,7 +9,7 @@ import InfoBox from '../UI/InfoBox'
 import ToggleSwitch from '../UI/ToggleSwitch'
 
 const {
-  remote: { dialog },
+  remote: { dialog }
 } = window.require('electron')
 
 interface Props {
@@ -31,7 +31,7 @@ export default function SyncSaves({
   setAutoSyncSaves,
   defaultFolder,
   isProton,
-  winePrefix,
+  winePrefix
 }: Props) {
   const [isSyncing, setIsSyncing] = useState(false)
   const [syncType, setSyncType] = useState('Download' as SyncType)
@@ -56,7 +56,7 @@ export default function SyncSaves({
     t('setting.manualsync.download'),
     t('setting.manualsync.upload'),
     t('setting.manualsync.forcedownload'),
-    t('setting.manualsync.forceupload'),
+    t('setting.manualsync.forceupload')
   ]
   async function handleSync() {
     setIsSyncing(true)
@@ -64,7 +64,7 @@ export default function SyncSaves({
       Download: '--skip-upload',
       'Force download': '--force-download',
       'Force upload': '--force-upload',
-      Upload: '--skip-download',
+      Upload: '--skip-download'
     }
 
     await syncSaves(savesPath, appName, command[syncType]).then((res: string) =>
@@ -98,7 +98,7 @@ export default function SyncSaves({
                         buttonLabel: t('box.sync.button'),
                         defaultPath: defaultFolder,
                         properties: ['openDirectory'],
-                        title: t('box.sync.title'),
+                        title: t('box.sync.title')
                       })
                       .then(({ filePaths }: Path) =>
                         setSavesPath(filePaths[0] ? `${filePaths[0]}` : '')
@@ -120,7 +120,7 @@ export default function SyncSaves({
           style={{
             display: 'flex',
             justifyContent: 'space-between',
-            width: '513px',
+            width: '513px'
           }}
         >
           <select

--- a/src/components/Settings/Tools.tsx
+++ b/src/components/Settings/Tools.tsx
@@ -8,8 +8,8 @@ const {
 } = remote
 
 interface Props {
+  winePrefix: string,
   wineVersion: WineProps
-  winePrefix: string
 }
 
 export default function Tools({ wineVersion, winePrefix }: Props) {

--- a/src/components/Settings/Tools.tsx
+++ b/src/components/Settings/Tools.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
 import { WineProps } from '../../types'
 import { useTranslation } from 'react-i18next'
+import React from 'react'
 
 const { ipcRenderer, remote } = window.require('electron')
 const {

--- a/src/components/Settings/Tools.tsx
+++ b/src/components/Settings/Tools.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 const { ipcRenderer, remote } = window.require('electron')
 const {
-  dialog: { showOpenDialog },
+  dialog: { showOpenDialog }
 } = remote
 
 interface Props {
@@ -20,7 +20,7 @@ export default function Tools({ wineVersion, winePrefix }: Props) {
       exe,
       prefix: winePrefix,
       tool,
-      wine: wineVersion.bin,
+      wine: wineVersion.bin
     })
 
   const handleRunExe = async () => {
@@ -29,7 +29,7 @@ export default function Tools({ wineVersion, winePrefix }: Props) {
       buttonLabel: t('box.select'),
       filters: ['exe', 'msi'],
       properties: ['openFile'],
-      title: t('box.runexe.title'),
+      title: t('box.runexe.title')
     })
     if (filePaths[0]) {
       exe = filePaths[0]

--- a/src/components/Settings/Tools.tsx
+++ b/src/components/Settings/Tools.tsx
@@ -17,19 +17,19 @@ export default function Tools({ wineVersion, winePrefix }: Props) {
 
   const callTools = (tool: string, exe?: string) =>
     ipcRenderer.send('callTool', {
+      exe,
+      prefix: winePrefix,
       tool,
       wine: wineVersion.bin,
-      prefix: winePrefix,
-      exe,
     })
 
   const handleRunExe = async () => {
     let exe = ''
     const { filePaths } = await showOpenDialog({
-      title: t('box.runexe.title'),
       buttonLabel: t('box.select'),
-      properties: ['openFile'],
       filters: ['exe', 'msi'],
+      properties: ['openFile'],
+      title: t('box.runexe.title'),
     })
     if (filePaths[0]) {
       exe = filePaths[0]

--- a/src/components/Settings/WineSettings.tsx
+++ b/src/components/Settings/WineSettings.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import AddBoxIcon from '@material-ui/icons/AddBox'
+import React, { useEffect, useState } from 'react'
 import RemoveCircleIcon from '@material-ui/icons/RemoveCircle'
 
-import { WineProps, Path } from '../../types'
+import { Path, WineProps } from '../../types'
 import CreateNewFolder from '@material-ui/icons/CreateNewFolder'
 import InfoBox from '../UI/InfoBox'
 import ToggleSwitch from '../UI/ToggleSwitch'

--- a/src/components/Settings/WineSettings.tsx
+++ b/src/components/Settings/WineSettings.tsx
@@ -57,9 +57,9 @@ export default function WineSettings({
   function selectCustomPath() {
     dialog
       .showOpenDialog({
-        title: t('box.customWine', 'Select the Wine or Proton Binary'),
         buttonLabel: t('box.choose'),
         properties: ['openFile'],
+        title: t('box.customWine', 'Select the Wine or Proton Binary'),
       })
       .then(({ filePaths }: Path) => {
         if (!customWinePaths.includes(filePaths[0])) {
@@ -92,9 +92,9 @@ export default function WineSettings({
             onClick={() =>
               dialog
                 .showOpenDialog({
-                  title: t('box.wineprefix'),
                   buttonLabel: t('box.choose'),
                   properties: ['openDirectory'],
+                  title: t('box.wineprefix'),
                 })
                 .then(({ filePaths }: Path) =>
                   setWinePrefix(filePaths[0] ? `${filePaths[0]}` : '~/.wine')

--- a/src/components/Settings/WineSettings.tsx
+++ b/src/components/Settings/WineSettings.tsx
@@ -9,7 +9,7 @@ import InfoBox from '../UI/InfoBox'
 import ToggleSwitch from '../UI/ToggleSwitch'
 const {
   ipcRenderer,
-  remote: { dialog },
+  remote: { dialog }
 } = window.require('electron')
 
 interface Props {
@@ -37,7 +37,7 @@ export default function WineSettings({
   autoInstallDxvk,
   customWinePaths,
   setCustomWinePaths,
-  isDefault,
+  isDefault
 }: Props) {
   const [selectedPath, setSelectedPath] = useState('')
 
@@ -59,7 +59,7 @@ export default function WineSettings({
       .showOpenDialog({
         buttonLabel: t('box.choose'),
         properties: ['openFile'],
-        title: t('box.customWine', 'Select the Wine or Proton Binary'),
+        title: t('box.customWine', 'Select the Wine or Proton Binary')
       })
       .then(({ filePaths }: Path) => {
         if (!customWinePaths.includes(filePaths[0])) {
@@ -94,7 +94,7 @@ export default function WineSettings({
                 .showOpenDialog({
                   buttonLabel: t('box.choose'),
                   properties: ['openDirectory'],
-                  title: t('box.wineprefix'),
+                  title: t('box.wineprefix')
                 })
                 .then(({ filePaths }: Path) =>
                   setWinePrefix(filePaths[0] ? `${filePaths[0]}` : '~/.wine')
@@ -125,7 +125,7 @@ export default function WineSettings({
                 onClick={() => removeCustomPath()}
                 style={{
                   color: selectedPath ? 'var(--danger)' : 'var(--background)',
-                  cursor: selectedPath ? 'pointer' : '',
+                  cursor: selectedPath ? 'pointer' : ''
                 }}
                 fontSize="large"
                 titleAccess={t('tooltip.removepath', 'Remove Path')}

--- a/src/components/Settings/WineSettings.tsx
+++ b/src/components/Settings/WineSettings.tsx
@@ -13,17 +13,17 @@ const {
 } = window.require('electron')
 
 interface Props {
-  winePrefix: string
-  setWinePrefix: (value: string) => void
-  setWineversion: (wine: WineProps) => void
+  altWine: WineProps[],
+  autoInstallDxvk: boolean,
+  customWinePaths: string[],
+  isDefault: boolean,
+  setAltWine: (altWine: WineProps[]) => void,
+  setCustomWinePaths: (value: string[]) => void,
+  setWinePrefix: (value: string) => void,
+  setWineversion: (wine: WineProps) => void,
+  toggleAutoInstallDxvk: () => void,
+  winePrefix: string,
   wineVersion: WineProps
-  altWine: WineProps[]
-  setAltWine: (altWine: WineProps[]) => void
-  autoInstallDxvk: boolean
-  toggleAutoInstallDxvk: () => void
-  customWinePaths: string[]
-  setCustomWinePaths: (value: string[]) => void
-  isDefault: boolean
 }
 
 export default function WineSettings({

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -51,7 +51,7 @@ function Settings() {
 
   const [wineVersion, setWineversion] = useState({
     bin: '/usr/bin/wine',
-    name: 'Wine Default',
+    name: 'Wine Default'
   } as WineProps)
   const [winePrefix, setWinePrefix] = useState('~/.wine')
   const [defaultInstallPath, setDefaultInstallPath] = useState('')
@@ -69,39 +69,39 @@ function Settings() {
   const {
     on: useGameMode,
     toggle: toggleUseGameMode,
-    setOn: setUseGameMode,
+    setOn: setUseGameMode
   } = useToggle(false)
   const { on: showFps, toggle: toggleFps, setOn: setShowFps } = useToggle(false)
   const { on: offlineMode, toggle: toggleOffline, setOn: setShowOffline } = useToggle(false)
   const {
     on: audioFix,
     toggle: toggleAudioFix,
-    setOn: setAudioFix,
+    setOn: setAudioFix
   } = useToggle(false)
   const {
     on: showMangohud,
     toggle: toggleMangoHud,
-    setOn: setShowMangoHud,
+    setOn: setShowMangoHud
   } = useToggle(false)
   const {
     on: exitToTray,
     toggle: toggleTray,
-    setOn: setExitToTray,
+    setOn: setExitToTray
   } = useToggle(false)
   const {
     on: darkTrayIcon,
     toggle: toggleDarkTrayIcon,
-    setOn: setDarkTrayIcon,
+    setOn: setDarkTrayIcon
   } = useToggle(false)
   const {
     on: autoInstallDxvk,
     toggle: toggleAutoInstallDxvk,
-    setOn: setAutoInstallDxvk,
+    setOn: setAutoInstallDxvk
   } = useToggle(false)
 
   const [haveCloudSaving, setHaveCloudSaving] = useState({
     cloudSaveEnabled: false,
-    saveFolder: '',
+    saveFolder: ''
   })
   const [autoSyncSaves, setAutoSyncSaves] = useState(false)
   const [altWine, setAltWine] = useState([] as WineProps[])
@@ -143,7 +143,7 @@ function Settings() {
         const {
           cloudSaveEnabled,
           saveFolder,
-          title: gameTitle,
+          title: gameTitle
         } = await getGameInfo(appName)
         setTitle(gameTitle)
         return setHaveCloudSaving({ cloudSaveEnabled, saveFolder })
@@ -173,8 +173,8 @@ function Settings() {
       showMangohud,
       useGameMode,
       winePrefix,
-      wineVersion,
-    } as AppSettings,
+      wineVersion
+    } as AppSettings
   }
 
   const GameSettings = {
@@ -190,8 +190,8 @@ function Settings() {
       showMangohud,
       useGameMode,
       winePrefix,
-      wineVersion,
-    } as AppSettings,
+      wineVersion
+    } as AppSettings
   }
 
   const settingsToSave = isDefault ? GlobalSettings : GameSettings

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -4,28 +4,28 @@ import React, {
 } from 'react'
 
 import { IpcRenderer } from 'electron'
-import { useTranslation } from 'react-i18next'
 import {
   NavLink,
   useLocation,
   useParams
 } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 
+import {
+  AppSettings,
+  WineProps
+} from '../../types'
 import {
   getGameInfo,
   writeConfig
 } from '../../helper'
 import { useToggle } from '../../hooks'
-import {
-  AppSettings,
-  WineProps
-} from '../../types'
-import Header from '../UI/Header'
-import UpdateComponent from '../UI/UpdateComponent'
 import GeneralSettings from './GeneralSettings'
+import Header from '../UI/Header'
 import OtherSettings from './OtherSettings'
 import SyncSaves from './SyncSaves'
 import Tools from './Tools'
+import UpdateComponent from '../UI/UpdateComponent'
 import WineSettings from './WineSettings'
 
 interface ElectronProps {

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -50,8 +50,8 @@ function Settings() {
   const { state } = useLocation() as { state: LocationState }
 
   const [wineVersion, setWineversion] = useState({
-    name: 'Wine Default',
     bin: '/usr/bin/wine',
+    name: 'Wine Default',
   } as WineProps)
   const [winePrefix, setWinePrefix] = useState('~/.wine')
   const [defaultInstallPath, setDefaultInstallPath] = useState('')
@@ -159,38 +159,38 @@ function Settings() {
 
   const GlobalSettings = {
     defaultSettings: {
-      defaultInstallPath,
-      wineVersion,
-      winePrefix,
-      otherOptions,
-      useGameMode,
-      egsLinkedPath,
-      showFps,
-      offlineMode,
-      exitToTray,
       audioFix,
-      showMangohud,
-      language,
-      darkTrayIcon,
-      maxWorkers,
       customWinePaths,
+      darkTrayIcon,
+      defaultInstallPath,
+      egsLinkedPath,
+      exitToTray,
+      language,
+      maxWorkers,
+      offlineMode,
+      otherOptions,
+      showFps,
+      showMangohud,
+      useGameMode,
+      winePrefix,
+      wineVersion,
     } as AppSettings,
   }
 
   const GameSettings = {
     [appName]: {
-      wineVersion,
-      winePrefix,
-      otherOptions,
-      launcherArgs,
-      useGameMode,
-      savesPath,
-      showFps,
-      offlineMode,
-      autoSyncSaves,
       audioFix,
       autoInstallDxvk,
+      autoSyncSaves,
+      launcherArgs,
+      offlineMode,
+      otherOptions,
+      savesPath,
+      showFps,
       showMangohud,
+      useGameMode,
+      winePrefix,
+      wineVersion,
     } as AppSettings,
   }
 

--- a/src/components/UI/GameCard.tsx
+++ b/src/components/UI/GameCard.tsx
@@ -1,17 +1,17 @@
 /* eslint-disable complexity */
-import React, { useContext, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { useTranslation } from 'react-i18next'
-import ContextProvider from '../../state/ContextProvider'
-import { GameStatus } from '../../types'
-import { getProgress, sendKill, launch, updateGame } from '../../helper'
-import { handleInstall } from '../utls'
 import { ReactComponent as DownIcon } from '../../assets/down-icon.svg'
+import { GameStatus } from '../../types'
+import { Link } from 'react-router-dom'
 import { ReactComponent as PlayIcon } from '../../assets/play-icon.svg'
+import { ReactComponent as SettingsIcon } from '../../assets/settings-sharp.svg'
 import { ReactComponent as StopIcon } from '../../assets/stop-icon.svg'
 import { ReactComponent as StopIconAlt } from '../../assets/stop-icon-alt.svg'
-import { ReactComponent as SettingsIcon } from '../../assets/settings-sharp.svg'
+import { getProgress, launch, sendKill, updateGame } from '../../helper'
+import { handleInstall } from '../utls'
+import { useTranslation } from 'react-i18next'
+import ContextProvider from '../../state/ContextProvider'
 import NewReleasesIcon from '@material-ui/icons/NewReleases'
+import React, { useContext, useEffect, useState } from 'react'
 
 const { ipcRenderer, remote } = window.require('electron')
 const {

--- a/src/components/UI/GameCard.tsx
+++ b/src/components/UI/GameCard.tsx
@@ -15,7 +15,7 @@ import React, { useContext, useEffect, useState } from 'react'
 
 const { ipcRenderer, remote } = window.require('electron')
 const {
-  dialog: { showMessageBox },
+  dialog: { showMessageBox }
 } = remote
 interface Card {
   appName: string,
@@ -43,12 +43,12 @@ const GameCard = ({
   logo,
   coverList,
   size,
-  hasUpdate,
+  hasUpdate
 }: Card) => {
   const [progress, setProgress] = useState({
     bytes: '0/0MB',
     eta: '',
-    percent: '0.00%',
+    percent: '0.00%'
   } as InstallProgress)
   const { t } = useTranslation('gamepage')
 
@@ -122,7 +122,7 @@ const GameCard = ({
         {haveStatus && <span className="progress">{getStatus()}</span>}
         <Link
           to={{
-            pathname: `/gameconfig/${appName}`,
+            pathname: `/gameconfig/${appName}`
           }}
         >
           <span
@@ -131,7 +131,7 @@ const GameCard = ({
                 grid ? cover : coverList
               }?h=400&resize=1&w=300')`,
               backgroundSize: 'cover',
-              filter: isInstalled ? 'none' : `grayscale(${effectPercent})`,
+              filter: isInstalled ? 'none' : `grayscale(${effectPercent})`
             }}
             className={grid ? 'gameImg' : 'gameImgList'}
           >
@@ -140,7 +140,7 @@ const GameCard = ({
                 alt="logo"
                 src={`${logo}?h=400&resize=1&w=300`}
                 style={{
-                  filter: isInstalled ? 'none' : `grayscale(${effectPercent})`,
+                  filter: isInstalled ? 'none' : `grayscale(${effectPercent})`
                 }}
                 className="gameLogo"
               />
@@ -155,7 +155,7 @@ const GameCard = ({
                 className="icons"
                 style={{
                   flexDirection: 'row',
-                  width: isInstalled ? '44%' : 'auto',
+                  width: isInstalled ? '44%' : 'auto'
                 }}
               >
                 {renderIcon()}
@@ -163,7 +163,7 @@ const GameCard = ({
                   <Link
                     to={{
                       pathname: `/settings/${appName}/wine`,
-                      state: { fromGameCard: true },
+                      state: { fromGameCard: true }
                     }}
                   >
                     <SettingsIcon fill={'var(--secondary)'} />
@@ -183,7 +183,7 @@ const GameCard = ({
                   <Link
                     to={{
                       pathname: `/settings/${appName}/wine`,
-                      state: { fromGameCard: true },
+                      state: { fromGameCard: true }
                     }}
                   >
                     <SettingsIcon fill={'var(--secondary)'} />
@@ -205,7 +205,7 @@ const GameCard = ({
         handleGameStatus,
         installPath: 'another',
         isInstalling,
-        t,
+        t
       })
     }
     if (status === 'playing' || status === 'updating') {
@@ -226,7 +226,7 @@ const GameCard = ({
         const { response } = await showMessageBox({
           buttons: [t('box.yes'), t('box.no')],
           message: t('box.update.message'),
-          title: t('box.update.title'),
+          title: t('box.update.title')
         })
 
         if (response === 0) {

--- a/src/components/UI/GameCard.tsx
+++ b/src/components/UI/GameCard.tsx
@@ -18,21 +18,21 @@ const {
   dialog: { showMessageBox },
 } = remote
 interface Card {
-  cover: string
-  coverList: string
-  logo: string
-  title: string
-  appName: string
-  isInstalled: boolean
+  appName: string,
+  cover: string,
+  coverList: string,
+  hasUpdate: boolean,
+  isInstalled: boolean,
+  logo: string,
+  size: string,
+  title: string,
   version: string
-  size: string
-  hasUpdate: boolean
 }
 
 interface InstallProgress {
+  bytes: string,
+  eta: string,
   percent: string
-  bytes: string
-  eta: string
 }
 
 const GameCard = ({

--- a/src/components/UI/GameCard.tsx
+++ b/src/components/UI/GameCard.tsx
@@ -46,9 +46,9 @@ const GameCard = ({
   hasUpdate,
 }: Card) => {
   const [progress, setProgress] = useState({
-    percent: '0.00%',
     bytes: '0/0MB',
     eta: '',
+    percent: '0.00%',
   } as InstallProgress)
   const { t } = useTranslation('gamepage')
 
@@ -194,7 +194,7 @@ const GameCard = ({
           </>
         )}
       </div>
-      {!grid ? <hr style={{ width: '90%', opacity: 0.1 }} /> : ''}
+      {!grid ? <hr style={{ opacity: 0.1, width: '90%' }} /> : ''}
     </>
   )
 
@@ -202,9 +202,9 @@ const GameCard = ({
     if (!isInstalled) {
       return await handleInstall({
         appName,
-        isInstalling,
-        installPath: 'another',
         handleGameStatus,
+        installPath: 'another',
+        isInstalling,
         t,
       })
     }
@@ -224,9 +224,9 @@ const GameCard = ({
         err.includes('ERROR: Game is out of date')
       ) {
         const { response } = await showMessageBox({
-          title: t('box.update.title'),
-          message: t('box.update.message'),
           buttons: [t('box.yes'), t('box.no')],
+          message: t('box.update.message'),
+          title: t('box.update.title'),
         })
 
         if (response === 0) {

--- a/src/components/UI/Header.tsx
+++ b/src/components/UI/Header.tsx
@@ -8,12 +8,12 @@ import React, { useContext } from 'react'
 import cx from 'classnames'
 
 interface Props {
-  renderBackButton: boolean
-  numberOfGames?: number
-  goTo: string | void | null
+  goTo: string | void | null,
+  handleFilter?: (value: string) => void,
+  handleLayout?: (value: string) => void,
+  numberOfGames?: number,
+  renderBackButton: boolean,
   title?: string
-  handleFilter?: (value: string) => void
-  handleLayout?: (value: string) => void
 }
 
 export default function Header({

--- a/src/components/UI/Header.tsx
+++ b/src/components/UI/Header.tsx
@@ -22,7 +22,7 @@ export default function Header({
   handleFilter,
   handleLayout,
   goTo,
-  title,
+  title
 }: Props) {
   const { t } = useTranslation()
   const { filter, libraryStatus, layout } = useContext(ContextProvider)

--- a/src/components/UI/Header.tsx
+++ b/src/components/UI/Header.tsx
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react'
-import { useTranslation } from 'react-i18next'
 import { Link, useHistory } from 'react-router-dom'
-import ArrowBack from '@material-ui/icons/ArrowBack'
+import { useTranslation } from 'react-i18next'
 import Apps from '@material-ui/icons/Apps'
-import List from '@material-ui/icons/List'
-import cx from 'classnames'
+import ArrowBack from '@material-ui/icons/ArrowBack'
 import ContextProvider from '../../state/ContextProvider'
+import List from '@material-ui/icons/List'
+import React, { useContext } from 'react'
+import cx from 'classnames'
 
 interface Props {
   renderBackButton: boolean

--- a/src/components/UI/InfoBox.tsx
+++ b/src/components/UI/InfoBox.tsx
@@ -12,7 +12,7 @@ export default function InfoBox({ children, text }: Props) {
   const { on: isHidden, toggle: toggleIsHidden } = useToggle(true)
   const { t } = useTranslation()
 
-  /* 
+  /*
     keys to parse
       t('infobox.help')
       t('infobox.requirements')

--- a/src/components/UI/InfoBox.tsx
+++ b/src/components/UI/InfoBox.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import { useToggle } from '../../hooks'
 import { useTranslation } from 'react-i18next'
 import Info from '@material-ui/icons/Info'
-import { useToggle } from '../../hooks'
+import React from 'react'
 
 interface Props {
   children: React.ReactNode

--- a/src/components/UI/LanguageSelector.tsx
+++ b/src/components/UI/LanguageSelector.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 export enum FlagPosition {
+  APPEND = 'append',
   NONE = 'none',
-  PREPEND = 'prepend',
-  APPEND = 'append'
+  PREPEND = 'prepend'
 }
 
 interface Props {

--- a/src/components/UI/LanguageSelector.tsx
+++ b/src/components/UI/LanguageSelector.tsx
@@ -13,13 +13,13 @@ interface Props {
   handleLanguageChange: (language: string) => void;
 }
 
-export default function LanguageSelector({ 
-  handleLanguageChange, 
-  currentLanguage = 'en', 
+export default function LanguageSelector({
+  handleLanguageChange,
+  currentLanguage = 'en',
   className = 'settingSelect',
-  flagPossition = FlagPosition.NONE,
+  flagPossition = FlagPosition.NONE
  }: Props) {
-   
+
   const languageLabels: {[key: string]: string} = {
     'de': 'Deutsch',
     'en': 'English',
@@ -30,7 +30,7 @@ export default function LanguageSelector({
     'pl': 'Polski',
     'pt': 'Português',
     'ru': 'Русский',
-    'tr': 'Türkçe',
+    'tr': 'Türkçe'
   }
 
   const languageFlags: {[key: string]: string} = {
@@ -43,7 +43,7 @@ export default function LanguageSelector({
     'pl': '🇵🇱',
     'pt': '🇵🇹',
     'ru': '🇷🇺',
-    'tr': '🇹🇷',
+    'tr': '🇹🇷'
   }
 
   const renderOption = (lang: string)  => {
@@ -55,7 +55,7 @@ export default function LanguageSelector({
     return <option key={lang} value={lang}>{label}</option>
   }
   return (
-    <select 
+    <select
       onChange={(event) => handleLanguageChange(event.target.value)}
       className={className}
       value={currentLanguage}

--- a/src/components/UI/LanguageSelector.tsx
+++ b/src/components/UI/LanguageSelector.tsx
@@ -21,29 +21,29 @@ export default function LanguageSelector({
  }: Props) {
    
   const languageLabels: {[key: string]: string} = {
-    'en': 'English',
-    'pt': 'Português',
     'de': 'Deutsch',
-    'fr': 'Français',
-    'ru': 'Русский',
-    'pl': 'Polski',
-    'tr': 'Türkçe',
-    'nl': 'Nederlands',
+    'en': 'English',
     'es': 'Español',
+    'fr': 'Français',
     'hu': 'Magyar',
+    'nl': 'Nederlands',
+    'pl': 'Polski',
+    'pt': 'Português',
+    'ru': 'Русский',
+    'tr': 'Türkçe',
   }
 
   const languageFlags: {[key: string]: string} = {
-    'en': '🇬🇧',
-    'pt': '🇵🇹',
     'de': '🇩🇪',
-    'fr': '🇫🇷',
-    'ru': '🇷🇺',
-    'pl': '🇵🇱',
-    'tr': '🇹🇷',
-    'nl': '🇳🇱',
+    'en': '🇬🇧',
     'es': '🇪🇸',
+    'fr': '🇫🇷',
     'hu': '🇭🇺',
+    'nl': '🇳🇱',
+    'pl': '🇵🇱',
+    'pt': '🇵🇹',
+    'ru': '🇷🇺',
+    'tr': '🇹🇷',
   }
 
   const renderOption = (lang: string)  => {

--- a/src/components/UI/SearchBar.tsx
+++ b/src/components/UI/SearchBar.tsx
@@ -24,7 +24,7 @@ export default function SearchBar() {
           placeholder={t('search')}
           id="search"
         />
-       
+
       {textValue.length > 0 && (
         <Close
           onClick={() => {

--- a/src/components/UI/SearchBar.tsx
+++ b/src/components/UI/SearchBar.tsx
@@ -1,8 +1,8 @@
-import React, { useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Search from '@material-ui/icons/Search';
 import Close from '@material-ui/icons/Close';
 import ContextProvider from '../../state/ContextProvider'
+import React, { useContext, useState } from 'react'
+import Search from '@material-ui/icons/Search';
 
 export default function SearchBar() {
   const { handleSearch } = useContext(ContextProvider)

--- a/src/components/UI/ToggleSwitch.tsx
+++ b/src/components/UI/ToggleSwitch.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
 interface Props {
-  handleChange: () => void
+  disabled?: boolean,
+  handleChange: () => void,
   value: boolean
-  disabled?: boolean
 }
 
 export default function ToggleSwitch({ handleChange, value, disabled }: Props) {

--- a/src/components/UI/UserSelector.tsx
+++ b/src/components/UI/UserSelector.tsx
@@ -3,7 +3,7 @@ import {
   handleQuit,
   legendary,
   openAboutWindow,
-  openDiscordLink,
+  openDiscordLink
 } from '../../helper'
 import { useTranslation } from 'react-i18next'
 import ArrowDropDown from '@material-ui/icons/ArrowDropDown'

--- a/src/components/UI/UserSelector.tsx
+++ b/src/components/UI/UserSelector.tsx
@@ -1,14 +1,14 @@
-import React from 'react'
-import { useTranslation } from 'react-i18next'
-import ArrowDropDown from '@material-ui/icons/ArrowDropDown'
 import {
+  handleKofi,
+  handleQuit,
   legendary,
   openAboutWindow,
-  handleQuit,
-  handleKofi,
   openDiscordLink,
 } from '../../helper'
+import { useTranslation } from 'react-i18next'
+import ArrowDropDown from '@material-ui/icons/ArrowDropDown'
 import ContextProvider from '../../state/ContextProvider'
+import React from 'react'
 
 export default function UserSelector() {
   const { t } = useTranslation()

--- a/src/components/utls.ts
+++ b/src/components/utls.ts
@@ -5,11 +5,11 @@ import {
   getGameInfo,
   handleStopInstallation,
   importGame,
-  install,
+  install
 } from '../helper'
 const { remote } = window.require('electron')
 const {
-  dialog: { showOpenDialog },
+  dialog: { showOpenDialog }
 } = remote
 
 interface Install {
@@ -25,7 +25,7 @@ export async function handleInstall({
   isInstalling,
   installPath,
   handleGameStatus,
-  t,
+  t
 }: Install) {
   if (isInstalling) {
     const { folderName } = await getGameInfo(appName)
@@ -46,7 +46,7 @@ export async function handleInstall({
     const { filePaths } = await showOpenDialog({
       buttonLabel: t('gamepage:box.choose'),
       properties: ['gamepage:openDirectory'],
-      title: t('gamepage:box.importpath'),
+      title: t('gamepage:box.importpath')
     })
 
     if (filePaths[0]) {
@@ -61,7 +61,7 @@ export async function handleInstall({
     const { filePaths } = await showOpenDialog({
       buttonLabel: t('gamepage:box.choose'),
       properties: ['openDirectory'],
-      title: t('gamepage:box.installpath'),
+      title: t('gamepage:box.installpath')
     })
 
     if (filePaths[0]) {

--- a/src/components/utls.ts
+++ b/src/components/utls.ts
@@ -44,9 +44,9 @@ export async function handleInstall({
 
   if (installPath === 'import') {
     const { filePaths } = await showOpenDialog({
-      title: t('gamepage:box.importpath'),
       buttonLabel: t('gamepage:box.choose'),
       properties: ['gamepage:openDirectory'],
+      title: t('gamepage:box.importpath'),
     })
 
     if (filePaths[0]) {
@@ -59,9 +59,9 @@ export async function handleInstall({
 
   if (installPath === 'another') {
     const { filePaths } = await showOpenDialog({
-      title: t('gamepage:box.installpath'),
       buttonLabel: t('gamepage:box.choose'),
       properties: ['openDirectory'],
+      title: t('gamepage:box.installpath'),
     })
 
     if (filePaths[0]) {

--- a/src/components/utls.ts
+++ b/src/components/utls.ts
@@ -1,12 +1,12 @@
 import { TFunction } from 'react-i18next'
 
+import { GameStatus } from '../types'
 import {
   getGameInfo,
   handleStopInstallation,
-  install,
   importGame,
+  install,
 } from '../helper'
-import { GameStatus } from '../types'
 const { remote } = window.require('electron')
 const {
   dialog: { showOpenDialog },

--- a/src/components/utls.ts
+++ b/src/components/utls.ts
@@ -14,9 +14,9 @@ const {
 
 interface Install {
   appName: string
-  isInstalling: boolean
+  handleGameStatus: (game: GameStatus) => Promise<void>,
   installPath: 'import' | 'default' | 'another'
-  handleGameStatus: (game: GameStatus) => Promise<void>
+  isInstalling: boolean,
   t: TFunction<'gamepage'>
 }
 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,6 +1,13 @@
-import { IpcRenderer, Remote } from 'electron'
-import { Game, InstallProgress } from './types'
+import {
+  IpcRenderer,
+  Remote
+} from 'electron'
 import { TFunction } from 'react-i18next'
+
+import {
+  Game,
+  InstallProgress
+} from './types'
 
 const { ipcRenderer, remote } = window.require('electron') as {
   ipcRenderer: IpcRenderer
@@ -14,52 +21,52 @@ const {
 const readFile = async (file: string) =>
   await ipcRenderer.invoke('readFile', file)
 
-export const writeConfig = async (
+const writeConfig = async (
   data: [appName: string, x: unknown]
 ): Promise<void> => await ipcRenderer.invoke('writeFile', data)
 
-export const install = async (args: {
+const install = async (args: {
   appName: string
   path: string
 }): Promise<void> => await ipcRenderer.invoke('install', args)
 
-export const repair = async (appName: string): Promise<void> =>
+const repair = async (appName: string): Promise<void> =>
   await ipcRenderer.invoke('repair', appName)
 
-export const launch = (args: string): Promise<string> =>
+const launch = (args: string): Promise<string> =>
   ipcRenderer.invoke('launch', args).then((res: string): string => res)
 
-export const updateGame = (appName: string): Promise<void> =>
+const updateGame = (appName: string): Promise<void> =>
   ipcRenderer.invoke('updateGame', appName)
 
-export const notify = ([title, message]: [
+const notify = ([title, message]: [
   title: string,
   message: string
 ]): void => ipcRenderer.send('Notify', [title, message])
 
-export const loginPage = (): void => ipcRenderer.send('openLoginPage')
+const loginPage = (): void => ipcRenderer.send('openLoginPage')
 
-export const sidInfoPage = (): void => ipcRenderer.send('openSidInfoPage')
+const sidInfoPage = (): void => ipcRenderer.send('openSidInfoPage')
 
-export const handleKofi = (): void => ipcRenderer.send('openSupportPage')
+const handleKofi = (): void => ipcRenderer.send('openSupportPage')
 
-export const handleQuit = (): void => ipcRenderer.send('quit')
+const handleQuit = (): void => ipcRenderer.send('quit')
 
-export const importGame = async (args: {
+const importGame = async (args: {
   appName: string
   path: string
 }): Promise<void> => await ipcRenderer.invoke('importGame', args)
 
-export const openAboutWindow = (): void => ipcRenderer.send('showAboutWindow')
+const openAboutWindow = (): void => ipcRenderer.send('showAboutWindow')
 
-export const openDiscordLink = (): void => ipcRenderer.send('openDiscordLink')
+const openDiscordLink = (): void => ipcRenderer.send('openDiscordLink')
 
-export let progress: string
+let progress: string
 
-export const sendKill = (appName: string): void =>
+const sendKill = (appName: string): void =>
   ipcRenderer.send('kill', appName)
 
-export const legendary = async (args: string): Promise<string> =>
+const legendary = async (args: string): Promise<string> =>
   await ipcRenderer
     .invoke('legendary', args)
     .then(async (res: string) => {
@@ -68,10 +75,10 @@ export const legendary = async (args: string): Promise<string> =>
     })
     .catch((err: string | null) => String(err))
 
-export const isLoggedIn = async (): Promise<void> =>
+const isLoggedIn = async (): Promise<void> =>
   await ipcRenderer.invoke('isLoggedIn')
 
-export const syncSaves = async (
+const syncSaves = async (
   savesPath: string,
   appName: string,
   arg?: string
@@ -89,7 +96,7 @@ export const syncSaves = async (
   return response
 }
 
-export const getLegendaryConfig = async (): Promise<{
+const getLegendaryConfig = async (): Promise<{
   user: string
   library: Game[]
 }> => {
@@ -111,7 +118,7 @@ const cleanTitle = (title: string) =>
     .toLowerCase()
     .split('--definitive')[0]
 
-export const getGameInfo = async (appName: string) => {
+const getGameInfo = async (appName: string) => {
   const library: Array<Game> = await readFile('library')
   const game = library.filter((game) => game.app_name === appName)[0]
   const extraInfo = await ipcRenderer.invoke(
@@ -122,28 +129,28 @@ export const getGameInfo = async (appName: string) => {
   return { ...game, extraInfo }
 }
 
-export const handleSavePath = async (game: string) => {
+const handleSavePath = async (game: string) => {
   const { cloudSaveEnabled, saveFolder } = await getGameInfo(game)
 
   return { cloudSaveEnabled, saveFolder }
 }
 
-export const createNewWindow = (url: string) =>
+const createNewWindow = (url: string) =>
   new BrowserWindow({ width: 1200, height: 700 }).loadURL(url)
 
-export const formatStoreUrl = (title: string, lang: string) => {
+const formatStoreUrl = (title: string, lang: string) => {
   const storeUrl = `https://www.epicgames.com/store/${lang}/product/`
   return `${storeUrl}${cleanTitle(title)}`
 }
 
-export function getProgress(progress: InstallProgress): number {
+function getProgress(progress: InstallProgress): number {
   if (progress && progress.percent) {
     return Number(progress.percent.replace('%', ''))
   }
   return 0
 }
 
-export async function fixSaveFolder(
+async function fixSaveFolder(
   folder: string,
   prefix: string,
   isProton: boolean
@@ -236,7 +243,7 @@ export async function fixSaveFolder(
   return folder
 }
 
-export async function handleStopInstallation(
+async function handleStopInstallation(
   appName: string,
   [path, folderName]: string[],
   t: TFunction<'gamepage'>
@@ -256,4 +263,33 @@ export async function handleStopInstallation(
     sendKill(appName)
     return ipcRenderer.send('removeFolder', [path, folderName])
   }
+}
+
+export {
+  createNewWindow,
+  fixSaveFolder,
+  formatStoreUrl,
+  getGameInfo,
+  getLegendaryConfig,
+  getProgress,
+  handleKofi,
+  handleQuit,
+  handleSavePath,
+  handleStopInstallation,
+  importGame,
+  install,
+  isLoggedIn,
+  launch,
+  legendary,
+  loginPage,
+  notify,
+  openAboutWindow,
+  openDiscordLink,
+  progress,
+  repair,
+  sendKill,
+  sidInfoPage,
+  syncSaves,
+  updateGame,
+  writeConfig
 }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -104,10 +104,10 @@ const getLegendaryConfig = async (): Promise<{
   const library: Array<Game> = await readFile('library')
 
   if (!user) {
-    return { user: '', library: [] }
+    return { library: [], user: '' }
   }
 
-  return { user, library }
+  return { library, user }
 }
 
 const specialCharactersRegex = /('\w)|(\\(\w|\d){5})|(\\"(\\.|[^"])*")|[^((0-9)|(a-z)|(A-Z)|\s)]/g // addeed regex for capturings "'s" + unicodes + remove subtitles in quotes
@@ -136,7 +136,7 @@ const handleSavePath = async (game: string) => {
 }
 
 const createNewWindow = (url: string) =>
-  new BrowserWindow({ width: 1200, height: 700 }).loadURL(url)
+  new BrowserWindow({ height: 700, width: 1200 }).loadURL(url)
 
 const formatStoreUrl = (title: string, lang: string) => {
   const storeUrl = `https://www.epicgames.com/store/${lang}/product/`
@@ -249,13 +249,13 @@ async function handleStopInstallation(
   t: TFunction<'gamepage'>
 ) {
   const { response } = await showMessageBox({
-    title: t('gamepage:box.stopInstall.title'),
-    message: t('gamepage:box.stopInstall.message'),
     buttons: [
       t('gamepage:box.stopInstall.keepInstalling'),
       t('box.yes'),
       t('box.no'),
     ],
+    message: t('gamepage:box.stopInstall.message'),
+    title: t('gamepage:box.stopInstall.title'),
   })
   if (response === 1) {
     return sendKill(appName)

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -97,8 +97,8 @@ const syncSaves = async (
 }
 
 const getLegendaryConfig = async (): Promise<{
+  library: Game[],
   user: string
-  library: Game[]
 }> => {
   const user: string = await readFile('user')
   const library: Array<Game> = await readFile('library')

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -15,7 +15,7 @@ const { ipcRenderer, remote } = window.require('electron') as {
 }
 const {
   BrowserWindow,
-  dialog: { showMessageBox },
+  dialog: { showMessageBox }
 } = remote
 
 const readFile = async (file: string) =>
@@ -91,7 +91,7 @@ const syncSaves = async (
   const response: string = await ipcRenderer.invoke('syncSaves', [
     arg,
     path,
-    appName,
+    appName
   ])
   return response
 }
@@ -252,10 +252,10 @@ async function handleStopInstallation(
     buttons: [
       t('gamepage:box.stopInstall.keepInstalling'),
       t('box.yes'),
-      t('box.no'),
+      t('box.no')
     ],
     message: t('gamepage:box.stopInstall.message'),
-    title: t('gamepage:box.stopInstall.title'),
+    title: t('gamepage:box.stopInstall.title')
   })
   if (response === 1) {
     return sendKill(appName)

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -15,5 +15,5 @@ export function useToggle(state = false): Toggle {
     setOn((o) => !o)
   }, [setOn])
 
-  return { on, toggle, close, setOn }
+  return { close, on, setOn, toggle }
 }

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,10 +1,10 @@
 import { useCallback, useState } from 'react'
 
 type Toggle = {
-  on: boolean
+  close: () => void,
+  on: boolean,
+  setOn: React.Dispatch<React.SetStateAction<boolean>>,
   toggle: () => void
-  close: () => void
-  setOn: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export function useToggle(state = false): Toggle {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,8 +11,8 @@ import GlobalState from './state/GlobalState'
 import UpdateComponent from './components/UI/UpdateComponent'
 
 const Backend = new HttpApi(null, {
-  allowMultiLoading: false,
   addPath: 'build/locales/{{lng}}/{{ns}}',
+  allowMultiLoading: false,
   loadPath: 'locales/{{lng}}/{{ns}}.json',
 })
 
@@ -25,15 +25,15 @@ i18next
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
+    fallbackLng: 'en',
     interpolation: {
       escapeValue: false,
     },
     lng: 'en',
-    fallbackLng: 'en',
-    supportedLngs: ['de', 'en', 'es', 'fr', 'nl', 'pl', 'pt', 'ru', 'tr', 'hu'],
     react: {
       useSuspense: true,
     },
+    supportedLngs: ['de', 'en', 'es', 'fr', 'nl', 'pl', 'pt', 'ru', 'tr', 'hu'],
   })
 
 ReactDOM.render(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ import UpdateComponent from './components/UI/UpdateComponent'
 const Backend = new HttpApi(null, {
   addPath: 'build/locales/{{lng}}/{{ns}}',
   allowMultiLoading: false,
-  loadPath: 'locales/{{lng}}/{{ns}}.json',
+  loadPath: 'locales/{{lng}}/{{ns}}.json'
 })
 
 i18next
@@ -27,13 +27,13 @@ i18next
   .init({
     fallbackLng: 'en',
     interpolation: {
-      escapeValue: false,
+      escapeValue: false
     },
     lng: 'en',
     react: {
-      useSuspense: true,
+      useSuspense: true
     },
-    supportedLngs: ['de', 'en', 'es', 'fr', 'nl', 'pl', 'pt', 'ru', 'tr', 'hu'],
+    supportedLngs: ['de', 'en', 'es', 'fr', 'nl', 'pl', 'pt', 'ru', 'tr', 'hu']
   })
 
 ReactDOM.render(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,9 @@
-import React, { Suspense } from 'react'
-import ReactDOM from 'react-dom'
 import { I18nextProvider, initReactI18next } from 'react-i18next'
-import i18next from 'i18next'
 import HttpApi from 'i18next-http-backend'
 import LanguageDetector from 'i18next-browser-languagedetector'
+import React, { Suspense } from 'react'
+import ReactDOM from 'react-dom'
+import i18next from 'i18next'
 
 import './index.css'
 import App from './App'

--- a/src/state/ContextProvider.tsx
+++ b/src/state/ContextProvider.tsx
@@ -15,7 +15,7 @@ const initialContext: ContextType = {
   refresh: () => Promise.resolve(),
   refreshLibrary: () => Promise.resolve(),
   refreshing: false,
-  user: '',
+  user: ''
 }
 
 export default React.createContext(initialContext)

--- a/src/state/ContextProvider.tsx
+++ b/src/state/ContextProvider.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
 import { ContextType } from '../types'
+import React from 'react'
 
 const initialContext: ContextType = {
   user: '',

--- a/src/state/ContextProvider.tsx
+++ b/src/state/ContextProvider.tsx
@@ -2,20 +2,20 @@ import { ContextType } from '../types'
 import React from 'react'
 
 const initialContext: ContextType = {
-  user: '',
   data: [],
-  libraryStatus: [],
-  refreshing: false,
-  filter: 'all',
-  layout: 'grid',
   error: false,
+  filter: 'all',
   gameUpdates: [],
+  handleFilter: () => null,
+  handleGameStatus: () => Promise.resolve(),
+  handleLayout: () => null,
+  handleSearch: () => null,
+  layout: 'grid',
+  libraryStatus: [],
   refresh: () => Promise.resolve(),
   refreshLibrary: () => Promise.resolve(),
-  handleGameStatus: () => Promise.resolve(),
-  handleSearch: () => null,
-  handleFilter: () => null,
-  handleLayout: () => null,
+  refreshing: false,
+  user: '',
 }
 
 export default React.createContext(initialContext)

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -6,7 +6,7 @@ import {
   getLegendaryConfig,
   getProgress,
   legendary,
-  notify,
+  notify
 } from '../helper'
 import { i18n } from 'i18next'
 import ContextProvider from './ContextProvider'
@@ -49,7 +49,7 @@ export class GlobalState extends PureComponent<Props> {
     layout: 'grid',
     libraryStatus: [],
     refreshing: false,
-    user: '',
+    user: ''
   }
 
   refresh = async (): Promise<void> => {
@@ -62,7 +62,7 @@ export class GlobalState extends PureComponent<Props> {
       filterText: '',
       gameUpdates: updates,
       refreshing: false,
-      user,
+      user
     })
   }
 
@@ -118,7 +118,7 @@ export class GlobalState extends PureComponent<Props> {
         (game) => game.appName !== appName
       )
       return this.setState({
-        libraryStatus: [...updatedLibraryStatus, { ...currentApp }],
+        libraryStatus: [...updatedLibraryStatus, { ...currentApp }]
       })
     }
 
@@ -200,7 +200,7 @@ export class GlobalState extends PureComponent<Props> {
     }
 
     return this.setState({
-      libraryStatus: [...libraryStatus, { appName, status }],
+      libraryStatus: [...libraryStatus, { appName, status }]
     })
   }
 
@@ -214,7 +214,7 @@ export class GlobalState extends PureComponent<Props> {
           'box.appupdate.message',
           'There is a new version of Heroic Available, do you want to update now?'
         ),
-        title: t('box.appupdate.title', 'Update Available'),
+        title: t('box.appupdate.title', 'Update Available')
       })
 
       if (response === 0) {
@@ -280,7 +280,7 @@ export class GlobalState extends PureComponent<Props> {
           handleLayout: this.handleLayout,
           handleSearch: this.handleSearch,
           refresh: this.refresh,
-          refreshLibrary: this.refreshLibrary,
+          refreshLibrary: this.refreshLibrary
         }}
       >
         {children}

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -21,21 +21,21 @@ const renderer: IpcRenderer = ipcRenderer
 
 interface Props {
   children: React.ReactNode
+  i18n: i18n,
   t: TFunction
-  i18n: i18n
 }
 
 interface StateProps {
-  user: string
-  data: Game[]
-  refreshing: boolean
-  error: boolean
-  filter: string
-  filterText: string
-  language: string
+  data: Game[],
+  error: boolean,
+  filter: string,
+  filterText: string,
+  gameUpdates: string[],
+  language: string,
+  layout: string,
   libraryStatus: GameStatus[]
-  layout: string
-  gameUpdates: string[]
+  refreshing: boolean,
+  user: string
 }
 
 export class GlobalState extends PureComponent<Props> {

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -40,16 +40,16 @@ interface StateProps {
 
 export class GlobalState extends PureComponent<Props> {
   state: StateProps = {
-    user: '',
-    filterText: '',
     data: [],
-    libraryStatus: [],
-    refreshing: false,
-    language: '',
     error: false,
     filter: 'all',
-    layout: 'grid',
+    filterText: '',
     gameUpdates: [],
+    language: '',
+    layout: 'grid',
+    libraryStatus: [],
+    refreshing: false,
+    user: '',
   }
 
   refresh = async (): Promise<void> => {
@@ -58,11 +58,11 @@ export class GlobalState extends PureComponent<Props> {
     const updates = await renderer.invoke('checkGameUpdates')
 
     this.setState({
-      user,
-      refreshing: false,
-      filterText: '',
       data: library,
+      filterText: '',
       gameUpdates: updates,
+      refreshing: false,
+      user,
     })
   }
 
@@ -209,12 +209,12 @@ export class GlobalState extends PureComponent<Props> {
     const newVersion = await renderer.invoke('checkVersion')
     if (newVersion) {
       const { response } = await showMessageBox({
-        title: t('box.appupdate.title', 'Update Available'),
+        buttons: [t('box.yes'), t('box.no')],
         message: t(
           'box.appupdate.message',
           'There is a new version of Heroic Available, do you want to update now?'
         ),
-        buttons: [t('box.yes'), t('box.no')],
+        title: t('box.appupdate.title', 'Update Available'),
       })
 
       if (response === 0) {
@@ -275,12 +275,12 @@ export class GlobalState extends PureComponent<Props> {
         value={{
           ...this.state,
           data: filteredLibrary,
+          handleFilter: this.handleFilter,
+          handleGameStatus: this.handleGameStatus,
+          handleLayout: this.handleLayout,
+          handleSearch: this.handleSearch,
           refresh: this.refresh,
           refreshLibrary: this.refreshLibrary,
-          handleGameStatus: this.handleGameStatus,
-          handleFilter: this.handleFilter,
-          handleSearch: this.handleSearch,
-          handleLayout: this.handleLayout,
         }}
       >
         {children}

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -1,8 +1,6 @@
+import { Game, GameStatus } from '../types'
 import { IpcRenderer } from 'electron'
-import { i18n } from 'i18next'
-import React, { PureComponent } from 'react'
 import { TFunction, withTranslation } from 'react-i18next'
-import UpdateComponent from '../components/UI/UpdateComponent'
 import {
   getGameInfo,
   getLegendaryConfig,
@@ -10,8 +8,10 @@ import {
   legendary,
   notify,
 } from '../helper'
-import { Game, GameStatus } from '../types'
+import { i18n } from 'i18next'
 import ContextProvider from './ContextProvider'
+import React, { PureComponent } from 'react'
+import UpdateComponent from '../components/UI/UpdateComponent'
 const storage: Storage = window.localStorage
 const { remote, ipcRenderer } = window.require('electron')
 const { dialog } = remote

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,43 +3,43 @@ interface About {
   shortDescription: string
 }
 export interface AppSettings {
-  wineVersion: WineProps
-  winePrefix: string
-  otherOptions: string
-  useGameMode: boolean
-  showFps: boolean
-  offlineMode: boolean
+  audioFix: boolean,
+  autoInstallDxvk: boolean,
+  autoSyncSaves: boolean,
+  customWinePaths: Array<string>,
+  darkTrayIcon: boolean,
+  defaultInstallPath: string,
   egsLinkedPath: string
-  savesPath: string
-  autoSyncSaves: boolean
-  exitToTray: boolean
-  launcherArgs: string
-  audioFix: boolean
-  showMangohud: boolean
-  defaultInstallPath: string
-  language: string
-  maxWorkers: number
-  darkTrayIcon: boolean
-  autoInstallDxvk: boolean
-  customWinePaths: Array<string>
+  exitToTray: boolean,
+  language: string,
+  launcherArgs: string,
+  maxWorkers: number,
+  offlineMode: boolean,
+  otherOptions: string,
+  savesPath: string,
+  showFps: boolean,
+  showMangohud: boolean,
+  useGameMode: boolean,
+  winePrefix: string,
+  wineVersion: WineProps
 }
 
 
 export interface ContextType {
-  user: string
-  data: Game[]
+  data: Game[],
+  error: boolean,
   filter: string
-  layout: string
-  refreshing: boolean
-  error: boolean
-  libraryStatus: GameStatus[]
-  gameUpdates: string[]
-  refresh: () => Promise<void>
-  refreshLibrary: () => void
-  handleGameStatus: (game: GameStatus) => Promise<void>
-  handleFilter: (value: string) => void
-  handleSearch: (input: string) => void
-  handleLayout: (value: string) => void
+  gameUpdates: string[],
+  handleFilter: (value: string) => void,
+  handleGameStatus: (game: GameStatus) => Promise<void>,
+  handleLayout: (value: string) => void,
+  handleSearch: (input: string) => void,
+  layout: string,
+  libraryStatus: GameStatus[],
+  refresh: () => Promise<void>,
+  refreshLibrary: () => void,
+  refreshing: boolean,
+  user: string
 }
 
 interface ExtraInfo {
@@ -49,28 +49,29 @@ interface ExtraInfo {
 
 
 export interface Game {
-  art_cover: string
-  art_square: string
-  app_name: string
-  art_logo: string
-  executable: string
-  title: string
+  app_name: string,
+  art_cover: string,
+  art_logo: string,
+  art_square: string,
+  cloudSaveEnabled: boolean,
+  developer: string,
+  dlcs: string[],
+  executable: string,
+  extraInfo: ExtraInfo,
+  folderName: string,
+  install_path: string,
+  install_size: string,
+  isInstalled: boolean,
+  is_dlc: boolean,
+  namespace: string,
+  saveFolder: string,
+  title: string,
   version: string
-  install_size: string
-  install_path: string
-  developer: string
-  isInstalled: boolean
-  cloudSaveEnabled: boolean
-  saveFolder: string
-  folderName: string
-  extraInfo: ExtraInfo
-  dlcs: string[]
-  is_dlc: boolean
-  namespace: string
 }
 
 export interface GameStatus {
   appName: string
+  progress?: number | null,
   status:
     | 'installing'
     | 'updating'
@@ -80,20 +81,19 @@ export interface GameStatus {
     | 'done'
     | 'canceled'
     | 'moving'
-  progress?: number | null
 }
 
 export interface InstallProgress {
+  bytes: string,
+  eta: string,
   percent: string
-  bytes: string
-  eta: string
 }
 export interface InstalledInfo {
   executable: string | null
-  version: string | null
+  install_path: string | null,
   install_size: string | null
-  install_path: string | null
-  is_dlc: boolean | null
+  is_dlc: boolean | null,
+  version: string | null
 }
 
 export interface KeyImage {
@@ -112,6 +112,6 @@ interface Reqs {
 export type SyncType = 'Download' | 'Upload' | 'Force download' | 'Force upload'
 
 export interface WineProps {
+  bin: string,
   name: string
-  bin: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,36 +1,7 @@
-export interface InstalledInfo {
-  executable: string | null
-  version: string | null
-  install_size: string | null
-  install_path: string | null
-  is_dlc: boolean | null
-}
-
-export interface KeyImage {
-  type: string
-}
-
 interface About {
   description: string
   shortDescription: string
 }
-
-interface Reqs {
-  minimum: string
-  recommended: string
-  title: string
-}
-
-interface ExtraInfo {
-  about: About
-  reqs: Reqs[]
-}
-
-export interface WineProps {
-  name: string
-  bin: string
-}
-
 export interface AppSettings {
   wineVersion: WineProps
   winePrefix: string
@@ -53,6 +24,30 @@ export interface AppSettings {
   customWinePaths: Array<string>
 }
 
+
+export interface ContextType {
+  user: string
+  data: Game[]
+  filter: string
+  layout: string
+  refreshing: boolean
+  error: boolean
+  libraryStatus: GameStatus[]
+  gameUpdates: string[]
+  refresh: () => Promise<void>
+  refreshLibrary: () => void
+  handleGameStatus: (game: GameStatus) => Promise<void>
+  handleFilter: (value: string) => void
+  handleSearch: (input: string) => void
+  handleLayout: (value: string) => void
+}
+
+interface ExtraInfo {
+  about: About
+  reqs: Reqs[]
+}
+
+
 export interface Game {
   art_cover: string
   art_square: string
@@ -74,20 +69,6 @@ export interface Game {
   namespace: string
 }
 
-export interface InstallProgress {
-  percent: string
-  bytes: string
-  eta: string
-}
-
-export interface Path {
-  filePaths: string[]
-}
-export interface WineProps {
-  name: string
-  bin: string
-}
-
 export interface GameStatus {
   appName: string
   status:
@@ -102,21 +83,35 @@ export interface GameStatus {
   progress?: number | null
 }
 
+export interface InstallProgress {
+  percent: string
+  bytes: string
+  eta: string
+}
+export interface InstalledInfo {
+  executable: string | null
+  version: string | null
+  install_size: string | null
+  install_path: string | null
+  is_dlc: boolean | null
+}
+
+export interface KeyImage {
+  type: string
+}
+
+export interface Path {
+  filePaths: string[]
+}
+interface Reqs {
+  minimum: string
+  recommended: string
+  title: string
+}
+
 export type SyncType = 'Download' | 'Upload' | 'Force download' | 'Force upload'
 
-export interface ContextType {
-  user: string
-  data: Game[]
-  filter: string
-  layout: string
-  refreshing: boolean
-  error: boolean
-  libraryStatus: GameStatus[]
-  gameUpdates: string[]
-  refresh: () => Promise<void>
-  refreshLibrary: () => void
-  handleGameStatus: (game: GameStatus) => Promise<void>
-  handleFilter: (value: string) => void
-  handleSearch: (input: string) => void
-  handleLayout: (value: string) => void
+export interface WineProps {
+  name: string
+  bin: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5322,6 +5322,13 @@ eslint-plugin-sort-imports-es6-autofix@^0.5.0:
   dependencies:
     eslint "^6.2.2"
 
+eslint-plugin-sort-keys-fix@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.1.1.tgz#2ed201b53fd4a89552c6e2abd38933f330a4b62e"
+  integrity sha512-x02SLBg+8OEaoT9vvMbsgeInw17wjHLsa9cOieIVQY+xMNRiXBbyMWw+NiBoxYyJIR4QKDOPDofCjQdoSvltQg==
+  dependencies:
+    requireindex "~1.2.0"
+
 eslint-plugin-testing-library@^3.9.2:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.10.1.tgz#4dd02306d601c3238fdabf1d1dbc5f2a8e85d531"
@@ -11217,6 +11224,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 requires-port@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,6 +2122,16 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
+"@typescript-eslint/experimental-utils@^2.32.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
+  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.34.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
 "@typescript-eslint/experimental-utils@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686"
@@ -2160,6 +2170,19 @@
   version "4.15.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.15.0.tgz#3011ae1ac3299bb9a5ac56bdd297cccf679d3662"
   integrity sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==
+
+"@typescript-eslint/typescript-estree@2.34.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
+  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@3.10.1":
   version "3.10.1"
@@ -5336,6 +5359,15 @@ eslint-plugin-testing-library@^3.9.2:
   dependencies:
     "@typescript-eslint/experimental-utils" "^3.10.1"
 
+eslint-plugin-typescript-sort-keys@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-1.5.0.tgz#cc2ae7a9311422d8eab760ae01524426fd204004"
+  integrity sha512-Pq0geV5TbkoGyxiPUH9AZhloRbQekrprmiXpMWmtSURfWvsWtPtsEPDLVKhDN19S791zbqnw+cm7enzu6833/w==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^2.32.0"
+    json-schema "^0.2.5"
+    natural-compare-lite "^1.4.0"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -8061,6 +8093,11 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
+json-schema@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.5.tgz#97997f50972dd0500214e208c407efa4b5d7063b"
+  integrity sha512-gWJOWYFrhQ8j7pVm0EM8Slr+EPVq1Phf6lvzvD/WCeqkrx/f2xBI0xOsRRS9xCn3I4vKtP519dvs3TP09r24wQ==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -8908,6 +8945,11 @@ native-url@^0.2.6:
   integrity sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==
   dependencies:
     querystring "^0.2.0"
+
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha1-F7CVgZiJef3a/gIB6TG6kzyWy7Q=
 
 natural-compare@^1.4.0:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2379,7 +2379,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.3.1:
+acorn-jsx@^5.2.0, acorn-jsx@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
@@ -2725,6 +2725,11 @@ ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
+
+astral-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 astral-regex@^2.0.0:
   version "2.0.0"
@@ -3517,7 +3522,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3546,6 +3551,11 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 check-types@^11.1.1:
   version "11.1.2"
@@ -3681,6 +3691,18 @@ cli-boxes@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
   integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
+
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -4118,7 +4140,7 @@ cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -5288,6 +5310,18 @@ eslint-plugin-react@^7.21.5, eslint-plugin-react@^7.22.0:
     resolve "^1.18.1"
     string.prototype.matchall "^4.0.2"
 
+eslint-plugin-sort-exports@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-exports/-/eslint-plugin-sort-exports-0.3.2.tgz#46901bd26fae41fb38fbb6507b1e438d02637c12"
+  integrity sha512-9wx4oHU3M/jFbqhRtR6vcmcbKoNj++1bnSMjLmNCNza+nWpCjo3o5gFIUmTFxr4JBOD1QL9ONR8EE9T9Rf1COQ==
+
+eslint-plugin-sort-imports-es6-autofix@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-imports-es6-autofix/-/eslint-plugin-sort-imports-es6-autofix-0.5.0.tgz#dabae09a457eac6e95c52d8edd7855f576d014b6"
+  integrity sha512-KEX2Uz6bAs67jDYiH/OT1xz1E7AzIJJOIRg1F7OnFAfUVlpws3ldSZj5oZySRHfoVkWqDX9GGExYxckdLrWhwg==
+  dependencies:
+    eslint "^6.2.2"
+
 eslint-plugin-testing-library@^3.9.2:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.10.1.tgz#4dd02306d601c3238fdabf1d1dbc5f2a8e85d531"
@@ -5310,6 +5344,13 @@ eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
+
+eslint-utils@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
 
 eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   version "2.1.0"
@@ -5338,6 +5379,49 @@ eslint-webpack-plugin@^2.1.0:
     jest-worker "^26.6.2"
     micromatch "^4.0.2"
     schema-utils "^3.0.0"
+
+eslint@^6.2.2:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
+  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.10.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^1.4.3"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.2"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^7.0.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.14"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.3"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^6.1.2"
+    strip-ansi "^5.2.0"
+    strip-json-comments "^3.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
 
 eslint@^7.11.0, eslint@^7.18.0:
   version "7.20.0"
@@ -5382,6 +5466,15 @@ eslint@^7.11.0, eslint@^7.18.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+espree@^6.1.2:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
+  integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-jsx "^5.2.0"
+    eslint-visitor-keys "^1.1.0"
+
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
@@ -5396,7 +5489,7 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.4.0:
+esquery@^1.0.1, esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
@@ -5591,6 +5684,15 @@ extend@^3.0.0, extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+external-editor@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -5691,6 +5793,20 @@ figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
   integrity sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==
+
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
 
 file-entry-cache@^6.0.0:
   version "6.0.0"
@@ -5809,6 +5925,15 @@ find-versions@^4.0.0:
   dependencies:
     semver-regex "^3.1.2"
 
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -5816,6 +5941,11 @@ flat-cache@^3.0.4:
   dependencies:
     flatted "^3.1.0"
     rimraf "^3.0.2"
+
+flatted@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
+  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
 flatted@^3.1.0:
   version "3.1.1"
@@ -6673,7 +6803,7 @@ i18next@^19.0.1, i18next@^19.7.0, i18next@^19.8.7:
   dependencies:
     "@babel/runtime" "^7.12.0"
 
-iconv-lite@0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6841,6 +6971,25 @@ ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+inquirer@^7.0.0:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.19"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -8148,6 +8297,14 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -8155,14 +8312,6 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
-
-levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
-  dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
 
 lie@~3.3.0:
   version "3.3.0"
@@ -8714,6 +8863,11 @@ mustache@^2.2.1:
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
   integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
 
+mute-stream@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
 nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
@@ -9111,7 +9265,7 @@ optimize-css-assets-webpack-plugin@5.0.4:
     cssnano "^4.1.10"
     last-call-webpack-plugin "^3.0.0"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
@@ -9153,6 +9307,11 @@ os-browserify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 p-any@^3.0.0:
   version "3.0.0"
@@ -10901,6 +11060,11 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.0:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
 regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
@@ -11156,6 +11320,14 @@ responselike@^2.0.0:
   dependencies:
     lowercase-keys "^2.0.0"
 
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -11193,6 +11365,13 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
+
+rimraf@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@^2.3.4, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
@@ -11273,6 +11452,11 @@ rsvp@^4.8.2, rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
+run-async@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -11286,6 +11470,13 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rxjs@^6.6.0:
+  version "6.6.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.6.tgz#14d8417aa5a07c5e633995b525e1e3c0dec03b70"
+  integrity sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -11438,7 +11629,7 @@ semver@7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
-semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -11627,6 +11818,15 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
+    is-fullwidth-code-point "^2.0.0"
 
 slice-ansi@^4.0.0:
   version "4.0.0"
@@ -12063,7 +12263,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@^3.0.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -12164,6 +12364,16 @@ symlink-or-copy@^1.1.8:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.3.1.tgz#9506dd64d8e98fa21dcbf4018d1eab23e77f71fe"
   integrity sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA==
+
+table@^5.2.3:
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
+  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+  dependencies:
+    ajv "^6.10.2"
+    lodash "^4.17.14"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
 
 table@^6.0.4:
   version "6.0.7"
@@ -12310,6 +12520,11 @@ through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0, through2@~2.
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
 thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
@@ -12336,6 +12551,13 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -13434,6 +13656,13 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 ws@^6.2.1:
   version "6.2.1"


### PR DESCRIPTION
This PR shouldn't change any code functionally.
---

The following are sorted alphabetically:
- [x] Imports
- [x] Module exports
- [x] Variables
- [x] Keys
- [x] Interface fields.

Also, trailing spaces and dangling commas are now disallowed (and autofixed).

### Why?
Consistency + much more readable. Now finding things in code is easier, and I'm working on further refactors. This is just the beginning.

### Do I need to keep this in mind while developing?
No. These are mostly autofixed (except type exports, they need to manually put in the right place I think). This PR also adds `yarn lint-fix` for this purpose, which also runs pre-commit.
**NOTE:** with this, commiting unlinted code is no longer possible. I think that's a good thing, but if you really need to push, use `--no-verify`. But I strongly recommend against it.

### Design Decisions
`export { ... }` at the end of the file is preffered over exporting at definition.

### Why was the inbuilt `sort-keys` not used?
No autofix. That's why. If the extra dependency is deemed not worth it, I'll use `sort-keys` instead or maybe remove this (or reduce it to a warning).

### Great. More conflicts.
I made a way to automatically resolve conflicts as well. Look [here](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/244#issuecomment-800206626).