### PR TITLE
Change submenu to be always visible on game page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,13 +4,13 @@ html {
   --background-secondary: #323035;
   --searchbar-background: rgba(26, 27, 28, 0.5);
   --primary: #07c5ef;
-  --secondary: #ffa800;
+  --secondary: #db9303;
   --tertiary: #252121;
   --danger: #bd0a0a;
   --success: #0bd58c;
 
   --primary-hover: #36d1f3;
-  --secondary-hover: #feba36;
+  --secondary-hover: #a36e04;
   --tertiary-hover: #322b2b;
   --success-hover: #30eca8;
   --danger-hover: #bd0a0a;

--- a/src/screens/Game/GamePage/index.css
+++ b/src/screens/Game/GamePage/index.css
@@ -4,9 +4,7 @@
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   border-radius: 20px;
   margin: auto;
-  display: grid;
-  position: relative;
-  place-items: flex-start;
+  display: flex;
 }
 
 .gameConfig {
@@ -14,7 +12,9 @@
   align-self: center;
   min-width: 780px;
   max-width: 800px;
-  margin: 44px 60px 16px 44px;
+  margin: 44px 0 44px 22px;
+  border-right: solid 1px var(--background-transparent);
+  padding-right: 20px;
 }
 
 .gameConfig .title {

--- a/src/screens/Game/GamePage/index.css
+++ b/src/screens/Game/GamePage/index.css
@@ -11,7 +11,7 @@
   display: flex;
   align-self: center;
   min-width: 780px;
-  max-width: 800px;
+  max-width: 830px;
   margin: 44px 0 44px 22px;
   border-right: solid 1px var(--background-transparent);
   padding-right: 20px;

--- a/src/screens/Game/GamePage/index.tsx
+++ b/src/screens/Game/GamePage/index.tsx
@@ -37,8 +37,6 @@ import {
   InstallProgress
 } from 'src/types'
 
-import Settings from '@material-ui/icons/Settings'
-
 import GamesSubmenu from '../GameSubMenu'
 
 const storage: Storage = window.localStorage
@@ -82,7 +80,6 @@ export default function GamePage(): JSX.Element | null {
   const [autoSyncSaves, setAutoSyncSaves] = useState(false)
   const [savesPath, setSavesPath] = useState('')
   const [isSyncing, setIsSyncing] = useState(false)
-  const [clicked, setClicked] = useState(false)
 
   const isInstalling = status === 'installing'
   const isPlaying = status === 'playing'
@@ -200,18 +197,6 @@ export default function GamePage(): JSX.Element | null {
         <div className="gameConfigContainer">
           {title ? (
             <>
-              {is_game && (
-                <Settings
-                  onClick={() => setClicked(!clicked)}
-                  className="material-icons is-secondary dots"
-                />
-              )}
-              <GamesSubmenu
-                appName={appName}
-                clicked={clicked}
-                isInstalled={is_installed}
-                title={title}
-              />
               <div className="gameConfig">
                 <div className="gamePicture">
                   <img
@@ -365,7 +350,13 @@ export default function GamePage(): JSX.Element | null {
                     )}
                   </div>
                 </div>
-              </div>{' '}
+              </div>
+              {is_game && (
+                <GamesSubmenu
+                  appName={appName}
+                  isInstalled={is_installed}
+                  title={title}
+                />)}
             </>
           ) : (
             <UpdateComponent />

--- a/src/screens/Game/GameSubMenu/index.css
+++ b/src/screens/Game/GameSubMenu/index.css
@@ -6,14 +6,12 @@
   flex-direction: column;
   justify-content: space-around;
   border-radius: 10px;
-  margin-top: 44px;
+  margin-top: 10px;
   transition: 150ms;
-  text-align: center;
-  padding: 10px 20px;
-  background: #1a1b1c;
-  box-shadow: 0px 4px 6px rgb(0 0 0 / 45%);
+  text-align: initial;
+  padding: 20px 8px;
   max-width: 240px;
-  margin: 44px auto;
+  margin: 30px auto;
 }
 
 .dots {
@@ -31,13 +29,13 @@
   font-weight: normal;
   font-size: 14px;
   line-height: 17px;
-  color: #ffffff;
+  color: var(--secondary);
   margin: 4px;
   cursor: pointer;
 }
 
 .link:hover {
-  color: var(--secondary);
+  color: var(--secondary-hover);
 }
 
 .linkTitle {

--- a/src/screens/Game/GameSubMenu/index.css
+++ b/src/screens/Game/GameSubMenu/index.css
@@ -1,20 +1,19 @@
 .more {
-  position: absolute;
-  top: 56px;
-  right: 42px;
-  color: var(--secondary);
   font-size: 25px;
-  width: max-content;
+  width: -webkit-fill-available;
   height: fit-content;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   justify-content: space-around;
   border-radius: 10px;
-  margin: auto;
+  margin-top: 44px;
   transition: 150ms;
   text-align: center;
-  padding: 20px;
+  padding: 10px 20px;
+  background: #1a1b1c;
+  box-shadow: 0px 4px 6px rgb(0 0 0 / 45%);
+  max-width: 240px;
+  margin: 44px auto;
 }
 
 .dots {
@@ -34,6 +33,11 @@
   line-height: 17px;
   color: #ffffff;
   margin: 4px;
+  cursor: pointer;
+}
+
+.link:hover {
+  color: var(--secondary);
 }
 
 .linkTitle {
@@ -43,21 +47,4 @@
   font-size: 16px;
   line-height: 19px;
   color: var(--primary);
-}
-
-.more .hidden {
-  display: none;
-  cursor: default;
-}
-
-.more.clicked {
-  background: #1a1b1c;
-  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.45);
-}
-
-.more.clicked > .hidden {
-  opacity: 1;
-  display: block;
-
-  cursor: pointer;
 }

--- a/src/screens/Game/GameSubMenu/index.tsx
+++ b/src/screens/Game/GameSubMenu/index.tsx
@@ -18,7 +18,6 @@ const renderer: IpcRenderer = ipcRenderer
 
 interface Props {
   appName: string
-  clicked: boolean
   isInstalled: boolean
   title: string
 }
@@ -26,8 +25,7 @@ interface Props {
 export default function GamesSubmenu({
   appName,
   isInstalled,
-  title,
-  clicked
+  title
 }: Props) {
   const { handleGameStatus, refresh, platform } = useContext(
     ContextProvider
@@ -98,11 +96,11 @@ export default function GamesSubmenu({
   }
 
   return (
-    <div className={`more ${clicked ? 'clicked' : ''}`}>
+    <div className={`more clicked`}>
       {isInstalled && (
         <>
           <Link
-            className="hidden link"
+            className="link"
             to={{
               pathname: isWin
                 ? `/settings/${appName}/other`
@@ -112,24 +110,24 @@ export default function GamesSubmenu({
           >
             {t('submenu.settings')}
           </Link>
-          <span onClick={() => handleRepair(appName)} className="hidden link">
+          <span onClick={() => handleRepair(appName)} className="link">
             {t('submenu.verify')}
           </span>{' '}
-          <span onClick={() => handleMoveInstall()} className="hidden link">
+          <span onClick={() => handleMoveInstall()} className="link">
             {t('submenu.move')}
           </span>{' '}
-          <span onClick={() => handleChangeInstall()} className="hidden link">
+          <span onClick={() => handleChangeInstall()} className="link">
             {t('submenu.change')}
           </span>{' '}
           <span
             onClick={() => renderer.send('getLog', appName)}
-            className="hidden link"
+            className="link"
           >
             {t('submenu.log')}
           </span>
           <span
             onClick={() => ipcRenderer.send('addShortcut', appName)}
-            className="hidden link"
+            className="link"
           >
             {t('submenu.addShortcut', 'Add shortcut')}
           </span>
@@ -137,13 +135,13 @@ export default function GamesSubmenu({
       )}
       <span
         onClick={() => createNewWindow(formatStoreUrl(title, lang))}
-        className="hidden link"
+        className="link"
       >
         {t('submenu.store')}
       </span>
       {!isWin && <span
         onClick={() => createNewWindow(protonDBurl)}
-        className="hidden link"
+        className="link"
       >
         {t('submenu.protondb')}
       </span>}


### PR DESCRIPTION
I got some user feedback about how difficult its sometimes to realise that we have a submenu under the game page. Some people think that that settings button is to open the game settings. so I think its better to keep it always visible from now on.

![image](https://user-images.githubusercontent.com/26871415/123799457-89bfe900-d8e8-11eb-9d3f-3553f311f216.png)

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Created / Updated Tests
- [ ] Created / Updated documentation

Tested on a Clean Install with AppImage:
- [ ] Login
- [ ] Download a Game
- [ ] Import a Game
- [ ] Launch Default config
- [ ] Launch Personalized Config
- [ ] Launch wine
- [ ] Launch Proton
- [ ] Launch Custom Proton
- [ ] Launch Tools (Winetricks and Winecfg)
- [ ] Uninstall Game
- [ ] Move Game
- [ ] Languages (Test if no translation stopped working)
