### PR TITLE
Fix grayscale/color for games with logo image

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroic",
-  "version": "2.3.0beta1",
+  "version": "2.3.0-beta.1",
   "private": true,
   "main": "public/main.js",
   "homepage": "./",

--- a/src/screens/Library/components/GameCard/index.css
+++ b/src/screens/Library/components/GameCard/index.css
@@ -224,8 +224,8 @@
   filter: grayscale(var(--installing-effect));
 }
 
-.gameImg:hover:not(.installed),
-.gameLogo:hover:not(.installed) {
+.gameCard:hover .gameImg:not(.installed),
+.gameCard:hover .gameLogo:not(.installed) {
   filter: grayscale(0);
   transition-duration: 0.2s;
 }


### PR DESCRIPTION
This is a simple fix for #1214. Just moved the `:hover` selector to the card instead of to the images.

Closes #1214

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
