### PR TITLE
[fix: issue-603] adjust library game card background coverage

### DIFF
--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -182,7 +182,7 @@ const GameCard = ({
                 backgroundImage: `url('${
                   grid ? cover : coverList
                 }?h=400&resize=1&w=300')`,
-                backgroundSize: 'cover',
+                backgroundSize: '100% 100%',
                 filter: isInstalled ? 'none' : `grayscale(${effectPercent})`
               }}
               className={grid ? 'gameImg' : 'gameImgList'}


### PR DESCRIPTION
Some game card background images are zoomed in too much / skewed.

issue: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/603

As recommended per the linked issue by @LukeVader-IV , stretching the images instead of setting the images to cover, fixes this.

A few examples:

`background-size: cover`
![Horace-cover](https://user-images.githubusercontent.com/14855999/133173709-97bd420a-7185-40e7-83e1-8c4b8ddbdb4e.png)

`background-size: 100% 100%`
![horace-stretch](https://user-images.githubusercontent.com/14855999/133173710-2c08827a-0949-4acf-a2fd-55059d792641.png)

`background-size: cover`
![cave-story-cover](https://user-images.githubusercontent.com/14855999/133173801-6738bfe7-7cc4-412f-a8f4-9a901a220636.png)

`background-size: 100% 100%`
![cave-story-stretch png](https://user-images.githubusercontent.com/14855999/133173820-bafad6ae-debf-4fae-8654-cc3a7bcdcda5.png)


-------------------------------------------------------------
Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
