### PR TITLE
Better Wine Installation management, better DXVK installation, some small fixes here and there

### DIFF
--- a/electron/dxvk.ts
+++ b/electron/dxvk.ts
@@ -8,6 +8,7 @@ import { execOptions, heroicToolsPath, home } from './constants'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
 import { dialog } from 'electron'
 import i18next from 'i18next'
+import { WineInstallation } from 'types'
 
 export const DXVK = {
   getLatest: async () => {
@@ -103,6 +104,32 @@ export const DXVK = {
           )
         })
     })
+  },
+
+  install: async (
+    wineVersion: WineInstallation,
+    prefix: string,
+    tool: 'dxvk' | 'vkd3d'
+  ) => {
+    const formattedToolName = tool.toUpperCase()
+    if (wineVersion.type != 'wine') {
+      logWarning(
+        `Unable to install ${formattedToolName}: Wine version ${wineVersion.name} unsupported`
+      )
+      return
+    }
+
+    const absolutePrefixDir = prefix.replace('~', home)
+    const isValidPrefix = existsSync(`${absolutePrefixDir}/.update-timestamp`)
+    if (!isValidPrefix) {
+      logWarning(
+        `Unable to install ${formattedToolName}: Prefix invalid`,
+        LogPrefix.DXVKInstaller
+      )
+      return
+    }
+
+    // TODO: Actually install DXVK
   },
 
   installRemove: async (

--- a/electron/games.ts
+++ b/electron/games.ts
@@ -36,6 +36,7 @@ abstract class Game {
   abstract syncSaves(arg: string, path: string): Promise<ExecResult>
   abstract uninstall(): Promise<ExecResult>
   abstract update(): Promise<unknown>
+  abstract runWineCommand(command: string): Promise<ExecResult>
 }
 
 import { LegendaryGame } from './legendary/games'

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -744,18 +744,22 @@ Categories=Game;
       return
     }
 
-    if (isProton && !existsSync(fixedWinePrefix)) {
+    // Create prefix directory if it doesn't exist
+    if (!existsSync(fixedWinePrefix)) {
       mkdirSync(fixedWinePrefix, { recursive: true })
     }
 
-    if (!existsSync(fixedWinePrefix)) {
-      mkdirSync(fixedWinePrefix, { recursive: true })
-      const initPrefixCommand = `WINEPREFIX='${fixedWinePrefix}' '${winePath}/wineboot' -i`
-      logInfo(['creating new prefix', fixedWinePrefix], LogPrefix.Backend)
-      return execAsync(initPrefixCommand)
-        .then(() => logInfo('Prefix created succesfuly!', LogPrefix.Backend))
-        .catch((error) => logError(`${error}`, LogPrefix.Backend))
+    let initPrefixCommand = ``
+    if (isProton) {
+      initPrefixCommand = `STEAM_COMPAT_CLIENT_INSTALL_PATH=${home}/.steam/steam STEAM_COMPAT_DATA_PATH='${fixedWinePrefix}' '${winePath}/proton' run wineboot -i`
+    } else {
+      initPrefixCommand = `WINEPREFIX='${fixedWinePrefix}' '${winePath}/wineboot' -i`
     }
+
+    logInfo(['Creating new prefix', fixedWinePrefix], LogPrefix.Backend)
+    return execAsync(initPrefixCommand)
+      .then(() => logInfo('Prefix created successfully!', LogPrefix.Backend))
+      .catch((error) => logError(`${error}`, LogPrefix.Backend))
   }
 
   public async stop() {

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -680,8 +680,7 @@ Categories=Game;
     if (isProton) {
       logWarning(
         [
-          `You are using Proton, this can lead to some bugs,
-          please do not open issues with bugs related with games`,
+          `You are using Proton, this can lead to some bugs. Please do not open issues with bugs related with games`,
           wineVersion.name
         ],
         LogPrefix.Backend

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -682,7 +682,7 @@ Categories=Game;
       )
     }
 
-    await this.createNewPrefix(isProton, fixedWinePrefix, winePath)
+    await this.verifyPrefix(isProton, fixedWinePrefix, winePath)
 
     // Install DXVK for non Proton/CrossOver Prefixes
     if (!isProton && !isCrossover && autoInstallDxvk) {
@@ -735,7 +735,7 @@ Categories=Game;
     return startLaunch
   }
 
-  private async createNewPrefix(
+  private async verifyPrefix(
     isProton: boolean,
     fixedWinePrefix: string,
     winePath: string

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -764,10 +764,9 @@ Categories=Game;
     command: string,
     wait = true
   ): Promise<ExecResult> {
-    const wineVersion = (await this.getSettings()).wineVersion
-    const winePrefix = (await this.getSettings()).winePrefix.replace('~', home)
+    const { wineVersion, winePrefix } = await this.getSettings()
 
-    const env_vars = this.getEnvSetup(wineVersion, winePrefix)
+    const env_vars = await this.getEnvSetup(wineVersion, winePrefix)
 
     let additional_command = ''
     if (wineVersion.type == 'proton') {
@@ -787,20 +786,19 @@ Categories=Game;
 
     logDebug(['Running Wine command: ', finalCommand], LogPrefix.Backend)
     return execAsync(finalCommand)
-      .then(() => logDebug('Ran Wine command'))
-      .catch((error) => logError(error, LogPrefix.Backend))
+      .then(() => logDebug('Ran Wine command', LogPrefix.Backend))
+      .catch((error) =>
+        logError(['Error running Wine command: ', error], LogPrefix.Backend)
+      )
   }
 
   private async getEnvSetup(
     wineVersion?: WineInstallation,
     winePrefix?: string
   ): Promise<string> {
-    if (!wineVersion) {
-      wineVersion = (await this.getSettings()).wineVersion
-    }
-    if (!winePrefix) {
-      winePrefix = (await this.getSettings()).winePrefix.replace('~', home)
-    }
+    wineVersion = wineVersion ?? (await this.getSettings()).wineVersion
+    winePrefix =
+      winePrefix ?? (await this.getSettings()).winePrefix.replace('~', home)
 
     if (wineVersion.type == 'proton') {
       return `STEAM_COMPAT_CLIENT_INSTALL_PATH=${home}/.steam/steam STEAM_COMPAT_DATA_PATH='${winePrefix}'`

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -757,7 +757,7 @@ Categories=Game;
       mkdirSync(winePrefix, { recursive: true })
     }
 
-    return this.runWineCommand('wineboot --init', true)
+    return this.runWineCommand('wineboot --init')
   }
 
   public async runWineCommand(

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -320,7 +320,7 @@ if (!gotTheLock) {
         logError('Failed to register protocol with OS.', LogPrefix.Backend)
       }
     } else {
-      logWarning('Protocol already registered.', LogPrefix.Backend)
+      logInfo('Protocol already registered.', LogPrefix.Backend)
     }
     if (process.argv[1]) {
       const url = process.argv[1]

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -214,6 +214,7 @@ export type UserInfo = {
 export interface WineInstallation {
   bin: string
   name: string
+  type: 'wine' | 'proton' | 'crossover'
   wineboot?: string
   wineserver?: string
 }


### PR DESCRIPTION
This improves a few things:
- [X] The log message about Proton is formatted properly again
- [X] The log message about the Heroic Protocol already being registered is now an Info message instead of a Warning (since it happens on every launch)
- [X] In code, it's now easier to tell if a Wine Version is Wine/Proton/Crossover. This is due to a new `type` property on WineInstallation
- [X] A new `runWineCommand` function now exists, to make it easy to run a Wine command with the context of the current game
- [X] Wine prefix creation was reworked: It now properly creates prefixes when the dir already exists, and Proton prefix creation also works now
- [ ]   DXVK is no longer installed with the `setup_dxvk` script, which makes it possible to install it on some Wine-GE versions again

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
