### PR TITLE
Fixed typo with Discord RPC indicating macOS is "MacOS" when it should be "macOS"

### DIFF
--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -536,7 +536,7 @@ Categories=Game;
           os = 'Windows'
           break
         case 'darwin':
-          os = 'MacOS'
+          os = 'macOS'
           break
         default:
           os = 'Unknown OS'


### PR DESCRIPTION
Just a typo fix with the Discord RPC saying what platform Heroic is running on (from "MacOS" to "macOS")