### PR TITLE
[Windows] Fix creation of log file

### DIFF
--- a/electron/logger/logger.ts
+++ b/electron/logger/logger.ts
@@ -161,7 +161,9 @@ interface createLogFileReturn {
 export function createNewLogFileAndClearOldOnces(): createLogFileReturn {
   const date = new Date()
   const logDir = app.getPath('logs')
-  const newLogFile = `${logDir}/heroic-${date.toISOString()}.log`
+  const newLogFile = `${logDir}/heroic-${date
+    .toISOString()
+    .replace(':', '_')}.log`
   try {
     openSync(newLogFile, 'w')
   } catch (error) {
@@ -176,7 +178,10 @@ export function createNewLogFileAndClearOldOnces(): createLogFileReturn {
     const logs = readdirSync(logDir)
     logs.forEach((log) => {
       if (log.includes('heroic-')) {
-        const dateString = log.replace('heroic-', '').replace('.log', '')
+        const dateString = log
+          .replace('heroic-', '')
+          .replace('.log', '')
+          .replace('_', ':')
         const logDate = new Date(dateString)
         if (
           logDate.getFullYear() < date.getFullYear() ||


### PR DESCRIPTION
Replaced not allowed characters ( ':' ) with allowed onces ( '_' ) for file creation on windows.
Can someone with windows test it ?
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
