### PR TITLE
[General] Refactor and enable spatial navigation

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -113,6 +113,7 @@ async function createWindow(): Promise<BrowserWindow> {
 
   mainWindow.setIcon(icon)
   app.setAppUserModelId('Heroic')
+  app.commandLine.appendSwitch('enable-spatial-navigation')
 
   if (isDev) {
     /* eslint-disable @typescript-eslint/ban-ts-comment */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,10 +41,12 @@ function App() {
                     renderBackButton={false}
                     numberOfGames={numberOfGames}
                   />
-                  {showRecentGames && (
-                    <Library showRecentsOnly library={recentGames} />
-                  )}
-                  <Library library={library} />
+                  <div className="listing">
+                    {showRecentGames && (
+                      <Library showRecentsOnly library={recentGames} />
+                    )}
+                    <Library library={library} />
+                  </div>
                 </>
               ) : (
                 <WebView isLogin />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ function App() {
                     numberOfGames={numberOfGames}
                   />
                   <div className="listing">
+                    <span id="top" />
                     {showRecentGames && (
                       <Library showRecentsOnly library={recentGames} />
                     )}

--- a/src/components/UI/Header/index.css
+++ b/src/components/UI/Header/index.css
@@ -144,7 +144,7 @@ option {
 }
 
 .refreshIcon:hover,
-:focus-visible .refreshIcon {
+.svg-button:focus-visible .refreshIcon {
   animation: refreshing 2s infinite;
 }
 

--- a/src/components/UI/SvgButton/index.tsx
+++ b/src/components/UI/SvgButton/index.tsx
@@ -1,9 +1,9 @@
 import './index.css'
 
-import React from 'react'
+import React, { MouseEvent } from 'react'
 
 interface Props {
-  onClick: () => void
+  onClick: (e: MouseEvent) => void
   children: JSX.Element
   className?: string
 }

--- a/src/screens/Library/components/GameCard/index.css
+++ b/src/screens/Library/components/GameCard/index.css
@@ -142,6 +142,7 @@
   max-height: 8vh;
   width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
 .gameListItem .gameImg {

--- a/src/screens/Library/components/GameCard/index.css
+++ b/src/screens/Library/components/GameCard/index.css
@@ -1,9 +1,6 @@
 .gameCard {
   background-color: var(--background-darker);
   text-align: left;
-  display: flex;
-  justify-content: center;
-  align-items: center;
   width: clamp(130px, 8vw, 200px);
   height: 10vw;
   max-height: 266px;
@@ -55,21 +52,31 @@
   height: 20px;
 }
 
-.gameCard > a > .gameImg {
-  width: 8vw;
-  height: 10vw;
-  max-width: 200px;
-  max-height: 266px;
-  min-width: 130px;
-  min-height: 173px;
-  object-fit: cover;
-  position: absolute;
-  border-radius: 0.5rem;
-  top: 0;
-  left: 0;
+.gameCard > a {
+  display: block;
+  position: relative;
 }
 
-.gameTitle {
+.gameCard .gameImg {
+  width: clamp(130px, 8vw, 200px);
+  height: clamp(173px, 10vw, 266px);
+  object-fit: cover;
+  border-radius: 0.5rem;
+}
+
+.gameCard .gameLogo {
+  position: absolute;
+  top: 35%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(70px, 7vw, 60%);
+}
+
+.gameCard .gameListInfo {
+  display: none;
+}
+
+.gameCard .gameTitle {
   position: absolute;
   width: 100%;
   bottom: -92px;
@@ -83,65 +90,16 @@
   font-weight: 700;
   line-height: 17px;
   color: var(--text-primary);
-  height: 4vw;
-  min-height: 80px;
-  max-height: 85px;
+  height: clamp(80px, 4vw, 85px);
   cursor: pointer;
   z-index: 3;
-}
-
-.gameTitle > span {
-  bottom: 0;
-  display: none;
-  z-index: 3;
-}
-
-.icons {
-  align-self: flex-end;
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-  z-index: 4;
-  padding: 6px;
-  margin-right: 4px;
-  transition: 300ms;
-}
-
-.icons > button > svg,
-.icons > a > svg,
-.icons > svg {
-  width: min(calc(1vw + 9px), 36px);
-  height: min(calc(1vw + 9px), 36px);
-  min-width: 22px;
-  min-height: 22px;
-  display: block;
-}
-.icons > .svg-button {
-  margin-left: 12px;
-}
-
-.playIcon > circle {
-  fill: var(--success);
-}
-
-.downIcon > circle {
-  fill: var(--secondary);
-}
-
-.cancelIcon > circle {
-  fill: var(--danger);
-}
-
-.iconDisabled circle {
-  fill: var(--icon-disabled);
-}
-
-.iconDisabled > * {
-  cursor: initial;
+  pointer-events: none;
 }
 
 .gameCard > .icons {
   opacity: 0;
+  position: absolute;
+  bottom: 0px;
 }
 
 .gameCard:hover > .icons,
@@ -164,66 +122,58 @@
   background: none;
 }
 
-.gameCard .gameTitle span {
-  flex-grow: 1;
-}
-
-.gameImg {
-  width: 210px;
-  height: 280px;
-  object-fit: cover;
-  border-radius: 0.5rem;
-}
-
 .gameListItem {
   display: grid;
   grid-template-columns: 2fr 1fr 6fr 1fr;
   grid-template-areas: 'cover infos name action';
-  height: 8vh;
   align-items: center;
   position: relative;
   cursor: default;
   place-self: center;
-  padding-left: 2rem;
-}
-
-.gameImgList {
-  max-width: 15vh;
-  height: inherit;
-  width: inherit;
-  grid-area: cover;
-  border-radius: 0.5rem;
-  contain: content;
-  cursor: pointer;
-  display: block;
-}
-
-.gameListItem > .gameLogo {
-  width: 3vw;
-  min-width: 45px;
-  position: absolute;
-  z-index: 2;
-  grid-area: cover;
-}
-
-.gameImgList > .gameLogo {
-  width: 45%;
-  min-width: 60px;
-  position: relative;
-  top: 25px;
-  z-index: 2;
-}
-
-.gameTitleList {
-  grid-area: name;
-  font-size: 1em;
+  margin: 0 2rem 0.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid gray;
 }
 
 .gameListItem > a {
   grid-area: cover;
+  position: relative;
   max-width: 15vh;
+  max-height: 8vh;
   width: 100%;
   height: 100%;
+}
+
+.gameListItem .gameImg {
+  width: 100%;
+  height: auto;
+  grid-area: cover;
+  border-radius: 0.5rem;
+  contain: content;
+  cursor: pointer;
+}
+
+.gameListItem .gameLogo {
+  width: min(45px, 3vw);
+  position: absolute;
+  grid-area: cover;
+  top: 50%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-50%);
+}
+
+.gameListItem .gameListInfo {
+  font-size: 1em;
+  grid-area: infos;
+}
+
+.gameListItem .gameTitle {
+  grid-area: name;
+  font-size: 1em;
+}
+
+.gameListItem .gameTitle span {
+  display: inline;
 }
 
 .gameListItem > .icons {
@@ -259,27 +209,54 @@
   top: 0;
 }
 
-.gameListInfo {
-  font-size: 1em;
-  grid-area: infos;
-}
-
-.gameImg > .gameLogo {
-  width: min(7vw, 60%);
-  position: relative;
-  top: 35%;
-  min-width: 79px;
-  z-index: 2;
-  left: 21%;
-}
-
 .progress > svg {
   cursor: pointer;
   z-index: 7;
 }
 
-hr {
-  opacity: 0.1;
-  margin-left: 2rem;
-  margin-right: 2rem;
+.gameImg:not(.installed),
+.gameLogo:not(.installed) {
+  filter: grayscale(var(--installing-effect));
+}
+
+.icons {
+  align-self: flex-end;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  z-index: 4;
+  padding: 6px;
+  margin-right: 4px;
+  transition: 300ms;
+}
+
+.icons > button > svg,
+.icons > a > svg,
+.icons > svg {
+  width: clamp(22px, calc(1vw + 9px), 36px);
+  height: clamp(22px, calc(1vw + 9px), 36px);
+  display: block;
+}
+.icons > .svg-button {
+  margin-left: 12px;
+}
+
+.playIcon > circle {
+  fill: var(--success);
+}
+
+.downIcon > circle {
+  fill: var(--secondary);
+}
+
+.cancelIcon > circle {
+  fill: var(--danger);
+}
+
+.iconDisabled circle {
+  fill: var(--icon-disabled);
+}
+
+.iconDisabled > * {
+  cursor: initial;
 }

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -1,6 +1,6 @@
 import './index.css'
 
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState, CSSProperties } from 'react'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faRepeat } from '@fortawesome/free-solid-svg-icons'
@@ -123,9 +123,13 @@ const GameCard = ({
   }, [isInstalling, appName])
 
   const { percent = '' } = progress
-  const effectPercent = isInstalling
+  const installingGrayscale = isInstalling
     ? `${125 - getProgress(progress)}%`
     : '100%'
+
+  const imgClasses = `gameImg ${isInstalled ? 'installed' : ''}`
+  const logoClasses = `gameLogo ${isInstalled ? 'installed' : ''}`
+  const imageSrc = `${grid ? cover : coverList}?h=400&resize=1&w=300')`
 
   async function handleUpdate() {
     await handleGameStatus({ appName, status: 'updating' })
@@ -178,7 +182,11 @@ const GameCard = ({
     }
     if (!isInstalled) {
       if (hasDownloads) {
-        return <DownIcon className="iconDisabled" />
+        return (
+          <SvgButton onClick={(e) => e.preventDefault()}>
+            <DownIcon className="iconDisabled" />
+          </SvgButton>
+        )
       }
       return (
         <SvgButton onClick={() => buttonClick()}>
@@ -198,80 +206,39 @@ const GameCard = ({
             to={{
               pathname: `/gameconfig/${appName}`
             }}
+            style={
+              { '--installing-effect': installingGrayscale } as CSSProperties
+            }
           >
-            <span
-              style={{
-                backgroundImage: `url('${
-                  grid ? cover : coverList
-                }?h=400&resize=1&w=300')`,
-                backgroundSize: '100% 100%',
-                filter: isInstalled ? 'none' : `grayscale(${effectPercent})`
-              }}
-              className={grid ? 'gameImg' : 'gameImgList'}
-            >
-              {logo && (
-                <img
-                  alt="logo"
-                  src={`${logo}?h=400&resize=1&w=300`}
-                  style={{
-                    filter: isInstalled ? 'none' : `grayscale(${effectPercent})`
-                  }}
-                  className="gameLogo"
-                />
+            <img src={imageSrc} className={imgClasses} alt="cover" />
+            {logo && (
+              <img
+                alt="logo"
+                src={`${logo}?h=400&resize=1&w=300`}
+                className={logoClasses}
+              />
+            )}
+          </Link>
+          <span className="gameListInfo">{isInstalled ? size : '---'}</span>
+          <span className="gameTitle">{title}</span>
+          {
+            <span className="icons">
+              {renderIcon()}
+              {isInstalled && isGame && (
+                <SvgButton
+                  onClick={() =>
+                    history.push({
+                      pathname: path,
+                      state: { fromGameCard: true }
+                    })
+                  }
+                >
+                  <SettingsIcon fill={'var(--text-primary)'} />
+                </SvgButton>
               )}
             </span>
-          </Link>
-          {grid ? (
-            <>
-              <div
-                className="gameTitle"
-                onClick={() => history.push(`/gameconfig/${appName}`)}
-              >
-                <span>{title}</span>
-              </div>
-              {
-                <span className="icons">
-                  {renderIcon()}
-                  {isInstalled && isGame && (
-                    <SvgButton
-                      onClick={() =>
-                        history.push({
-                          pathname: path,
-                          state: { fromGameCard: true }
-                        })
-                      }
-                    >
-                      <SettingsIcon fill={'var(--text-primary)'} />
-                    </SvgButton>
-                  )}
-                </span>
-              }
-            </>
-          ) : (
-            <>
-              {<div className="gameListInfo">{isInstalled ? size : '---'}</div>}
-              <span className="gameTitleList">{title}</span>
-              {
-                <span className="icons">
-                  {renderIcon()}
-                  {isInstalled && isGame && (
-                    <SvgButton
-                      onClick={() =>
-                        history.push({
-                          pathname: path,
-                          state: { fromGameCard: true }
-                        })
-                      }
-                    >
-                      <SettingsIcon fill={'var(--text-primary)'} />
-                    </SvgButton>
-                  )}
-                </span>
-              }
-            </>
-          )}
+          }
         </div>
-        {!grid && <hr />}
         <ContextMenu id={appName} className="contextMenu">
           {isInstalled && (
             <>

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -129,7 +129,7 @@ const GameCard = ({
 
   const imgClasses = `gameImg ${isInstalled ? 'installed' : ''}`
   const logoClasses = `gameLogo ${isInstalled ? 'installed' : ''}`
-  const imageSrc = `${grid ? cover : coverList}?h=400&resize=1&w=300')`
+  const imageSrc = `${grid ? cover : coverList}?h=400&resize=1&w=300`
 
   async function handleUpdate() {
     await handleGameStatus({ appName, status: 'updating' })

--- a/src/screens/Library/components/InstallModal/index.css
+++ b/src/screens/Library/components/InstallModal/index.css
@@ -4,6 +4,7 @@
   width: var(--content-width);
   height: 100%;
   position: fixed;
+  top: 0px;
   z-index: 8;
 }
 

--- a/src/screens/Library/index.css
+++ b/src/screens/Library/index.css
@@ -48,6 +48,11 @@
   animation: apparition 0.3s ease-in forwards;
 }
 
+.listing {
+  overflow-y: auto;
+  flex: 100% 1 1;
+}
+
 @keyframes apparition {
   from {
     color: var(--secondary);

--- a/src/screens/Library/index.css
+++ b/src/screens/Library/index.css
@@ -33,7 +33,7 @@
   right: 0;
   margin: 1em 3em;
   border: 1px var(--secondary) solid;
-  background-color: transparent;
+  background-color: var(--background);
   color: var(--secondary);
   display: flex;
   align-items: center;
@@ -41,25 +41,16 @@
   align-self: flex-end;
   z-index: 9;
   visibility: hidden;
+  transition: all 0.3s ease-in;
+  cursor: pointer;
 }
 
 #backToTopBtn:hover {
-  cursor: pointer;
-  animation: apparition 0.3s ease-in forwards;
+  background-color: var(--secondary);
+  color: var(--text-primary);
 }
 
 .listing {
   overflow-y: auto;
   flex: 100% 1 1;
-}
-
-@keyframes apparition {
-  from {
-    color: var(--secondary);
-    background-color: transparent;
-  }
-  to {
-    background-color: var(--secondary);
-    color: var(--text-primary);
-  }
 }

--- a/src/screens/Library/index.tsx
+++ b/src/screens/Library/index.tsx
@@ -1,6 +1,6 @@
 import './index.css'
 
-import React, { lazy, useContext, useState } from 'react'
+import React, { lazy, useContext, useEffect, useRef, useState } from 'react'
 
 import { GameInfo } from 'src/types'
 import ContextProvider from 'src/state/ContextProvider'
@@ -22,18 +22,28 @@ interface Props {
   showRecentsOnly?: boolean
 }
 
-window.onscroll = () => {
-  const pageOffset =
-    document.documentElement.scrollTop || document.body.scrollTop
-  const btn = document.getElementById('backToTopBtn')
-  if (btn) btn.style.visibility = pageOffset > 450 ? 'visible' : 'hidden'
-}
-
 export const Library = ({ library, showRecentsOnly }: Props) => {
   const { layout, gameUpdates, refreshing, category, filter } =
     useContext(ContextProvider)
   const [showModal, setShowModal] = useState({ game: '', show: false })
   const { t } = useTranslation()
+  const backToTopElement = useRef(null)
+
+  useEffect(() => {
+    if (backToTopElement.current) {
+      const listing = document.querySelector('.listing')
+      if (listing) {
+        listing.addEventListener('scroll', () => {
+          const btn = document.getElementById('backToTopBtn')
+          const topSpan = document.getElementById('top')
+          if (btn && topSpan) {
+            btn.style.visibility =
+              listing.scrollTop > 450 ? 'visible' : 'hidden'
+          }
+        })
+      }
+    }
+  }, [backToTopElement])
 
   const backToTop = () => {
     const anchor = document.getElementById('top')
@@ -67,7 +77,6 @@ export const Library = ({ library, showRecentsOnly }: Props) => {
           backdropClick={() => setShowModal({ game: '', show: false })}
         />
       )}
-      <span id="top" />
       <h3 className="libraryHeader">
         {showRecentsOnly ? t('Recent', 'Played Recently') : titleWithIcons()}
       </h3>
@@ -116,9 +125,11 @@ export const Library = ({ library, showRecentsOnly }: Props) => {
             }
           )}
       </div>
-      <button id="backToTopBtn" onClick={backToTop}>
-        <ArrowDropUp className="material-icons" />
-      </button>
+      {!showRecentsOnly && (
+        <button id="backToTopBtn" onClick={backToTop} ref={backToTopElement}>
+          <ArrowDropUp className="material-icons" />
+        </button>
+      )}
     </>
   )
 }


### PR DESCRIPTION
This PR adds the `enable-spatial-navigation` flag so the app can be navigated using the arrow keys so the keyboard accessibility is better (and this may enable the spatial navigation to use with the gamepad). The PR includes some refactoring that fixed the bugs with the browser's native spatial navigation, this way we don't have to use a javascript solution.

I had to make some refactoring to fix the spatial navigation:
- the library screen header is not position: sticky, now the listings are wrapped in a div and that div has scroll, so the header won't break the spatial navigation
- because of the previous change, I had to add a small fix to the install modal that was offset
- I made a big refactor of the gameCard/gameListItem component so the same html works for both formats
- I replaced some divs with spans, because the spatial navigation was focusing the divs too for some reason

I'll add some comments in the diff.

I tested moving around the app with the arrow keys, tried installing a game, cancelling the installation, opening a game details and executing a game.

EDIT: since I was already refactoring things on that screen, I did a small refactor to fix the `back to top` button that got missing and the html was duplicated

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
