### PR TITLE
Use $SHELL instead of bash in Linux and Mac

### DIFF
--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -45,7 +45,7 @@ function getShell() {
   default:
     // $SHELL is set by login
     // If it's 0-value, use bash
-    return process.env.SHELL || "/usr/bin/bash"
+    return process.env.SHELL || '/usr/bin/bash'
   }
 }
 

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -42,12 +42,10 @@ function getShell() {
   switch (process.platform) {
   case 'win32':
     return 'powershell.exe'
-  case 'linux':
-    return '/bin/bash'
-  case 'darwin':
-    return '/bin/zsh'
   default:
-    return '/bin/bash'
+    // $SHELL is set by login
+    // If it's 0-value, use bash
+    return process.env.SHELL || "/usr/bin/bash"
   }
 }
 


### PR DESCRIPTION

Uses the custom shell (provided by every user) instead of bash by default. In case it's not set, it uses bash.
----------------------------------

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Created / Updated Tests
- [x] Created / Updated documentation

Tested on a Clean Install with AppImage:
- [x] Login
- [x] Download a Game
- [x] Import a Game
- [x] Launch Default config
- [x] Launch Personalized Config
- [x] Launch wine
- [ ] Launch Proton (Doesn't work with main branch on my pc)
- [ ] Launch Custom Proton
- [x] Launch Tools (Winetricks and Winecfg)
- [x] Uninstall Game
- [x] Move Game
- [x] Languages (Test if no translation stopped working)
