### PR TITLE
Add installation on MacOS via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ download Heroic.Setup.x.x.x.exe or the Portable Heroic-x.x.x.exe file and run it
 
 ### macOS
 
-Download Heroic-x.x.x.dmg and move the Heroic App to the Applications folder.
+If you use Homebrew, just type: `brew install --cask heroic`. Otherwise, download Heroic-x.x.x.dmg and move the Heroic App to the Applications folder.
 
 ### Build binaries locally (All platforms)
 


### PR DESCRIPTION
<--- Put the description here --->
Added installation instructions for Heroic in MacOS via Homebrew. Heroic is available in Homebrew as a cask. https://formulae.brew.sh/cask/heroic#default
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Created / Updated documentation (If necessary)
