### PR TITLE
Fix using wrong shell on linux for some commands

### DIFF
--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -415,7 +415,7 @@ Categories=Game;
     }
 
     logInfo('\n syncing saves for ', this.appName)
-    return await execAsync(command)
+    return await execAsync(command, execOptions)
   }
 
   public async launch() {
@@ -477,7 +477,7 @@ Categories=Game;
     if (isWindows) {
       const command = `${legendaryBin} launch ${this.appName} ${runOffline} ${launcherArgs}`
       logInfo('\n Launch Command:', command)
-      const v = await execAsync(command)
+      const v = await execAsync(command, execOptions)
 
       logInfo('Stopping Discord Rich Presence if running...')
       DiscordRPC.disconnect()
@@ -523,7 +523,7 @@ Categories=Game;
     // Proton doesn't create a prefix folder so this is a workaround
     if (isProton && !existsSync(fixedWinePrefix)) {
       const command = `mkdir '${fixedWinePrefix}' -p`
-      await execAsync(command)
+      await execAsync(command, execOptions)
     }
 
     // Install DXVK for non Proton Prefixes
@@ -547,7 +547,7 @@ Categories=Game;
 
     const command = `${envVars} ${runWithGameMode} ${legendaryBin} launch ${this.appName} ${runOffline} ${wineCommand} ${prefix} ${launcherArgs}`
     logInfo('\n Launch Command:', command)
-    const v = await execAsync(command).then((v) => {
+    const v = await execAsync(command, execOptions).then((v) => {
       this.state.status = 'playing'
       mainWindow.show()
       return v

--- a/electron/legendary/library.ts
+++ b/electron/legendary/library.ts
@@ -20,6 +20,7 @@ import {
   isOnline
 } from '../utils';
 import {
+  execOptions,
   installed,
   legendaryBin,
   legendaryConfigPath,
@@ -151,7 +152,7 @@ class LegendaryLibrary {
     }
 
     const command = `${legendaryBin} list-installed --check-updates --tsv`
-    const { stdout } = await execAsync(command)
+    const { stdout } = await execAsync(command, execOptions)
     return stdout
       .split('\n')
       .filter((item) => item.includes('True'))

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,6 +43,7 @@ import {
 } from './utils'
 import {
   discordLink,
+  execOptions,
   getShell,
   heroicGamesConfigPath,
   heroicGithubURL,
@@ -414,7 +415,7 @@ ipcMain.handle('callTool', async (event, { tool, wine, prefix, exe }: Tools) => 
 
   logInfo('trying to run', command)
   try {
-    await execAsync(command)
+    await execAsync(command, execOptions)
   } catch (error) {
     logError(`Something went wrong! Check if ${tool} is available and ${wineBin} exists`)
   }


### PR DESCRIPTION
Another fix to this issue. Last time I forgot a few commands weren't using the `execOptions`.

-------------------------------------------------------------
Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
