### PR TITLE
Fix: Not starting on new installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,5 @@ yarn-debug.log*
 yarn-error.log*
 .eslintcache
 
-public/main.js
-public/types.js
-public/utils.js
-public/images
+public/**/*.js
 .vscode/settings.json
-public/legendary_utils/library.js
-public/legendary_utils/utils.js

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -119,7 +119,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
     })
   })
 
-  await getSettings().then(({ customWinePaths }) => {
+  getSettings().then(({ customWinePaths }) => {
     if (customWinePaths.length) {
       customWinePaths.forEach((path) => {
         if (path.endsWith('proton')) {

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -8,7 +8,7 @@ import {
   readFileSync,
   readdirSync,
   writeFile,
-  writeFileSync,
+  writeFileSync
 } from 'graceful-fs'
 import { fixPathForAsarUnpack } from 'electron-util'
 import { homedir, userInfo as user } from 'os'
@@ -51,7 +51,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
   const steamPaths: string[] = [
     `${home}/.local/share/Steam`,
     `${home}/.var/app/com.valvesoftware.Steam/.local/share/Steam`,
-    '/usr/share/steam',
+    '/usr/share/steam'
   ]
 
   if (!existsSync(`${heroicToolsPath}/wine`)) {
@@ -96,7 +96,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
         if (version.toLowerCase().startsWith('proton')) {
           proton.add({
             bin: `'${path}${version}/proton'`,
-            name: `Proton - ${version}`,
+            name: `Proton - ${version}`
           })
         }
       })
@@ -107,7 +107,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
     readdirSync(lutrisCompatPath).forEach((version) => {
       altWine.add({
         bin: `'${lutrisCompatPath}${version}/bin/wine64'`,
-        name: `Wine - ${version}`,
+        name: `Wine - ${version}`
       })
     })
   }
@@ -115,7 +115,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
   readdirSync(`${heroicToolsPath}/wine/`).forEach((version) => {
     altWine.add({
       bin: `'${lutrisCompatPath}${version}/bin/wine64'`,
-      name: `Wine - ${version}`,
+      name: `Wine - ${version}`
     })
   })
 
@@ -127,12 +127,12 @@ async function getAlternativeWine(): Promise<WineProps[]> {
         if (path.endsWith('proton')) {
           return customPaths.add({
             bin: `'${path}'`,
-            name: `Proton Custom - ${path}`,
+            name: `Proton Custom - ${path}`
           })
         }
         return customPaths.add({
           bin: `'${path}'`,
-          name: `Wine Custom - ${path}`,
+          name: `Wine Custom - ${path}`
         })
       })
     }
@@ -199,7 +199,7 @@ const launchGame = async (appName: string) => {
     launcherArgs = '',
     showMangohud,
     audioFix,
-    autoInstallDxvk,
+    autoInstallDxvk
   } = await getSettings(appName)
 
   const fixedWinePrefix = winePrefix.replace('~', home)
@@ -225,7 +225,7 @@ const launchGame = async (appName: string) => {
           .replaceAll("'", '')
           .replace('~', home)}'`
       : '',
-    showMangohud: showMangohud ? `MANGOHUD=1` : '',
+    showMangohud: showMangohud ? `MANGOHUD=1` : ''
   }
 
   envVars = Object.values(options).join(' ')
@@ -298,7 +298,7 @@ async function getLatestDxvk() {
     return
   }
   const {
-    data: { assets },
+    data: { assets }
   } = await axios.default.get(
     'https://api.github.com/repos/lutris/dxvk/releases/latest'
   )
@@ -394,11 +394,11 @@ const writeDefaultconfig = async () => {
         useGameMode: false,
         userInfo: {
           epicId: account_id,
-          name: userName,
+          name: userName
         },
         winePrefix: `${home}/.wine`,
-        wineVersion: defaultWine,
-      } as AppSettings,
+        wineVersion: defaultWine
+      } as AppSettings
     }
 
     writeFileSync(heroicConfigPath, JSON.stringify(config, null, 2))
@@ -419,7 +419,7 @@ const writeGameconfig = async (game: string) => {
       otherOptions,
       useGameMode,
       showFps,
-      userInfo,
+      userInfo
     } = await getSettings('default')
 
     const config = {
@@ -429,8 +429,8 @@ const writeGameconfig = async (game: string) => {
         useGameMode,
         userInfo,
         winePrefix,
-        wineVersion,
-      },
+        wineVersion
+      }
     }
 
     writeFileSync(
@@ -448,7 +448,7 @@ async function checkForUpdates() {
   }
   try {
     const {
-      data: { tag_name },
+      data: { tag_name }
     } = await axios.default.get(
       'https://api.github.com/repos/flavioislima/HeroicGamesLauncher/releases/latest'
     )
@@ -467,7 +467,7 @@ const showAboutWindow = () => {
     applicationVersion: `${app.getVersion()} Magelan`,
     copyright: 'GPL V3',
     iconPath: icon,
-    website: 'https://github.com/flavioislima/HeroicGamesLauncher',
+    website: 'https://github.com/flavioislima/HeroicGamesLauncher'
   })
   return app.showAboutPanel()
 }
@@ -493,7 +493,7 @@ const handleExit = async () => {
         'box.quit.message',
         'There are pending operations, are you sure?'
       ),
-      title: i18next.t('box.quit.title', 'Exit'),
+      title: i18next.t('box.quit.title', 'Exit')
     })
 
     if (response === 0) {
@@ -560,5 +560,5 @@ export {
   updateGame,
   userInfo,
   writeDefaultconfig,
-  writeGameconfig,
+  writeGameconfig
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroic",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "private": true,
   "main": "public/main.js",
   "homepage": "./",
@@ -132,7 +132,7 @@
       "post-checkout": "yarn",
       "post-merge": "yarn",
       "post-rebase": "yarn",
-      "pre-push": "yarn lint && pretty-quick --staged lint-staged",
+      "pre-push": "yarn lint-fix && pretty-quick --staged lint-staged",
       "pre-commit": "yarn lint-fix"
     }
   },

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
       "post-checkout": "yarn",
       "post-merge": "yarn",
       "post-rebase": "yarn",
-      "pre-push": "yarn lint-fix && pretty-quick --staged lint-staged",
+      "pre-push": "yarn lint && pretty-quick --staged lint-staged",
       "pre-commit": "yarn lint-fix"
     }
   },

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,25 +1,12 @@
-import React, {
-  useEffect,
-  useState
-} from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { IpcRenderer } from 'electron'
 import { useTranslation } from 'react-i18next'
-import {
-  NavLink,
-  useLocation,
-  useParams
-} from 'react-router-dom'
+import { NavLink, useLocation, useParams } from 'react-router-dom'
 
-import {
-  getGameInfo,
-  writeConfig
-} from '../../helper'
+import { getGameInfo, writeConfig } from '../../helper'
 import { useToggle } from '../../hooks'
-import {
-  AppSettings,
-  WineProps
-} from '../../types'
+import { AppSettings, WineProps } from '../../types'
 import Header from '../UI/Header'
 import UpdateComponent from '../UI/UpdateComponent'
 import GeneralSettings from './GeneralSettings'
@@ -62,7 +49,7 @@ function Settings() {
   const [maxWorkers, setMaxWorkers] = useState(0)
   const [egsPath, setEgsPath] = useState(egsLinkedPath)
   const [language, setLanguage] = useState(
-    () => storage.getItem('language') || ''
+    () => storage.getItem('language') || 'en'
   )
   const [customWinePaths, setCustomWinePaths] = useState([] as Array<string>)
   const [savesPath, setSavesPath] = useState('')
@@ -72,7 +59,11 @@ function Settings() {
     setOn: setUseGameMode,
   } = useToggle(false)
   const { on: showFps, toggle: toggleFps, setOn: setShowFps } = useToggle(false)
-  const { on: offlineMode, toggle: toggleOffline, setOn: setShowOffline } = useToggle(false)
+  const {
+    on: offlineMode,
+    toggle: toggleOffline,
+    setOn: setShowOffline,
+  } = useToggle(false)
   const {
     on: audioFix,
     toggle: toggleAudioFix,

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -38,7 +38,7 @@ function Settings() {
 
   const [wineVersion, setWineversion] = useState({
     bin: '/usr/bin/wine',
-    name: 'Wine Default',
+    name: 'Wine Default'
   } as WineProps)
   const [winePrefix, setWinePrefix] = useState('~/.wine')
   const [defaultInstallPath, setDefaultInstallPath] = useState('')
@@ -56,43 +56,43 @@ function Settings() {
   const {
     on: useGameMode,
     toggle: toggleUseGameMode,
-    setOn: setUseGameMode,
+    setOn: setUseGameMode
   } = useToggle(false)
   const { on: showFps, toggle: toggleFps, setOn: setShowFps } = useToggle(false)
   const {
     on: offlineMode,
     toggle: toggleOffline,
-    setOn: setShowOffline,
+    setOn: setShowOffline
   } = useToggle(false)
   const {
     on: audioFix,
     toggle: toggleAudioFix,
-    setOn: setAudioFix,
+    setOn: setAudioFix
   } = useToggle(false)
   const {
     on: showMangohud,
     toggle: toggleMangoHud,
-    setOn: setShowMangoHud,
+    setOn: setShowMangoHud
   } = useToggle(false)
   const {
     on: exitToTray,
     toggle: toggleTray,
-    setOn: setExitToTray,
+    setOn: setExitToTray
   } = useToggle(false)
   const {
     on: darkTrayIcon,
     toggle: toggleDarkTrayIcon,
-    setOn: setDarkTrayIcon,
+    setOn: setDarkTrayIcon
   } = useToggle(false)
   const {
     on: autoInstallDxvk,
     toggle: toggleAutoInstallDxvk,
-    setOn: setAutoInstallDxvk,
+    setOn: setAutoInstallDxvk
   } = useToggle(false)
 
   const [haveCloudSaving, setHaveCloudSaving] = useState({
     cloudSaveEnabled: false,
-    saveFolder: '',
+    saveFolder: ''
   })
   const [autoSyncSaves, setAutoSyncSaves] = useState(false)
   const [altWine, setAltWine] = useState([] as WineProps[])
@@ -134,7 +134,7 @@ function Settings() {
         const {
           cloudSaveEnabled,
           saveFolder,
-          title: gameTitle,
+          title: gameTitle
         } = await getGameInfo(appName)
         setTitle(gameTitle)
         return setHaveCloudSaving({ cloudSaveEnabled, saveFolder })
@@ -164,8 +164,8 @@ function Settings() {
       showMangohud,
       useGameMode,
       winePrefix,
-      wineVersion,
-    } as AppSettings,
+      wineVersion
+    } as AppSettings
   }
 
   const GameSettings = {
@@ -181,8 +181,8 @@ function Settings() {
       showMangohud,
       useGameMode,
       winePrefix,
-      wineVersion,
-    } as AppSettings,
+      wineVersion
+    } as AppSettings
   }
 
   const settingsToSave = isDefault ? GlobalSettings : GameSettings


### PR DESCRIPTION
Fixed #256 
The bug was introduced with the latest fix I sent related with the custom wine 🤦🏽 . Shit happens.
It happens not only in ubuntu, but all distros since Heroic starts a never-ending loop when looking for custom wine on new installations.
Added a check to skip looking for custom wine/proton when there is no config file.