### PR TITLE
[Fix] Override exe file for GOG games, launch exe on prefix now sets working directory to the location of exe file

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -96,7 +96,8 @@ async function launch(
       return
     }
   }
-  const exe = targetExe && isLegendary ? `--override-exe ${targetExe}` : ''
+  const exe =
+    targetExe && (isLegendary || isGOG) ? `--override-exe ${targetExe}` : ''
   const isMacNative = gameInfo.is_mac_native
   // const isLinuxNative = gameInfo.is_linux_native
   const mangohud = showMangohud ? 'mangohud --dlsym' : ''

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,3 +1,5 @@
+import { ExecOptions } from 'child_process'
+import { dirname } from 'path'
 import {
   InstallParams,
   LaunchResult,
@@ -492,6 +494,9 @@ ipcMain.handle(
     const oldProtonWinePath = wine.replace("proton'", "dist/bin/wine64'")
     const isProton = wine.includes('proton')
     const winetricks = `${heroicToolsPath}/winetricks`
+    const options: ExecOptions = {
+      ...execOptions
+    }
 
     // existsSync is weird because it returns false always if the path has single-quotes in it
     const protonWinePath = existsSync(newProtonWinePath.replaceAll("'", ''))
@@ -524,11 +529,12 @@ ipcMain.handle(
 
     if (tool === 'runExe') {
       command = `WINEPREFIX='${winePrefix}' ${wineBin} '${exe}'`
+      options.cwd = dirname(exe)
     }
 
     logInfo(['trying to run', command], LogPrefix.Backend)
     try {
-      await execAsync(command, execOptions)
+      await execAsync(command, options)
     } catch (error) {
       logError(
         `Something went wrong! Check if ${tool} is available and ${wineBin} exists`,


### PR DESCRIPTION
Tested on HoMM 3 with HD laucher which requires to be located in the same directory as game and searches for executables in the working directory

--

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
