### PR TITLE
ci: Switch to Node 14 for all tasks, don't report coverage (for now).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout repository.
         uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Install modules.
         run: yarn
       - name: Build 'src'.

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -10,7 +10,10 @@ jobs:
   draft-releases:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - run: sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - run: yarn install
       - run: GH_TOKEN="${{ secrets.WORKFLOW_TOKEN }}" yarn ci-build

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -16,4 +16,6 @@ jobs:
         with:
           node-version: '14'
       - run: yarn install
-      - run: GH_TOKEN="${{ secrets.WORKFLOW_TOKEN }}" yarn ci-build
+      - run: yarn ci-build
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Install modules.
         run: yarn
       - name: Lint code.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
     - name: Checkout repository.
       uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
     - name: Install modules.
       run: yarn
     - name: Test and collect coverage.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
   workflow_dispatch:
 


### PR DESCRIPTION
This should fix the issues we've been having with deploying tests on CI. Now we use Node 14 everywhere.
See https://github.com/actions/setup-node for details.

Also, since we're having issues with coverage plugins, I think we should just run tests for now, coverage can come later.