### PR TITLE
electron: Implement monitoring game progress using a TCP server.

### DIFF
--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -6,6 +6,7 @@ import { join } from 'path'
 const currentGameConfigVersion : GameConfigVersion = 'v0'
 const currentGlobalConfigVersion : GlobalConfigVersion = 'v0'
 const home = homedir()
+const heroicPort = 40627
 const legendaryConfigPath = `${home}/.config/legendary`
 const heroicFolder = `${home}/.config/heroic/`
 const heroicConfigPath = `${heroicFolder}config.json`
@@ -46,6 +47,7 @@ export {
   heroicGamesConfigPath,
   heroicGithubURL,
   heroicInstallPath,
+  heroicPort,
   heroicToolsPath,
   home,
   icon,

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -6,7 +6,6 @@ import { join } from 'path'
 const currentGameConfigVersion : GameConfigVersion = 'v0'
 const currentGlobalConfigVersion : GlobalConfigVersion = 'v0'
 const home = homedir()
-const heroicPort = 40627
 const legendaryConfigPath = `${home}/.config/legendary`
 const heroicFolder = `${home}/.config/heroic/`
 const heroicConfigPath = `${heroicFolder}config.json`
@@ -47,7 +46,6 @@ export {
   heroicGamesConfigPath,
   heroicGithubURL,
   heroicInstallPath,
-  heroicPort,
   heroicToolsPath,
   home,
   icon,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -499,35 +499,7 @@ ipcMain.handle('updateGame', async (e, game) => {
   ).catch((res) => res)
 })
 
-// TODO(adityaruplaha): Use UNIX sockets to refactor this.
-ipcMain.handle('requestGameProgress', async (event, appName) => {
-  const logPath = `"${heroicGamesConfigPath}${appName}.log"`
-  const progress_command = `tail ${logPath} | grep 'Progress: ' | awk '{print $5, $11}' | tail -1`
-  const downloaded_command = `tail ${logPath} | grep 'Downloaded: ' | awk '{print $5}' | tail -1`
-  const progress = {
-    bytes: '0.00MiB',
-    eta: '00:00:00',
-    percent: '0.00%'
-  }
-
-  try {
-    const { stdout: progress_result } = await execAsync(progress_command)
-    const { stdout: downloaded_result } = await execAsync(downloaded_command)
-
-    progress.bytes = downloaded_result + 'MiB'
-    progress.eta = progress_result.split(' ')[1]
-    progress.percent = progress_result.split(' ')[0]
-
-    console.log(
-      `Progress: ${appName} ${progress.percent}/${progress.bytes}/${progress.eta}`
-    )
-
-    return progress
-  } catch (error) {
-    console.log(error);
-    return progress
-  }
-})
+ipcMain.handle('requestGameProgress',  (event, appName) => LegendaryGame.get(appName).currentProgress)
 
 ipcMain.handle('moveInstall', async (event, [appName, path]: string[]) => {
   const newPath = await LegendaryGame.get(appName).moveInstall(path)

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -86,7 +86,7 @@ export interface GameStatus {
 
 export type GlobalConfigVersion = 'auto' | 'v0'
 export interface InstallProgress {
-  bytes: string
+  bytes?: string
   eta: string
   folder?: string
   percent: string


### PR DESCRIPTION
Create a TCP server ~~on port 40627~~ (see the 3rd commit) where the log gets tee'd (relies on bash magic).
Theoretically, can also be used to monitor progress of a remote machine.

I tried to use UNIX sockets but couldn't manage to find a way to easily shove data into the socket using readily available tools. We don't have netcat available on all machines unfortunately.

Breaks Windows compatibility. Also doesn't work on MacOS since Zsh doesn't have the ability to easily pass data into a Unix socket. However, it can still be acheived as shown here: https://who23.github.io/2020/12/03/sockets-in-your-shell.html

An easier solution would be to periodically shove the entire file into the progress management algorithm. However this has its downsides of higher disk usage and higher memory footprint.

----

## Checklist

- [x] Install/Update
- [x] Repair
- [x] Multiple Progress Servers