### PR TITLE
Remove unnecessary spaces from launch commands

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -190,7 +190,7 @@ async function launch(
           audioFix ? `PULSE_LATENCY_MSEC=60` : '',
           // This must be always last
           steamRuntime
-        ]
+        ].filter((n) => n)
         envVars = options.join(' ')
       }
       command = `${envVars} ${gogdlBin} launch "${
@@ -261,7 +261,9 @@ async function launch(
       : ''
   }
 
-  envVars = Object.values(options).join(' ')
+  envVars = Object.values(options)
+    .filter((n) => n)
+    .join(' ')
   if (isProton) {
     logWarning(
       [
@@ -289,16 +291,42 @@ async function launch(
 
   let command = ''
   if (isLegendary) {
-    command = `${envVars} ${runWithGameMode} ${mangohud} ${legendaryBin} launch ${appName} ${exe} ${runOffline} ${wineCommand} ${prefix} ${
-      launchArguments ?? ''
-    } ${launcherArgs}`
+    command = [
+      envVars,
+      runWithGameMode,
+      mangohud,
+      legendaryBin,
+      'launch',
+      appName,
+      exe,
+      runOffline,
+      wineCommand,
+      prefix,
+      launchArguments,
+      launcherArgs
+    ]
+      .filter((n) => n)
+      .join(' ')
     logInfo(['Launch Command:', command], LogPrefix.Legendary)
   } else if (isGOG) {
-    command = `${envVars} ${runWithGameMode} ${mangohud} ${gogdlBin} launch "${
-      gameInfo.install.install_path
-    }" ${exe} ${appName} ${wineCommand} ${prefix} --os ${gameInfo.install.platform.toLowerCase()} ${
-      launchArguments ?? ''
-    } ${launcherArgs}`
+    command = [
+      envVars,
+      runWithGameMode,
+      mangohud,
+      gogdlBin,
+      'launch',
+      `"${gameInfo.install.install_path}"`,
+      exe,
+      appName,
+      wineCommand,
+      prefix,
+      '--os',
+      gameInfo.install.platform.toLowerCase(),
+      launchArguments,
+      launcherArgs
+    ]
+      .filter((n) => n)
+      .join(' ')
     logInfo(['Launch Command:', command], LogPrefix.Gog)
   }
 


### PR DESCRIPTION
Before, all necessary launch options were inserted into a string with pre-defined spaces. This caused issues, as when an option wasn't set, a space was still inserted.
Now, the "command parts" are collected in a list, which is then filtered to remove empty entries, and then joined together with spaces.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
