### PR TITLE
More robust version checks.

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -37,6 +37,7 @@ import {
   handleExit,
   isOnline,
   openUrlOrFile,
+  semverGt,
   showAboutWindow
 } from './utils'
 import {
@@ -246,10 +247,19 @@ if (!gotTheLock) {
     })
 
     if (process.platform === 'linux'){
-      const {stdout: pythonInfo} = await execAsync('python --version')
-      const pythonVersion: number | null = pythonInfo ? parseFloat(pythonInfo.split(' ')[1].replace('\n', '')) : null
-      if (pythonVersion < 3.8) {
-        console.log(`Python Version incompatible. Python needed: >= 3.8, Python found: ${pythonVersion}`);
+      let pythonFound = false
+      for (const python of ['python', 'python3']) {
+        const { stdout } = await execAsync(python + ' --version')
+        const pythonVersion: string | null = stdout.includes('Python ') ? stdout.replace('\n', '').split(' ')[1] : null
+        if (!pythonVersion) {
+          console.log(`Python '${python}' not found.`);
+          continue
+        } else {
+          console.log(`Python '${python}' found. Version: '${pythonVersion}'`)
+          pythonFound ||= semverGt(pythonVersion, '3.8.0') || pythonVersion === '3.8.0'
+        }
+      }
+      if (!pythonFound) {
         dialog.showErrorBox('Python Error', `${i18next.t('box.error.python', 'Heroic requires Python 3.8 or newer.')}`)
       }
     }

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -57,8 +57,8 @@ async function checkForUpdates() {
     } = await axios.default.get(
       'https://api.github.com/repos/flavioislima/HeroicGamesLauncher/releases/latest'
     )
-    const newVersion = tag_name.replace('v', '').replaceAll('.', '')
-    const currentVersion = app.getVersion().replaceAll('.', '')
+    const newVersion = tag_name.replace('v', '')
+    const currentVersion = app.getVersion()
 
     return semverGt(newVersion, currentVersion)
   } catch (error) {

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -24,6 +24,21 @@ const statAsync = promisify(stat)
 
 const { showErrorBox, showMessageBox } = dialog
 
+/**
+ * Compares 2 SemVer strings following "major.minor.patch".
+ * Checks if target is newer than base.
+ */
+function semverGt(target : string, base : string) {
+  const [bmajor, bminor, bpatch] = base.split('.').map(Number)
+  const [tmajor, tminor, tpatch] = target.split('.').map(Number)
+  let isGE = false
+  // A pretty nice piece of logic if you ask me. :P
+  isGE ||= tmajor > bmajor
+  isGE ||= tmajor === bmajor && tminor > bminor
+  isGE ||= tmajor === bmajor && tminor === bminor && tpatch > bpatch
+  return isGE
+}
+
 async function isOnline() {
   return net.isOnline()
 }
@@ -45,7 +60,7 @@ async function checkForUpdates() {
     const newVersion = tag_name.replace('v', '').replaceAll('.', '')
     const currentVersion = app.getVersion().replaceAll('.', '')
 
-    return newVersion > currentVersion
+    return semverGt(newVersion, currentVersion)
   } catch (error) {
     console.log('Could not check for new version of heroic')
   }
@@ -148,6 +163,7 @@ export {
   handleExit,
   isOnline,
   openUrlOrFile,
+  semverGt,
   showAboutWindow,
   statAsync
 }


### PR DESCRIPTION
Now we can check for even the patch version.
Also, versions aren't floats, and they shouldn't be treated as such.

Also fixes the Python check, supersedes #420.