### PR TITLE
Added missing alternate exe parameter for GOG Linux

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -195,7 +195,7 @@ async function launch(
       }
       command = `${envVars} ${gogdlBin} launch "${
         gameInfo.install.install_path
-      }" ${gameInfo.app_name} --platform=${gameInfo.install.platform} ${
+      }" ${exe} ${gameInfo.app_name} --platform=${gameInfo.install.platform} ${
         launchArguments ?? ''
       } ${launcherArgs}`
       logInfo(['Launch Command:', command], LogPrefix.Gog)


### PR DESCRIPTION
I've added the missing alternate executable variable that is included in the launch parameters for GOG Linux games. Since it was a very tiny addition, I didn't build and test it.
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
