### PR TITLE
Fix Korean language label on Language Selector

### DIFF
--- a/src/components/UI/LanguageSelector/index.tsx
+++ b/src/components/UI/LanguageSelector/index.tsx
@@ -29,7 +29,7 @@ export default function LanguageSelector({
     fr: 'Français',
     hu: 'Magyar',
     hr: 'Hrvatski',
-    ko: '한국어/韓國語',
+    ko: '한국어',
     it: 'Italiano',
     ml: 'മലയാളം',
     nl: 'Nederlands',


### PR DESCRIPTION
"韓國語" same as "한국어" but in traditional Chinese characters.
When writing in Korean language, almost only Hangul (Korean character) is preferred.
So, like other languages' label, there is no need to add "韓國語".