### PR TITLE
Remove Prettier.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,8 +7,7 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:@typescript-eslint/recommended",
-    "prettier"
+    "plugin:@typescript-eslint/recommended"
   ],
   "root": true,
   "parser": "@typescript-eslint/parser",
@@ -33,15 +32,18 @@
     }
   },
   "rules": {
-    "complexity": "off",
-    "no-trailing-spaces": "error",
-    "sort-keys-fix/sort-keys-fix": "error",
-    "typescript-sort-keys/interface": "error",
-    "sort-vars": "error",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-unused-vars": "error",
+    "complexity": "off",
+    "comma-dangle": ["error", "never"],
+    "indent": ["error", 2],
+    "no-trailing-spaces": "error",
+    "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
+    "sort-exports/sort-exports": ["error", { "sortDir": "asc" }],
     "sort-imports-es6-autofix/sort-imports-es6": ["error", {}],
-    "sort-exports/sort-exports": ["error", { "sortDir": "asc" }]
+    "sort-keys-fix/sort-keys-fix": "error",
+    "sort-vars": "error",
+    "typescript-sort-keys/interface": "error"
   }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,0 @@
-node_modules
-dist
-build
-public/index.html

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,0 @@
-{
-  "trailingComma": "es5",
-  "tabWidth": 2,
-  "semi": false,
-  "singleQuote": true
-}

--- a/electron/legendary_utils/library.ts
+++ b/electron/legendary_utils/library.ts
@@ -10,7 +10,7 @@ import {
   heroicConfigPath,
   isLoggedIn,
   legendaryConfigPath,
-  writeDefaultconfig,
+  writeDefaultconfig
 } from '../utils'
 
 const statAsync = promisify(stat)
@@ -36,7 +36,7 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
       .then(() => JSON.parse(readFileSync(installed, 'utf-8')))
       .catch(() => []),
     library: `${legendaryConfigPath}/metadata/`,
-    user: getUserInfo(),
+    user: getUserInfo()
   }
 
   if (file === 'user') {
@@ -62,7 +62,7 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
             title,
             developer,
             dlcItemList,
-            customAttributes: { CloudSaveFolder, FolderName },
+            customAttributes: { CloudSaveFolder, FolderName }
           } = metadata
 
           const { namespace } = asset_info
@@ -109,7 +109,7 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
             version = null,
             install_size = null,
             install_path = null,
-            is_dlc = dlc(),
+            is_dlc = dlc()
           } = info as InstalledInfo
 
           const convertedSize =
@@ -134,7 +134,7 @@ export async function getLegendaryConfig(file: string): Promise<unknown> {
             namespace,
             saveFolder,
             title,
-            version,
+            version
           }
         })
         .sort((a: { title: string }, b: { title: string }) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,7 +6,7 @@ import {
   Tray,
   app,
   ipcMain,
-  powerSaveBlocker,
+  powerSaveBlocker
 } from 'electron'
 import { cpus, userInfo as user } from 'os'
 import { exec, spawn } from 'child_process'
@@ -16,7 +16,7 @@ import {
   readFileSync,
   unlinkSync,
   writeFile,
-  writeFileSync,
+  writeFileSync
 } from 'graceful-fs'
 import { promisify } from 'util'
 import Backend from 'i18next-fs-backend'
@@ -55,7 +55,7 @@ import {
   supportURL,
   updateGame,
   userInfo,
-  writeGameconfig,
+  writeGameconfig
 } from './utils'
 
 const execAsync = promisify(exec)
@@ -71,9 +71,9 @@ function createWindow(): BrowserWindow {
     webPreferences: {
       contextIsolation: false,
       enableRemoteModule: true,
-      nodeIntegration: true,
+      nodeIntegration: true
     },
-    width: isDev ? 1800 : 1280,
+    width: isDev ? 1800 : 1280
   })
 
   setTimeout(() => {
@@ -133,39 +133,39 @@ const contextMenu = () =>
       click: function () {
         mainWindow.show()
       },
-      label: i18next.t('tray.show'),
+      label: i18next.t('tray.show')
     },
     {
       click: function () {
         showAboutWindow()
       },
-      label: i18next.t('tray.about', 'About'),
+      label: i18next.t('tray.about', 'About')
     },
     {
       click: function () {
         openUrlOrFile(heroicGithubURL)
       },
-      label: 'Github',
+      label: 'Github'
     },
     {
       click: function () {
         openUrlOrFile(supportURL)
       },
-      label: i18next.t('tray.support', 'Support Us'),
+      label: i18next.t('tray.support', 'Support Us')
     },
     {
       accelerator: 'ctrl + R',
       click: function () {
         mainWindow.reload()
       },
-      label: i18next.t('tray.reload', 'Reload'),
+      label: i18next.t('tray.reload', 'Reload')
     },
     {
       click: function () {
         handleExit()
       },
-      label: i18next.t('tray.quit', 'Quit'),
-    },
+      label: i18next.t('tray.quit', 'Quit')
+    }
   ])
 
 if (!gotTheLock) {
@@ -184,7 +184,7 @@ if (!gotTheLock) {
       backend: {
         addPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}'),
         allowMultiLoading: false,
-        loadPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}.json'),
+        loadPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}.json')
       },
       debug: false,
       fallbackLng: 'en',
@@ -199,8 +199,8 @@ if (!gotTheLock) {
         'pt',
         'ru',
         'tr',
-        'hu',
-      ],
+        'hu'
+      ]
     })
 
     createWindow()
@@ -222,7 +222,7 @@ if (!gotTheLock) {
 ipcMain.on('Notify', (event, args) => {
   const notify = new Notification({
     body: args[1],
-    title: args[0],
+    title: args[0]
   })
 
   notify.on('click', () => mainWindow.show())
@@ -280,12 +280,12 @@ ipcMain.on('quit', async () => handleExit())
 const getProductSlug = async (namespace: string, game: string) => {
   const graphql = JSON.stringify({
     query: `{Catalog{catalogOffers( namespace:"${namespace}"){elements {productSlug}}}}`,
-    variables: {},
+    variables: {}
   })
   const result = await axios('https://www.epicgames.com/graphql', {
     data: graphql,
     headers: { 'Content-Type': 'application/json' },
-    method: 'POST',
+    method: 'POST'
   })
   const res = result.data.data.Catalog.catalogOffers
   const slug = res.elements.find((e: { productSlug: string }) => e.productSlug)
@@ -316,7 +316,7 @@ ipcMain.handle('getGameInfo', async (event, game, namespace: string | null) => {
   try {
     const response = await axios({
       method: 'GET',
-      url: epicUrl,
+      url: epicUrl
     })
     delete response.data.pages[0].data.requirements.systems[0].details[0]
     const about = response.data.pages.find(
@@ -324,7 +324,7 @@ ipcMain.handle('getGameInfo', async (event, game, namespace: string | null) => {
     )
     return {
       about: about.data.about,
-      reqs: about.data.requirements.systems[0].details,
+      reqs: about.data.requirements.systems[0].details
     }
   } catch (error) {
     return {}

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -8,7 +8,7 @@ import {
   readFileSync,
   readdirSync,
   writeFile,
-  writeFileSync,
+  writeFileSync
 } from 'graceful-fs'
 import { fixPathForAsarUnpack } from 'electron-util'
 import { homedir, userInfo as user } from 'os'
@@ -52,7 +52,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
   const steamPaths: string[] = [
     `${home}/.local/share/Steam`,
     `${home}/.var/app/com.valvesoftware.Steam/.local/share/Steam`,
-    '/usr/share/steam',
+    '/usr/share/steam'
   ]
 
   if (!existsSync(`${heroicToolsPath}/wine`)) {
@@ -97,7 +97,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
         if (version.toLowerCase().startsWith('proton')) {
           proton.add({
             bin: `'${path}${version}/proton'`,
-            name: `Proton - ${version}`,
+            name: `Proton - ${version}`
           })
         }
       })
@@ -108,7 +108,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
     readdirSync(lutrisCompatPath).forEach((version) => {
       altWine.add({
         bin: `'${lutrisCompatPath}${version}/bin/wine64'`,
-        name: `Wine - ${version}`,
+        name: `Wine - ${version}`
       })
     })
   }
@@ -116,7 +116,7 @@ async function getAlternativeWine(): Promise<WineProps[]> {
   readdirSync(`${heroicToolsPath}/wine/`).forEach((version) => {
     altWine.add({
       bin: `'${lutrisCompatPath}${version}/bin/wine64'`,
-      name: `Wine - ${version}`,
+      name: `Wine - ${version}`
     })
   })
 
@@ -128,12 +128,12 @@ async function getAlternativeWine(): Promise<WineProps[]> {
         if (path.endsWith('proton')) {
           return customPaths.add({
             bin: `'${path}'`,
-            name: `Proton Custom - ${path}`,
+            name: `Proton Custom - ${path}`
           })
         }
         return customPaths.add({
           bin: `'${path}'`,
-          name: `Wine Custom - ${path}`,
+          name: `Wine Custom - ${path}`
         })
       })
     }
@@ -200,7 +200,7 @@ const launchGame = async (appName: string) => {
     launcherArgs = '',
     showMangohud,
     audioFix,
-    autoInstallDxvk,
+    autoInstallDxvk
   } = await getSettings(appName)
 
   const fixedWinePrefix = winePrefix.replace('~', home)
@@ -223,10 +223,10 @@ const launchGame = async (appName: string) => {
     other: otherOptions ? otherOptions : '',
     proton: isProton
       ? `STEAM_COMPAT_DATA_PATH='${winePrefix
-          .replaceAll("'", '')
-          .replace('~', home)}'`
+        .replaceAll("'", '')
+        .replace('~', home)}'`
       : '',
-    showMangohud: showMangohud ? `MANGOHUD=1` : '',
+    showMangohud: showMangohud ? `MANGOHUD=1` : ''
   }
 
   envVars = Object.values(options).join(' ')
@@ -299,7 +299,7 @@ async function getLatestDxvk() {
     return
   }
   const {
-    data: { assets },
+    data: { assets }
   } = await axios.default.get(
     'https://api.github.com/repos/lutris/dxvk/releases/latest'
   )
@@ -395,11 +395,11 @@ const writeDefaultconfig = async () => {
         useGameMode: false,
         userInfo: {
           epicId: account_id,
-          name: userName,
+          name: userName
         },
         winePrefix: `${home}/.wine`,
-        wineVersion: defaultWine,
-      } as AppSettings,
+        wineVersion: defaultWine
+      } as AppSettings
     }
 
     writeFileSync(heroicConfigPath, JSON.stringify(config, null, 2))
@@ -420,7 +420,7 @@ const writeGameconfig = async (game: string) => {
       otherOptions,
       useGameMode,
       showFps,
-      userInfo,
+      userInfo
     } = await getSettings('default')
 
     const config = {
@@ -430,8 +430,8 @@ const writeGameconfig = async (game: string) => {
         useGameMode,
         userInfo,
         winePrefix,
-        wineVersion,
-      },
+        wineVersion
+      }
     }
 
     writeFileSync(
@@ -449,7 +449,7 @@ async function checkForUpdates() {
   }
   try {
     const {
-      data: { tag_name },
+      data: { tag_name }
     } = await axios.default.get(
       'https://api.github.com/repos/flavioislima/HeroicGamesLauncher/releases/latest'
     )
@@ -468,7 +468,7 @@ const showAboutWindow = () => {
     applicationVersion: `${app.getVersion()} Magelan`,
     copyright: 'GPL V3',
     iconPath: icon,
-    website: 'https://github.com/flavioislima/HeroicGamesLauncher',
+    website: 'https://github.com/flavioislima/HeroicGamesLauncher'
   })
   return app.showAboutPanel()
 }
@@ -494,7 +494,7 @@ const handleExit = async () => {
         'box.quit.message',
         'There are pending operations, are you sure?'
       ),
-      title: i18next.t('box.quit.title', 'Exit'),
+      title: i18next.t('box.quit.title', 'Exit')
     })
 
     if (response === 0) {
@@ -571,5 +571,5 @@ export {
   updateGame,
   userInfo,
   writeDefaultconfig,
-  writeGameconfig,
+  writeGameconfig
 }

--- a/package.json
+++ b/package.json
@@ -85,13 +85,11 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "prettier": "prettier --check .",
-    "format-files": "prettier --write .",
     "ci-build": "GH_TOKEN='${{ secrets.WORKFLOW_TOKEN }}' npm run build-electron && npm run build && electron-builder -c.extraMetadata.main=build/main.js --linux deb AppImage rpm pacman",
     "dist": "yarn build-electron && yarn build && electron-builder -c.extraMetadata.main=build/main.js --linux",
     "dist-mac": "yarn build-electron && yarn build && electron-builder -c.extraMetadata.main=build/main.js --mac",
-    "lint": "eslint -c .eslintrc --ext .tsx,ts ./src && eslint -c .eslintrc --ext .ts ./electron && pretty-quick --check",
-    "lint-fix": "eslint --fix -c .eslintrc --ext .tsx,ts ./src && eslint --fix -c .eslintrc --ext .ts ./electron && pretty-quick --staged",
+    "lint": "eslint -c .eslintrc --ext .tsx,ts ./src && eslint -c .eslintrc --ext .ts ./electron",
+    "lint-fix": "eslint --fix -c .eslintrc --ext .tsx,ts ./src && eslint --fix -c .eslintrc --ext .ts ./electron",
     "build-electron": "tsc --project electron/tsconfig.json",
     "watch-electron": "tsc --watch --project electron/tsconfig.json",
     "i18n": "i18next"
@@ -125,8 +123,6 @@
     "foreman": "^3.0.1",
     "husky": "^4.3.8",
     "i18next-parser": "^3.6.0",
-    "prettier": "2.2.1",
-    "pretty-quick": "^3.1.0",
     "typescript": "^4.1.3"
   },
   "husky": {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,11 @@
-import { render, screen } from '@testing-library/react'
-import App from './App'
-import React from 'react'
+import React from 'react';
+
+import {
+  render,
+  screen
+} from '@testing-library/react';
+
+import App from './App';
 
 test('renders learn react link', () => {
   render(<App />)

--- a/src/components/Navbar/components/UserSelector/index.tsx
+++ b/src/components/Navbar/components/UserSelector/index.tsx
@@ -5,7 +5,7 @@ import {
   handleQuit,
   legendary,
   openAboutWindow,
-  openDiscordLink,
+  openDiscordLink
 } from 'src/helpers'
 
 import { useTranslation } from 'react-i18next'

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -36,7 +36,7 @@ export default function NavBar() {
           activeStyle={{ color: '#FFA800', fontWeight: 500 }}
           isActive={(match, location) => location.pathname.includes('settings')}
           to={{
-            pathname: '/settings/default/general',
+            pathname: '/settings/default/general'
           }}
         >
           {t('Settings')}

--- a/src/components/UI/Header/index.tsx
+++ b/src/components/UI/Header/index.tsx
@@ -25,7 +25,7 @@ export default function Header({
   handleFilter,
   handleLayout,
   goTo,
-  title,
+  title
 }: Props) {
   const { t } = useTranslation()
   const { filter, libraryStatus, layout } = useContext(ContextProvider)

--- a/src/components/UI/LanguageSelector/index.tsx
+++ b/src/components/UI/LanguageSelector/index.tsx
@@ -17,7 +17,7 @@ export default function LanguageSelector({
   handleLanguageChange,
   currentLanguage = 'en',
   className = 'settingSelect',
-  flagPossition = FlagPosition.NONE,
+  flagPossition = FlagPosition.NONE
 }: Props) {
   const languageLabels: { [key: string]: string } = {
     de: 'Deutsch',
@@ -29,7 +29,7 @@ export default function LanguageSelector({
     pl: 'Polski',
     pt: 'Português',
     ru: 'Русский',
-    tr: 'Türkçe',
+    tr: 'Türkçe'
   }
 
   const languageFlags: { [key: string]: string } = {
@@ -42,7 +42,7 @@ export default function LanguageSelector({
     pl: '🇵🇱',
     pt: '🇵🇹',
     ru: '🇷🇺',
-    tr: '🇹🇷',
+    tr: '🇹🇷'
   }
 
   const renderOption = (lang: string) => {

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -2,7 +2,7 @@ import {
   getGameInfo,
   handleStopInstallation,
   importGame,
-  install,
+  install
 } from 'src/helpers'
 
 import { GameStatus } from 'src/types'
@@ -10,7 +10,7 @@ import { TFunction } from 'react-i18next'
 
 const { remote } = window.require('electron')
 const {
-  dialog: { showOpenDialog },
+  dialog: { showOpenDialog }
 } = remote
 
 interface Install {
@@ -26,7 +26,7 @@ export async function handleInstall({
   isInstalling,
   installPath,
   handleGameStatus,
-  t,
+  t
 }: Install) {
   if (isInstalling) {
     const { folderName } = await getGameInfo(appName)
@@ -47,7 +47,7 @@ export async function handleInstall({
     const { filePaths } = await showOpenDialog({
       buttonLabel: t('gamepage:box.choose'),
       properties: ['gamepage:openDirectory'],
-      title: t('gamepage:box.importpath'),
+      title: t('gamepage:box.importpath')
     })
 
     if (filePaths[0]) {
@@ -62,7 +62,7 @@ export async function handleInstall({
     const { filePaths } = await showOpenDialog({
       buttonLabel: t('gamepage:box.choose'),
       properties: ['openDirectory'],
-      title: t('gamepage:box.installpath'),
+      title: t('gamepage:box.installpath')
     })
 
     if (filePaths[0]) {

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -9,7 +9,7 @@ const { ipcRenderer, remote } = window.require('electron') as {
 }
 const {
   BrowserWindow,
-  dialog: { showMessageBox },
+  dialog: { showMessageBox }
 } = remote
 
 const readFile = async (file: string) =>
@@ -82,7 +82,7 @@ const syncSaves = async (
   const response: string = await ipcRenderer.invoke('syncSaves', [
     arg,
     path,
-    appName,
+    appName
   ])
   return response
 }
@@ -243,10 +243,10 @@ async function handleStopInstallation(
     buttons: [
       t('gamepage:box.stopInstall.keepInstalling'),
       t('box.yes'),
-      t('box.no'),
+      t('box.no')
     ],
     message: t('gamepage:box.stopInstall.message'),
-    title: t('gamepage:box.stopInstall.title'),
+    title: t('gamepage:box.stopInstall.title')
   })
   if (response === 1) {
     return sendKill(appName)
@@ -282,5 +282,5 @@ export {
   sidInfoPage,
   syncSaves,
   updateGame,
-  writeConfig,
+  writeConfig
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ import UpdateComponent from 'src/components/UI/UpdateComponent'
 const Backend = new HttpApi(null, {
   addPath: 'build/locales/{{lng}}/{{ns}}',
   allowMultiLoading: false,
-  loadPath: 'locales/{{lng}}/{{ns}}.json',
+  loadPath: 'locales/{{lng}}/{{ns}}.json'
 })
 
 i18next
@@ -27,13 +27,13 @@ i18next
   .init({
     fallbackLng: 'en',
     interpolation: {
-      escapeValue: false,
+      escapeValue: false
     },
     lng: 'en',
     react: {
-      useSuspense: true,
+      useSuspense: true
     },
-    supportedLngs: ['de', 'en', 'es', 'fr', 'nl', 'pl', 'pt', 'ru', 'tr', 'hu'],
+    supportedLngs: ['de', 'en', 'es', 'fr', 'nl', 'pl', 'pt', 'ru', 'tr', 'hu']
   })
 
 ReactDOM.render(

--- a/src/screens/Game/GamePage/index.tsx
+++ b/src/screens/Game/GamePage/index.tsx
@@ -14,7 +14,7 @@ import {
   legendary,
   sendKill,
   syncSaves,
-  updateGame,
+  updateGame
 } from 'src/helpers'
 import React, { Fragment, useContext, useEffect, useState } from 'react'
 
@@ -32,7 +32,7 @@ const { ipcRenderer, remote } = window.require('electron') as {
   remote: Remote
 }
 const {
-  dialog: { showOpenDialog, showMessageBox },
+  dialog: { showOpenDialog, showMessageBox }
 } = remote
 
 // This component is becoming really complex and it needs to be refactored in smaller ones
@@ -49,7 +49,7 @@ export default function GamePage(): JSX.Element | null {
     libraryStatus,
     handleGameStatus,
     data,
-    gameUpdates,
+    gameUpdates
   } = useContext(ContextProvider)
   const gameStatus: GameStatus = libraryStatus.filter(
     (game: GameStatus) => game.appName === appName
@@ -61,7 +61,7 @@ export default function GamePage(): JSX.Element | null {
   const [progress, setProgress] = useState({
     bytes: '0.00MiB',
     eta: '00:00:00',
-    percent: '0.00%',
+    percent: '0.00%'
   } as InstallProgress)
   const [installPath, setInstallPath] = useState('default')
   const [defaultPath, setDefaultPath] = useState('...')
@@ -85,7 +85,7 @@ export default function GamePage(): JSX.Element | null {
           autoSyncSaves,
           winePrefix,
           wineVersion,
-          savesPath,
+          savesPath
         }: AppSettings = await ipcRenderer.invoke('requestSettings', appName)
         const isProton = wineVersion?.name?.includes('Proton') || false
         setAutoSyncSaves(autoSyncSaves)
@@ -124,7 +124,7 @@ export default function GamePage(): JSX.Element | null {
         handleGameStatus({
           appName,
           progress: getProgress(progress),
-          status,
+          status
         })
       }
     }, 1500)
@@ -144,7 +144,7 @@ export default function GamePage(): JSX.Element | null {
       version,
       extraInfo,
       developer,
-      cloudSaveEnabled,
+      cloudSaveEnabled
     }: Game = gameInfo
 
     if (savesPath.includes('{InstallDir}')) {
@@ -198,14 +198,14 @@ export default function GamePage(): JSX.Element | null {
                         ? extraInfo.about.shortDescription
                           ? extraInfo.about.shortDescription
                           : extraInfo.about.description
-                          ? extraInfo.about.description
-                          : ''
+                            ? extraInfo.about.description
+                            : ''
                         : ''}
                     </div>
                     {cloudSaveEnabled && (
                       <div
                         style={{
-                          color: autoSyncSaves ? '#07C5EF' : '',
+                          color: autoSyncSaves ? '#07C5EF' : ''
                         }}
                       >
                         {t('info.syncsaves')}:{' '}
@@ -244,7 +244,7 @@ export default function GamePage(): JSX.Element | null {
                       style={{
                         color:
                           isInstalled || isInstalling ? '#0BD58C' : '#BD0A0A',
-                        fontStyle: 'italic',
+                        fontStyle: 'italic'
                       }}
                     >
                       {getInstallLabel(isInstalled)}
@@ -438,7 +438,7 @@ export default function GamePage(): JSX.Element | null {
             const { response } = await showMessageBox({
               buttons: [t('box.yes'), t('box.no')],
               message: t('box.update.message'),
-              title: t('box.update.title'),
+              title: t('box.update.title')
             })
 
             if (response === 0) {
@@ -493,7 +493,7 @@ export default function GamePage(): JSX.Element | null {
         const { filePaths } = await showOpenDialog({
           buttonLabel: t('box.choose'),
           properties: ['openDirectory'],
-          title: t('box.importpath'),
+          title: t('box.importpath')
         })
 
         if (filePaths[0]) {
@@ -508,7 +508,7 @@ export default function GamePage(): JSX.Element | null {
         const { filePaths } = await showOpenDialog({
           buttonLabel: t('box.choose'),
           properties: ['openDirectory'],
-          title: t('box.installpath'),
+          title: t('box.installpath')
         })
 
         if (filePaths[0]) {
@@ -530,7 +530,7 @@ export default function GamePage(): JSX.Element | null {
       buttons: [t('box.yes'), t('box.no')],
       message: t('box.uninstall.message'),
       title: t('box.uninstall.title'),
-      type: 'warning',
+      type: 'warning'
     })
 
     if (response === 0) {

--- a/src/screens/Game/GameSubMenu/index.tsx
+++ b/src/screens/Game/GameSubMenu/index.tsx
@@ -8,14 +8,14 @@ import {
   createNewWindow,
   formatStoreUrl,
   repair,
-  updateGame,
+  updateGame
 } from 'src/helpers'
 import { useTranslation } from 'react-i18next'
 import ContextProvider from 'src/state/ContextProvider'
 
 const { ipcRenderer, remote } = window.require('electron')
 const {
-  dialog: { showMessageBox, showOpenDialog },
+  dialog: { showMessageBox, showOpenDialog }
 } = remote
 
 const renderer: IpcRenderer = ipcRenderer
@@ -31,7 +31,7 @@ export default function GamesSubmenu({
   appName,
   isInstalled,
   title,
-  clicked,
+  clicked
 }: Props) {
   const { handleGameStatus, refresh, gameUpdates } = useContext(ContextProvider)
 
@@ -48,13 +48,13 @@ export default function GamesSubmenu({
     const { response } = await showMessageBox({
       buttons: [t('box.yes'), t('box.no')],
       message: t('box.move.message'),
-      title: t('box.move.title'),
+      title: t('box.move.title')
     })
     if (response === 0) {
       const { filePaths } = await showOpenDialog({
         buttonLabel: t('box.choose'),
         properties: ['openDirectory'],
-        title: t('box.move.path'),
+        title: t('box.move.path')
       })
       if (filePaths[0]) {
         const path = filePaths[0]
@@ -71,13 +71,13 @@ export default function GamesSubmenu({
     const { response } = await showMessageBox({
       buttons: [t('box.yes'), t('box.no')],
       message: t('box.change.message'),
-      title: t('box.change.title'),
+      title: t('box.change.title')
     })
     if (response === 0) {
       const { filePaths } = await showOpenDialog({
         buttonLabel: t('box.choose'),
         properties: ['openDirectory'],
-        title: t('box.change.path'),
+        title: t('box.change.path')
       })
       if (filePaths[0]) {
         const path = filePaths[0]
@@ -93,7 +93,7 @@ export default function GamesSubmenu({
     const { response } = await showMessageBox({
       buttons: [t('box.yes'), t('box.no')],
       message: t('box.update.message'),
-      title: t('box.update.title'),
+      title: t('box.update.title')
     })
 
     if (response === 0) {
@@ -108,7 +108,7 @@ export default function GamesSubmenu({
     const { response } = await showMessageBox({
       buttons: [t('box.yes'), t('box.no')],
       message: t('box.repair.message'),
-      title: t('box.repair.title'),
+      title: t('box.repair.title')
     })
 
     if (response === 1) {
@@ -128,7 +128,7 @@ export default function GamesSubmenu({
             className="hidden link"
             to={{
               pathname: `/settings/${appName}/wine`,
-              state: { fromGameCard: false },
+              state: { fromGameCard: false }
             }}
           >
             {t('submenu.settings')}

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -19,7 +19,7 @@ import NewReleasesIcon from '@material-ui/icons/NewReleases'
 
 const { ipcRenderer, remote } = window.require('electron')
 const {
-  dialog: { showMessageBox },
+  dialog: { showMessageBox }
 } = remote
 interface Card {
   appName: string
@@ -47,12 +47,12 @@ const GameCard = ({
   logo,
   coverList,
   size,
-  hasUpdate,
+  hasUpdate
 }: Card) => {
   const [progress, setProgress] = useState({
     bytes: '0/0MB',
     eta: '',
-    percent: '0.00%',
+    percent: '0.00%'
   } as InstallProgress)
   const { t } = useTranslation('gamepage')
 
@@ -126,7 +126,7 @@ const GameCard = ({
         {haveStatus && <span className="progress">{getStatus()}</span>}
         <Link
           to={{
-            pathname: `/gameconfig/${appName}`,
+            pathname: `/gameconfig/${appName}`
           }}
         >
           <span
@@ -135,7 +135,7 @@ const GameCard = ({
                 grid ? cover : coverList
               }?h=400&resize=1&w=300')`,
               backgroundSize: 'cover',
-              filter: isInstalled ? 'none' : `grayscale(${effectPercent})`,
+              filter: isInstalled ? 'none' : `grayscale(${effectPercent})`
             }}
             className={grid ? 'gameImg' : 'gameImgList'}
           >
@@ -144,7 +144,7 @@ const GameCard = ({
                 alt="logo"
                 src={`${logo}?h=400&resize=1&w=300`}
                 style={{
-                  filter: isInstalled ? 'none' : `grayscale(${effectPercent})`,
+                  filter: isInstalled ? 'none' : `grayscale(${effectPercent})`
                 }}
                 className="gameLogo"
               />
@@ -159,7 +159,7 @@ const GameCard = ({
                 className="icons"
                 style={{
                   flexDirection: 'row',
-                  width: isInstalled ? '44%' : 'auto',
+                  width: isInstalled ? '44%' : 'auto'
                 }}
               >
                 {renderIcon()}
@@ -167,7 +167,7 @@ const GameCard = ({
                   <Link
                     to={{
                       pathname: `/settings/${appName}/wine`,
-                      state: { fromGameCard: true },
+                      state: { fromGameCard: true }
                     }}
                   >
                     <SettingsIcon fill={'var(--secondary)'} />
@@ -187,7 +187,7 @@ const GameCard = ({
                   <Link
                     to={{
                       pathname: `/settings/${appName}/wine`,
-                      state: { fromGameCard: true },
+                      state: { fromGameCard: true }
                     }}
                   >
                     <SettingsIcon fill={'var(--secondary)'} />
@@ -209,7 +209,7 @@ const GameCard = ({
         handleGameStatus,
         installPath: 'another',
         isInstalling,
-        t,
+        t
       })
     }
     if (status === 'playing' || status === 'updating') {
@@ -230,7 +230,7 @@ const GameCard = ({
         const { response } = await showMessageBox({
           buttons: [t('box.yes'), t('box.no')],
           message: t('box.update.message'),
-          title: t('box.update.title'),
+          title: t('box.update.title')
         })
 
         if (response === 0) {

--- a/src/screens/Library/index.tsx
+++ b/src/screens/Library/index.tsx
@@ -35,7 +35,7 @@ export const Library = ({ library }: Props) => {
         style={!library.length ? { backgroundColor: 'transparent' } : {}}
         className={cx({
           gameList: layout === 'grid',
-          gameListLayout: layout !== 'grid',
+          gameListLayout: layout !== 'grid'
         })}
       >
         {!!library.length &&
@@ -49,7 +49,7 @@ export const Library = ({ library }: Props) => {
               isInstalled,
               version,
               install_size,
-              is_dlc,
+              is_dlc
             }: Game) => {
               if (is_dlc) {
                 return null

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react'
 import { legendary, loginPage, sidInfoPage } from 'src/helpers'
 import { useTranslation } from 'react-i18next'
 import LanguageSelector, {
-  FlagPosition,
+  FlagPosition
 } from 'src/components/UI/LanguageSelector'
 
 import Autorenew from '@material-ui/icons/Autorenew'
@@ -23,7 +23,7 @@ export default function Login({ refresh }: Props) {
   const [input, setInput] = useState('')
   const [status, setStatus] = useState({
     loading: false,
-    message: '',
+    message: ''
   })
   const { loading, message } = status
 
@@ -37,14 +37,14 @@ export default function Login({ refresh }: Props) {
   const handleLogin = async (sid: string) => {
     setStatus({
       loading: true,
-      message: t('status.logging', 'Logging In...'),
+      message: t('status.logging', 'Logging In...')
     })
 
     await legendary(`auth --sid ${sid}`).then(async (res) => {
       if (res !== 'error') {
         setStatus({
           loading: true,
-          message: t('status.loading', 'Loading Game list, please wait'),
+          message: t('status.loading', 'Loading Game list, please wait')
         })
 
         await legendary(`list-games`)
@@ -129,7 +129,7 @@ export default function Login({ refresh }: Props) {
               justifyContent: 'flex-end',
               marginBottom: '22px',
               paddingRight: '22px',
-              width: '100%',
+              width: '100%'
             }}
           >
             <LanguageSelector

--- a/src/screens/Settings/components/GeneralSettings/index.tsx
+++ b/src/screens/Settings/components/GeneralSettings/index.tsx
@@ -12,7 +12,7 @@ import CreateNewFolder from '@material-ui/icons/CreateNewFolder'
 
 const {
   ipcRenderer,
-  remote: { dialog },
+  remote: { dialog }
 } = window.require('electron')
 const { showErrorBox, showMessageBox, showOpenDialog } = dialog
 const storage: Storage = window.localStorage
@@ -48,7 +48,7 @@ export default function GeneralSettings({
   maxWorkers,
   setMaxWorkers,
   darkTrayIcon,
-  toggleDarkTrayIcon,
+  toggleDarkTrayIcon
 }: Props) {
   const [isSyncing, setIsSyncing] = useState(false)
   const [maxCpus, setMaxCpus] = useState(maxWorkers)
@@ -75,7 +75,7 @@ export default function GeneralSettings({
       return await ipcRenderer.invoke('egsSync', 'unlink').then(async () => {
         await showMessageBox({
           message: t('message.unsync'),
-          title: 'EGS Sync',
+          title: 'EGS Sync'
         })
         setEgsLinkedPath('')
         setEgsPath('')
@@ -96,7 +96,7 @@ export default function GeneralSettings({
         }
         await dialog.showMessageBox({
           message: t('message.sync'),
-          title: 'EGS Sync',
+          title: 'EGS Sync'
         })
 
         setIsSyncing(false)
@@ -135,7 +135,7 @@ export default function GeneralSettings({
               showOpenDialog({
                 buttonLabel: t('box.choose'),
                 properties: ['openDirectory'],
-                title: t('box.default-install-path'),
+                title: t('box.default-install-path')
               }).then(({ filePaths }: Path) =>
                 setDefaultInstallPath(filePaths[0] ? `'${filePaths[0]}'` : '')
               )
@@ -162,14 +162,14 @@ export default function GeneralSettings({
                 isLinked
                   ? ''
                   : dialog
-                      .showOpenDialog({
-                        buttonLabel: t('box.choose'),
-                        properties: ['openDirectory'],
-                        title: t('box.choose-egs-prefix'),
-                      })
-                      .then(({ filePaths }: Path) =>
-                        setEgsPath(filePaths[0] ? `'${filePaths[0]}'` : '')
-                      )
+                    .showOpenDialog({
+                      buttonLabel: t('box.choose'),
+                      properties: ['openDirectory'],
+                      title: t('box.choose-egs-prefix')
+                    })
+                    .then(({ filePaths }: Path) =>
+                      setEgsPath(filePaths[0] ? `'${filePaths[0]}'` : '')
+                    )
               }
             />
           ) : (
@@ -194,8 +194,8 @@ export default function GeneralSettings({
               isLinked
                 ? t('button.unsync')
                 : isSyncing
-                ? t('button.syncing')
-                : t('button.sync')
+                  ? t('button.syncing')
+                  : t('button.sync')
             }`}
           </button>
         </span>

--- a/src/screens/Settings/components/OtherSettings/index.tsx
+++ b/src/screens/Settings/components/OtherSettings/index.tsx
@@ -38,7 +38,7 @@ export default function OtherSettings({
   toggleAudioFix,
   showMangohud,
   toggleMangoHud,
-  isDefault,
+  isDefault
 }: Props) {
   const handleOtherOptions = (event: ChangeEvent<HTMLInputElement>) =>
     setOtherOptions(event.currentTarget.value)

--- a/src/screens/Settings/components/SyncSaves/index.tsx
+++ b/src/screens/Settings/components/SyncSaves/index.tsx
@@ -10,7 +10,7 @@ import Backspace from '@material-ui/icons/Backspace'
 import CreateNewFolder from '@material-ui/icons/CreateNewFolder'
 
 const {
-  remote: { dialog },
+  remote: { dialog }
 } = window.require('electron')
 
 interface Props {
@@ -32,7 +32,7 @@ export default function SyncSaves({
   setAutoSyncSaves,
   defaultFolder,
   isProton,
-  winePrefix,
+  winePrefix
 }: Props) {
   const [isSyncing, setIsSyncing] = useState(false)
   const [syncType, setSyncType] = useState('Download' as SyncType)
@@ -57,7 +57,7 @@ export default function SyncSaves({
     t('setting.manualsync.download'),
     t('setting.manualsync.upload'),
     t('setting.manualsync.forcedownload'),
-    t('setting.manualsync.forceupload'),
+    t('setting.manualsync.forceupload')
   ]
   async function handleSync() {
     setIsSyncing(true)
@@ -65,7 +65,7 @@ export default function SyncSaves({
       Download: '--skip-upload',
       'Force download': '--force-download',
       'Force upload': '--force-upload',
-      Upload: '--skip-download',
+      Upload: '--skip-download'
     }
 
     await syncSaves(savesPath, appName, command[syncType]).then((res: string) =>
@@ -95,15 +95,15 @@ export default function SyncSaves({
                 isLinked
                   ? ''
                   : dialog
-                      .showOpenDialog({
-                        buttonLabel: t('box.sync.button'),
-                        defaultPath: defaultFolder,
-                        properties: ['openDirectory'],
-                        title: t('box.sync.title'),
-                      })
-                      .then(({ filePaths }: Path) =>
-                        setSavesPath(filePaths[0] ? `${filePaths[0]}` : '')
-                      )
+                    .showOpenDialog({
+                      buttonLabel: t('box.sync.button'),
+                      defaultPath: defaultFolder,
+                      properties: ['openDirectory'],
+                      title: t('box.sync.title')
+                    })
+                    .then(({ filePaths }: Path) =>
+                      setSavesPath(filePaths[0] ? `${filePaths[0]}` : '')
+                    )
               }
             />
           ) : (
@@ -121,7 +121,7 @@ export default function SyncSaves({
           style={{
             display: 'flex',
             justifyContent: 'space-between',
-            width: '513px',
+            width: '513px'
           }}
         >
           <select

--- a/src/screens/Settings/components/Tools/index.tsx
+++ b/src/screens/Settings/components/Tools/index.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 
 const { ipcRenderer, remote } = window.require('electron')
 const {
-  dialog: { showOpenDialog },
+  dialog: { showOpenDialog }
 } = remote
 
 interface Props {
@@ -23,7 +23,7 @@ export default function Tools({ wineVersion, winePrefix }: Props) {
       exe,
       prefix: winePrefix,
       tool,
-      wine: wineVersion.bin,
+      wine: wineVersion.bin
     })
 
   const handleRunExe = async () => {
@@ -32,7 +32,7 @@ export default function Tools({ wineVersion, winePrefix }: Props) {
       buttonLabel: t('box.select'),
       filters: ['exe', 'msi'],
       properties: ['openFile'],
-      title: t('box.runexe.title'),
+      title: t('box.runexe.title')
     })
     if (filePaths[0]) {
       exe = filePaths[0]

--- a/src/screens/Settings/components/WineSettings/index.tsx
+++ b/src/screens/Settings/components/WineSettings/index.tsx
@@ -11,7 +11,7 @@ import RemoveCircleIcon from '@material-ui/icons/RemoveCircle'
 
 const {
   ipcRenderer,
-  remote: { dialog },
+  remote: { dialog }
 } = window.require('electron')
 
 interface Props {
@@ -39,7 +39,7 @@ export default function WineSettings({
   autoInstallDxvk,
   customWinePaths,
   setCustomWinePaths,
-  isDefault,
+  isDefault
 }: Props) {
   const [selectedPath, setSelectedPath] = useState('')
 
@@ -61,7 +61,7 @@ export default function WineSettings({
       .showOpenDialog({
         buttonLabel: t('box.choose'),
         properties: ['openFile'],
-        title: t('box.customWine', 'Select the Wine or Proton Binary'),
+        title: t('box.customWine', 'Select the Wine or Proton Binary')
       })
       .then(({ filePaths }: Path) => {
         if (!customWinePaths.includes(filePaths[0])) {
@@ -96,7 +96,7 @@ export default function WineSettings({
                 .showOpenDialog({
                   buttonLabel: t('box.choose'),
                   properties: ['openDirectory'],
-                  title: t('box.wineprefix'),
+                  title: t('box.wineprefix')
                 })
                 .then(({ filePaths }: Path) =>
                   setWinePrefix(filePaths[0] ? `${filePaths[0]}` : '~/.wine')
@@ -127,7 +127,7 @@ export default function WineSettings({
                 onClick={() => removeCustomPath()}
                 style={{
                   color: selectedPath ? 'var(--danger)' : 'var(--background)',
-                  cursor: selectedPath ? 'pointer' : '',
+                  cursor: selectedPath ? 'pointer' : ''
                 }}
                 fontSize="large"
                 titleAccess={t('tooltip.removepath', 'Remove Path')}

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -39,7 +39,7 @@ function Settings() {
 
   const [wineVersion, setWineversion] = useState({
     bin: '/usr/bin/wine',
-    name: 'Wine Default',
+    name: 'Wine Default'
   } as WineProps)
   const [winePrefix, setWinePrefix] = useState('~/.wine')
   const [defaultInstallPath, setDefaultInstallPath] = useState('')
@@ -57,43 +57,43 @@ function Settings() {
   const {
     on: useGameMode,
     toggle: toggleUseGameMode,
-    setOn: setUseGameMode,
+    setOn: setUseGameMode
   } = useToggle(false)
   const { on: showFps, toggle: toggleFps, setOn: setShowFps } = useToggle(false)
   const {
     on: offlineMode,
     toggle: toggleOffline,
-    setOn: setShowOffline,
+    setOn: setShowOffline
   } = useToggle(false)
   const {
     on: audioFix,
     toggle: toggleAudioFix,
-    setOn: setAudioFix,
+    setOn: setAudioFix
   } = useToggle(false)
   const {
     on: showMangohud,
     toggle: toggleMangoHud,
-    setOn: setShowMangoHud,
+    setOn: setShowMangoHud
   } = useToggle(false)
   const {
     on: exitToTray,
     toggle: toggleTray,
-    setOn: setExitToTray,
+    setOn: setExitToTray
   } = useToggle(false)
   const {
     on: darkTrayIcon,
     toggle: toggleDarkTrayIcon,
-    setOn: setDarkTrayIcon,
+    setOn: setDarkTrayIcon
   } = useToggle(false)
   const {
     on: autoInstallDxvk,
     toggle: toggleAutoInstallDxvk,
-    setOn: setAutoInstallDxvk,
+    setOn: setAutoInstallDxvk
   } = useToggle(false)
 
   const [haveCloudSaving, setHaveCloudSaving] = useState({
     cloudSaveEnabled: false,
-    saveFolder: '',
+    saveFolder: ''
   })
   const [autoSyncSaves, setAutoSyncSaves] = useState(false)
   const [altWine, setAltWine] = useState([] as WineProps[])
@@ -135,7 +135,7 @@ function Settings() {
         const {
           cloudSaveEnabled,
           saveFolder,
-          title: gameTitle,
+          title: gameTitle
         } = await getGameInfo(appName)
         setTitle(gameTitle)
         return setHaveCloudSaving({ cloudSaveEnabled, saveFolder })
@@ -165,8 +165,8 @@ function Settings() {
       showMangohud,
       useGameMode,
       winePrefix,
-      wineVersion,
-    } as AppSettings,
+      wineVersion
+    } as AppSettings
   }
 
   const GameSettings = {
@@ -182,8 +182,8 @@ function Settings() {
       showMangohud,
       useGameMode,
       winePrefix,
-      wineVersion,
-    } as AppSettings,
+      wineVersion
+    } as AppSettings
   }
 
   const settingsToSave = isDefault ? GlobalSettings : GameSettings

--- a/src/state/ContextProvider.tsx
+++ b/src/state/ContextProvider.tsx
@@ -16,7 +16,7 @@ const initialContext: ContextType = {
   refresh: () => Promise.resolve(),
   refreshLibrary: () => Promise.resolve(),
   refreshing: false,
-  user: '',
+  user: ''
 }
 
 export default React.createContext(initialContext)

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -8,7 +8,7 @@ import {
   getLegendaryConfig,
   getProgress,
   legendary,
-  notify,
+  notify
 } from 'src/helpers'
 import { i18n } from 'i18next'
 import UpdateComponent from 'src/components/UI/UpdateComponent'
@@ -52,7 +52,7 @@ export class GlobalState extends PureComponent<Props> {
     layout: 'grid',
     libraryStatus: [],
     refreshing: false,
-    user: '',
+    user: ''
   }
 
   refresh = async (): Promise<void> => {
@@ -65,7 +65,7 @@ export class GlobalState extends PureComponent<Props> {
       filterText: '',
       gameUpdates: updates,
       refreshing: false,
-      user,
+      user
     })
   }
 
@@ -84,27 +84,27 @@ export class GlobalState extends PureComponent<Props> {
 
   filterLibrary = (library: Game[], filter: string) => {
     switch (filter) {
-      case 'installed':
-        return library.filter((game) => game.isInstalled)
-      case 'uninstalled':
-        return library.filter((game) => !game.isInstalled)
-      case 'downloading':
-        return library.filter((game) => {
-          const currentApp = this.state.libraryStatus.filter(
-            (app) => app.appName === game.app_name
-          )[0]
-          if (!currentApp) {
-            return false
-          }
-          return (
-            currentApp.status === 'installing' ||
+    case 'installed':
+      return library.filter((game) => game.isInstalled)
+    case 'uninstalled':
+      return library.filter((game) => !game.isInstalled)
+    case 'downloading':
+      return library.filter((game) => {
+        const currentApp = this.state.libraryStatus.filter(
+          (app) => app.appName === game.app_name
+        )[0]
+        if (!currentApp) {
+          return false
+        }
+        return (
+          currentApp.status === 'installing' ||
             currentApp.status === 'repairing' ||
             currentApp.status === 'updating' ||
             currentApp.status === 'moving'
-          )
-        })
-      default:
-        return library
+        )
+      })
+    default:
+      return library
     }
   }
 
@@ -121,7 +121,7 @@ export class GlobalState extends PureComponent<Props> {
         (game) => game.appName !== appName
       )
       return this.setState({
-        libraryStatus: [...updatedLibraryStatus, { ...currentApp }],
+        libraryStatus: [...updatedLibraryStatus, { ...currentApp }]
       })
     }
 
@@ -203,7 +203,7 @@ export class GlobalState extends PureComponent<Props> {
     }
 
     return this.setState({
-      libraryStatus: [...libraryStatus, { appName, status }],
+      libraryStatus: [...libraryStatus, { appName, status }]
     })
   }
 
@@ -217,7 +217,7 @@ export class GlobalState extends PureComponent<Props> {
           'box.appupdate.message',
           'There is a new version of Heroic Available, do you want to update now?'
         ),
-        title: t('box.appupdate.title', 'Update Available'),
+        title: t('box.appupdate.title', 'Update Available')
       })
 
       if (response === 0) {
@@ -283,7 +283,7 @@ export class GlobalState extends PureComponent<Props> {
           handleLayout: this.handleLayout,
           handleSearch: this.handleSearch,
           refresh: this.refresh,
-          refreshLibrary: this.refreshLibrary,
+          refreshLibrary: this.refreshLibrary
         }}
       >
         {children}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,7 +1941,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/minimatch@*", "@types/minimatch@^3.0.3":
+"@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -2631,11 +2631,6 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
-
-array-differ@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
-  integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
 
 array-flatten@1.1.1:
   version "1.1.1"
@@ -8853,11 +8848,6 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-mri@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.6.tgz#49952e1044db21dbf90f6cd92bc9c9a777d415a6"
-  integrity sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -8890,17 +8880,6 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
-
-multimatch@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-4.0.0.tgz#8c3c0f6e3e8449ada0af3dd29efb491a375191b3"
-  integrity sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==
-  dependencies:
-    "@types/minimatch" "^3.0.3"
-    array-differ "^3.0.0"
-    array-union "^2.1.0"
-    arrify "^2.0.1"
-    minimatch "^3.0.4"
 
 mustache@^2.2.1:
   version "2.3.2"
@@ -10481,11 +10460,6 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
-
 pretty-bytes@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.5.0.tgz#0cecda50a74a941589498011cf23275aa82b339e"
@@ -10508,18 +10482,6 @@ pretty-format@^26.0.0, pretty-format@^26.6.0, pretty-format@^26.6.2:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
-
-pretty-quick@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-3.1.0.tgz#cb172e9086deb57455dea7c7e8f136cd0a4aef6c"
-  integrity sha512-DtxIxksaUWCgPFN7E1ZZk4+Aav3CCuRdhrDSFZENb404sYMtuo9Zka823F+Mgeyt8Zt3bUiCjFzzWYE9LYqkmQ==
-  dependencies:
-    chalk "^3.0.0"
-    execa "^4.0.0"
-    find-up "^4.1.0"
-    ignore "^5.1.4"
-    mri "^1.1.5"
-    multimatch "^4.0.0"
 
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
I found that prettier was (still) not set up properly, and was conflicting with some ESLint rules (I couldn't figure out the root cause). I found one of them in #263. 

Also, all the rules we defined in Prettier were available and autofixable in ESLint anyways, so I decided that it was more hassle than it was worth, and removed it. It will also simplify our pre-commit and pre-push workflows.

This is just a proposal so that we can discuss the merits and demerits of this.

----

Functionally, only a few tabs got shifted around and the dangling commas got removed.