### PR TITLE
Display EGS free products popup on startup

### DIFF
--- a/electron/config.ts
+++ b/electron/config.ts
@@ -329,6 +329,7 @@ class GlobalConfigV0 extends GlobalConfig {
       checkForUpdatesOnStartup: true,
       customWinePaths: isWindows ? null : [],
       defaultInstallPath: heroicInstallPath,
+      displayFreeProductsOnStartup: true,
       language: 'en',
       maxWorkers: 0,
       nvidiaPrime: false,

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -38,6 +38,7 @@ const supportURL =
   'https://github.com/flavioislima/HeroicGamesLauncher/blob/main/Support.md'
 const discordLink = 'https://discord.gg/rHJ2uqdquK'
 const weblateUrl = 'https://hosted.weblate.org/projects/heroic-games-launcher'
+const epicStoreURL = 'https://www.epicgames.com/store/'
 
 /**
  * Get shell for different os
@@ -105,5 +106,6 @@ export {
   sidInfoUrl,
   supportURL,
   userInfo,
-  weblateUrl
+  weblateUrl,
+  epicStoreURL
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -56,7 +56,8 @@ import {
   loginUrl,
   sidInfoUrl,
   supportURL,
-  weblateUrl
+  weblateUrl,
+  epicStoreURL
 } from './constants'
 import { handleProtocol } from './protocol'
 import { listenStdout } from './logger'
@@ -386,6 +387,13 @@ ipcMain.on('openLoginPage', () => openUrlOrFile(loginUrl))
 ipcMain.on('openDiscordLink', () => openUrlOrFile(discordLink))
 ipcMain.on('openSidInfoPage', () => openUrlOrFile(sidInfoUrl))
 ipcMain.on('updateHeroic', () => checkUpdates())
+ipcMain.on('openEGSFreeProducts', () => {
+  const { displayFreeProductsOnStartup, language } = GlobalConfig.get().config
+  if (displayFreeProductsOnStartup) {
+    const freeProductsUrl = `${epicStoreURL}${language}/free-games`
+    new BrowserWindow({ height: 700, width: 1200 }).loadURL(freeProductsUrl)
+  }
+})
 
 ipcMain.on('getLog', (event, appName) =>
   openUrlOrFile(`${heroicGamesConfigPath}${appName}-lastPlay.log`)

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -16,6 +16,7 @@ export interface AppSettings {
   darkTrayIcon: boolean
   defaultInstallPath: string
   discordRPC: boolean
+  displayFreeProductsOnStartup: boolean
   egsLinkedPath: string
   exitToTray: boolean
   enableEsync: boolean

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Emprar la icona fosca al Tray",
         "default-install-path": "Ruta d'instal·lació predeterminada",
         "discordRPC": "Activa la Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Sincronitza amb Epic Games",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Použít tmavou ikonu v systémové oblasti",
         "default-install-path": "Výchozí cesta pro instalaci",
         "discordRPC": "Povolit Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Synchronizovat s instalovaným Epic Games Store",
         "enableFSRHack": "Povolte FSR Hack (verze Wine jej musí podporovat)",
         "esync": "Enable Esync",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Benutze Dunkles Taskleisten-Icon",
         "default-install-path": "Standard-Installationspfad",
         "discordRPC": "Discord Rich Presence aktivieren",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Mit installiertem Epic Games synchronisieren",
         "enableFSRHack": "FSR Hack aktivieren (Wine-Version muss es unterstützen)",
         "esync": "Enable Esync",

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Χρήση σκοτεινού εικονιδίου",
         "default-install-path": "Προεπιλεγμένη Διαδρομή Εγκατάστασης",
         "discordRPC": "Ενεργοποίηση Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Συγχρονισμός με εγκατεστημένο Epic Games",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Use Dark Tray Icon",
         "default-install-path": "Default Installation Path",
         "discordRPC": "Enable Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Sync with Installed Epic Games",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Utilice el icono de bandeja oscura",
         "default-install-path": "Ruta de instalación predeterminada",
         "discordRPC": "Enable Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Sincronizar con juegos EGS",
         "enableFSRHack": "Habilitar el hack FSR (La versión de Wine debe soportarlo)",
         "esync": "Enable Esync",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Utiliser Dark Tray Icon",
         "default-install-path": "Chemin par défaut de l'installation",
         "discordRPC": "Activer Rich Presence dans Discord",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Synchroniser avec l'installation d'Epic Games",
         "enableFSRHack": "Activer FSR Hack (la version de wine doit le prendre en charge)",
         "esync": "Enable Esync",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Koristi tamnu ikonu",
         "default-install-path": "Zadani put instalacije",
         "discordRPC": "Omogući Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Sinkroniziraj sa instaliranim Epic Games",
         "enableFSRHack": "Omogući FSR Hack (Wine potreban za koristiti)",
         "esync": "Enable Esync",

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Sötét Tálca Ikon Használata",
         "default-install-path": "Alapértelmezett Telepítési Útvonal",
         "discordRPC": "Discord Rich Presence Engedélyezése",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Szinkronizálás a Telepített Epic Games-el",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Usa l'icona scura della barra delle applicazioni",
         "default-install-path": "Percorso d'installazione predefinito",
         "discordRPC": "Attiva \"Discord Rich Presence\"",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Sincronizza con l'Epic Games già installato",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -145,6 +145,7 @@
         "darktray": "다크 트레이 아이콘 사용",
         "default-install-path": "기본 설치 경로",
         "discordRPC": "Discord Rich Presence 활성화",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "설치된 Epic Games와 동기화",
         "enableFSRHack": "FSR 활성화 (지원하는 Wine 버전을 사용해야 합니다)",
         "esync": "Enable Esync",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -145,6 +145,7 @@
         "darktray": "താലത്തില്‍(ട്രേയില്‍) ഇരുണ്ട ചിത്രം ഉപയോഗിക്കുക",
         "default-install-path": "തനത് സ്ഥാപനയിടം",
         "discordRPC": "ഡിസ്കോര്‍ഡ് റിച്ച് പ്രെസന്‍സ് വക്കൂ",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "സ്ഥാപിച്ച എപിക് ഗെയിംസുമായി ഒന്നിപ്പിക്കുക",
         "enableFSRHack": "എഫ്എസ്ആര്‍ ഹാക്ക് വയ്ക്കൂ (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Gebruik donker tray icoon",
         "default-install-path": "Standaard installatie pad",
         "discordRPC": "\"Discord Rich Presence\" inschakelen",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Synchronisatie met geïnstalleerde Epic Games",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Użyj ciemnego motywu ikony",
         "default-install-path": "Domyślna ścieżka instalacyjna",
         "discordRPC": "Włącz Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Synchronizuj zapisy gier z Epic Games Store",
         "enableFSRHack": "Włącz FSR Hack (Wersja Wine musi to wspierać)",
         "esync": "Enable Esync",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Usar ícone escuro",
         "default-install-path": "Pasta de instalação padrão",
         "discordRPC": "Habilitar Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Sincronizar com Epic Games Store",
         "enableFSRHack": "Habilitar Hack FSR (Wine precisa supportar a feature)",
         "esync": "Enable Esync",

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Usar o ícone escuro na barra de tarefas",
         "default-install-path": "Local de instalação padrão",
         "discordRPC": "Habilitar o Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Sincronizar com a Epic Games Store",
         "enableFSRHack": "Habilitar Hack FSR (Wine precisa supportar a feature)",
         "esync": "Enable Esync",

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Использовать темную иконку в трее",
         "default-install-path": "Стандартный путь установки",
         "discordRPC": "Enable Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Синхронизировать с установленнными играми EGS",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Använd mörk ikon i systembrickan",
         "default-install-path": "Standard installationssökväg",
         "discordRPC": "Aktivera Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Synkronisera med installerade Epic spel",
         "enableFSRHack": "Aktivera FSR Hack (Wine versionen behöver stöd för det)",
         "esync": "Enable Esync",

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -145,6 +145,7 @@
         "darktray": "கணினி தட்டில் இருண்ட சின்னத்தை பயன்படுத்து",
         "default-install-path": "இயல்புநிலை நிறுவல் பாதை",
         "discordRPC": "Enable Discord Rich Presence",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "நிறுவப்பட்ட எபிக் விளையாட்டுகளுடன் ஒத்திசை",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -145,6 +145,7 @@
         "darktray": "Karanlık Tepsi İkonu Kullan",
         "default-install-path": "Varsayılan Kurulum Yeri",
         "discordRPC": "Discord Rich Presence'i Etkinleştir",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "Kurulu Epic Games ile Eşzamanla",
         "enableFSRHack": "FSR Hack'i Etkinleştir (Wine sürümünün desteklemesi gerekiyor)",
         "esync": "Enable Esync",

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -145,6 +145,7 @@
         "darktray": "使用暗色托盘图标",
         "default-install-path": "默认安装路径",
         "discordRPC": "启用Discord的Rich Presence（活动状态）",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "与已安装的Epic Games同步",
         "enableFSRHack": "启用FSR（需要支持的WINE版本）",
         "esync": "Enable Esync",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -145,6 +145,7 @@
         "darktray": "使用暗色系統列圖示",
         "default-install-path": "預設安裝路徑",
         "discordRPC": "啟用Discord的Rich Presence（活動狀態）",
+        "displayFreeProductsOnStartup": "Display EGS Free Games Popup On Startup",
         "egs-sync": "與已安裝的Epic Games同步",
         "enableFSRHack": "啟用FSR（需要支持的WINE版本）",
         "esync": "Enable Esync",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
-import React, { lazy, useContext } from 'react'
+import React, { lazy, useContext, useEffect } from 'react'
 
 import './App.css'
 import { HashRouter, Route, Switch } from 'react-router-dom'
 import { Library } from './screens/Library'
+import { openFreeProductsPage } from 'src/helpers';
 import ContextProvider from './state/ContextProvider'
 import ElectronStore from 'electron-store'
 import Login from './screens/Login'
@@ -21,6 +22,9 @@ function App() {
   const context = useContext(ContextProvider)
   const user = configStore.get('userInfo')
   const { data: library, refresh } = context
+  useEffect(() => {
+    openFreeProductsPage();
+  }, []);
 
   if (!user) {
     return <Login refresh={refresh} />

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -29,6 +29,8 @@ const openAboutWindow = (): void => ipcRenderer.send('showAboutWindow')
 
 const openDiscordLink = (): void => ipcRenderer.send('openDiscordLink')
 
+const openFreeProductsPage = (): void => ipcRenderer.send('openEGSFreeProducts')
+
 let progress: string
 
 const sendKill = (appName: string): Promise<void> => ipcRenderer.invoke('kill', appName)
@@ -230,6 +232,7 @@ export {
   notify,
   openAboutWindow,
   openDiscordLink,
+  openFreeProductsPage,
   progress,
   repair,
   sendKill,

--- a/src/screens/Settings/components/GeneralSettings/index.test.tsx
+++ b/src/screens/Settings/components/GeneralSettings/index.test.tsx
@@ -15,6 +15,7 @@ interface Props {
   checkForUpdatesOnStartup: boolean,
   darkTrayIcon: boolean,
   defaultInstallPath: string,
+  displayFreeProductsOnStartup: boolean,
   egsLinkedPath: string,
   egsPath: string,
   exitToTray: boolean,
@@ -28,6 +29,7 @@ interface Props {
   startInTray: boolean,
   toggleCheckUpdatesOnStartup: () => void,
   toggleDarkTrayIcon: () => void,
+  toggleDisplayFreeProductsOnStartup: () => void,
   toggleStartInTray: () => void,
   toggleTray: () => void
   }
@@ -38,6 +40,7 @@ async function renderGeneralSettings(props: Partial<Props> = {})
     checkForUpdatesOnStartup: true,
     darkTrayIcon: false,
     defaultInstallPath: 'default/install/path',
+    displayFreeProductsOnStartup: true,
     egsLinkedPath: 'egs/linked/path',
     egsPath: 'egs/path',
     exitToTray: false,
@@ -51,6 +54,7 @@ async function renderGeneralSettings(props: Partial<Props> = {})
     startInTray: false,
     toggleCheckUpdatesOnStartup: () => {return},
     toggleDarkTrayIcon: () => {return;},
+    toggleDisplayFreeProductsOnStartup: () => {return;},
     toggleStartInTray: () => {return;},
     toggleTray: () => {return;}
   };
@@ -245,6 +249,14 @@ describe('GeneralSettings', () => {
   test('start minimized is shown when exitToTray is true', async () => {
     const { getByTestId } = await renderGeneralSettings({ exitToTray: true });
     expect(()=>getByTestId('startInTray')).not.toThrow()
+  })
+
+  test('toggle display free products invokes correct function', async () => {
+    const toggleDisplayFreeProductsOnStartup = jest.fn();
+    const { getByTestId } = await renderGeneralSettings({toggleDisplayFreeProductsOnStartup: toggleDisplayFreeProductsOnStartup});
+    const toggleSwitch = getByTestId('toggleDisplayFreeProducts');
+    fireEvent.click(toggleSwitch);
+    await waitFor(() => expect(toggleDisplayFreeProductsOnStartup).toHaveBeenCalledTimes(1));
   })
 
 })

--- a/src/screens/Settings/components/GeneralSettings/index.tsx
+++ b/src/screens/Settings/components/GeneralSettings/index.tsx
@@ -25,6 +25,7 @@ interface Props {
   checkForUpdatesOnStartup: boolean,
   darkTrayIcon: boolean,
   defaultInstallPath: string,
+  displayFreeProductsOnStartup: boolean,
   egsLinkedPath: string,
   egsPath: string,
   exitToTray: boolean,
@@ -38,7 +39,8 @@ interface Props {
   startInTray: boolean,
   toggleDarkTrayIcon: () => void,
   toggleStartInTray: () => void,
-  toggleCheckUpdatesOnStartup: () => void
+  toggleCheckUpdatesOnStartup: () => void,
+  toggleDisplayFreeProductsOnStartup: () => void,
   toggleTray: () => void
 }
 
@@ -60,7 +62,9 @@ export default function GeneralSettings({
   setMaxWorkers,
   darkTrayIcon,
   toggleDarkTrayIcon,
-  toggleCheckUpdatesOnStartup
+  toggleCheckUpdatesOnStartup,
+  displayFreeProductsOnStartup,
+  toggleDisplayFreeProductsOnStartup
 }: Props) {
   const [isSyncing, setIsSyncing] = useState(false)
   const [maxCpus, setMaxCpus] = useState(maxWorkers)
@@ -271,6 +275,16 @@ export default function GeneralSettings({
           <ToggleSwitch
             value={checkForUpdatesOnStartup}
             handleChange={toggleCheckUpdatesOnStartup}
+          />
+        </span>
+      </span>
+      <span className="setting">
+        <span className="toggleWrapper">
+          {t('setting.displayFreeProductsOnStartup', 'Display EGS Free Games Popup On Startup')}
+          <ToggleSwitch
+            value={displayFreeProductsOnStartup}
+            handleChange={toggleDisplayFreeProductsOnStartup}
+            dataTestId='toggleDisplayFreeProducts'
           />
         </span>
       </span>

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -160,7 +160,11 @@ function Settings() {
     toggle: toggleFsync,
     setOn: setEnableFsync
   } = useToggle(false)
-
+  const {
+    on: displayFreeProductsOnStartup,
+    toggle: toggleDisplayFreeProductsOnStartup,
+    setOn: setdisplayFreeProductsOnStartup
+  } = useToggle(true)
 
   const [haveCloudSaving, setHaveCloudSaving] = useState({
     cloudSaveEnabled: false,
@@ -213,7 +217,8 @@ function Settings() {
       setAddDesktopShortcuts(config.addDesktopShortcuts || false)
       setAddGamesToStartMenu(config.addStartMenuShortcuts || false)
       setCustomWinePaths(config.customWinePaths || [])
-      setCheckForUpdatesOnStartup(config.checkForUpdatesOnStartup || true)
+      setCheckForUpdatesOnStartup(config.checkForUpdatesOnStartup || false)
+      setdisplayFreeProductsOnStartup(config.displayFreeProductsOnStartup || false)
 
       if (!isDefault) {
         const {
@@ -243,6 +248,7 @@ function Settings() {
     darkTrayIcon,
     defaultInstallPath,
     discordRPC,
+    displayFreeProductsOnStartup,
     egsLinkedPath,
     enableEsync,
     enableFsync,
@@ -344,6 +350,8 @@ function Settings() {
               darkTrayIcon={darkTrayIcon}
               toggleCheckUpdatesOnStartup={toggleCheckForUpdatesOnStartup}
               checkForUpdatesOnStartup={checkForUpdatesOnStartup}
+              displayFreeProductsOnStartup={displayFreeProductsOnStartup}
+              toggleDisplayFreeProductsOnStartup={toggleDisplayFreeProductsOnStartup}
             />
           )}
           {isWineSettings && (

--- a/src/test_helpers/mock/electron.ts
+++ b/src/test_helpers/mock/electron.ts
@@ -55,7 +55,8 @@ export function initElectronMocks()
       {response: test_openmessagebox_response.get()})
     .calledWith(stringAtIndex(0, 'syncSaves')).mockResolvedValue('success')
     .calledWith(stringAtIndex(0, 'writeConfig')).mockResolvedValue({})
-    .calledWith(stringAtIndex(0, 'callTool')).mockResolvedValue({});
+    .calledWith(stringAtIndex(0, 'callTool')).mockResolvedValue({})
+    .calledWith('openEGSFreeProducts').mockResolvedValue({});
 
   // setup mocks for ipcRenderer.removeAllListeners
   when(ipcRenderer.removeAllListeners).calledWith('requestSettings').mockResolvedValue({});

--- a/src/test_helpers/testTypes.ts
+++ b/src/test_helpers/testTypes.ts
@@ -200,6 +200,7 @@ const test_appsettings = new TestType<AppSettings>({
   darkTrayIcon: false,
   defaultInstallPath: 'default/install/path',
   discordRPC: true,
+  displayFreeProductsOnStartup: true,
   egsLinkedPath: 'egs/linked/path',
   exitToTray: false,
   enableEsync: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface AppSettings {
   darkTrayIcon: boolean
   defaultInstallPath: string
   discordRPC: boolean
+  displayFreeProductsOnStartup: boolean
   egsLinkedPath: string
   exitToTray: boolean
   enableEsync: boolean


### PR DESCRIPTION
# Display EGS free products on startup
issue: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/305

Added feature to open new window to (regionally correct) Epic Game's free games of the week page.

New window is a popup handled exactly the same as the store link. 

```
    new BrowserWindow({ height: 700, width: 1200 }).loadURL(freeProductsUrl)
```

The IPC render action occurs once at start up, and is triggered in `App.tsx`

This new feature is toggle-able with a new General Setting ToggleSwitch which defaults to ON.

![freetoggle](https://user-images.githubusercontent.com/14855999/133496991-163f958b-a555-4c9a-aeaa-52611b402275.png)


![freegamespopup](https://user-images.githubusercontent.com/14855999/133495762-90554f83-4c5b-4f7e-81b2-fca1770b80cf.png)

### Bug Fix 
There was also a bug I noticed regarding the behavior of `setCheckForUpdatesOnStartup` toggle.
Even when checked into the `OFF` position using the toggle, the setting always reverted back to `ON` by itself.
This was because the following line would always resolve to true.
```
setCheckForUpdatesOnStartup(config.checkForUpdatesOnStartup || true)
```
I have replaced the `true` with `false`

My assumption is this was done to have the default value be `true`.

But this seems to be accomplished [here](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/main/electron/config.ts#L329)

-------------------------------------------------------------
Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
