### PR TITLE
[Fix] Dialogs hiding behind app window

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -1,6 +1,5 @@
 // This handles launching games, prefix creation etc..
 
-import { dialog } from 'electron'
 import makeClient from 'discord-rich-presence-typescript'
 import i18next from 'i18next'
 import { existsSync, mkdirSync } from 'graceful-fs'
@@ -17,7 +16,8 @@ import {
   getGOGdlBin,
   getLegendaryBin,
   isEpicServiceOffline,
-  isOnline
+  isOnline,
+  showErrorBoxModalAuto
 } from './utils'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
 import { GlobalConfig } from './config'
@@ -86,7 +86,7 @@ async function launch(
     if (gameInfo.canRunOffline) {
       runOffline = '--offline'
     } else {
-      dialog.showErrorBox(
+      showErrorBoxModalAuto(
         i18next.t(
           'box.error.no-offline-mode.title',
           'Offline mode not supported.'
@@ -231,7 +231,7 @@ async function launch(
   }
 
   if (!wineVersion.bin) {
-    dialog.showErrorBox(
+    showErrorBoxModalAuto(
       i18next.t('box.error.wine-not-found.title', 'Wine Not Found'),
       i18next.t(
         'box.error.wine-not-found.message',

--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -30,7 +30,7 @@ export async function handleProtocol(window: BrowserWindow, url: string) {
       // wait for the frontend to be ready
       if (!is_installed) {
         logInfo(`"${arg}" not installed.`, LogPrefix.ProtocolHandler)
-        const { response } = await dialog.showMessageBox({
+        const { response } = await dialog.showMessageBox(window, {
           buttons: [i18next.t('box.yes'), i18next.t('box.no')],
           cancelId: 1,
           message: `${title} ${i18next.t(

--- a/electron/tools.ts
+++ b/electron/tools.ts
@@ -3,10 +3,9 @@ import * as axios from 'axios'
 import { exec } from 'child_process'
 import { existsSync, readFileSync } from 'graceful-fs'
 
-import { execAsync, isOnline } from './utils'
+import { execAsync, isOnline, showErrorBoxModalAuto } from './utils'
 import { execOptions, heroicToolsPath, userHome } from './constants'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
-import { dialog } from 'electron'
 import i18next from 'i18next'
 import { dirname } from 'path'
 
@@ -88,7 +87,7 @@ export const DXVK = {
             [`Error when downloading ${tool.name}`, error],
             LogPrefix.DXVKInstaller
           )
-          dialog.showErrorBox(
+          showErrorBoxModalAuto(
             i18next.t('box.error.dxvk.title', 'DXVK/VKD3D error'),
             i18next.t(
               'box.error.dxvk.message',


### PR DESCRIPTION
Change dialogs (message boxes and file selection) to be modal (attached to window) so they will block application window until user closes dialog.

Sadly it doesn't work for file selection dialogs because of bug in electron: https://github.com/electron/electron/issues/32857 but I expect it will work after they fix it.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
