### PR TITLE
Fix wine prefixes not being created

### DIFF
--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -671,11 +671,11 @@ Categories=Game;
     }
 
     if (isProton && !existsSync(fixedWinePrefix)) {
-      const command = `mkdir '${fixedWinePrefix}' -p`
-      await execAsync(command, execOptions)
+      mkdirSync(fixedWinePrefix, { recursive: true })
     }
 
     if (!existsSync(fixedWinePrefix)) {
+      mkdirSync(fixedWinePrefix, { recursive: true })
       const initPrefixCommand = `WINEPREFIX='${fixedWinePrefix}' '${winePath}/wineboot' -i &&  '${winePath}/wineserver' --wait`
       logInfo('creating new prefix', fixedWinePrefix)
       return execAsync(initPrefixCommand)


### PR DESCRIPTION
Changed a way of creating prefix for Proton. Instead of preparing `mkdir` command it uses mkdirSync from graceful-fs library.
Same for Wine prefixes. Before running `wineboot`, creates directory recursively.  

Fixes one problem out of two in#840 

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
