### PR TITLE
ci: Use Yarn for building and deploying releases.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository.
+        uses: actions/checkout@v2
       - name: Install modules.
         run: yarn
       - name: Build 'src'.

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
@@ -13,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2.1.4
       - run: sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm
-      - run: npm install
-      - run: GH_TOKEN="${{ secrets.WORKFLOW_TOKEN }}" npm run ci-build
+      - run: yarn install
+      - run: GH_TOKEN="${{ secrets.WORKFLOW_TOKEN }}" yarn ci-build


### PR DESCRIPTION
Switches to using Yarn instead of npm for releases, as recommended by electron-builder's README.

Spliced from #312.