### PR TITLE
Define a simple container for development, add instructions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/docker-existing-dockerfile
+{
+	"name": "Heroic Games Launcher",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	"postCreateCommand": "pacman -Syyu --noconfirm && pacman -S nodejs npm yarn --noconfirm",
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,3 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/docker-existing-dockerfile
 {
 	"name": "Heroic Games Launcher",
 
@@ -9,12 +7,8 @@
 	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
 	"dockerFile": "../Dockerfile",
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-	
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [],
 
-	// Uncomment the next line to run commands after the container is created - for example installing curl.
 	"postCreateCommand": "pacman -Syyu --noconfirm && pacman -S nodejs npm yarn --noconfirm",
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM archlinux:latest
+
+RUN pacman -Syyu --noconfirm && pacman -S nodejs npm yarn --noconfirm 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,46 @@ Heroic is built with Web Technologies like: TypeScript, React, NodeJS and Electr
 2. Download the dependencies with `yarn`
 3. Open the tasks. Select "Build with [your OS]"
 
+### Development Using a Container
+
+If you would prefer, we have a docker container defined to develop / build Heroic with (a potential reason being to avoid loading tons of dependencies on your host filesystem). There are two methods, based on whether you use VS Code.
+
+**VS Code**
+
+There is a `.devcontainer` directory containing a definition that VS Code will recognize for automatically opening your local Heroic directory in a container in VS Code. 
+
+**NOTE: this requires that you install the 'Remote - Containers' extension.**
+
+1. Open the root of your local Heroic directory in VS Code.
+2. You should get a prompt in the bottom right to build and open the project in the dev container.
+3. If the above prompt does not occur, on the bottom left, there is a green icon that should be there if the remote extension is installed. Click on it, and select "Reopen in container".
+4. The bottom left green icon should now say: "Dev Container: Heroic Games Launcher".
+
+After the container's package manager runs, open a new terminal session and you should be able to run bash commands from within the container. Any yarn dist builds should also now show up on your host filesystem.
+
+**Manually Building the Docker Image**
+
+If you don't use VS Code or don't want it integrated with the container, you can build and run the container manually using either Docker or Podman.
+
+1. From the root of your local Heroic directory, run:
+```
+docker build -t heroicdevcontainer -f Dockerfile .
+```
+
+2. Assuming all went well, you can now enter the container: 
+
+```
+docker run -it -v ./:/tmp/heroic localhost/heroicdevcontainer:latest
+```
+
+3. The above command will mount your local Heroic dir to `/tmp/heroic` in the container (unless you used a different path). 
+
+```
+cd /tmp/heoric
+```
+
+And you should be good to go, code and build away!
+
 ### Linux
 
 #### Debian, Ubuntu and Derivatives


### PR DESCRIPTION
This PR defines a simple container image for Heroic development. (Not specific to Heroic, and anyone can set this up on their own, but it's a nice default to have in my opinion for a project). 

Also adds instructions in the README for setting this up using VS Code's `devcontainer` integration, or running the Docker container manually. 

Let me know if there are any questions / concerns, also happy to change the base image from arch, but figured it would help guarantee the newest-ish versions. 