### PR TITLE
[Linux] Remove redundant if statement in getCrossover

### DIFF
--- a/electron/config.ts
+++ b/electron/config.ts
@@ -183,14 +183,12 @@ abstract class GlobalConfig {
         .split('\n')[2]
         .split(':')[1]
         .trim()
-      if (existsSync(crossoverWineBin)) {
-        crossover.add({
-          bin: `'${crossoverWineBin}'`,
-          name: `CrossOver - ${crossoverVersion}`,
-          type: 'crossover',
-          ...this.getWineExecs(crossoverWineBin)
-        })
-      }
+      crossover.add({
+        bin: `'${crossoverWineBin}'`,
+        name: `CrossOver - ${crossoverVersion}`,
+        type: 'crossover',
+        ...this.getWineExecs(crossoverWineBin)
+      })
     }
 
     return crossover


### PR DESCRIPTION
In `getCrossover`, we're returning early if CX is not found. This makes a later if statement always be true. I've removed this statement

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
