### PR TITLE
Enable shortcuts config on windows and refactor

### DIFF
--- a/electron/games.ts
+++ b/electron/games.ts
@@ -20,7 +20,7 @@ abstract class Game {
   abstract hasUpdate() : Promise<boolean>
   abstract import(path : string) : Promise<ExecResult>
   abstract install(args: InstallArgs) : Promise<{status: string}>
-  abstract addDesktopShortcut(): Promise<void>
+  abstract addShortcuts(): Promise<void>
   abstract launch(launchArguments?: string) : Promise<ExecResult>
   abstract moveInstall(newInstallPath : string) : Promise<string>
   abstract repair() : Promise<ExecResult>

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -268,7 +268,7 @@ class LegendaryGame extends Game {
   /**
    * Adds a desktop shortcut to $HOME/Desktop and to /usr/share/applications
    * so that the game can be opened from the start menu and the desktop folder.
-   * Both can be disabled with enableDesktopShortcutsOnDesktop and enableDesktopShortcutsOnStartMenu
+   * Both can be disabled with addDesktopShortcuts and addStartMenuShortcuts
    * @async
    * @public
    */
@@ -374,7 +374,6 @@ Categories=Game;
           errorHandler({error: {stdout, stderr}, logPath})
           return {status: 'error'}
         }
-        this.addDesktopShortcut()
         return {status: 'done'}
       })
   }
@@ -387,7 +386,6 @@ Categories=Game;
     LegendaryLibrary.get().installState(this.appName, false)
     return await execAsync(command, execOptions).then((v) => {
       this.state.status = 'done'
-      this.removeDesktopShortcut()
       return v
     })
   }

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -272,7 +272,7 @@ class LegendaryGame extends Game {
    * @async
    * @public
    */
-  public async addDesktopShortcut(fromMenu?: boolean) {
+  public async addShortcuts(fromMenu?: boolean) {
     if (process.platform === 'darwin') {
       return
     }
@@ -333,7 +333,7 @@ Categories=Game;
    * @async
    * @public
    */
-  public async removeDesktopShortcut() {
+  public async removeShortcuts() {
     const gameInfo = await this.getGameInfo()
     const [ desktopFile, menuFile ] = this.shortcutFiles(gameInfo.title)
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -682,9 +682,13 @@ ipcMain.handle('openDialog', async (e, args) => {
   return { canceled }
 })
 
-ipcMain.handle('openMessageBox', async (e, args) => {
+const openMessageBox = async (args: Electron.MessageBoxOptions) => {
   const { response } = await showMessageBox({ ...args })
   return { response }
+}
+
+ipcMain.handle('openMessageBox', async (_, args: Electron.MessageBoxOptions) => {
+  return openMessageBox(args)
 })
 
 
@@ -826,9 +830,19 @@ ipcMain.handle('egsSync', async (event, args) => {
   }
 })
 
-ipcMain.on('addShortcut', async (event, appName) => {
+ipcMain.on('addShortcut', async (event, appName: string, fromMenu: boolean) => {
   const game = Game.get(appName)
-  game.addDesktopShortcut(true)
+  game.addDesktopShortcut(fromMenu)
+  openMessageBox({
+    buttons: [i18next.t('box.ok', 'Ok')],
+    message: i18next.t('box.shortcuts.message', 'Shortcuts were created on Desktop and Start Menu'),
+    title: i18next.t('box.shortcuts.title', 'Shortcuts')
+  })
+})
+
+ipcMain.on('removeShortcut', async (event, appName: string) => {
+  const game = Game.get(appName)
+  game.removeDesktopShortcut()
 })
 
 ipcMain.handle('syncSaves', async (event, args) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -832,7 +832,7 @@ ipcMain.handle('egsSync', async (event, args) => {
 
 ipcMain.on('addShortcut', async (event, appName: string, fromMenu: boolean) => {
   const game = Game.get(appName)
-  game.addDesktopShortcut(fromMenu)
+  game.addShortcuts(fromMenu)
   openMessageBox({
     buttons: [i18next.t('box.ok', 'Ok')],
     message: i18next.t('box.shortcuts.message', 'Shortcuts were created on Desktop and Start Menu'),
@@ -842,7 +842,7 @@ ipcMain.on('addShortcut', async (event, appName: string, fromMenu: boolean) => {
 
 ipcMain.on('removeShortcut', async (event, appName: string) => {
   const game = Game.get(appName)
-  game.removeDesktopShortcut()
+  game.removeShortcuts()
 })
 
 ipcMain.handle('syncSaves', async (event, args) => {

--- a/src/screens/Game/GameSubMenu/index.tsx
+++ b/src/screens/Game/GameSubMenu/index.tsx
@@ -105,12 +105,7 @@ export default function GamesSubmenu({
   }
 
   function handleShortcuts() {
-    ipcRenderer.send('addShortcut', appName)
-    return ipcRenderer.invoke('openMessageBox', {
-      buttons: [t('box.ok', 'Ok')],
-      message: t('box.shortcuts.message', 'Shortcuts were created on Desktop and Start Menu'),
-      title: t('box.shortcuts.title', 'Shortcuts')
-    })
+    ipcRenderer.send('addShortcut', appName, true)
   }
 
   useEffect(() => {

--- a/src/screens/Settings/components/OtherSettings/index.tsx
+++ b/src/screens/Settings/components/OtherSettings/index.tsx
@@ -82,6 +82,7 @@ export default function OtherSettings({
   const { platform } = useContext(ContextProvider)
   const isWin = platform === 'win32'
   const isLinux = platform === 'linux'
+  const supportsShortcuts = isWin || isLinux
 
   return (
     <>
@@ -157,13 +158,12 @@ export default function OtherSettings({
           <ToggleSwitch value={offlineMode} handleChange={toggleOffline} />
         </span>
       </span>
-      {isLinux && isDefault && <>
+      {supportsShortcuts && isDefault && <>
         <span className="setting">
           <span className="toggleWrapper">
             {t('setting.adddesktopshortcuts', 'Add desktop shortcuts automatically')}
             <ToggleSwitch
               value={addDesktopShortcuts}
-              disabled={!navigator.platform.startsWith('Linux')}
               handleChange={toggleAddDesktopShortcuts}
             />
           </span>
@@ -173,7 +173,6 @@ export default function OtherSettings({
             {t('setting.addgamestostartmenu', 'Add games to start menu automatically')}
             <ToggleSwitch
               value={addGamesToStartMenu}
-              disabled={!navigator.platform.startsWith('Linux')}
               handleChange={toggleAddGamesToStartMenu}
             />
           </span>


### PR DESCRIPTION
This PR enables the settings to automatically create desktop and start menu shortcuts on windows.

I moved the trigger of those function to the GlobalState class (the execAsync callback was never triggered on windows).

I'll add some comments on the diff.

Again, I'm not really sure how to add automated tests for this but I accept any advice on how to do that.

Closes #726 

-------------------------------------------------------------
Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
