### PR TITLE
Fix typo and add extra styling to copy to clipboard button

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -231,7 +231,7 @@
     "Settings": "Settings",
     "settings": {
         "clear-cache": "Clear Heroic Cache",
-        "copyToClipboard": "Copy All Setting to Clipboard",
+        "copyToClipboard": "Copy All Settings to Clipboard",
         "navbar": {
             "general": "General",
             "other": "Other",

--- a/src/screens/Settings/index.css
+++ b/src/screens/Settings/index.css
@@ -188,3 +188,7 @@ a {
   margin-left: 8px;
   padding-top: 0;
 }
+
+.settingsWrapper > .button.success-override-color:hover {
+  color: var(--success) !important;
+}

--- a/src/screens/Settings/index.css
+++ b/src/screens/Settings/index.css
@@ -189,6 +189,6 @@ a {
   padding-top: 0;
 }
 
-.settingsWrapper > .button.success-override-color:hover {
+.settingsWrapper > .button.isSuccess:hover {
   color: var(--success) !important;
 }

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -1,6 +1,7 @@
 import './index.css'
 
 import React, { useContext, useEffect, useState } from 'react'
+import classNames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faWindows, faApple } from '@fortawesome/free-brands-svg-icons'
 
@@ -465,9 +466,9 @@ function Settings() {
           )}
           <span className="save">{t('info.settings')}</span>
           <button
-            className={`button is-text ${
-              isCopiedToClipboard ? 'success-override-color' : ''
-            }`}
+            className={classNames('button', 'is-text', {
+              isSuccess: isCopiedToClipboard
+            })}
             onClick={() => {
               clipboard.writeText(
                 JSON.stringify({ appName, title, ...settingsToSave })

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -166,6 +166,8 @@ function Settings() {
 
   const [isMacNative, setIsMacNative] = useState(false)
 
+  const [isCopiedToClipboard, setCopiedToClipboard] = useState(false)
+
   const { appName, type } = useParams() as RouteParams
   const isDefault = appName === 'default'
   const isGeneralSettings = type === 'general'
@@ -451,14 +453,24 @@ function Settings() {
           )}
           <span className="save">{t('info.settings')}</span>
           <button
-            className="button is-text"
-            onClick={() =>
+            className={`button is-text ${isCopiedToClipboard ? 'success-override-color' : null}`}
+            onClick={() => {
               clipboard.writeText(
                 JSON.stringify({ appName, title, ...settingsToSave })
               )
-            }
+              // set copied to clipboard status to true if it's not already set to true
+              // used for changing text and color
+              if (!isCopiedToClipboard) {
+                setCopiedToClipboard(true)
+
+                setTimeout(() => {
+                  setCopiedToClipboard(false)
+                  console.log('doing')
+                }, 3000)
+              }
+          }}
           >
-            {t('settings.copyToClipboard', 'Copy All Setting to Clipboard')}
+            {isCopiedToClipboard ? t('settings.copiedToClipboard', 'Copied to Clipboard!') : t('settings.copyToClipboard', 'Copy All Settings to Clipboard')}
           </button>
           {isDefault && (
             <>

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -305,6 +305,18 @@ function Settings() {
     writeConfig([appName, settingsToSave])
   }, [GlobalSettings, GameSettings, appName])
 
+  useEffect(() => {
+    // set copied to clipboard status to true if it's not already set to true
+    // used for changing text and color
+    if (!isCopiedToClipboard) return
+
+    const timer = setTimeout(() => {
+      setCopiedToClipboard(false)
+    }, 3000)
+
+    return () => clearTimeout(timer)
+  }, [isCopiedToClipboard])
+
   if (!title) {
     return <UpdateComponent />
   }
@@ -454,22 +466,13 @@ function Settings() {
           <span className="save">{t('info.settings')}</span>
           <button
             className={`button is-text ${
-              isCopiedToClipboard ? 'success-override-color' : null
+              isCopiedToClipboard ? 'success-override-color' : ''
             }`}
             onClick={() => {
               clipboard.writeText(
                 JSON.stringify({ appName, title, ...settingsToSave })
               )
-              // set copied to clipboard status to true if it's not already set to true
-              // used for changing text and color
-              if (!isCopiedToClipboard) {
-                setCopiedToClipboard(true)
-
-                setTimeout(() => {
-                  setCopiedToClipboard(false)
-                  console.log('doing')
-                }, 3000)
-              }
+              setCopiedToClipboard(true)
             }}
           >
             {isCopiedToClipboard

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -453,7 +453,9 @@ function Settings() {
           )}
           <span className="save">{t('info.settings')}</span>
           <button
-            className={`button is-text ${isCopiedToClipboard ? 'success-override-color' : null}`}
+            className={`button is-text ${
+              isCopiedToClipboard ? 'success-override-color' : null
+            }`}
             onClick={() => {
               clipboard.writeText(
                 JSON.stringify({ appName, title, ...settingsToSave })
@@ -468,9 +470,11 @@ function Settings() {
                   console.log('doing')
                 }, 3000)
               }
-          }}
+            }}
           >
-            {isCopiedToClipboard ? t('settings.copiedToClipboard', 'Copied to Clipboard!') : t('settings.copyToClipboard', 'Copy All Settings to Clipboard')}
+            {isCopiedToClipboard
+              ? t('settings.copiedToClipboard', 'Copied to Clipboard!')
+              : t('settings.copyToClipboard', 'Copy All Settings to Clipboard')}
           </button>
           {isDefault && (
             <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5075,11 +5075,6 @@ electron-devtools-installer@^3.2.0:
     tslib "^2.1.0"
     unzip-crx-3 "^0.2.0"
 
-electron-is-dev@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-2.0.0.tgz#833487a069b8dad21425c67a19847d9064ab19bd"
-  integrity sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==
-
 electron-osx-sign@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz#fc258c5e896859904bbe3d01da06902c04b51c3a"


### PR DESCRIPTION
First things first, I noticed that the "Copy All Settings to Clipboard" button in the settings menu actually says "Setting" instead of "Settings." I'm not entirely sure if I need to do anything to update the translations, but I've fixed it where it appeared in the code. 

The other thing I added was just a small styling improvement (in my opinion) to that same button. When clicked, it now changes the text to "Copied to Clipboard!" and changes the text color to green on hover (success variable) for 3 seconds, after which it changes back to normal.

Hope you like the changes, and let me know if I should fix anything

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
