### PR TITLE
Add WinePrefix to Install Modal with auto naming

### DIFF
--- a/src/screens/Settings/components/Tools/index.tsx
+++ b/src/screens/Settings/components/Tools/index.tsx
@@ -79,30 +79,27 @@ export default function Tools({ wineVersion, winePrefix }: Props) {
     <>
       <div data-testid="toolsSettings" className="settingsTools">
         <div className="toolsWrapper">
-          <a
-            href="#"
+          <button
             data-testid="wineCFG"
-            className="tools"
+            className="button is-transparent"
             style={{
               color: winecfgRunning ? 'var(--secondary)' : 'var(--primary)'
             }}
             onClick={() => callTools('winecfg')}
           >
             Winecfg
-          </a>
-          <a
-            href="#"
+          </button>
+          <button
             data-testid="wineTricks"
-            className="tools"
+            className="button is-transparent"
             style={{
               color: winetricksRunning ? 'var(--secondary)' : 'var(--primary)'
             }}
             onClick={() => callTools('winetricks')}
           >
             Winetricks
-          </a>
+          </button>
           <a
-            href="#"
             data-testid="toolsDrag"
             draggable
             onDrop={(ev) => dropHandler(ev)}

--- a/src/screens/Settings/components/WineSettings/index.tsx
+++ b/src/screens/Settings/components/WineSettings/index.tsx
@@ -107,34 +107,36 @@ export default function WineSettings({
 
   return (
     <>
-      <span data-testid="wineSettings" className="setting">
-        <span className="settingText">{t('setting.wineprefix')}</span>
-        <span>
-          <input
-            data-testid="selectWinePrefix"
-            type="text"
-            value={winePrefix}
-            className="settingSelect"
-            onChange={(event) => setWinePrefix(event.target.value)}
-          />
-          <SvgButton
-            className="material-icons settings folder"
-            onClick={() =>
-              ipcRenderer
-                .invoke('openDialog', {
-                  buttonLabel: t('box.choose'),
-                  properties: ['openDirectory'],
-                  title: t('box.wineprefix')
-                })
-                .then(({ path }: Path) =>
-                  setWinePrefix(path ? `${path}` : winePrefix)
-                )
-            }
-          >
-            <CreateNewFolder data-testid="addWinePrefix" />
-          </SvgButton>
+      {isLinux && (
+        <span data-testid="wineSettings" className="setting">
+          <span className="settingText">{t('setting.wineprefix')}</span>
+          <span>
+            <input
+              data-testid="selectWinePrefix"
+              type="text"
+              value={winePrefix}
+              className="settingSelect"
+              onChange={(event) => setWinePrefix(event.target.value)}
+            />
+            <SvgButton
+              className="material-icons settings folder"
+              onClick={() =>
+                ipcRenderer
+                  .invoke('openDialog', {
+                    buttonLabel: t('box.choose'),
+                    properties: ['openDirectory'],
+                    title: t('box.wineprefix')
+                  })
+                  .then(({ path }: Path) =>
+                    setWinePrefix(path ? `${path}` : winePrefix)
+                  )
+              }
+            >
+              <CreateNewFolder data-testid="addWinePrefix" />
+            </SvgButton>
+          </span>
         </span>
-      </span>
+      )}
       {isDefault && (
         <span className="setting">
           <span className="settingText">


### PR DESCRIPTION
- [x] Add wine prefix selection on install modal. #738 
- [x] The Name of the prefix should contain the game name.


![image](https://user-images.githubusercontent.com/26871415/147386805-42386a62-83e8-4871-b41f-cbf0fd6b7c92.png)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
