### PR TITLE
Avoid paralell downloads for now

### DIFF
--- a/src/components/UI/Header/index.tsx
+++ b/src/components/UI/Header/index.tsx
@@ -36,7 +36,6 @@ export default function Header({
     handleLayout } = useContext(ContextProvider)
 
   const hasDownloads = libraryStatus.filter(
-
     (game) => game.status === 'installing' || game.status === 'updating'
   ).length
   const hasUpdates = gameUpdates.length

--- a/src/helpers/helpers.test.ts
+++ b/src/helpers/helpers.test.ts
@@ -67,7 +67,7 @@ describe('handleInstall', () => {
     await callHandleInstall({ handleGameStatus: onHandleGameStatus, isInstalling: true });
     expect(ipcRenderer.invoke).toBeCalledWith('getGameInfo', 'game');
     expect(ipcRenderer.invoke).toBeCalledWith('kill', 'game');
-    expect(ipcRenderer.send).toBeCalledWith('removeFolder', ['default', 'folder_name']);
+    expect(ipcRenderer.send).toBeCalledWith('removeFolder', ['default/install/path', 'folder_name']);
   })
 
   test('install game on import path', async () => {

--- a/src/helpers/library.ts
+++ b/src/helpers/library.ts
@@ -28,8 +28,10 @@ async function install({appName, installPath, t, progress, isInstalling, handleG
 
   const {folder_name, is_game, is_installed}: GameInfo = await getGameInfo(appName)
   if (isInstalling) {
-    const {defaultInstallPath}: AppSettings = await ipcRenderer.invoke('requestSettings', 'default')
-    installPath = defaultInstallPath
+    if (installPath === 'default') {
+      const { defaultInstallPath }: AppSettings = await ipcRenderer.invoke('requestSettings', 'default')
+      installPath = defaultInstallPath
+    }
     return handleStopInstallation(appName, [installPath, folder_name], t, progress)
   }
 

--- a/src/helpers/library.ts
+++ b/src/helpers/library.ts
@@ -28,6 +28,8 @@ async function install({appName, installPath, t, progress, isInstalling, handleG
 
   const {folder_name, is_game, is_installed}: GameInfo = await getGameInfo(appName)
   if (isInstalling) {
+    const {defaultInstallPath}: AppSettings = await ipcRenderer.invoke('requestSettings', 'default')
+    installPath = defaultInstallPath
     return handleStopInstallation(appName, [installPath, folder_name], t, progress)
   }
 

--- a/src/screens/Game/GamePage/index.tsx
+++ b/src/screens/Game/GamePage/index.tsx
@@ -86,6 +86,9 @@ export default function GamePage(): JSX.Element | null {
   const isUpdating = status === 'updating'
   const isReparing = status === 'repairing'
   const isMoving = status === 'moving'
+  const hasDownloads = Boolean(libraryStatus.filter(
+    (game) => game.status === 'installing' || game.status === 'updating'
+  ).length)
 
   useEffect(() => {
     const updateConfig = async () => {
@@ -291,7 +294,7 @@ export default function GamePage(): JSX.Element | null {
                     <button
                       onClick={() => handleInstall()}
                       disabled={
-                        isPlaying || isUpdating || isReparing || isMoving
+                        isPlaying || isUpdating || isReparing || isMoving || (hasDownloads && !isInstalling)
                       }
                       className={`button ${getButtonClass(is_installed)}`}
                     >

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -80,6 +80,9 @@ const GameCard = ({
     (game) => game.appName === appName
   )[0]
 
+  const hasDownloads = Boolean(libraryStatus.filter(
+    (game) => game.status === 'installing' || game.status === 'updating'
+  ).length)
   const { status } = gameStatus || {}
   const isInstalling = status === 'installing' || status === 'updating'
   const isReparing = status === 'repairing'
@@ -143,7 +146,7 @@ const GameCard = ({
     if (isInstalled && isGame) {
       return <PlayIcon onClick={() => handlePlay()} />
     }
-    if (!isInstalled) {
+    if (!isInstalled && !hasDownloads) {
       return <DownIcon onClick={() => handlePlay()} />
     }
     return null
@@ -250,9 +253,11 @@ const GameCard = ({
       await handleGameStatus({ appName, status: 'done' })
       return sendKill(appName)
     }
-
-    await handleGameStatus({ appName, status: 'playing' })
-    return await launch(appName, t, handleGameStatus)
+    if (isInstalled) {
+      await handleGameStatus({ appName, status: 'playing' })
+      return await launch(appName, t, handleGameStatus)
+    }
+    return
   }
 }
 


### PR DESCRIPTION
Since legendary its not supporting the feature, until we develop a Queue, Heroic won't allow starting a new download until the other has finished.


-------------------------------------------------------------
Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
