### PR TITLE
Add Desktop shortcuts(backend)

### DIFF
--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -239,13 +239,13 @@ Categories=Game;
           const enabledInDesktop = GlobalConfig.get().config.enableDesktopShortcutsOnDesktop
           const enabledInStartMenu = GlobalConfig.get().config.enableDesktopShortcutsOnStartMenu
 
-          if (enabledInDesktop === true || enabledInDesktop === undefined) {
+          if (enabledInDesktop || enabledInDesktop === undefined) {
             writeFile(desktopFolder, linuxShortcut, (err) => {
               if(err) console.error(err)
               console.log("Couldn't save shortcut to " + desktopFolder)
             })
           }
-          if (enabledInStartMenu === true || enabledInStartMenu === undefined) {
+          if (enabledInStartMenu || enabledInStartMenu === undefined) {
             writeFile('/usr/share/applications', linuxShortcut, (err) => {
               if(err) console.error(err)
               console.log("Couldn't save shortcut to /usr/share/applications")

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -236,14 +236,21 @@ Type=Application
 Icon=${gameInfo.art_square}
 Categories=Game;
 `
-          writeFile(desktopFolder, linuxShortcut, (err) => {
-            if(err) console.error(err)
-            console.log("Couldn't save shortcut to " + desktopFolder)
-          })
-          writeFile('/usr/share/applications', linuxShortcut, (err) => {
-            if(err) console.error(err)
-            console.log("Couldn't save shortcut to /usr/share/applications")
-          })
+          const enabledInDesktop = GlobalConfig.get().config.enableDesktopShortcutsOnDesktop
+          const enabledInStartMenu = GlobalConfig.get().config.enableDesktopShortcutsOnStartMenu
+
+          if (enabledInDesktop === true || enabledInDesktop === undefined) {
+            writeFile(desktopFolder, linuxShortcut, (err) => {
+              if(err) console.error(err)
+              console.log("Couldn't save shortcut to " + desktopFolder)
+            })
+          }
+          if (enabledInStartMenu === true || enabledInStartMenu === undefined) {
+            writeFile('/usr/share/applications', linuxShortcut, (err) => {
+              if(err) console.error(err)
+              console.log("Couldn't save shortcut to /usr/share/applications")
+            })
+          }
           break; }
         default:
           console.error("Shortcuts haven't been implemented in the current platform.")

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -230,7 +230,7 @@ class LegendaryGame extends Game {
         case 'linux': {
           const linuxShortcut = `[Desktop Entry]
 Name=${gameInfo.title}
-Exec=xdg-open heroic://launch?appName=${gameInfo.app_name}
+Exec=xdg-open heroic://launch/${gameInfo.app_name}
 Terminal=false
 Type=Application
 Icon=${gameInfo.art_square}

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -230,7 +230,7 @@ class LegendaryGame extends Game {
         case 'linux': {
           const linuxShortcut = `[Desktop Entry]
 Name=${gameInfo.title}
-Exec=${legendaryBin} ${gameInfo.app_name}
+Exec=xdg-open heroic://launch?appName=${gameInfo.app_name}
 Terminal=false
 Type=Application
 Icon=${gameInfo.art_square}

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -220,6 +220,8 @@ class LegendaryGame extends Game {
     const gameInfo = await this.getGameInfo()
     const command = `${legendaryBin} install ${this.appName} --base-path ${path} ${workers} -y ${writeLog}`
     console.log(`Installing ${this.appName} with:`, command)
+    const bm = await fetch(gameInfo.art_square)
+    const bodyText = await bm.text()
     try {
       LegendaryLibrary.get().installState(this.appName, true)
       return await execAsync(command, execOptions).then((v) => {
@@ -228,12 +230,15 @@ class LegendaryGame extends Game {
         const desktopFolder = app.getPath('desktop')
         switch(process.platform) {
         case 'linux': {
+          writeFile(app.getAppPath() + '/images/' + gameInfo.app_name, bodyText, null, (err) => {
+            if (err) throw err
+          })
           const linuxShortcut = `[Desktop Entry]
 Name=${gameInfo.title}
 Exec=xdg-open heroic://launch/${gameInfo.app_name}
 Terminal=false
 Type=Application
-Icon=${gameInfo.art_square}
+Icon=${app.getAppPath()}/images/${gameInfo.app_name}
 Categories=Game;
 `
           const enabledInDesktop = GlobalConfig.get().config.enableDesktopShortcutsOnDesktop

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -21,12 +21,12 @@ export interface AppSettings {
   offlineMode: boolean,
   otherOptions: string,
   savesPath: string,
-  useGameMode: boolean
-  userInfo: UserInfo
-  winePrefix: string
-  wineVersion: WineInstallation,
   showFps: boolean,
   showMangohud: boolean,
+  useGameMode: boolean,
+  userInfo: UserInfo,
+  winePrefix: string,
+  wineVersion: WineInstallation
 }
 
 export type ExecResult = void | {stderr : string, stdout : string}

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -11,20 +11,22 @@ export interface AppSettings {
   darkTrayIcon: boolean
   defaultInstallPath: string
   egsLinkedPath: string
-  exitToTray: boolean
-  language: string
-  launcherArgs: string
-  maxWorkers: number
-  nvidiaPrime: boolean
-  offlineMode: boolean
-  otherOptions: string
-  savesPath: string
-  showFps: boolean
-  showMangohud: boolean
+  enableDesktopShortcutsOnDesktop: boolean,
+  enableDesktopShortcutsOnStartMenu: boolean,
+  exitToTray: boolean,
+  language: string,
+  launcherArgs: string,
+  maxWorkers: number,
+  nvidiaPrime: boolean,
+  offlineMode: boolean,
+  otherOptions: string,
+  savesPath: string,
   useGameMode: boolean
   userInfo: UserInfo
   winePrefix: string
-  wineVersion: WineInstallation
+  wineVersion: WineInstallation,
+  showFps: boolean,
+  showMangohud: boolean,
 }
 
 export type ExecResult = void | {stderr : string, stdout : string}


### PR DESCRIPTION
I've added desktop shortcuts for Linux (GNOME)
----------------------------------

Use the following Checklist if you have changed something on the Backend or Frontend:

Not applicable:

- [ ] Created / Updated Tests
- [ ] Created / Updated documentation

Tested on a Clean Install with AppImage:
- [x] Login
- [x] Download a Game
- [x] Import a Game
- [x] Launch Default config
- [x] Launch Personalized Config
- [x] Launch wine
- [ ] Launch Proton (doesn't work on my pc, even on the current main branch)
- [ ] Launch Custom Proton
- [x] Launch Tools (Winetricks and Winecfg)
- [x] Uninstall Game
- [x] Move Game
- [x] Languages (Test if no translation stopped working)


Fixes #140

Depends on the protocol launch command to be fixed. (#445)