### PR TITLE
[All] Truly use `path.join()` everywhere (Fix "Show log file in folder" and wrong game settings path)

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  required: false
 
 jobs:
   build_windows:

--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
-  required: false
 
 jobs:
   build_windows:

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -17,6 +17,7 @@ import {
   heroicInstallPath,
   heroicToolsPath,
   home,
+  isFlatpak,
   isMac,
   isWindows
 } from './constants'
@@ -475,7 +476,7 @@ class GlobalConfigV0 extends GlobalConfig {
       addStartMenuShortcuts: false,
       autoInstallDxvk: false,
       autoInstallVkd3d: false,
-      checkForUpdatesOnStartup: true,
+      checkForUpdatesOnStartup: !isFlatpak,
       customWinePaths: isWindows ? null : [],
       defaultInstallPath: heroicInstallPath,
       defaultWinePrefix: `${home}/Games/Heroic/Prefixes`,

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -173,7 +173,7 @@ abstract class GlobalConfig {
       })
     } else if (!isWindows) {
       // Linux
-      const crossoverWineBin = join('opt', 'cxoffice', 'bin', 'wine')
+      const crossoverWineBin = '/opt/cxoffice/bin/wine'
       if (!existsSync(crossoverWineBin)) {
         return crossover
       }
@@ -244,16 +244,8 @@ abstract class GlobalConfig {
     // Just add a new string here in case another path is found on another distro.
     const steamPaths = [
       join(home, '.steam'),
-      join(
-        home,
-        '.var',
-        'app',
-        'com.valvesoftware.Steam',
-        '.local',
-        'share',
-        'Steam'
-      ),
-      join('/', 'usr', 'share', 'steam')
+      join(home, '.var/app/com.valvesoftware.Steam/.local/share/Steam'),
+      '/usr/share/steam'
     ].filter((path) => existsSync(path))
 
     steamPaths.forEach((path) => {

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -172,7 +172,7 @@ abstract class GlobalConfig {
       })
     } else if (!isWindows) {
       // Linux
-      const crossoverWineBin = '/opt/cxoffice/bin/wine'
+      const crossoverWineBin = join('opt', 'cxoffice', 'bin', 'wine')
       if (!existsSync(crossoverWineBin)) {
         return crossover
       }
@@ -242,9 +242,17 @@ abstract class GlobalConfig {
     // Known places where Steam might be found.
     // Just add a new string here in case another path is found on another distro.
     const steamPaths = [
-      `${home}/.steam`,
-      `${home}/.var/app/com.valvesoftware.Steam/.local/share/Steam`,
-      '/usr/share/steam'
+      join(home, '.steam'),
+      join(
+        home,
+        '.var',
+        'app',
+        'com.valvesoftware.Steam',
+        '.local',
+        'share',
+        'Steam'
+      ),
+      join('/', 'usr', 'share', 'steam')
     ].filter((path) => existsSync(path))
 
     steamPaths.forEach((path) => {

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -20,17 +20,14 @@ function getLegendaryBin() {
   const settings = configStore.get('settings') as { altLeg: string }
   const bin =
     settings?.altLeg ||
-    `${fixAsarPath(
+    `"${fixAsarPath(
       join(
         __dirname,
-        '/bin/',
+        'bin',
         process.platform,
-        isWindows ? '/legendary.exe' : '/legendary'
+        isWindows ? 'legendary.exe' : 'legendary'
       )
-    )}`
-  if (bin.includes(' ')) {
-    return `"${bin}"`
-  }
+    )}"`
   logInfo(`Location: ${bin}`, LogPrefix.Legendary)
   return bin
 }
@@ -41,9 +38,9 @@ function getGOGdlBin() {
     settings?.altGogdl ||
       join(
         __dirname,
-        '/bin/',
+        'bin',
         process.platform,
-        isWindows ? '/gogdl.exe' : '/gogdl'
+        isWindows ? 'gogdl.exe' : 'gogdl'
       )
   )
   logInfo(`Location: ${bin}`, LogPrefix.Gog)

--- a/electron/dxvk.ts
+++ b/electron/dxvk.ts
@@ -8,6 +8,7 @@ import { execOptions, heroicToolsPath, home } from './constants'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
 import { dialog } from 'electron'
 import i18next from 'i18next'
+import { dirname } from 'path'
 
 export const DXVK = {
   getLatest: async () => {
@@ -116,9 +117,7 @@ export const DXVK = {
     }
 
     // remove the last part of the path since we need the folder only
-    const winePathSplit = winePath.replaceAll("'", '').split('/')
-    winePathSplit.pop()
-    const wineBin = winePathSplit.join('/').concat('/')
+    const wineBin = dirname(winePath.replace("'", ''))
 
     if (!existsSync(`${heroicToolsPath}/${tool}/latest_${tool}`)) {
       logError('dxvk not found!', LogPrefix.DXVKInstaller)

--- a/electron/game_config.ts
+++ b/electron/game_config.ts
@@ -8,6 +8,7 @@ import {
   heroicGamesConfigPath
 } from './constants'
 import { logError, logInfo, LogPrefix } from './logger/logger'
+import { join } from 'path'
 
 /**
  * This class does config handling for games.
@@ -28,7 +29,7 @@ abstract class GameConfig {
 
   protected constructor(appName: string) {
     this.appName = appName
-    this.path = `${heroicGamesConfigPath}${appName}.json`
+    this.path = join(heroicGamesConfigPath, appName + '.json')
   }
 
   /**
@@ -40,7 +41,7 @@ abstract class GameConfig {
    */
   public static get(appName: string): GameConfig {
     let version: GameConfigVersion
-    const path = `${heroicGamesConfigPath}${appName}.json`
+    const path = join(heroicGamesConfigPath, appName + '.json')
     // Config file doesn't already exist, make one with the current version.
     if (!existsSync(path)) {
       version = currentGameConfigVersion

--- a/electron/gog/games.ts
+++ b/electron/gog/games.ts
@@ -124,7 +124,7 @@ class GOGGame extends Game {
       installPlatform = 'osx'
     }
 
-    const logPath = `"${heroicGamesConfigPath}${this.appName}.log"`
+    const logPath = `"${join(heroicGamesConfigPath, this.appName + '.log')}"`
     const writeLog = isWindows ? `2>&1 > ${logPath}` : `|& tee ${logPath}`
 
     // In the future we need to add Language select option
@@ -401,7 +401,7 @@ class GOGGame extends Game {
     const credentials = configStore.get('credentials') as GOGLoginData
 
     const installPlatform = gameData.install.platform
-    const logPath = `"${heroicGamesConfigPath}${this.appName}.log"`
+    const logPath = `"${join(heroicGamesConfigPath, this.appName + '.log')}"`
     const writeLog = isWindows ? `2>&1 > ${logPath}` : `|& tee ${logPath}`
 
     return {

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -23,6 +23,7 @@ import { Runner } from './types'
 import { GOGLibrary } from './gog/library'
 import { LegendaryLibrary } from './legendary/library'
 import setup from './gog/setup'
+import { dirname } from 'path'
 
 function getGameInfo(appName: string, runner: Runner) {
   switch (runner) {
@@ -235,9 +236,7 @@ async function launch(
   const isProton = wineVersion.type === 'proton'
   const isCrossover = wineVersion.type === 'crossover'
   prefix = isProton || isCrossover ? '' : prefix
-  const x = wineVersion.bin.split('/')
-  x.pop()
-  const winePath = x.join('/').replaceAll("'", '')
+  const winePath = dirname(wineVersion.bin)
   const options = {
     audio: audioFix ? `PULSE_LATENCY_MSEC=60` : '',
     crossoverBottle:

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -21,6 +21,7 @@ import { spawn } from 'child_process'
 import Store from 'electron-store'
 import { launch } from '../launcher'
 import { addShortcuts, removeShortcuts } from '../shortcuts'
+import { join } from 'path'
 
 const store = new Store({
   cwd: 'lib-cache',
@@ -230,7 +231,7 @@ class LegendaryGame extends Game {
     })
     const { maxWorkers } = await GlobalConfig.get().getSettings()
     const workers = maxWorkers === 0 ? '' : ` --max-workers ${maxWorkers}`
-    const logPath = `"${heroicGamesConfigPath}${this.appName}.log"`
+    const logPath = `"${join(heroicGamesConfigPath, this.appName + '.log')}"`
     const writeLog = isWindows ? `2>&1 > ${logPath}` : `|& tee ${logPath}`
     const command = `${legendaryBin} update ${this.appName}${workers} -y ${writeLog}`
     return execAsync(command, execOptions)
@@ -300,7 +301,7 @@ class LegendaryGame extends Game {
     const withDlcs = installDlcs ? '--with-dlcs' : '--skip-dlcs'
     const installSdl = sdlList.length ? this.getSdlList(sdlList) : '--skip-sdl'
 
-    const logPath = `"${heroicGamesConfigPath}${this.appName}.log"`
+    const logPath = `"${join(heroicGamesConfigPath, this.appName + '.log')}"`
     const writeLog = isWindows ? `2>&1 > ${logPath}` : `|& tee ${logPath}`
     const command = `${legendaryBin} install ${this.appName} --platform ${platformToInstall} --base-path '${path}' ${withDlcs} ${installSdl} ${workers} -y ${writeLog}`
     logInfo([`Installing ${this.appName} with:`, command], LogPrefix.Legendary)
@@ -346,7 +347,7 @@ class LegendaryGame extends Game {
     const { maxWorkers } = await GlobalConfig.get().getSettings()
     const workers = maxWorkers ? `--max-workers ${maxWorkers}` : ''
 
-    const logPath = `"${heroicGamesConfigPath}${this.appName}.log"`
+    const logPath = `"${join(heroicGamesConfigPath, this.appName + '.log')}"`
     const writeLog = isWindows ? `2>&1 > ${logPath}` : `|& tee ${logPath}`
 
     const command = `${legendaryBin} repair ${this.appName} ${workers} -y ${writeLog}`
@@ -392,7 +393,7 @@ class LegendaryGame extends Game {
       : path.replaceAll("'", '')
 
     const command = `${legendaryBin} sync-saves ${arg} --save-path "${fixedPath}" ${this.appName} -y`
-    const legendarySavesPath = `${home}/legendary/.saves`
+    const legendarySavesPath = join(home, 'legendary', '.saves')
 
     //workaround error when no .saves folder exists
     if (!existsSync(legendarySavesPath)) {

--- a/electron/logger/logger.ts
+++ b/electron/logger/logger.ts
@@ -12,6 +12,7 @@ import {
   lastLogFile
 } from '../constants'
 import { app } from 'electron'
+import { join } from 'path'
 
 export enum LogPrefix {
   General = '',
@@ -161,9 +162,8 @@ interface createLogFileReturn {
 export function createNewLogFileAndClearOldOnces(): createLogFileReturn {
   const date = new Date()
   const logDir = app.getPath('logs')
-  const newLogFile = `${logDir}/heroic-${date
-    .toISOString()
-    .replace(':', '_')}.log`
+  const fmtDate = date.toISOString().replace(':', '_')
+  const newLogFile = join(logDir, `heroic-${fmtDate}.log`)
   try {
     openSync(newLogFile, 'w')
   } catch (error) {
@@ -238,7 +238,7 @@ export function getLogFile(
     ? defaultLast
       ? lastLogFile
       : currentLogFile
-    : `${heroicGamesConfigPath}${appName}-lastPlay.log`
+    : join(heroicGamesConfigPath, appName + '-lastPlay.log')
 }
 
 /**

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -286,9 +286,9 @@ if (!gotTheLock) {
 
     await i18next.use(Backend).init({
       backend: {
-        addPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}'),
+        addPath: path.join(__dirname, 'locales', '{{lng}}', '{{ns}}'),
         allowMultiLoading: false,
-        loadPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}.json')
+        loadPath: path.join(__dirname, 'locales', '{{lng}}', '{{ns}}.json')
       },
       debug: false,
       fallbackLng: 'en',

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -25,10 +25,12 @@ import {
   rmSync,
   unlinkSync,
   watch,
-  writeFile
+  writeFile,
+  writeFileSync
 } from 'graceful-fs'
 import Backend from 'i18next-fs-backend'
 import i18next from 'i18next'
+import { join } from 'path'
 
 import { DXVK } from './dxvk'
 import { Game } from './games'
@@ -399,8 +401,8 @@ process.on('uncaughtException', (err) => {
 
 let powerId: number | null
 ipcMain.on('lock', () => {
-  if (!existsSync(`${heroicGamesConfigPath}/lock`)) {
-    writeFile(`${heroicGamesConfigPath}/lock`, '', () => 'done')
+  if (!existsSync(join(heroicGamesConfigPath, 'lock'))) {
+    writeFileSync(join(heroicGamesConfigPath, 'lock'), '')
     if (!powerId) {
       powerId = powerSaveBlocker.start('prevent-app-suspension')
       return powerId
@@ -409,8 +411,8 @@ ipcMain.on('lock', () => {
 })
 
 ipcMain.on('unlock', () => {
-  if (existsSync(`${heroicGamesConfigPath}/lock`)) {
-    unlinkSync(`${heroicGamesConfigPath}/lock`)
+  if (existsSync(join(heroicGamesConfigPath, 'lock'))) {
+    unlinkSync(join(heroicGamesConfigPath, 'lock'))
     if (powerId) {
       return powerSaveBlocker.stop(powerId)
     }
@@ -796,7 +798,7 @@ ipcMain.handle(
           status: 'done'
         })
 
-        const gameLogFile = `${heroicGamesConfigPath}${game}-lastPlay.log`
+        const gameLogFile = join(heroicGamesConfigPath, game + '-lastPlay.log')
         writeFile(gameLogFile, logResult, () =>
           logInfo(`Log was written to ${gameLogFile}`, LogPrefix.Backend)
         )
@@ -807,7 +809,7 @@ ipcMain.handle(
         const stderr = `${exception.name} - ${exception.message}`
         errorHandler({ error: { stderr, stdout: '' } })
         writeFile(
-          `${heroicGamesConfigPath}${game}-lastPlay.log`,
+          join(heroicGamesConfigPath, game + '-lastPlay.log'),
           stderr,
           () => 'done'
         )
@@ -1086,7 +1088,7 @@ ipcMain.handle('updateGame', async (e, game, runner) => {
 })
 
 ipcMain.handle('requestGameProgress', async (event, appName) => {
-  const logPath = `${heroicGamesConfigPath}${appName}.log`
+  const logPath = join(heroicGamesConfigPath, appName + '.log')
   // eslint-disable-next-line no-debugger
   debugger
   if (!existsSync(logPath)) {

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -18,6 +18,7 @@ import {
   legendaryBin
 } from './constants'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
+import { join } from 'path'
 
 const execAsync = promisify(exec)
 const statAsync = promisify(stat)
@@ -166,7 +167,7 @@ const showAboutWindow = () => {
 }
 
 const handleExit = async () => {
-  const isLocked = existsSync(`${heroicGamesConfigPath}/lock`)
+  const isLocked = existsSync(join(heroicGamesConfigPath, 'lock'))
 
   if (isLocked) {
     const { response } = await showMessageBox({

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -14,6 +14,7 @@ import {
   heroicConfigPath,
   heroicGamesConfigPath,
   icon,
+  isWindows,
   legendaryBin
 } from './constants'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
@@ -326,7 +327,11 @@ function resetHeroic() {
 function showItemInFolder(item: string) {
   if (existsSync(item)) {
     try {
-      shell.showItemInFolder(item)
+      if (isWindows) {
+        execAsync(`explorer /Select,"${item}"`)
+      } else {
+        shell.showItemInFolder(item)
+      }
     } catch (error) {
       logError(
         `Failed to show item in folder with: ${error}`,


### PR DESCRIPTION
This PR addresses two things:
- Paths are now combined with [`path.join()`](https://nodejs.org/api/path.html#pathjoinpaths) instead of just combining them together as strings
- On Windows, a workaround is used to display files in a folder. This fixes the "Show log file in folder" button not doing anything

**It is very likely that I missed a path when moving to join**. Please double- and triple-check everywhere and let me know if you find any issues.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
