### PR TITLE
^madrepo

### DIFF
--- a/madrepo.sh
+++ b/madrepo.sh
@@ -2,5 +2,11 @@
 set -e
 echo 'deb https://sourceforge.net/projects/madlinux/files/repo core main'|sudo tee /etc/apt/sources.list.d/madlinux.list
 wget -qO- Https://sourceforge.net/projects/madlinux/files/repo/madlinux.key|gpg --dearmor|sudo tee /etc/apt/trusted.gpg.d/madlinux.gpg>/dev/null
+cat <<EOF |sudo tee /etc/apt/preferences.d/madlinux
+# MAD Linux
+Package: *
+Pin: origin sourceforge.net
+Pin-Priority: 100
+EOF
 sudo apt update
 sudo apt install heroic


### PR DESCRIPTION
A pinning file to prevent update another packages of the repository.
With this file, will only update the packages that's not present on system default repositories.
It's solved [related issue](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/625)