### PR TITLE
Support nagivating Heroic using a gamepad

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,7 +2,8 @@ import {
   InstallParams,
   LaunchResult,
   GamepadInputEventKey,
-  GamepadInputEventWheel
+  GamepadInputEventWheel,
+  GamepadInputEventMouse
 } from './types'
 import * as path from 'path'
 import {
@@ -1049,8 +1050,13 @@ ipcMain.handle('syncSaves', async (event, args) => {
   return `\n ${stdout} - ${stderr}`
 })
 
-ipcMain.handle('gamepadAction', async (event, action) => {
+ipcMain.handle('gamepadAction', async (event, args) => {
+  const [action, metadata] = args
   const window = BrowserWindow.getAllWindows()[0]
+  let inputEvent:
+    | GamepadInputEventKey
+    | GamepadInputEventWheel
+    | GamepadInputEventMouse
 
   /*
    * How to extend:
@@ -1060,9 +1066,6 @@ ipcMain.handle('gamepadAction', async (event, action) => {
    * https://www.electronjs.org/docs/latest/api/accelerator#available-key-codes
    *
    */
-
-  let inputEvent: GamepadInputEventKey | GamepadInputEventWheel
-
   switch (action) {
     case 'rightStickUp':
       inputEvent = {
@@ -1092,6 +1095,31 @@ ipcMain.handle('gamepadAction', async (event, action) => {
       inputEvent = {
         type: 'keyDown',
         keyCode: action.replace(/pad|leftStick/, '')
+      }
+      break
+    case 'leftClick':
+      inputEvent = {
+        type: 'mouseDown',
+        button: 'left',
+        x: metadata.x,
+        y: metadata.y
+      }
+      break
+    case 'rightClick':
+      inputEvent = {
+        type: 'mouseDown',
+        button: 'right',
+        x: metadata.x,
+        y: metadata.y
+      }
+      break
+    case 'back':
+      window.webContents.goBack()
+      break
+    case 'esc':
+      inputEvent = {
+        type: 'keyDown',
+        keyCode: 'Esc'
       }
       break
   }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1050,6 +1050,7 @@ ipcMain.handle('syncSaves', async (event, args) => {
   return `\n ${stdout} - ${stderr}`
 })
 
+// Simulate keyboard and mouse actions as if the real input device is used
 ipcMain.handle('gamepadAction', async (event, args) => {
   const [action, metadata] = args
   const window = BrowserWindow.getAllWindows()[0]
@@ -1071,7 +1072,7 @@ ipcMain.handle('gamepadAction', async (event, args) => {
     case 'rightStickUp':
       inputEvents.push({
         type: 'mouseWheel',
-        deltaY: 53,
+        deltaY: 50,
         x: window.getBounds().width / 2,
         y: window.getBounds().height / 2
       })
@@ -1079,7 +1080,7 @@ ipcMain.handle('gamepadAction', async (event, args) => {
     case 'rightStickDown':
       inputEvents.push({
         type: 'mouseWheel',
-        deltaY: -53,
+        deltaY: -50,
         x: window.getBounds().width / 2,
         y: window.getBounds().height / 2
       })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1094,9 +1094,6 @@ ipcMain.handle('gamepadAction', async (event, action) => {
         keyCode: action.replace(/pad|leftStick/, '')
       }
       break
-    case 'mainAction':
-      inputEvent = { type: 'keyDown', keyCode: 'Return' }
-      break
   }
 
   if (inputEvent) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,9 @@
-import { InstallParams, LaunchResult } from './types'
+import {
+  InstallParams,
+  LaunchResult,
+  GamepadInputEventKey,
+  GamepadInputEventWheel
+} from './types'
 import * as path from 'path'
 import {
   BrowserWindow,
@@ -1042,4 +1047,59 @@ ipcMain.handle('syncSaves', async (event, args) => {
   logInfo(`${stdout}`)
   logError(`${stderr}`)
   return `\n ${stdout} - ${stderr}`
+})
+
+ipcMain.handle('gamepadAction', async (event, action) => {
+  const window = BrowserWindow.getAllWindows()[0]
+
+  /*
+   * How to extend:
+   *
+   * Valid values for type are 'keyDown', 'keyUp' and 'char'
+   * Valid values for keyCode are defined here:
+   * https://www.electronjs.org/docs/latest/api/accelerator#available-key-codes
+   *
+   */
+
+  let inputEvent: GamepadInputEventKey | GamepadInputEventWheel
+
+  switch (action) {
+    case 'rightStickUp':
+      inputEvent = {
+        type: 'mouseWheel',
+        deltaY: 53,
+        x: window.getBounds().width / 2,
+        y: window.getBounds().height / 2
+      }
+      break
+    case 'rightStickDown':
+      inputEvent = {
+        type: 'mouseWheel',
+        deltaY: -53,
+        x: window.getBounds().width / 2,
+        y: window.getBounds().height / 2
+      }
+      break
+    case 'leftStickUp':
+    case 'leftStickDown':
+    case 'leftStickLeft':
+    case 'leftStickRight':
+    case 'padUp':
+    case 'padDown':
+    case 'padLeft':
+    case 'padRight':
+      // spatial navigation
+      inputEvent = {
+        type: 'keyDown',
+        keyCode: action.replace(/pad|leftStick/, '')
+      }
+      break
+    case 'mainAction':
+      inputEvent = { type: 'keyDown', keyCode: 'Return' }
+      break
+  }
+
+  if (inputEvent) {
+    window.webContents.sendInputEvent(inputEvent)
+  }
 })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1053,10 +1053,11 @@ ipcMain.handle('syncSaves', async (event, args) => {
 ipcMain.handle('gamepadAction', async (event, args) => {
   const [action, metadata] = args
   const window = BrowserWindow.getAllWindows()[0]
-  let inputEvent:
+  const inputEvents: (
     | GamepadInputEventKey
     | GamepadInputEventWheel
     | GamepadInputEventMouse
+  )[] = []
 
   /*
    * How to extend:
@@ -1068,20 +1069,20 @@ ipcMain.handle('gamepadAction', async (event, args) => {
    */
   switch (action) {
     case 'rightStickUp':
-      inputEvent = {
+      inputEvents.push({
         type: 'mouseWheel',
         deltaY: 53,
         x: window.getBounds().width / 2,
         y: window.getBounds().height / 2
-      }
+      })
       break
     case 'rightStickDown':
-      inputEvent = {
+      inputEvents.push({
         type: 'mouseWheel',
         deltaY: -53,
         x: window.getBounds().width / 2,
         y: window.getBounds().height / 2
-      }
+      })
       break
     case 'leftStickUp':
     case 'leftStickDown':
@@ -1092,39 +1093,59 @@ ipcMain.handle('gamepadAction', async (event, args) => {
     case 'padLeft':
     case 'padRight':
       // spatial navigation
-      inputEvent = {
+      inputEvents.push({
         type: 'keyDown',
         keyCode: action.replace(/pad|leftStick/, '')
-      }
+      })
+      inputEvents.push({
+        type: 'keyUp',
+        keyCode: action.replace(/pad|leftStick/, '')
+      })
       break
     case 'leftClick':
-      inputEvent = {
+      inputEvents.push({
         type: 'mouseDown',
         button: 'left',
         x: metadata.x,
         y: metadata.y
-      }
+      })
+      inputEvents.push({
+        type: 'mouseUp',
+        button: 'left',
+        x: metadata.x,
+        y: metadata.y
+      })
       break
     case 'rightClick':
-      inputEvent = {
+      inputEvents.push({
         type: 'mouseDown',
         button: 'right',
         x: metadata.x,
         y: metadata.y
-      }
+      })
+      inputEvents.push({
+        type: 'mouseUp',
+        button: 'right',
+        x: metadata.x,
+        y: metadata.y
+      })
       break
     case 'back':
       window.webContents.goBack()
       break
     case 'esc':
-      inputEvent = {
+      inputEvents.push({
         type: 'keyDown',
         keyCode: 'Esc'
-      }
+      })
+      inputEvents.push({
+        type: 'keyUp',
+        keyCode: 'Esc'
+      })
       break
   }
 
-  if (inputEvent) {
-    window.webContents.sendInputEvent(inputEvent)
+  if (inputEvents.length) {
+    inputEvents.forEach((event) => window.webContents.sendInputEvent(event))
   }
 })

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -231,7 +231,7 @@ export interface InstallParams {
 }
 
 export interface GamepadInputEventKey {
-  type: 'keyDown' | 'keyDown' | 'char'
+  type: 'keyDown' | 'keyUp' | 'char'
   keyCode: string
 }
 
@@ -240,4 +240,11 @@ export interface GamepadInputEventWheel {
   deltaY: number
   x: number
   y: number
+}
+
+export interface GamepadInputEventMouse {
+  type: 'mouseDown' | 'mouseUp'
+  x: number
+  y: number
+  button: 'left' | 'middle' | 'right'
 }

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -229,3 +229,15 @@ export interface InstallParams {
   installDlcs?: boolean
   sdlList?: Array<string>
 }
+
+export interface GamepadInputEventKey {
+  type: 'keyDown' | 'keyDown' | 'char'
+  keyCode: string
+}
+
+export interface GamepadInputEventWheel {
+  type: 'mouseWheel'
+  deltaY: number
+  x: number
+  y: number
+}

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "react-i18next": "^11.8.15",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
+    "simple-keyboard": "^3.4.24",
     "systeminformation": "^5.9.17",
     "tslib": "^2.3.1"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div class="simple-keyboard"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/components/UI/SearchBar/index.tsx
+++ b/src/components/UI/SearchBar/index.tsx
@@ -1,25 +1,33 @@
 import './index.css'
 
-import React, { useContext, useState } from 'react'
+import React, { useContext, useEffect, useRef } from 'react'
 
 import { useTranslation } from 'react-i18next'
 import ContextProvider from 'src/state/ContextProvider'
 
 export default function SearchBar() {
   const { handleSearch, filterText } = useContext(ContextProvider)
-  const [textValue, setTextValue] = useState(filterText)
   const { t } = useTranslation()
+  const input = useRef<HTMLInputElement>(null)
+
+  // we have to use an event listener instead of the react
+  // onChange callback so it works with the virtual keyboard
+  useEffect(() => {
+    if (input.current) {
+      const element = input.current
+      element.value = filterText
+      element.addEventListener('change', () => {
+        handleSearch(element.value)
+      })
+    }
+  }, [input])
 
   return (
     <div className="SearchBar" data-testid="searchBar">
       <input
+        ref={input}
         data-testid="searchInput"
         className="searchInput"
-        value={textValue}
-        onChange={(event) => {
-          setTextValue(event.target.value)
-          handleSearch(event.target.value)
-        }}
         placeholder={t('search')}
         id="search"
       />

--- a/src/components/UI/SearchBar/index.tsx
+++ b/src/components/UI/SearchBar/index.tsx
@@ -16,7 +16,7 @@ export default function SearchBar() {
     if (input.current) {
       const element = input.current
       element.value = filterText
-      element.addEventListener('change', () => {
+      element.addEventListener('input', () => {
         handleSearch(element.value)
       })
     }

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -30,7 +30,6 @@ export const initGamepad = () => {
     rightStickRight: { triggered: 0, repeatDelay: SCROLL_REPEAT_DELAY },
     mainAction: { triggered: 0, repeatDelay: false },
     back: { triggered: 0, repeatDelay: false },
-    rightClick: { triggered: 0, repeatDelay: false },
     altAction: { triggered: 0, repeatDelay: false }
   }
 
@@ -172,47 +171,14 @@ export const initGamepad = () => {
       if (!controller) return
 
       const buttons = controller.buttons
-
-      if (!controller) return
-
-      // TODO: check the controller type and define different buttons and axes
-      const A = buttons[0],
-        B = buttons[1],
-        // X = buttons[2],
-        Y = buttons[3],
-        // LB = buttons[4],
-        // RB = buttons[5],
-        // LT = buttons[6], // has .value
-        // RT = buttons[7], // has .value
-        // view = buttons[8],
-        // menu = buttons[9],
-        // leftStick = buttons[10], // press
-        // rightStick = buttons[11], // press
-        up = buttons[12],
-        down = buttons[13],
-        left = buttons[14],
-        right = buttons[15],
-        // XBOX = buttons[16],
-        leftAxisX = controller.axes[0],
-        leftAxisY = controller.axes[1],
-        rightAxisX = controller.axes[2],
-        rightAxisY = controller.axes[3]
-
-      checkAction('padUp', up.pressed)
-      checkAction('padDown', down.pressed)
-      checkAction('padLeft', left.pressed)
-      checkAction('padRight', right.pressed)
-      checkAction('leftStickLeft', leftAxisX < -0.5)
-      checkAction('leftStickRight', leftAxisX > 0.5)
-      checkAction('leftStickUp', leftAxisY < -0.5)
-      checkAction('leftStickDown', leftAxisY > 0.5)
-      checkAction('rightStickLeft', rightAxisX < -0.5)
-      checkAction('rightStickRight', rightAxisX > 0.5)
-      checkAction('rightStickUp', rightAxisY < -0.5)
-      checkAction('rightStickDown', rightAxisY > 0.5)
-      checkAction('mainAction', A.pressed)
-      checkAction('back', B.pressed)
-      checkAction('altAction', Y.pressed)
+      const axes = controller.axes
+      if (controller.id.match(/xbox|microsoft/i)) {
+        checkActionsForXbox(buttons, axes)
+      } else if (controller.id.match(/gamecube/i)) {
+        checkActionsForGameCube(buttons, axes)
+      } else if (controller.id.match(/PS3|PS4|PS5|PLAYSTATION/i)) {
+        checkActionsForPlayStation(buttons, axes)
+      }
     })
 
     requestAnimationFrame(updateStatus)
@@ -233,6 +199,185 @@ export const initGamepad = () => {
 
   function removegamepad(gamepad: Gamepad) {
     controllers = controllers.filter((idx) => idx !== gamepad.index)
+  }
+
+  function checkActionsForXbox(
+    buttons: readonly GamepadButton[],
+    axes: readonly number[]
+  ) {
+    const A = buttons[0],
+      B = buttons[1],
+      // X = buttons[2],
+      Y = buttons[3],
+      // LB = buttons[4],
+      // RB = buttons[5],
+      // LT = buttons[6], // has .value
+      // RT = buttons[7], // has .value
+      // view = buttons[8],
+      // menu = buttons[9],
+      // leftStick = buttons[10], // press
+      // rightStick = buttons[11], // press
+      up = buttons[12],
+      down = buttons[13],
+      left = buttons[14],
+      right = buttons[15],
+      // XBOX = buttons[16],
+      leftAxisX = axes[0],
+      leftAxisY = axes[1],
+      rightAxisX = axes[2],
+      rightAxisY = axes[3]
+
+    checkAction('padUp', up.pressed)
+    checkAction('padDown', down.pressed)
+    checkAction('padLeft', left.pressed)
+    checkAction('padRight', right.pressed)
+    checkAction('leftStickLeft', leftAxisX < -0.5)
+    checkAction('leftStickRight', leftAxisX > 0.5)
+    checkAction('leftStickUp', leftAxisY < -0.5)
+    checkAction('leftStickDown', leftAxisY > 0.5)
+    checkAction('rightStickLeft', rightAxisX < -0.5)
+    checkAction('rightStickRight', rightAxisX > 0.5)
+    checkAction('rightStickUp', rightAxisY < -0.5)
+    checkAction('rightStickDown', rightAxisY > 0.5)
+    checkAction('mainAction', A.pressed)
+    checkAction('back', B.pressed)
+    checkAction('altAction', Y.pressed)
+  }
+
+  function checkActionsForGameCube(
+    buttons: readonly GamepadButton[],
+    axes: readonly number[]
+  ) {
+    // B0: A
+    // B1: X
+    // B2: Y
+    // B3: B
+    // B4: LT (gets "pressed" once the trigger presses all the way down, there's some resistance on the controller so you can feel it)
+    // B5: RT
+    // B6: Z
+    // B7: Start
+    // B8: Dpad Up
+    // B9: Dpad Down
+    // B10: Dpad Left
+    // B11: Dpad Right
+    // Axis 0: Control stick L/R
+    // -1 -> Left
+    // 1 -> Right
+    // Axis 1: Control stick Up/Down
+    // -1 -> Up
+    // 1 -> Down
+    // Axis 2: Left trigger
+    // -1 -> Up (default position
+    // 1 -> Pressed in all the way
+    // Axis 3 and 4 work like 0 and 1 just for the C stick
+    // Axis 5 works like Axis 2 just for the right trigger
+
+    const A = buttons[0],
+      // X = buttons[1],
+      Y = buttons[2],
+      B = buttons[3],
+      // LT = buttons[4], // has .value
+      // RT = buttons[5], // has .value
+      // Z = buttons[6],
+      // Start = buttons[7],
+      up = buttons[8],
+      down = buttons[9],
+      left = buttons[10],
+      right = buttons[11],
+      leftAxisX = axes[0],
+      leftAxisY = axes[1],
+      rightAxisX = axes[3],
+      rightAxisY = axes[4]
+    // there are 2 more axes to map as triggers
+
+    checkAction('padUp', up.pressed)
+    checkAction('padDown', down.pressed)
+    checkAction('padLeft', left.pressed)
+    checkAction('padRight', right.pressed)
+    checkAction('leftStickLeft', leftAxisX < -0.5)
+    checkAction('leftStickRight', leftAxisX > 0.5)
+    checkAction('leftStickUp', leftAxisY < -0.5)
+    checkAction('leftStickDown', leftAxisY > 0.5)
+    checkAction('rightStickLeft', rightAxisX < -0.5)
+    checkAction('rightStickRight', rightAxisX > 0.5)
+    checkAction('rightStickUp', rightAxisY < -0.5)
+    checkAction('rightStickDown', rightAxisY > 0.5)
+    checkAction('mainAction', A.pressed)
+    checkAction('back', B.pressed)
+    checkAction('altAction', Y.pressed)
+  }
+
+  function checkActionsForPlayStation(
+    buttons: readonly GamepadButton[],
+    axes: readonly number[]
+  ) {
+    // B0: X
+    // B1: Circle
+    // B2: Triangle
+    // B3: Square
+    // B4: LB
+    // B5: RB
+    // B6: LT (gets "pressed" as soon as the trigger is moved down slightly)
+    // B7: RT
+    // B8: Select
+    // B9: Start
+    // B10: PS Button
+    // B11: L3 (pressing in the control sticks)
+    // B12: R3
+    // B13: Dpad Up
+    // B14: Dpad Down
+    // B15: Dpad Left
+    // B16: Dpad Right
+
+    // Axis 0: Left control stick L/R
+    // 1 -> Right
+    // -1 -> Left
+    // Axis 1: Left control stick Up/Down
+    // 1 -> Down
+    // -1 -> Up
+    // Axis 2: Left Trigger
+    // -1 -> Up
+    // 1 -> Down
+    // Axis 3, 4 & 5 work the same way as 0, 1 & 2, just for the right side of the controller
+
+    const X = buttons[0],
+      Circle = buttons[1],
+      Triangle = buttons[2],
+      // Square = buttons[3],
+      // LB = buttons[4],
+      // RB = buttons[5],
+      // LT = buttons[6], // has .value
+      // RT = buttons[7], // has .value
+      // select = buttons[8],
+      // start = buttons[9],
+      // PSButton = buttons[10],
+      // leftStick = buttons[11], // press
+      // rightStick = buttons[12], // press
+      up = buttons[13],
+      down = buttons[14],
+      left = buttons[15],
+      right = buttons[16],
+      leftAxisX = axes[0],
+      leftAxisY = axes[1],
+      rightAxisX = axes[3],
+      rightAxisY = axes[4]
+    // there are 2 more axes to map as triggers
+
+    checkAction('padUp', up.pressed)
+    checkAction('padDown', down.pressed)
+    checkAction('padLeft', left.pressed)
+    checkAction('padRight', right.pressed)
+    checkAction('leftStickLeft', leftAxisX < -0.5)
+    checkAction('leftStickRight', leftAxisX > 0.5)
+    checkAction('leftStickUp', leftAxisY < -0.5)
+    checkAction('leftStickDown', leftAxisY > 0.5)
+    checkAction('rightStickLeft', rightAxisX < -0.5)
+    checkAction('rightStickRight', rightAxisX > 0.5)
+    checkAction('rightStickUp', rightAxisY < -0.5)
+    checkAction('rightStickDown', rightAxisY > 0.5)
+    checkAction('mainAction', X.pressed)
+    checkAction('back', Circle.pressed)
+    checkAction('altAction', Triangle.pressed)
   }
 
   window.addEventListener('gamepadconnected', connecthandler)

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -1,0 +1,134 @@
+import { IpcRenderer } from 'electron'
+import { GamepadActionStatus } from 'src/types'
+const { ipcRenderer } = window.require('electron') as {
+  ipcRenderer: IpcRenderer
+}
+
+const KEY_REPEAT_DELAY = 500
+const STICK_REPEAT_DELAY = 250
+const SCROLL_REPEAT_DELAY = 50
+
+export const initGamepad = () => {
+  // store the current controllers
+  let controllers: number[] = []
+
+  // store the status and metadata for each action
+  // triggered is either 0 (inactive) or a unix timestamp of the last `invoke` call
+  const actions: GamepadActionStatus = {
+    padUp: { triggered: 0, repeatDelay: KEY_REPEAT_DELAY },
+    padDown: { triggered: 0, repeatDelay: KEY_REPEAT_DELAY },
+    padLeft: { triggered: 0, repeatDelay: KEY_REPEAT_DELAY },
+    padRight: { triggered: 0, repeatDelay: KEY_REPEAT_DELAY },
+    leftStickUp: { triggered: 0, repeatDelay: STICK_REPEAT_DELAY },
+    leftStickDown: { triggered: 0, repeatDelay: STICK_REPEAT_DELAY },
+    leftStickLeft: { triggered: 0, repeatDelay: STICK_REPEAT_DELAY },
+    leftStickRight: { triggered: 0, repeatDelay: STICK_REPEAT_DELAY },
+    rightStickUp: { triggered: 0, repeatDelay: SCROLL_REPEAT_DELAY },
+    rightStickDown: { triggered: 0, repeatDelay: SCROLL_REPEAT_DELAY },
+    rightStickLeft: { triggered: 0, repeatDelay: SCROLL_REPEAT_DELAY },
+    rightStickRight: { triggered: 0, repeatDelay: SCROLL_REPEAT_DELAY },
+    mainAction: { triggered: 0, repeatDelay: false }
+  }
+
+  // check if an action should be triggered
+  function checkAction(action: string, pressed: boolean) {
+    if (!pressed) {
+      // set 0 if not pressed (means inactive button)
+      actions[action].triggered = 0
+      return
+    }
+
+    const now = new Date().getTime()
+
+    // if it the action was already active or not
+    const wasActive = actions[action].triggered !== 0
+    let shouldRepeat = false
+
+    if (wasActive) {
+      // it it was active, check if the action should be repeated
+      if (actions[action].repeatDelay) {
+        const lastTriggered = actions[action].triggered
+        if (now - lastTriggered > actions[action].repeatDelay) {
+          shouldRepeat = true
+        }
+      }
+    }
+
+    if (!wasActive || shouldRepeat) {
+      // set last trigger timestamp, used for repeater
+      actions[action].triggered = now
+
+      if (action === 'mainAction') {
+        currentElement()?.click()
+      } else {
+        // we have to tell Electron to simulate key presses
+        // so the spatial navigation works
+        ipcRenderer.invoke('gamepadAction', action)
+      }
+    }
+  }
+
+  // check all the buttons and axes every frame
+  function updateStatus() {
+    const gamepads = navigator.getGamepads()
+
+    controllers.forEach((index) => {
+      const controller = gamepads[index]
+
+      if (!controller) return
+
+      // TODO: check the controller type and define different buttons and axes
+      const buttons = {
+        up: controller.buttons[12] as GamepadButton,
+        down: controller.buttons[13] as GamepadButton,
+        left: controller.buttons[14] as GamepadButton,
+        right: controller.buttons[15] as GamepadButton,
+        A: controller.buttons[0] as GamepadButton
+      }
+      const leftAxisX = controller.axes[0] as number
+      const leftAxisY = controller.axes[1] as number
+      const rightAxisX = controller.axes[2] as number
+      const rightAxisY = controller.axes[3] as number
+
+      checkAction('padUp', buttons.up.pressed)
+      checkAction('padDown', buttons.down.pressed)
+      checkAction('padLeft', buttons.left.pressed)
+      checkAction('padRight', buttons.right.pressed)
+      checkAction('leftStickLeft', leftAxisX < -0.5)
+      checkAction('leftStickRight', leftAxisX > 0.5)
+      checkAction('leftStickUp', leftAxisY < -0.5)
+      checkAction('leftStickDown', leftAxisY > 0.5)
+      checkAction('rightStickLeft', rightAxisX < -0.5)
+      checkAction('rightStickRight', rightAxisX > 0.5)
+      checkAction('rightStickUp', rightAxisY < -0.5)
+      checkAction('rightStickDown', rightAxisY > 0.5)
+      checkAction('mainAction', buttons['A'].pressed)
+    })
+
+    requestAnimationFrame(updateStatus)
+  }
+
+  function currentElement() {
+    return document?.querySelector(':focus') as HTMLElement
+  }
+
+  function connecthandler(e: GamepadEvent) {
+    addgamepad(e.gamepad)
+  }
+
+  function addgamepad(gamepad: Gamepad) {
+    controllers.push(gamepad.index)
+    requestAnimationFrame(updateStatus)
+  }
+
+  function disconnecthandler(e: GamepadEvent) {
+    removegamepad(e.gamepad)
+  }
+
+  function removegamepad(gamepad: Gamepad) {
+    controllers = controllers.filter((idx) => idx !== gamepad.index)
+  }
+
+  window.addEventListener('gamepadconnected', connecthandler)
+  window.addEventListener('gamepaddisconnected', disconnecthandler)
+}

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -143,11 +143,17 @@ export const initGamepad = () => {
   }
 
   function isSelect() {
-    return currentElement().tagName === 'SELECT'
+    const el = currentElement()
+    if (!el) return false
+
+    return el.tagName === 'SELECT'
   }
 
   function isSearchInput() {
-    return currentElement().classList.contains('searchInput')
+    const el = currentElement()
+    if (!el) return false
+
+    return el.classList.contains('searchInput')
   }
 
   function playable() {
@@ -202,10 +208,10 @@ export const initGamepad = () => {
         checkActionsForXbox(buttons, axes, index)
       } else if (controller.id.match(/gamecube|0337/i)) {
         checkActionsForGameCube(buttons, axes, index)
-      } else if (
-        controller.id.match(/PS3|PS4|PS5|PLAYSTATION|Sony|0268|0c36/i)
-      ) {
-        checkActionsForPlayStation(buttons, axes, index)
+      } else if (controller.id.match(/0c36/i)) {
+        checkActionsForPlayStation5(buttons, axes, index)
+      } else if (controller.id.match(/PS3|PLAYSTATION|0268/i)) {
+        checkActionsForPlayStation3(buttons, axes, index)
       }
     })
 
@@ -218,8 +224,6 @@ export const initGamepad = () => {
 
   function addgamepad(gamepad: Gamepad) {
     console.log(`Gamepad added: ${JSON.stringify(gamepad.id)}`)
-    console.log(gamepad.buttons)
-    console.log(gamepad.axes)
     controllers.push(gamepad.index)
     requestAnimationFrame(updateStatus)
   }
@@ -259,7 +263,7 @@ export const initGamepad = () => {
       rightAxisX = axes[2],
       rightAxisY = axes[3]
 
-    logState(buttons, axes)
+    logState(controllerIndex)
 
     checkAction('padUp', up.pressed, controllerIndex)
     checkAction('padDown', down.pressed, controllerIndex)
@@ -301,7 +305,7 @@ export const initGamepad = () => {
       rightAxisY = axes[4]
     // there are 2 more axes to map as triggers
 
-    logState(buttons, axes)
+    logState(controllerIndex)
 
     checkAction('padUp', up.pressed, controllerIndex)
     checkAction('padDown', down.pressed, controllerIndex)
@@ -320,35 +324,35 @@ export const initGamepad = () => {
     checkAction('altAction', Y.pressed, controllerIndex)
   }
 
-  function checkActionsForPlayStation(
+  function checkActionsForPlayStation3(
     buttons: readonly GamepadButton[],
     axes: readonly number[],
     controllerIndex: number
   ) {
     const X = buttons[0],
       Circle = buttons[1],
-      Triangle = buttons[2],
-      // Square = buttons[3],
+      // Square = buttons[2],
+      Triangle = buttons[3],
       // LB = buttons[4],
       // RB = buttons[5],
       // LT = buttons[6],
       // RT = buttons[7],
       // select = buttons[8],
       // start = buttons[9],
+      // L3 = buttons[10], // press left stick
+      // R3 = buttons[11], // press right stick
+      up = buttons[12],
+      down = buttons[13],
+      left = buttons[14],
+      right = buttons[15],
       // PSButton = buttons[10],
-      // L3 = buttons[11], // press left stick
-      // R3 = buttons[12], // press right stick
-      up = buttons[13],
-      down = buttons[14],
-      left = buttons[15],
-      right = buttons[16],
       leftAxisX = axes[0],
       leftAxisY = axes[1],
-      rightAxisX = axes[3],
-      rightAxisY = axes[4]
+      rightAxisX = axes[2],
+      rightAxisY = axes[3]
     // there are 2 more axes to map as triggers
 
-    logState(buttons, axes)
+    logState(controllerIndex)
 
     checkAction('padUp', up.pressed, controllerIndex)
     checkAction('padDown', down.pressed, controllerIndex)
@@ -367,12 +371,58 @@ export const initGamepad = () => {
     checkAction('altAction', Triangle.pressed, controllerIndex)
   }
 
-  function logState(
+  function checkActionsForPlayStation5(
     buttons: readonly GamepadButton[],
-    axes: readonly number[]
+    axes: readonly number[],
+    controllerIndex: number
   ) {
+    const Circle = buttons[0],
+      Triangle = buttons[1],
+      X = buttons[2],
+      // Square = buttons[3],
+      // LB = buttons[4],
+      // RB = buttons[5],
+      rightAxisX = buttons[6],
+      rightAxisY = buttons[7],
+      // share = buttons[8],
+      // menu = buttons[9],
+      up = buttons[12],
+      down = buttons[13],
+      left = buttons[14],
+      right = buttons[15],
+      leftAxisX = axes[0],
+      leftAxisY = axes[1]
+    // there are 2 more axes to map as triggers
+
+    logState(controllerIndex)
+
+    checkAction('padUp', up.pressed, controllerIndex)
+    checkAction('padDown', down.pressed, controllerIndex)
+    checkAction('padLeft', left.pressed, controllerIndex)
+    checkAction('padRight', right.pressed, controllerIndex)
+    checkAction('leftStickLeft', leftAxisX < -0.5, controllerIndex)
+    checkAction('leftStickRight', leftAxisX > 0.5, controllerIndex)
+    checkAction('leftStickUp', leftAxisY < -0.5, controllerIndex)
+    checkAction('leftStickDown', leftAxisY > 0.5, controllerIndex)
+    checkAction('rightStickLeft', rightAxisX.value < 0.25, controllerIndex)
+    checkAction('rightStickRight', rightAxisX.value > 0.75, controllerIndex)
+    checkAction('rightStickUp', rightAxisY.value < 0.25, controllerIndex)
+    checkAction('rightStickDown', rightAxisY.value > 0.75, controllerIndex)
+    checkAction('mainAction', X.pressed, controllerIndex)
+    checkAction('back', Circle.pressed, controllerIndex)
+    checkAction('altAction', Triangle.pressed, controllerIndex)
+  }
+
+  function logState(index: number) {
+    const controller = navigator.getGamepads()[index]
+    if (!controller) return
+
+    const buttons = controller.buttons
+    const axes = controller.axes
+
     for (const button in buttons) {
-      if (buttons[button].pressed) console.log(`button ${button} pressed`)
+      if (buttons[button].pressed)
+        console.log(`button ${button} pressed ${buttons[button].value}`)
     }
     for (const axis in axes) {
       if (axes[axis] < -0.5) console.log(`axis ${axis} activated negative`)

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -9,9 +9,17 @@ const KEY_REPEAT_DELAY = 500
 const STICK_REPEAT_DELAY = 250
 const SCROLL_REPEAT_DELAY = 50
 
+/*
+ * For more documentation, check here https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki/Gamepad-Navigation
+ */
+
 export const initGamepad = () => {
   // store the current controllers
   let controllers: number[] = []
+
+  let heroicIsFocused = true
+  window.addEventListener('focus', () => (heroicIsFocused = true))
+  window.addEventListener('blur', () => (heroicIsFocused = false))
 
   // store the status and metadata for each action
   // triggered is either 0 (inactive) or a unix timestamp of the last `invoke` call
@@ -35,8 +43,9 @@ export const initGamepad = () => {
 
   // check if an action should be triggered
   function checkAction(action: string, pressed: boolean) {
-    if (!currentElement()) {
-      // ignore gamepad events if there no focused element
+    if (!heroicIsFocused) {
+      // ignore gamepad events if heroic is not the focused app
+      //
       // the browser still detects the gamepad interactions even
       // if the screen is not focused when playing a game
       return
@@ -224,8 +233,8 @@ export const initGamepad = () => {
       // RT = buttons[7], // has .value
       // view = buttons[8],
       // menu = buttons[9],
-      // leftStick = buttons[10], // press
-      // rightStick = buttons[11], // press
+      // L3 = buttons[10], // press left stick
+      // R3 = buttons[11], // press right stick
       up = buttons[12],
       down = buttons[13],
       left = buttons[14],
@@ -261,8 +270,8 @@ export const initGamepad = () => {
       // X = buttons[1],
       Y = buttons[2],
       B = buttons[3],
-      // LT = buttons[4], // has .value
-      // RT = buttons[5], // has .value
+      // LT = buttons[4],
+      // RT = buttons[5],
       // Z = buttons[6],
       // Start = buttons[7],
       up = buttons[8],
@@ -302,13 +311,13 @@ export const initGamepad = () => {
       // Square = buttons[3],
       // LB = buttons[4],
       // RB = buttons[5],
-      // LT = buttons[6], // has .value
-      // RT = buttons[7], // has .value
+      // LT = buttons[6],
+      // RT = buttons[7],
       // select = buttons[8],
       // start = buttons[9],
       // PSButton = buttons[10],
-      // leftStick = buttons[11], // press
-      // rightStick = buttons[12], // press
+      // L3 = buttons[11], // press left stick
+      // R3 = buttons[12], // press right stick
       up = buttons[13],
       down = buttons[14],
       left = buttons[15],

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -164,7 +164,10 @@ export const initGamepad = () => {
     if (!parent) return false
 
     const classes = parent.classList
-    return classes.contains('gameCard') || classes.contains('gameListItem')
+    const isGameCard =
+      classes.contains('gameCard') || classes.contains('gameListItem')
+    const isInstalled = classes.contains('installed')
+    return isGameCard && isInstalled
   }
 
   function playGame() {
@@ -208,7 +211,7 @@ export const initGamepad = () => {
         checkActionsForXbox(buttons, axes, index)
       } else if (controller.id.match(/gamecube|0337/i)) {
         checkActionsForGameCube(buttons, axes, index)
-      } else if (controller.id.match(/0c36/i)) {
+      } else if (controller.id.match(/0ce6/i)) {
         checkActionsForPlayStation5(buttons, axes, index)
       } else if (controller.id.match(/PS3|PLAYSTATION|0268/i)) {
         checkActionsForPlayStation3(buttons, axes, index)

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -183,7 +183,9 @@ export const initGamepad = () => {
         checkActionsForXbox(buttons, axes)
       } else if (controller.id.match(/gamecube|0337/i)) {
         checkActionsForGameCube(buttons, axes)
-      } else if (controller.id.match(/PS3|PS4|PS5|PLAYSTATION|0268|0c36/i)) {
+      } else if (
+        controller.id.match(/PS3|PS4|PS5|PLAYSTATION|Sony|0268|0c36/i)
+      ) {
         checkActionsForPlayStation(buttons, axes)
       }
     })

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -35,6 +35,13 @@ export const initGamepad = () => {
 
   // check if an action should be triggered
   function checkAction(action: string, pressed: boolean) {
+    if (!currentElement()) {
+      // ignore gamepad events if there no focused element
+      // the browser still detects the gamepad interactions even
+      // if the screen is not focused when playing a game
+      return
+    }
+
     if (!pressed) {
       // set 0 if not pressed (means inactive button)
       actions[action].triggered = 0
@@ -172,11 +179,11 @@ export const initGamepad = () => {
 
       const buttons = controller.buttons
       const axes = controller.axes
-      if (controller.id.match(/xbox|microsoft/i)) {
+      if (controller.id.match(/xbox|microsoft|02ea/i)) {
         checkActionsForXbox(buttons, axes)
-      } else if (controller.id.match(/gamecube/i)) {
+      } else if (controller.id.match(/gamecube|0337/i)) {
         checkActionsForGameCube(buttons, axes)
-      } else if (controller.id.match(/PS3|PS4|PS5|PLAYSTATION/i)) {
+      } else if (controller.id.match(/PS3|PS4|PS5|PLAYSTATION|0268|0c36/i)) {
         checkActionsForPlayStation(buttons, axes)
       }
     })
@@ -248,30 +255,6 @@ export const initGamepad = () => {
     buttons: readonly GamepadButton[],
     axes: readonly number[]
   ) {
-    // B0: A
-    // B1: X
-    // B2: Y
-    // B3: B
-    // B4: LT (gets "pressed" once the trigger presses all the way down, there's some resistance on the controller so you can feel it)
-    // B5: RT
-    // B6: Z
-    // B7: Start
-    // B8: Dpad Up
-    // B9: Dpad Down
-    // B10: Dpad Left
-    // B11: Dpad Right
-    // Axis 0: Control stick L/R
-    // -1 -> Left
-    // 1 -> Right
-    // Axis 1: Control stick Up/Down
-    // -1 -> Up
-    // 1 -> Down
-    // Axis 2: Left trigger
-    // -1 -> Up (default position
-    // 1 -> Pressed in all the way
-    // Axis 3 and 4 work like 0 and 1 just for the C stick
-    // Axis 5 works like Axis 2 just for the right trigger
-
     const A = buttons[0],
       // X = buttons[1],
       Y = buttons[2],
@@ -311,35 +294,6 @@ export const initGamepad = () => {
     buttons: readonly GamepadButton[],
     axes: readonly number[]
   ) {
-    // B0: X
-    // B1: Circle
-    // B2: Triangle
-    // B3: Square
-    // B4: LB
-    // B5: RB
-    // B6: LT (gets "pressed" as soon as the trigger is moved down slightly)
-    // B7: RT
-    // B8: Select
-    // B9: Start
-    // B10: PS Button
-    // B11: L3 (pressing in the control sticks)
-    // B12: R3
-    // B13: Dpad Up
-    // B14: Dpad Down
-    // B15: Dpad Left
-    // B16: Dpad Right
-
-    // Axis 0: Left control stick L/R
-    // 1 -> Right
-    // -1 -> Left
-    // Axis 1: Left control stick Up/Down
-    // 1 -> Down
-    // -1 -> Up
-    // Axis 2: Left Trigger
-    // -1 -> Up
-    // 1 -> Down
-    // Axis 3, 4 & 5 work the same way as 0, 1 & 2, just for the right side of the controller
-
     const X = buttons[0],
       Circle = buttons[1],
       Triangle = buttons[2],

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -225,6 +225,11 @@ export const initGamepad = () => {
         checkActionsForPlayStation5(buttons, axes, index)
       } else if (controller.id.match(/PS3|PLAYSTATION|0268/i)) {
         checkActionsForPlayStation3(buttons, axes, index)
+      } else {
+        // if not specific, fallback to the xbox layout, seems
+        // to be the most common for now and if not exact it seems
+        // to cover at least the left stick and the main 2 buttons
+        checkActionsForXbox(buttons, axes, index)
       }
     })
 

--- a/src/helpers/virtualKeyboard.ts
+++ b/src/helpers/virtualKeyboard.ts
@@ -1,0 +1,58 @@
+import Keyboard from 'simple-keyboard'
+import 'simple-keyboard/build/css/index.css'
+
+let virtualKeyboard: Keyboard | null = null
+
+function currentElement() {
+  return document.querySelector(':focus') as HTMLElement
+}
+
+function searchInput() {
+  return document.querySelector('.searchInput') as HTMLInputElement
+}
+
+function focusKeyboard() {
+  const firstButton = document.querySelector(
+    '.hg-button[data-skbtn="h"]'
+  ) as HTMLElement
+  firstButton?.focus()
+}
+
+function typeInSearchInput(button: string) {
+  const input = searchInput()
+  if (!input) return
+
+  if (button.length === 1) {
+    input.value = input.value + button
+  } else if (button === '{bksp}') {
+    if (input.value.length > 0) {
+      input.value = input.value.slice(0, -1)
+    }
+  }
+  input.dispatchEvent(new Event('change'))
+}
+
+export const VirtualKeyboardController = {
+  initOrFocus: () => {
+    if (!virtualKeyboard) {
+      virtualKeyboard = new Keyboard({
+        onKeyPress: (button: string) => typeInSearchInput(button),
+        onRender: () => focusKeyboard()
+      })
+    } else {
+      focusKeyboard()
+    }
+  },
+  isButtonFocused: () => {
+    return currentElement().classList.contains('hg-button')
+  },
+  isActive: () => virtualKeyboard !== null,
+  destroy: () => {
+    if (virtualKeyboard) virtualKeyboard.destroy()
+    virtualKeyboard = null
+    searchInput()?.focus()
+  },
+  backspace: () => {
+    typeInSearchInput('{bksp}')
+  }
+}

--- a/src/helpers/virtualKeyboard.ts
+++ b/src/helpers/virtualKeyboard.ts
@@ -29,7 +29,7 @@ function typeInSearchInput(button: string) {
       input.value = input.value.slice(0, -1)
     }
   }
-  input.dispatchEvent(new Event('change'))
+  input.dispatchEvent(new Event('input'))
 }
 
 export const VirtualKeyboardController = {

--- a/src/helpers/virtualKeyboard.ts
+++ b/src/helpers/virtualKeyboard.ts
@@ -44,6 +44,9 @@ export const VirtualKeyboardController = {
     }
   },
   isButtonFocused: () => {
+    const el = currentElement()
+    if (!el) return false
+
     return currentElement().classList.contains('hg-button')
   },
   isActive: () => virtualKeyboard !== null,

--- a/src/index.css
+++ b/src/index.css
@@ -70,3 +70,12 @@ code {
   background: var(--text-secondary);
   border-radius: 4px;
 }
+
+.simple-keyboard {
+  position: fixed;
+  z-index: 10;
+  bottom: 0px;
+  left: 50%;
+  width: 100vw;
+  transform: translateX(-50%);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -75,7 +75,6 @@ code {
   position: fixed;
   z-index: 10;
   bottom: 0px;
-  left: 50%;
-  width: 100vw;
-  transform: translateX(-50%);
+  left: 0px;
+  right: 0px;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import LanguageDetector from 'i18next-browser-languagedetector'
 import React, { Suspense } from 'react'
 import ReactDOM from 'react-dom'
 import i18next from 'i18next'
+import { initGamepad } from './helpers/gamepad'
 
 import './index.css'
 import App from 'src/App'
@@ -15,6 +16,8 @@ const Backend = new HttpApi(null, {
   allowMultiLoading: false,
   loadPath: 'locales/{{lng}}/{{ns}}.json'
 })
+
+initGamepad()
 
 i18next
   // load translation using http -> see /public/locales

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -127,9 +127,11 @@ const GameCard = ({
     ? `${125 - getProgress(progress)}%`
     : '100%'
 
-  const imgClasses = `gameImg ${isInstalled ? 'installed' : ''}`
-  const logoClasses = `gameLogo ${isInstalled ? 'installed' : ''}`
+  const instClass = isInstalled ? 'installed' : ''
+  const imgClasses = `gameImg ${instClass}`
+  const logoClasses = `gameLogo ${instClass}`
   const imageSrc = `${grid ? cover : coverList}?h=400&resize=1&w=300`
+  const wrapperClasses = `${grid ? 'gameCard' : 'gameListItem'}  ${instClass}`
 
   async function handleUpdate() {
     await handleGameStatus({ appName, status: 'updating' })
@@ -200,7 +202,7 @@ const GameCard = ({
   return (
     <>
       <ContextMenuTrigger id={appName}>
-        <div className={grid ? 'gameCard' : 'gameListItem'}>
+        <div className={wrapperClasses}>
           {haveStatus && <span className="progress">{getStatus()}</span>}
           <Link
             to={{

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -175,7 +175,7 @@ const GameCard = ({
     }
     if (isInstalled && isGame) {
       return (
-        <SvgButton onClick={() => handlePlay()}>
+        <SvgButton className="playButton" onClick={() => handlePlay()}>
           <PlayIcon className="playIcon" />
         </SvgButton>
       )

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,5 +210,8 @@ export type ElWebview = {
 export type Webview = HTMLWebViewElement & ElWebview
 
 export interface GamepadActionStatus {
-  [key: string]: { triggered: number; repeatDelay: false | number }
+  [key: string]: {
+    triggeredAt: { [key: number]: number }
+    repeatDelay: false | number
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,3 +208,7 @@ export type ElWebview = {
 }
 
 export type Webview = HTMLWebViewElement & ElWebview
+
+export interface GamepadActionStatus {
+  [key: string]: { triggered: number; repeatDelay: false | number }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11738,6 +11738,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
   integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
 
+simple-keyboard@^3.4.24:
+  version "3.4.24"
+  resolved "https://registry.yarnpkg.com/simple-keyboard/-/simple-keyboard-3.4.24.tgz#57e2e4e79f1a97f922ae81573d59b20558a4b0ce"
+  integrity sha512-P3pUjhYYPX/41UWgFxOVDjG+rswK2KGPGkhMgpLR5Sq7LKQ1R6Shk78WIUzCcxCif19RV+K9Vt+rq5FLZRqeIg==
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"


### PR DESCRIPTION
This PR adds support to control Heroic using a gamepad.

Implemented:
- using the Gamepad API
- invoke methods on electron to simulate key presses and wheel
- navigate the app using pad or left stick
- scroll the main window using right stick
- repeat actions when holding a button/stick
- trigger a `click` on the currently focused element when pressing A in an Xbox controller
- Xbox, PS3, PS5 and Gamecub layouts
- interacting with select tags
- virtual keyboard

TODO:
- ~~try other controllers (I only have an Xbox controller to test this)~~
- ~~I cannot find a way to trigger the dropdown for `select` tags (tried with the `click()` method, simulating a `Return` key press and simulating a `mouseDown` event with electron), maybe we need to display a custom dropdown when using a gamepad~~

Ideas to improve this for the futre (I'd say to leave them for another PR as V2 of this feature):
- ~~for the search field to work we'll need a virtual keyboard~~
- let the user re-assign controller buttons (decide which stick scrolls, pick what to do with each button, etc)
- let the user configure the scroll sensitivity
- let the user configure the repeat speed

Closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/107

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
