### PR TITLE
[Tech] Disable eslint during development, added options to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,17 +1,19 @@
 root = true
 
 [*.css]
-indent_style = space
+charset = utf-8
+end_of_line = lf
 indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
 
-[*.js]
-indent_style = space
+[{*.ts, *.tsx, *.js}]
+charset = utf-8
+end_of_line = lf
 indent_size = 2
-
-[*.ts]
 indent_style = space
-indent_size = 2
-
-[*.tsx]
-indent_style = space
-indent_size = 2
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "tslib": "^2.3.1"
   },
   "scripts": {
-    "start": "nf start -p 3000 && electron-start",
+    "start": "DISABLE_ESLINT_PLUGIN=true nf start -p 3000 && electron-start",
     "electron-start": "ELECTRON_IS_DEV=1 node public/start-react",
     "electron": "yarn build-electron && electron . --trace-warnings",
     "react-start": "HOST=localhost BROWSER=none react-scripts start",


### PR DESCRIPTION
Added addition options to .editorconfig
Disable eslint validation during development

Rationale:
The reason to disable it is that it's infuriating to develop anything with eslint enabled.
You comment single line for then you get bombarded with unused variables and import which must also be commented which will cause new errors.
Moving code around is impossible without getting perfect indents.
I don't see any value with checking that during development, especially since prettier will take care of it anyway.
They'll still be checked during build and pipeline execution.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
