### PR TITLE
Support Ctrl+F and CMD+F shortcut to focus search bar

### DIFF
--- a/src/helpers/shortcuts.ts
+++ b/src/helpers/shortcuts.ts
@@ -1,0 +1,8 @@
+export const initShortcuts = () => {
+  document.addEventListener('keydown', (e) => {
+    // Ctrl+F or Cmd+F, focus search bar
+    if ((e.ctrlKey || e.metaKey) && e.key.toLocaleLowerCase() === 'f') {
+      document.getElementById('search')?.focus()
+    }
+  })
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import './index.css'
 import App from 'src/App'
 import GlobalState from 'src/state/GlobalState'
 import UpdateComponent from 'src/components/UI/UpdateComponent'
+import { initShortcuts } from './helpers/shortcuts'
 
 const Backend = new HttpApi(null, {
   addPath: 'build/locales/{{lng}}/{{ns}}',
@@ -18,6 +19,7 @@ const Backend = new HttpApi(null, {
 })
 
 initGamepad()
+initShortcuts()
 
 i18next
   // load translation using http -> see /public/locales


### PR DESCRIPTION
This PR adds the code to handle Ctrl+F and CMD+F shortucts to move the cursor to the search bar if we are in the library screen.

Closes #867 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
