### PR TITLE
[Windows] Fix "Show log file in folder" once and for all

### DIFF
--- a/electron/logger/logger.ts
+++ b/electron/logger/logger.ts
@@ -162,7 +162,7 @@ interface createLogFileReturn {
 export function createNewLogFileAndClearOldOnces(): createLogFileReturn {
   const date = new Date()
   const logDir = app.getPath('logs')
-  const fmtDate = date.toISOString().replace(':', '_')
+  const fmtDate = date.toISOString().replaceAll(':', '_')
   const newLogFile = join(logDir, `heroic-${fmtDate}.log`)
   try {
     openSync(newLogFile, 'w')
@@ -174,6 +174,7 @@ export function createNewLogFileAndClearOldOnces(): createLogFileReturn {
     )
   }
 
+  // Clean out logs that are more than a month old
   try {
     const logs = readdirSync(logDir)
     logs.forEach((log) => {
@@ -181,7 +182,7 @@ export function createNewLogFileAndClearOldOnces(): createLogFileReturn {
         const dateString = log
           .replace('heroic-', '')
           .replace('.log', '')
-          .replace('_', ':')
+          .replaceAll('_', ':')
         const logDate = new Date(dateString)
         if (
           logDate.getFullYear() < date.getFullYear() ||

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -14,7 +14,6 @@ import {
   heroicConfigPath,
   heroicGamesConfigPath,
   icon,
-  isWindows,
   legendary
 } from './constants'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
@@ -328,11 +327,7 @@ function resetHeroic() {
 function showItemInFolder(item: string) {
   if (existsSync(item)) {
     try {
-      if (isWindows) {
-        execAsync(`explorer /Select,"${item}"`)
-      } else {
-        shell.showItemInFolder(item)
-      }
+      shell.showItemInFolder(item)
     } catch (error) {
       logError(
         `Failed to show item in folder with: ${error}`,


### PR DESCRIPTION
- Remove the workaround for showing a file, as `shell.showItemInFolder` actually works fine (it just didn't work back when we mixed / and \ in paths
- Properly remove forbidden characters from log filename

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
