### PR TITLE
[FIX] Don't reset the filterText when refreshing the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroic",
-  "version": "2.3.0beta1",
+  "version": "2.3.0-beta.1",
   "private": true,
   "main": "public/main.js",
   "homepage": "./",

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -130,7 +130,6 @@ export class GlobalState extends PureComponent<Props> {
     }
 
     this.setState({
-      filterText: '',
       epicLibrary,
       gogLibrary,
       gameUpdates: updates,


### PR DESCRIPTION
This PR fixes #1216 by not resetting the value of `filterText` in the state when refreshing the library.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
