### PR TITLE
Support adding desktop and start menu shortcuts on windows

### DIFF
--- a/src/screens/Game/GameSubMenu/index.tsx
+++ b/src/screens/Game/GameSubMenu/index.tsx
@@ -38,7 +38,7 @@ export default function GamesSubmenu({
     ContextProvider
   )
   const isWin = platform === 'win32'
-  const isLinux = platform === 'linux'
+  const isMac = platform === 'darwin'
   const [info, setInfo] = useState({prefix: '', wine: ''} as otherInfo)
 
   const { t, i18n } = useTranslation('gamepage')
@@ -163,7 +163,7 @@ export default function GamesSubmenu({
             >
               {t('submenu.log')}
             </span>
-            {isLinux && <span
+            {!isMac && <span
               onClick={() => handleShortcuts()}
               className="link"
             >


### PR DESCRIPTION
<--- Put the description here --->

This PR implements the functionality of adding shortcut icons on Windows when the user clicks the `Add shortcut` action in the game page.

It also implements removing the shortcuts when the game is uninstalled.

I tried to make the `Add desktop shortcuts automatically` and `Add games to start menu automatically` settings work but there's some issue on Windows with the install callback that is not fired properly and it was getting too complicated to do both things on 1 PR so I decided to leave that for another moment.

I'm not really sure how to add tests for this since it's too tied to the system.

Closes #724 

-------------------------------------------------------------
Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
