### PR TITLE
frontend: Fix erroneous use of `import`, fixes 1.5.8-dontuse.

### DIFF
--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -4,7 +4,11 @@ import { LegendaryGame } from './games'
 
 // TODO(adityaruplaha): Translate strings used here.
 export async function handleProtocol(window : BrowserWindow, url : string) {
-  const [command, args_string] = url.split('://')[1].split('?')
+  const [scheme, path] = url.split('://')
+  if (!url || scheme != 'heroic' || !path) {
+    return
+  }
+  const [command, args_string] = path.split('?')
   const args = new Map<string, string>()
   args_string.split(',').forEach((arg) => {
     const [k, v] = arg.split('=')

--- a/src/components/Navbar/components/UserSelector/index.tsx
+++ b/src/components/Navbar/components/UserSelector/index.tsx
@@ -7,7 +7,7 @@ import {
   openDiscordLink
 } from 'src/helpers'
 
-import { ipcRenderer } from 'electron'
+import { IpcRenderer } from 'electron'
 import { useTranslation } from 'react-i18next'
 import ArrowDropDown from '@material-ui/icons/ArrowDropDown'
 import ContextProvider from 'src/state/ContextProvider'
@@ -15,6 +15,9 @@ import React from 'react'
 
 export default function UserSelector() {
   const { t } = useTranslation()
+  const { ipcRenderer } = window.require('electron') as {
+    ipcRenderer : IpcRenderer
+  }
 
   const { user, refresh, refreshLibrary } = React.useContext(ContextProvider)
   const handleLogout = async () => {

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -8,7 +8,7 @@ import LanguageSelector, {
   FlagPosition
 } from 'src/components/UI/LanguageSelector'
 
-import { ipcRenderer } from 'electron'
+import { IpcRenderer } from 'electron'
 import Autorenew from '@material-ui/icons/Autorenew'
 import Info from '@material-ui/icons/Info'
 
@@ -20,6 +20,9 @@ interface Props {
 
 export default function Login({ refresh }: Props) {
   const { t, i18n } = useTranslation('login')
+  const { ipcRenderer } = window.require('electron') as {
+    ipcRenderer : IpcRenderer
+  }
 
   const [input, setInput] = useState('')
   const [status, setStatus] = useState({


### PR DESCRIPTION
I'm a certified fuckwad who knew this would happen but forgot to fix it before the refactor PR was merged. Please drown me in lava.

NOTE: You **_CANNOT_** `import` `ipcRenderer`, you have to use `require`.

Oh yeah this PR also amends some protocol stuff I guess.

---

Fixes #329, fixes #330.