### PR TITLE
Add 'report a problem' action in game screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroic",
-  "version": "2.3.0beta1",
+  "version": "2.3.0-beta.1",
   "private": true,
   "main": "public/main.js",
   "homepage": "./",

--- a/public/locales/bg/gamepage.json
+++ b/public/locales/bg/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Параметри за стартиране…"
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Изберете компоненти за инсталиране"
     },

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -25,6 +25,10 @@
                 "message": "Грешка при инсталирането на DXVK/VKD3D! Проверете връзката си, или дали имате инсталиран пакета zstd/libzstd1",
                 "title": "Грешка от DXVK/VKD3D"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Грешка при пускането на играта. Проверете журнала!",
             "no-offline-mode": {
                 "message": "Пускането е прекратено! Играта изисква връзка с Интернет, за да бъде пусната.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Копиране на съдържанието на журнала в буфера за обмен",
             "current-log": "Текущ журнал",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Последен журнал",
             "no-file": "Не е намерен файл с журнал",
             "show-in-folder": "Показване на файла с журнала в папката му"

--- a/public/locales/ca/gamepage.json
+++ b/public/locales/ca/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Opcions d'execució..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Selecciona els components a instal·lar"
     },

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -25,6 +25,10 @@
                 "message": "Hi ha hagut un error en instal·lar el DXVK/VKD3D. Comprova la connexió o si teniu instal·lat el zstd/libzstd1",
                 "title": "Error del DXVK/VKD3D"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Error en iniciar el joc, comprova el registre.",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copia el registre al porta-retalls",
             "current-log": "Registre actual",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Últim registre",
             "no-file": "No s'ha trobat cap registre",
             "show-in-folder": "Obre la carpeta del registre"

--- a/public/locales/cs/gamepage.json
+++ b/public/locales/cs/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Launch Options..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Select components to Install"
     },

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -25,6 +25,10 @@
                 "message": "Error installing DXVK/VKD3D! Check your connection or if you have zstd/libzstd1 installed",
                 "title": "DXVK/VKD3D error"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Chyba při spouštění hry, zkontrolujte záznamy!",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"

--- a/public/locales/de/gamepage.json
+++ b/public/locales/de/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Startoptionen..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Zu installierende Komponenten auswählen"
     },

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -25,6 +25,10 @@
                 "message": "Fehler beim Installieren von DXVK/VKD3D! Überprüfe deine Verbindung oder ob du zstd/libzstd1 installiert hast",
                 "title": "DXVK/VKD3D Fehler"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Fehler beim Starten des Spiels, prüfe die Logs!",
             "no-offline-mode": {
                 "message": "Start abgebrochen! Das Spiel benötigt eine Internetverbindung, damit es läuft.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Log-Inhalt in Zwischenablage kopieren",
             "current-log": "Aktueller Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Letzter Log",
             "no-file": "Keine Log-Datei gefunden",
             "show-in-folder": "Log-Datei in Ordner anzeigen"

--- a/public/locales/el/gamepage.json
+++ b/public/locales/el/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Ρυθμίσεις εκκίνησης..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Διαλέξτε στοιχεία για εγκατάσταση"
     },

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -25,6 +25,10 @@
                 "message": "Σφάλμα εγκατάστασης DXVK/VKD3D! Ελέγξτε την σύνδεση σας ή εαν έχετε τα zstd/libzstd1 εγκατεστημένα",
                 "title": "DXVK/VKD3D σφάλμα"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Σφάλμα στην εκκίνηση του παιχνιδιού, ελέγξτε τα αρχεία καταγραφής!",
             "no-offline-mode": {
                 "message": "Η έναρξη διακόπηκε! Το παιχνίδι απαιτεί σύνδεση στο διαδύκτιο για να τρέξει.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Αντιγραφή αρχείου καταγραφής στο πρόχειρο",
             "current-log": "Τρέχων Αρχείο Καταγραφής",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Τελευταίο Αρχείο Καταγραφής",
             "no-file": "Δεν βρέθηκε αρχείο σύνδεσης",
             "show-in-folder": "Εμφάνιση αρχείου καταγραφής στον φάκελο"

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Launch Options..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Select components to Install"
     },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -25,6 +25,10 @@
                 "message": "Error installing DXVK/VKD3D! Check your connection or if you have zstd/libzstd1 installed",
                 "title": "DXVK/VKD3D error"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Error when launching the game, check the logs!",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"

--- a/public/locales/es/gamepage.json
+++ b/public/locales/es/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Opciones de Arranque..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Elija Componentes a Instalar"
     },

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -25,6 +25,10 @@
                 "message": "¡Error al instalar DXVK/VKD3D! Comprueba tu conexión o si tienes instalado zstd/libzstd1",
                 "title": "Error de DXVK/VKD3D"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Error al iniciar el juego, ¡revisa los registros!",
             "no-offline-mode": {
                 "message": "¡Lanzamiento abortado! El juego requiere una conexión a Internet para ejecutarlo.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copiar el contenido del registro en el portapapeles",
             "current-log": "Registro actual",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Último registro",
             "no-file": "No se ha encontrado ningún archivo de registro",
             "show-in-folder": "Mostrar el archivo de registro en la carpeta"

--- a/public/locales/et/gamepage.json
+++ b/public/locales/et/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Käivitusvalikud..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Valige komponendid, mida installida"
     },

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -25,6 +25,10 @@
                 "message": "Viga DXVK/VKD3D installimisel! Kontrollige ühendust või seda, kas teil on installitud zstd/libzstd1",
                 "title": "DXVK/VKD3D viga"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Viga mängu käivitamisel, kontrollige logisid!",
             "no-offline-mode": {
                 "message": "Käivitamine katkestatud! Mängu käivitamiseks on vaja internetiühendust.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Kopeeri logi sisu lõikelauale",
             "current-log": "Praegune logi",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Viimane logi",
             "no-file": "Logifaili ei leitud",
             "show-in-folder": "Kuva logifail kaustas"

--- a/public/locales/fa/gamepage.json
+++ b/public/locales/fa/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "گزینههای اجرا..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "انتخاب محتواها برای نصب"
     },

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -25,6 +25,10 @@
                 "message": "خطا در نصب DXVK/VKD3D! اتصال به اینترنت خود یا نصب داشتن zstd/libzstd1 را چک کنید",
                 "title": "خطای DXVK/VKD3D"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "خطا در هنگام اجرای بازی، لاگها را چک کنید!",
             "no-offline-mode": {
                 "message": "اجرا متوقف شد! بازی برای اجرا به اتصال اینترنت نیاز دارد.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "کپی کردن محتوای لاگ در کليپ بورد",
             "current-log": "لاگ اخیر",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "آخرین لاگ",
             "no-file": "فایل لاگی پیدا نشد",
             "show-in-folder": "نمایش فایل لاگ در پوشه"

--- a/public/locales/fi/gamepage.json
+++ b/public/locales/fi/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Käynnistysasetukset..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Valitse asennettavat komponentit"
     },

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -25,6 +25,10 @@
                 "message": "Virhe DXVK/VKD3D:n asennuksessa! Tarkista yhteys tai onko zstd/libzstd1 asennettu",
                 "title": "DXVK/VKD3D-virhe"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Virhe pelin käynnistyksessä, tarkista pelin lokitiedostot!",
             "no-offline-mode": {
                 "message": "Käynnistys keskeytetty! Peli vaatii Internet-yhteyden toimiakseen.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Kopioi lokin sisältö leikepöydälle",
             "current-log": "Nykyinen loki",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Viimeisin loki",
             "no-file": "Lokitiedostoja ei löytynyt",
             "show-in-folder": "Näytä lokitiedosto kansiossa"

--- a/public/locales/fr/gamepage.json
+++ b/public/locales/fr/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Paramètres de démarrage..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Sélectionnez les composants à installer"
     },

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -25,6 +25,10 @@
                 "message": "Error installing DXVK/VKD3D! Check your connection or if you have zstd/libzstd1 installed",
                 "title": "DXVK/VKD3D error"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Erreur lors du lancement du jeu, consultez les fichiers de journalisation !",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"

--- a/public/locales/gl/gamepage.json
+++ b/public/locales/gl/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Opcións de arrinque..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Seleccione os compoñentes a instalar"
     },

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -25,6 +25,10 @@
                 "message": "Erro ao instalar DXVK/VKD3D! Comproba a túa conexión ou se tes instalado zstd/libzstd1",
                 "title": "Erro de DXVK/VKD3D"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Produciuse un erro ao iniciar o xogo, revisa os rexistros!",
             "no-offline-mode": {
                 "message": "Lanzamento abortado! O xogo reqire dunha conexión a Internet para executalo.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"

--- a/public/locales/hr/gamepage.json
+++ b/public/locales/hr/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Opcije za pokretanje..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Odaberite kompomente za instalaciju"
     },

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -25,6 +25,10 @@
                 "message": "Error installing DXVK/VKD3D! Check your connection or if you have zstd/libzstd1 installed",
                 "title": "DXVK/VKD3D error"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Greška kod pokretanja igrice, provjerite dnevnik!",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard.",
             "current-log": "Current log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found.",
             "show-in-folder": "Show log file in folder"

--- a/public/locales/hu/gamepage.json
+++ b/public/locales/hu/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Indítási opciók..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Válaszd ki a telepíteni kívánt elemeket"
     },

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -25,6 +25,10 @@
                 "message": "Hiba a DXVK/VKD3D telepítésekor! Ellenőrizd le az internetkapcsolatod, illetve hogy a zstd/libzstd1 telepítve van",
                 "title": "DXVK/VKD3D hiba"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Hiba a játék indításakor, ellenőrizd a naplófájlokat!",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Napló tartalmának vágólapra másolása",
             "current-log": "Jelenlegi napló",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Utolsó napló",
             "no-file": "Nem található naplófájl",
             "show-in-folder": "Naplófájl megjelenítése mappában"

--- a/public/locales/id/gamepage.json
+++ b/public/locales/id/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Opsi Peluncuran…"
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Pilih komponen untuk dipasang"
     },

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -25,6 +25,10 @@
                 "message": "Galat saat memasang DXVK/VKD3D! Periksa koneksi Anda atau apakah Anda telah memasang zstd/libzstd1",
                 "title": "Galat DXVK/VKD3D"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Terjadi kesalahan ketika meluncurkan gim, periksa log!",
             "no-offline-mode": {
                 "message": "Peluncuran dibatalkan! Gim membutuhkan koneksi internet untuk menjalankannya.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Salin konten log ke papan klip",
             "current-log": "Log Saat Ini",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Log Terakhir",
             "no-file": "Tidak ditemukan berkas log",
             "show-in-folder": "Tampilkan berkas log di dalam folder"

--- a/public/locales/it/gamepage.json
+++ b/public/locales/it/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Opzioni di avvio..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Seleziona i componenti da installare"
     },

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -25,6 +25,10 @@
                 "message": "Error installing DXVK/VKD3D! Check your connection or if you have zstd/libzstd1 installed",
                 "title": "DXVK/VKD3D error"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Errore durante l'avvio del gioco, controlla i logs!",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"

--- a/public/locales/ja/gamepage.json
+++ b/public/locales/ja/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Launch Options..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "インストールするコンポーネントを選択します"
     },

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -25,6 +25,10 @@
                 "message": "Error installing DXVK/VKD3D! Check your connection or if you have zstd/libzstd1 installed",
                 "title": "DXVK/VKD3D error"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "ゲームの起動時にエラーが発生しました、ログを確認してください！",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"

--- a/public/locales/ko/gamepage.json
+++ b/public/locales/ko/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "시작 옵션..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "설치할 구성 요소를 선택합니다"
     },

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -25,6 +25,10 @@
                 "message": "DXVK/VKD3D 설치 오류! 연결을 확인하거나 zstd/libzstd1이 설치되어 있는지 확인하십시오",
                 "title": "DXVK/VKD3D 오류"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "게임을 실행할 때 오류가 발생했습니다, 로그를 확인 해주세요!",
             "no-offline-mode": {
                 "message": "시작 실패! 게임을 실행하려면 인터넷 연결이 필요합니다.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "로그 내용을 클립보드에 복사",
             "current-log": "현재 로그",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "마지막 로그",
             "no-file": "로그 파일을 찾을 수 없습니다",
             "show-in-folder": "폴더에 있는 로그 파일 표시"

--- a/public/locales/ml/gamepage.json
+++ b/public/locales/ml/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "വിക്ഷേപണ ബദലുകൾ..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "നടുവാനുള്ള ഘടകങ്ങള് തിരഞ്ഞെടുക്കൂ"
     },

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -25,6 +25,10 @@
                 "message": "Error installing DXVK/VKD3D! Check your connection or if you have zstd/libzstd1 installed",
                 "title": "DXVK/VKD3D error"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "കളി ഓടിക്കുന്നതിനിടക്ക് എന്തോ കുഴപ്പം പറ്റിയട്ടുണ്ട്, കുറികള് നോക്കൂ!",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"

--- a/public/locales/nl/gamepage.json
+++ b/public/locales/nl/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Opstartopties..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Selecteer componenten om te installeren"
     },

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -25,6 +25,10 @@
                 "message": "Error installing DXVK/VKD3D! Check your connection or if you have zstd/libzstd1 installed",
                 "title": "DXVK/VKD3D error"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Een probleem tijdens het lanceren van het spel, check de logs!",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"

--- a/public/locales/pl/gamepage.json
+++ b/public/locales/pl/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Opcje Uruchamiania..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Wybierz komponenty do Instalacji"
     },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -25,6 +25,10 @@
                 "message": "Błąd podczas instalacji DXVK/VKD3D! Sprawdź połączenie lub czy zstd/libzstd1 jest zainstalowany",
                 "title": "Błąd DXVK/VKD3D"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Błąd przy uruchamianiu gry, sprawdź logi!",
             "no-offline-mode": {
                 "message": "Uruchomienie przerwane! Gra wymaga połączenia z internetem aby ją uruchomić.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Skopiuj zawartość logu do schowka",
             "current-log": "Obecny Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Ostatni Log",
             "no-file": "Plik logu nie znaleziony",
             "show-in-folder": "Pokaż plik logu w folderze"

--- a/public/locales/pt/gamepage.json
+++ b/public/locales/pt/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Launch Options..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Selecione os componentes para instalar"
     },

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -25,6 +25,10 @@
                 "message": "Error installing DXVK/VKD3D! Check your connection or if you have zstd/libzstd1 installed",
                 "title": "DXVK/VKD3D error"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Houve um erro ao rodar o jogo, veja os Logs para ver o que aconteceu!",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"

--- a/public/locales/pt_BR/gamepage.json
+++ b/public/locales/pt_BR/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Opções de Inicialização..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Selecione os componentes para instalar"
     },

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -25,6 +25,10 @@
                 "message": "Erro ao Instalar DXVK/VKD3D! Cheque sua conexão Ou se você tem o zstd/libzstd1 instalado",
                 "title": "DXVK/VKD3D Erro"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Erro ao iniciar o jogo, confira os logs!",
             "no-offline-mode": {
                 "message": "Lançamento cancelado! O jogo requer uma conexão com a internet para executá-lo.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copiar log para a área de transferência",
             "current-log": "Log atual",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Último log",
             "no-file": "Arquivo de log não encontrado",
             "show-in-folder": "Mostrar arquivo de log na pasta"

--- a/public/locales/ru/gamepage.json
+++ b/public/locales/ru/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Параметры запуска..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Выбрать компоненты для установки"
     },

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -25,6 +25,10 @@
                 "message": "Ошибка при установке DXVK/VKD3D! Проверьте подключение или наличие установленного zstd/libzstd1",
                 "title": "Ошибка DXVK/VKD3D"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Ошибка при запуске игры, проверьте журнал!",
             "no-offline-mode": {
                 "message": "Запуск прерван! Для запуска игры требуется подключение к интернету.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Копировать содержимое журнала в буфер обмена",
             "current-log": "Текущий журнал",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Последний журнал",
             "no-file": "Файл журнала не найден",
             "show-in-folder": "Показать файл журнала в папке"

--- a/public/locales/sv/gamepage.json
+++ b/public/locales/sv/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Startalternativ..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Ange komponenter att installera"
     },

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -25,6 +25,10 @@
                 "message": "Problem vid installation av DXVK/VKD3D! Kontrollera internetanslutningen och att du har zstd/libzstd1 installerade",
                 "title": "DXVK/VKD3D problem"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Problem vid speluppstart, kontrollera loggen!",
             "no-offline-mode": {
                 "message": "Speluppstart avbröts! Internetanslutning krävs.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Kopiera loggen till urklipp/klippbord",
             "current-log": "Aktuell logg",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Senaste logg",
             "no-file": "Ingen loggfil hittades",
             "show-in-folder": "Visa loggfiler i mapp"

--- a/public/locales/ta/gamepage.json
+++ b/public/locales/ta/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Launch Options..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Select components to Install"
     },

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -25,6 +25,10 @@
                 "message": "Error installing DXVK/VKD3D! Check your connection or if you have zstd/libzstd1 installed",
                 "title": "DXVK/VKD3D error"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "விளையாட்டை துவக்கும்போது பிழை, பதிவுகளை பார்க்கவும்!",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"

--- a/public/locales/tr/gamepage.json
+++ b/public/locales/tr/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Başlatma Seçenekleri..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Kurulacak bileşenleri seç"
     },

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -25,6 +25,10 @@
                 "message": "DXVK/VKD3D kurulurken hata oluştu! Bağlantınıza veya zstd/libzstd1 kurulu olup olmadığına bakın",
                 "title": "DXVK/VKD3D hatası"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Oyun başlatılırken hata oluştu, günlük kayıtlarına bakın!",
             "no-offline-mode": {
                 "message": "Başlatma iptal edildi! Oyunu çalıştırmak için internet bağlantısı gereklidir.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Günlük içeriğini panoya kopyala",
             "current-log": "Geçerli Günlük",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Son Günlük",
             "no-file": "Günlük dosyası bulunamadı",
             "show-in-folder": "Günlük dosyasını klasörde göster"

--- a/public/locales/uk/gamepage.json
+++ b/public/locales/uk/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Параметри запуску..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Оберіть компоненти для встановлення"
     },

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -25,6 +25,10 @@
                 "message": "Помилка встановлення DXVK/VKD3D! Перевірте з'єднання та чи встановлено zstd/libzstd1",
                 "title": "Помилка DXVK/VKD3D"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Помилка під час запуску гри, перевірте лоґи!",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Копіювати вміст логу в сховище обміну",
             "current-log": "Поточний лог",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Останній лог",
             "no-file": "Лог файл не знайдено",
             "show-in-folder": "Показати файл логу в теці"

--- a/public/locales/vi/gamepage.json
+++ b/public/locales/vi/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Tuỳ chọn khởi động..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Chọn các thành phần cần cài"
     },

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -25,6 +25,10 @@
                 "message": "Lỗi cài đặt DXVK/VKD3D! Kiểm tra kết nối hoặc zstd/libzstd1",
                 "title": "DXVK/VKD3D lỗi"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "Lỗi khi khởi chạy game, vui lòng kiểm tra log!",
             "no-offline-mode": {
                 "message": "Quá trình khởi chạy đã hủy! Cần có kết nối mạng để chạy game.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Sao chép nội dung log vào bộ nhớ tạm",
             "current-log": "Log hiện tại",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Log lần trước",
             "no-file": "Không tìm thấy file log",
             "show-in-folder": "Hiển thị file log trong thư mục"

--- a/public/locales/zh_Hans/gamepage.json
+++ b/public/locales/zh_Hans/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "启动选项..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "选择要安装的组件"
     },

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -25,6 +25,10 @@
                 "message": "安装 DXVK/VKD3D 出错！检查你的互联网连接或者是否已安装 zstd/libzstd1",
                 "title": "DXVK/VKD3D 错误"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "启动游戏时出现错误，请检查日志！",
             "no-offline-mode": {
                 "message": "启动失败！游戏需要网络连接才能运行。",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "复制日志内容到剪贴板",
             "current-log": "当前日志",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "上一日志",
             "no-file": "未找到日志文件",
             "show-in-folder": "显示文件夹中的日志文件"

--- a/public/locales/zh_Hant/gamepage.json
+++ b/public/locales/zh_Hant/gamepage.json
@@ -85,6 +85,7 @@
     "launch": {
         "options": "Launch Options..."
     },
+    "report_problem": "Report a problem running this game",
     "sdl": {
         "title": "Select components to Install"
     },

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -25,6 +25,10 @@
                 "message": "Error installing DXVK/VKD3D! Check your connection or if you have zstd/libzstd1 installed",
                 "title": "DXVK/VKD3D error"
             },
+            "generic": {
+                "message": "",
+                "title": ""
+            },
             "launch": "啟動遊戲時出現錯誤，請檢查日誌！",
             "no-offline-mode": {
                 "message": "Launch aborted! The game requires a internet connection to run it.",
@@ -246,6 +250,8 @@
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",
+            "instructions": "Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.",
+            "instructions_title": "How to report a problem?",
             "last-log": "Last Log",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"

--- a/src/screens/Game/GamePage/index.css
+++ b/src/screens/Game/GamePage/index.css
@@ -245,6 +245,20 @@
   padding: 2px;
 }
 
+.reportProblem {
+  align-self: flex-start;
+  margin-top: 1.2em;
+  color: var(--accent);
+}
+
+.reportProblem:hover {
+  color: var(--text-hover);
+}
+
+.reportProblem svg {
+  margin-right: 0.4em;
+}
+
 @keyframes animate-stripes {
   100% {
     background-position: -100px 0px;

--- a/src/screens/Game/GamePage/index.tsx
+++ b/src/screens/Game/GamePage/index.tsx
@@ -37,6 +37,9 @@ import { InstallModal } from 'src/screens/Library/components'
 import { install } from 'src/helpers/library'
 import EpicLogo from 'src/assets/epic-logo.svg'
 import GOGLogo from 'src/assets/gog-logo.svg'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons'
+
 const storage: Storage = window.localStorage
 
 const { ipcRenderer } = window.require('electron') as {
@@ -425,6 +428,21 @@ export default function GamePage(): JSX.Element | null {
                         </button>
                       )}
                     </div>
+                    <NavLink
+                      to={{
+                        pathname: `/settings/${appName}/log`,
+                        state: {
+                          runner
+                        }
+                      }}
+                      className="link is-text is-link reportProblem"
+                    >
+                      {<FontAwesomeIcon icon={faTriangleExclamation} />}
+                      {t(
+                        'report_problem',
+                        'Report a problem running this game'
+                      )}
+                    </NavLink>
                   </div>
 
                   <GameSubMenu

--- a/src/screens/Settings/components/LogSettings/index.css
+++ b/src/screens/Settings/components/LogSettings/index.css
@@ -58,3 +58,7 @@
   font-size: 40px;
   animation: refreshing 1.5s infinite;
 }
+
+.report-problem-instructions {
+  text-align: left;
+}

--- a/src/screens/Settings/components/LogSettings/index.tsx
+++ b/src/screens/Settings/components/LogSettings/index.tsx
@@ -104,6 +104,13 @@ export default function LogSettings({ isDefault, appName }: LogSettingsProps) {
 
   return (
     <>
+      <h2>{t('setting.log.instructions_title', 'How to report a problem?')}</h2>
+      <p className="report-problem-instructions">
+        {t(
+          'setting.log.instructions',
+          'Join our Discord and look for the channel that matches your operating system. Share the content of the logs displayed here, and include a clear description of the problem with any relevant information and details.'
+        )}
+      </p>
       {isDefault && (
         <span className="setting log-buttongroup toggleWrapper">
           <a


### PR DESCRIPTION
This PR adds an action under the Play button in the game screen for users to learn how to ask for help when they have issues running a game.

The action takes the user to the last log screen and I also added a note what and how to share the information in discord.

![image](https://user-images.githubusercontent.com/188464/163485519-b1ca422b-918a-4e02-ad6b-bba24e8a27f6.png)
![image](https://user-images.githubusercontent.com/188464/163485586-337decf5-4875-4ef6-b9f5-e815feff6d2d.png)

Closes #1148 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
