### PR TITLE
Remove MimeType from Shortcut

### DIFF
--- a/electron/shortcuts.ts
+++ b/electron/shortcuts.ts
@@ -33,7 +33,6 @@ Name=${removeSpecialcharacters(gameInfo.title)}
 Exec=xdg-open ${launchWithProtocol}
 Terminal=false
 Type=Application
-MimeType=x-scheme-handler/heroic;
 Icon=${icon}
 Categories=Game;
 `


### PR DESCRIPTION
Heroic add the MimeType=x-scheme-handler/heroic to all shortcuts. The MimeType line means, that the App, that belongs to this .desktop file can open this MimeType. In this case, it says basically, that Game xy can open heric:// links,what is not true. Only Heroic itself can do that.