### PR TITLE
Show the switch focus outline only with keyboard, not mouse

### DIFF
--- a/src/components/UI/ToggleSwitch/index.css
+++ b/src/components/UI/ToggleSwitch/index.css
@@ -7,25 +7,18 @@
   height: 11px;
 }
 
-.switch:focus-within {
-  outline: -webkit-focus-ring-color auto 1px;
-}
-
 /* Hide default HTML checkbox */
 .switch input {
-  opacity: 0;
-  width: 0;
-  height: 0;
+  display: none;
 }
 
 /* The slider */
 .slider {
-  position: absolute;
+  position: relative;
   cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  display: inline-block;
+  width: 100%;
+  height: 100%;
   background: none;
   border: 2px solid;
   -webkit-transition: 0.4s;
@@ -44,16 +37,16 @@
   transition: 0.4s;
 }
 
+.slider:focus-visible {
+  outline: 1px solid var(--secondary);
+}
+
+input:checked + .slider:focus-visible {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
 input:checked + .slider {
   border-color: var(--secondary);
-}
-
-input:checked span {
-  color: var(--secondary);
-}
-
-input:focus + .slider {
-  box-shadow: 0 0 1px var(--secondary);
 }
 
 input:checked + .slider:before {


### PR DESCRIPTION
This PR updates the css of the switch in the ToggleSwitch component to only display the focus outline when using the keyboard to focus an element but not when using a mouse.

I also updated the ouline style to be the oposite to the current color (so if the switch is off -white- the outline is yellow, and when the switch is on -yellow- the outline is white)

Closes #876 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
