### PR TITLE
Get the desktop folder from the system instead of hardcoding '/Desktop'

### DIFF
--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -1,5 +1,4 @@
 import { GlobalConfig } from './config'
-import { app } from 'electron'
 import {
   homedir,
   platform
@@ -20,7 +19,6 @@ const isMac = platform() === 'darwin'
 const isWindows = platform() === 'win32'
 const currentGameConfigVersion : GameConfigVersion = 'v0'
 const currentGlobalConfigVersion : GlobalConfigVersion = 'v0'
-const desktopFolder = app.getPath('desktop')
 const home = homedir()
 const legendaryConfigPath = `${home}/.config/legendary`
 const heroicFolder = `${home}/.config/heroic/`
@@ -89,7 +87,6 @@ const execOptions = {
 export {
   currentGameConfigVersion,
   currentGlobalConfigVersion,
-  desktopFolder,
   discordLink,
   execOptions,
   fixAsarPath,

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -1,5 +1,5 @@
-import { execSync } from 'child_process'
 import { GlobalConfig } from './config'
+import { app } from 'electron'
 import {
   homedir,
   platform
@@ -16,24 +16,11 @@ function getLegendaryBin(){
   return bin
 }
 
-// Get the "Desktop" directory with multilingual support, fallback to "~/Desktop"
-function getDesktopPath() {
-  if (platform() === 'linux') {
-    try {
-      return execSync('xdg-user-dir DESKTOP').toString().trim()
-    } catch {
-      return `${homedir()}/Desktop`
-    }
-  } else {
-    return `${homedir()}/Desktop`
-  }
-}
-
 const isMac = platform() === 'darwin'
 const isWindows = platform() === 'win32'
 const currentGameConfigVersion : GameConfigVersion = 'v0'
 const currentGlobalConfigVersion : GlobalConfigVersion = 'v0'
-const desktopFolder = getDesktopPath()
+const desktopFolder = app.getPath('desktop')
 const home = homedir()
 const legendaryConfigPath = `${home}/.config/legendary`
 const heroicFolder = `${home}/.config/heroic/`

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process'
 import { GlobalConfig } from './config'
 import {
   homedir,
@@ -15,10 +16,24 @@ function getLegendaryBin(){
   return bin
 }
 
+// Get the "Desktop" directory with multilingual support, fallback to "~/Desktop"
+function getDesktopPath() {
+  if (platform() === 'linux') {
+    try {
+      return execSync('xdg-user-dir DESKTOP').toString().trim()
+    } catch {
+      return `${homedir()}/Desktop`
+    }
+  } else {
+    return `${homedir()}/Desktop`
+  }
+}
+
 const isMac = platform() === 'darwin'
 const isWindows = platform() === 'win32'
 const currentGameConfigVersion : GameConfigVersion = 'v0'
 const currentGlobalConfigVersion : GlobalConfigVersion = 'v0'
+const desktopFolder = getDesktopPath()
 const home = homedir()
 const legendaryConfigPath = `${home}/.config/legendary`
 const heroicFolder = `${home}/.config/heroic/`
@@ -87,6 +102,7 @@ const execOptions = {
 export {
   currentGameConfigVersion,
   currentGlobalConfigVersion,
+  desktopFolder,
   discordLink,
   execOptions,
   fixAsarPath,

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -6,7 +6,7 @@ import {
 } from 'graceful-fs'
 import axios from 'axios';
 
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, app } from 'electron';
 import { DXVK } from '../dxvk'
 import { ExtraInfo, GameStatus, InstallArgs } from '../types';
 import { Game } from '../games';
@@ -21,7 +21,6 @@ import {
 } from '../utils'
 import {
   execOptions,
-  desktopFolder,
   heroicGamesConfigPath,
   heroicIconFolder,
   home,
@@ -256,7 +255,7 @@ class LegendaryGame extends Game {
       return
     }
     const gameInfo = await this.getGameInfo()
-    const desktopFile = `${desktopFolder}/${gameInfo.title}.desktop`
+    const desktopFile = `${app.getPath('desktop')}/${gameInfo.title}.desktop`
     const applicationsFolder = `${home}/.local/share/applications/${gameInfo.title}.desktop`
     let shortcut;
     const icon = await this.getIcon(gameInfo.app_name)
@@ -303,7 +302,7 @@ Categories=Game;
       return
     }
     const gameInfo = await this.getGameInfo()
-    const desktopFile = `${desktopFolder}/${gameInfo.title}.desktop`
+    const desktopFile = `${app.getPath('desktop')}/${gameInfo.title}.desktop`
     const applicationsFile = `${home}/.local/share/applications/${gameInfo.title}.desktop`
     unlink(desktopFile, () => logInfo('Desktop shortcut removed'))
     unlink(applicationsFile, () => logInfo('Applications shortcut removed'))

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -21,6 +21,7 @@ import {
 } from '../utils'
 import {
   execOptions,
+  desktopFolder,
   heroicGamesConfigPath,
   heroicIconFolder,
   home,
@@ -255,7 +256,7 @@ class LegendaryGame extends Game {
       return
     }
     const gameInfo = await this.getGameInfo()
-    const desktopFolder = `${home}/Desktop/${gameInfo.title}.desktop`
+    const desktopFile = `${desktopFolder}/${gameInfo.title}.desktop`
     const applicationsFolder = `${home}/.local/share/applications/${gameInfo.title}.desktop`
     let shortcut;
     const icon = await this.getIcon(gameInfo.app_name)
@@ -280,8 +281,8 @@ Categories=Game;
     const { addDesktopShortcuts, addStartMenuShortcuts } = await GlobalConfig.get().getSettings()
 
     if (addDesktopShortcuts || fromMenu) {
-      writeFile(desktopFolder, shortcut, () => {
-        logInfo('Shortcut saved on ' + desktopFolder)
+      writeFile(desktopFile, shortcut, () => {
+        logInfo('Shortcut saved on ' + desktopFile)
       })
     }
     if (addStartMenuShortcuts || fromMenu) {
@@ -302,7 +303,7 @@ Categories=Game;
       return
     }
     const gameInfo = await this.getGameInfo()
-    const desktopFile = `${home}/Desktop/${gameInfo.title}.desktop`
+    const desktopFile = `${desktopFolder}/${gameInfo.title}.desktop`
     const applicationsFile = `${home}/.local/share/applications/${gameInfo.title}.desktop`
     unlink(desktopFile, () => logInfo('Desktop shortcut removed'))
     unlink(applicationsFile, () => logInfo('Applications shortcut removed'))


### PR DESCRIPTION
Use `xdg-user-dir DESKTOP` on linux systems to get the correct Desktop folder path that depends on the system language.

My system is in spanish, so my `Desktop` folder is actually `Escritorio`, using the `xdg-user-dir` command returns the full path to that directory.

This is only implemented for linux since adding shortcuts to desktop is only implemented on linux.

Closes #721

I couldn't add a test since I would have to stub the system command somehow which feels too hacky, but I accept any suggestion on how to add a test for this fix!

-------------------------------------------------------------
Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
