### PR TITLE
[Windows] Fixed manifest path creation for egsSync

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1068,7 +1068,7 @@ ipcMain.handle('egsSync', async (event, args) => {
 
   if (isWindows) {
     if (!existsSync(egl_manifestPath)) {
-      mkdirSync(egl_manifestPath)
+      mkdirSync(egl_manifestPath, { recursive: true })
     }
   }
 


### PR DESCRIPTION
There was a problem, where the creation of folder  'C:/ProgramData/Epic/EpicGamesLauncher/Data/Manifests' failed, because mkdirSync wasn't called with recursive option. With recursive set to true, folder should be created now.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
