### PR TITLE
Removed electron-util

### DIFF
--- a/electron/__tests__/constants.test.ts
+++ b/electron/__tests__/constants.test.ts
@@ -1,0 +1,58 @@
+import { fixAsarPath, getShell } from '../constants';
+
+describe('Constants - fixAsarPath', () => {
+  test('need to fix path and replace correctly', () => {
+    const fixed_path = fixAsarPath('path/app.asar/bin');
+    expect(fixed_path).toBe('path/app.asar.unpacked/bin');
+  })
+
+  test(' no need to fix path and replace is skipped', () => {
+    const fixed_path = fixAsarPath('fixed/path/app.asar.unpacked/bin');
+    expect(fixed_path).toBe('fixed/path/app.asar.unpacked/bin');
+  })
+})
+
+describe('Constants - getShell', () => {
+  test('get enviroment SHELL for unix os', () => {
+    // store original shell
+    const stored_shell = process.env.SHELL;
+
+    process.env.SHELL = 'path/to/bash';
+    const shell = getShell();
+    expect(shell).toBe('path/to/bash');
+
+    // get back to original shell
+    process.env.SHELL = stored_shell;
+    expect(process.env.SHELL).toBe(stored_shell);
+  })
+
+  test('get default shell for unix os', () => {
+    // store original shell
+    const stored_shell = process.env.SHELL;
+
+    delete process.env.SHELL;
+    const shell = getShell();
+    expect(shell).toBe('/usr/bin/bash');
+
+    // get back to original shell
+    process.env.SHELL = stored_shell;
+    expect(process.env.SHELL).toBe(stored_shell);
+  })
+
+  test('get powershell windows', () => {
+    // store original platform
+    const originalPlatform = process.platform;
+
+    Object.defineProperty(process, 'platform', {
+      value: 'win32'
+    });
+    const shell = getShell();
+    expect(shell).toBe('powershell.exe');
+
+    // get back to original platform
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform
+    });
+    expect(process.platform).toBe(originalPlatform);
+  })
+})

--- a/electron/__tests__/constants.test.ts
+++ b/electron/__tests__/constants.test.ts
@@ -23,7 +23,6 @@ describe('Constants - getShell', () => {
 
     // get back to original shell
     process.env.SHELL = stored_shell;
-    expect(process.env.SHELL).toBe(stored_shell);
   })
 
   test('get default shell for unix os', () => {
@@ -36,7 +35,6 @@ describe('Constants - getShell', () => {
 
     // get back to original shell
     process.env.SHELL = stored_shell;
-    expect(process.env.SHELL).toBe(stored_shell);
   })
 
   test('get powershell windows', () => {

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -1,4 +1,3 @@
-import { fixPathForAsarUnpack } from 'electron-util'
 import {
   homedir,
   platform
@@ -9,6 +8,7 @@ import {
   GameConfigVersion,
   GlobalConfigVersion
 } from './types'
+
 
 const isWindows = platform() === 'win32'
 const currentGameConfigVersion : GameConfigVersion = 'v0'
@@ -21,10 +21,10 @@ const heroicGamesConfigPath = `${heroicFolder}GamesConfig/`
 const heroicToolsPath = `${heroicFolder}tools`
 const userInfo = `${legendaryConfigPath}/user.json`
 const heroicInstallPath = `${home}/Games/Heroic`
-const legendaryBin = fixPathForAsarUnpack(join(__dirname, '/bin/', process.platform, isWindows ? '/legendary.exe' : '/legendary'))
-const icon = fixPathForAsarUnpack(join(__dirname, '/icon.png'))
-const iconDark = fixPathForAsarUnpack(join(__dirname, '/icon-dark.png'))
-const iconLight = fixPathForAsarUnpack(join(__dirname, '/icon-light.png'))
+const legendaryBin = join(__dirname, '/bin/', process.platform, isWindows ? '/legendary.exe' : '/legendary').replace('app.asar', 'app.asar.unpacked')
+const icon = join(__dirname, '/icon.png').replace('app.asar', 'app.asar.unpacked')
+const iconDark = join(__dirname, '/icon-dark.png').replace('app.asar', 'app.asar.unpacked')
+const iconLight = join(__dirname, '/icon-light.png').replace('app.asar', 'app.asar.unpacked')
 const installed = `${legendaryConfigPath}/installed.json`
 const libraryPath = `${legendaryConfigPath}/metadata/`
 const loginUrl =

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -9,7 +9,6 @@ import {
   GlobalConfigVersion
 } from './types'
 
-
 const isWindows = platform() === 'win32'
 const currentGameConfigVersion : GameConfigVersion = 'v0'
 const currentGlobalConfigVersion : GlobalConfigVersion = 'v0'
@@ -21,10 +20,10 @@ const heroicGamesConfigPath = `${heroicFolder}GamesConfig/`
 const heroicToolsPath = `${heroicFolder}tools`
 const userInfo = `${legendaryConfigPath}/user.json`
 const heroicInstallPath = `${home}/Games/Heroic`
-const legendaryBin = join(__dirname, '/bin/', process.platform, isWindows ? '/legendary.exe' : '/legendary').replace('app.asar', 'app.asar.unpacked')
-const icon = join(__dirname, '/icon.png').replace('app.asar', 'app.asar.unpacked')
-const iconDark = join(__dirname, '/icon-dark.png').replace('app.asar', 'app.asar.unpacked')
-const iconLight = join(__dirname, '/icon-light.png').replace('app.asar', 'app.asar.unpacked')
+const legendaryBin = fixAsarPath(join(__dirname, '/bin/', process.platform, isWindows ? '/legendary.exe' : '/legendary'))
+const icon = fixAsarPath(join(__dirname, '/icon.png'))
+const iconDark = fixAsarPath(join(__dirname, '/icon-dark.png'))
+const iconLight = fixAsarPath(join(__dirname, '/icon-light.png'))
 const installed = `${legendaryConfigPath}/installed.json`
 const libraryPath = `${legendaryConfigPath}/metadata/`
 const loginUrl =
@@ -38,6 +37,11 @@ const supportURL =
 const discordLink = 'https://discord.gg/rHJ2uqdquK'
 const weblateUrl = 'https://hosted.weblate.org/projects/heroic-games-launcher'
 
+/**
+ * Get shell for different os
+ * @returns Windows: powershell
+ * @returns unix: $SHELL or /usr/bin/bash
+ */
 function getShell() {
   switch (process.platform) {
   case 'win32':
@@ -47,6 +51,19 @@ function getShell() {
     // If it's 0-value, use bash
     return process.env.SHELL || '/usr/bin/bash'
   }
+}
+
+/**
+ * Fix path for packed files with asar, else will do nothing.
+ * @param origin  original path
+ * @returns fixed path
+ */
+function fixAsarPath(origin: string): string {
+  if( !origin.includes('app.asar.unpacked'))
+  {
+    return origin.replace('app.asar', 'app.asar.unpacked');
+  }
+  return origin;
 }
 
 const MAX_BUFFER = 25 * 1024 * 1024 // 25MB should be safe enough for big installations even on really slow internet
@@ -61,6 +78,7 @@ export {
   currentGlobalConfigVersion,
   discordLink,
   execOptions,
+  fixAsarPath,
   getShell,
   heroicConfigPath,
   heroicFolder,

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -7,7 +7,7 @@
     "baseUrl": ".",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "ES2015"
+    "target": "ES2021"
   },
   "include": ["."]
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "classnames": "^2.2.6",
     "discord-rich-presence-typescript": "^0.0.8",
     "electron-is-dev": "^2.0.0",
-    "electron-util": "^0.16.0",
     "graceful-fs": "^4.2.6",
     "i18next": "^20.2.2",
     "i18next-browser-languagedetector": "^6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5776,11 +5776,6 @@ electron-devtools-installer@^3.2.0:
     tslib "^2.1.0"
     unzip-crx-3 "^0.2.0"
 
-electron-is-dev@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz"
-  integrity sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw==
-
 electron-is-dev@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz"
@@ -5809,14 +5804,6 @@ electron-to-chromium@^1.3.723:
   version "1.3.727"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz"
   integrity sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==
-
-electron-util@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.npmjs.org/electron-util/-/electron-util-0.16.0.tgz"
-  integrity sha512-r13cauuQ8p8d++ZVdeMDtQ2VlpblJBcpKnK7sf2tGnN8CCWyRGYerS2K5f3FiblFIQkyS0rE4tFVG0IOEc2F3A==
-  dependencies:
-    electron-is-dev "^1.1.0"
-    new-github-issue-url "^0.2.1"
 
 electron@^13.1.1:
   version "13.1.1"
@@ -9909,11 +9896,6 @@ neo-async@^2.5.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-new-github-issue-url@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/new-github-issue-url/-/new-github-issue-url-0.2.1.tgz"
-  integrity sha512-md4cGoxuT4T4d/HDOXbrUHkTKrp/vp+m3aOA7XXVYwNsUNMK49g3SQicTSeV5GIz/5QVGAeYRAOlyp9OvlgsYA==
 
 next-tick@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
We only use eletron-util to fix asar paths. This is just a simple string replace, so we don't need a whole library for that.

- [x] removed electron-util
- [x] added fixAsarPath function in electron/constants.ts
- [x] updated documentation for functions in electron/constants.ts
- [x] wrote tests for electron/constants.ts

----------------------------------

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Created / Updated Tests
- [ ] Created / Updated documentation

Tested on a Clean Install with AppImage:
- [x] Login
- [x] Download a Game
- [x] Import a Game
- [ ] Launch Default config
- [ ] Launch Personalized Config
- [x] Launch wine
- [ ] Launch Proton
- [ ] Launch Custom Proton
- [x] Launch Tools (Winetricks and Winecfg)
- [x] Uninstall Game
- [ ] Move Game
- [x] Languages (Test if no translation stopped working)
