### PR TITLE
Fixup protocol handling when Heroic is already running

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -245,6 +245,7 @@ const contextMenu = () => {
 }
 
 if (!gotTheLock) {
+  logInfo('Heroic is already running, quitting this instance')
   app.quit()
 } else {
   app.on('second-instance', (event, argv) => {
@@ -252,9 +253,17 @@ if (!gotTheLock) {
     if (mainWindow) {
       mainWindow.show()
     }
-    if (argv[1]) {
-      const url = argv[1]
-      handleProtocol(mainWindow, url)
+
+    // Figure out which argv element is our protocol
+    let heroicProtocolString = ''
+    argv.forEach((value) => {
+      if (value.startsWith('heroic://')) {
+        heroicProtocolString = value
+      }
+    })
+
+    if (heroicProtocolString) {
+      handleProtocol(mainWindow, heroicProtocolString)
     }
   })
   app.whenReady().then(async () => {


### PR DESCRIPTION
The current `second-instance` handling function blindly passes `argv[1]` to `handleProtocol`. This is problematic, as `argv[1]` might not always be the protocol.  In my case (when adding simple logging to the function), I've found that it was always `--enable-crashpad`, so protocol links were not working if Heroic was already running.

This is now fixed, by iterating over every element in `argv` and checking if it starts with `heroic://`

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
