### PR TITLE
Fix 'The Spectrum Retreat' page not opening due to missing title

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "start": "nf start -p 3000 && electron-start",
     "electron-start": "ELECTRON_IS_DEV=1 node public/start-react",
     "electron": "yarn build-electron && electron .",
-    "react-start": "BROWSER=none react-scripts start",
+    "react-start": "HOST=localhost BROWSER=none react-scripts start",
     "react-start:win": "react-scripts start",
     "build": "react-scripts build",
     "test": "jest",

--- a/src/screens/Game/GamePage/index.tsx
+++ b/src/screens/Game/GamePage/index.tsx
@@ -325,7 +325,7 @@ export default function GamePage(): JSX.Element | null {
                                 {t('specs.recommended').toUpperCase()}
                               </td>
                             </tr>
-                            {extra.reqs.map((e) => (
+                            {extra.reqs.map((e) => e && e.title && (
                               <Fragment key={e.title}>
                                 <tr>
                                   <td>


### PR DESCRIPTION
Fix issue #500 


![image](https://user-images.githubusercontent.com/26871415/124181069-58484880-dab5-11eb-939e-37f7d29c25e1.png)


Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Created / Updated Tests
- [ ] Created / Updated documentation

Tested on a Clean Install with AppImage:
- [ ] Login
- [ ] Download a Game
- [ ] Import a Game
- [ ] Launch Default config
- [ ] Launch Personalized Config
- [ ] Launch wine
- [ ] Launch Proton
- [ ] Launch Custom Proton
- [ ] Launch Tools (Winetricks and Winecfg)
- [ ] Uninstall Game
- [ ] Move Game
- [ ] Languages (Test if no translation stopped working)
