### PR TITLE
Show game Launch Output on terminal

### DIFF
--- a/electron/games.ts
+++ b/electron/games.ts
@@ -20,7 +20,7 @@ abstract class Game {
   abstract import(path : string) : Promise<ExecResult>
   abstract install(path : string) : Promise<ExecResult>
   abstract addDesktopShortcut(): Promise<void>
-  abstract launch() : Promise<ExecResult>
+  abstract launch() : Promise<unknown>
   abstract moveInstall(newInstallPath : string) : Promise<string>
   abstract repair() : Promise<ExecResult>
   abstract state: GameStatus

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -34,7 +34,6 @@ import { LegendaryUser } from './legendary/user';
 import {
   checkCommandVersion,
   checkForUpdates,
-  errorHandler,
   execAsync,
   handleExit,
   isOnline,
@@ -515,32 +514,7 @@ ipcMain.handle('launch', async (event, game: string) => {
     store.set('games.recent', [{appName: game, title: title}])
   }
 
-  return Game.get(game).launch().then(({ stderr }) => {
-    writeFile(
-      `${heroicGamesConfigPath}${game}-lastPlay.log`,
-      stderr,
-      () => 'done'
-    )
-    if (stderr.includes('Errno')) {
-      showErrorBox(
-        i18next.t('box.error', 'Something Went Wrong'),
-        i18next.t(
-          'box.error.launch',
-          'Error when launching the game, check the logs!'
-        )
-      )
-    }
-  }).catch(async (exception) => {
-    // This stuff is completely borken, I have no idea what the hell we should do here.
-    const stderr = `${exception.name} - ${exception.message}`
-    errorHandler({error: {stderr, stdout: ''}})
-    writeFile(
-      `${heroicGamesConfigPath}${game}-lastPlay.log`,
-      stderr,
-      () => 'done'
-    )
-    return stderr
-  })
+  return Game.get(game).launch()
 })
 
 ipcMain.handle('openDialog', async (e, args) => {

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -63,7 +63,6 @@ async function checkForUpdates() {
     )
     const newVersion = tag_name.replace('v', '')
     const currentVersion = app.getVersion()
-    console.log({currentVersion, newVersion});
     return semverGt(newVersion, currentVersion)
   } catch (error) {
     logError('Could not check for new version of heroic')

--- a/src/helpers/library.ts
+++ b/src/helpers/library.ts
@@ -165,14 +165,13 @@ const repair = async (appName: string): Promise<void> =>
 
 const launch = (appName: string, t: TFunction<'gamepage'>, handleGameStatus: (game: GameStatus) => Promise<void>): Promise<void> =>
   ipcRenderer.invoke('launch', appName)
-    .then(async (err: string | string[]) => {
-      if (!err) {
-        return
+    .then(async (msg: string | string[]) => {
+      if (msg === 'finished') {
+        return handleGameStatus({appName, status: 'done'})
       }
-
       if (
-        typeof err === 'string' &&
-      err.includes('ERROR: Game is out of date')
+        typeof msg === 'string' &&
+      msg.includes('ERROR: Game is out of date')
       ) {
         const args = {
           buttons: [t('gamepage:box.yes'), t('box.no')],


### PR DESCRIPTION
This changes the game output to be shown on terminal when launching a game, like Steam and Lutris does, but I"m not sure and still need to test with games that needs updates and also remove related buttons and calls.
----------------------------------

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Created / Updated Tests
- [ ] Created / Updated documentation

Tested on a Clean Install with AppImage:
- [ ] Login
- [ ] Download a Game
- [ ] Import a Game
- [ ] Launch Default config
- [ ] Launch Personalized Config
- [ ] Launch wine
- [ ] Launch Proton
- [ ] Launch Custom Proton
- [ ] Launch Tools (Winetricks and Winecfg)
- [ ] Uninstall Game
- [ ] Move Game
- [ ] Languages (Test if no translation stopped working)
