### PR TITLE
Order games by status

### DIFF
--- a/src/components/UI/Header/index.tsx
+++ b/src/components/UI/Header/index.tsx
@@ -1,7 +1,7 @@
 import { faApple, faLinux, faWindows } from '@fortawesome/free-brands-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import cx from 'classnames'
-import React, { useContext, useMemo } from 'react'
+import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SearchBar } from 'src/components/UI'
 import ContextProvider from 'src/state/ContextProvider'
@@ -18,22 +18,12 @@ export default function Header({ numberOfGames }: HeaderProps) {
   const {
     category,
     filter,
-    gameUpdates = [],
-    libraryStatus,
     handleFilter,
     filterPlatform,
     handlePlatformFilter,
     platform
   } = useContext(ContextProvider)
 
-  const hasDownloads = useMemo(
-    () =>
-      libraryStatus.filter(
-        (game) => game.status === 'installing' || game.status === 'updating'
-      ).length !== 0,
-    [libraryStatus]
-  )
-  const hasUpdates = gameUpdates.length !== 0
   const isMac = platform === 'darwin'
   const isLinux = platform === 'linux'
 
@@ -97,35 +87,6 @@ export default function Header({ numberOfGames }: HeaderProps) {
               )}
             </FormControl>
           )}
-          <FormControl select>
-            <select
-              id="games-filter"
-              className="FormControl__select"
-              onChange={(e) => handleFilter(e.target.value)}
-              value={filter}
-              data-testid="games-filter"
-            >
-              <option data-testid="all" value="all">
-                {t('filter.noFilter', 'No Filter')}
-              </option>
-              <option data-testid="installed" value="installed">
-                {t('Ready')}
-              </option>
-              <option data-testid="uninstalled" value="uninstalled">
-                {t('Not Ready')}
-              </option>
-              {hasDownloads && (
-                <option data-testid="downloading" value="downloading">
-                  {`${t('Downloading')} (${hasDownloads})`}
-                </option>
-              )}
-              {hasUpdates && (
-                <option data-testid="updates" value="updates">
-                  {`${t('Updates', 'Updates')} (${hasUpdates})`}
-                </option>
-              )}
-            </select>
-          </FormControl>
         </div>
       )}
       {category === 'unreal' && (

--- a/src/screens/Library/constants.ts
+++ b/src/screens/Library/constants.ts
@@ -6,18 +6,7 @@ export function getLibraryTitle(
   t: TFunction<'translation'>
 ) {
   if (category === 'epic' || category === 'gog') {
-    switch (filter) {
-      case 'installed':
-        return t('title.installedGames', 'Installed Games')
-      case 'updates':
-        return t('title.updates', 'Pending Updates')
-      case 'downloading':
-        return t('title.downloading', 'Downloading')
-      case 'uninstalled':
-        return t('title.notInstalledGames', 'Not Installed')
-      default:
-        return t('title.allGames', 'All Games')
-    }
+    return t('title.allGames', 'All Games')
   }
 
   switch (filter) {

--- a/src/screens/Library/index.tsx
+++ b/src/screens/Library/index.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 export const Library = ({ library, showRecentsOnly }: Props) => {
-  const { layout, gameUpdates, refreshing, category, filter } =
+  const { layout, libraryStatus, gameUpdates, refreshing, category, filter } =
     useContext(ContextProvider)
   const [showModal, setShowModal] = useState({
     game: '',
@@ -73,6 +73,25 @@ export const Library = ({ library, showRecentsOnly }: Props) => {
     )
   }
 
+  let list = library
+
+  // installed games listed first
+  if (!showRecentsOnly) {
+    const installing = libraryStatus
+      .filter((st) => st.status === 'installing')
+      .map((st) => st.appName)
+
+    list = library.sort((g1, g2) => {
+      if (g1.is_installed) return -1
+
+      if (g2.is_installed) return 1
+
+      if (installing.includes(g1.app_name)) return -1
+
+      return 1
+    })
+  }
+
   return (
     <>
       {showModal.show && (
@@ -95,7 +114,7 @@ export const Library = ({ library, showRecentsOnly }: Props) => {
         })}
       >
         {!!library.length &&
-          library.map(
+          list.map(
             ({
               title,
               art_square,

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -199,29 +199,6 @@ export class GlobalState extends PureComponent<Props> {
       })
     } else {
       switch (filter) {
-        case 'installed':
-          return library.filter((game) => game.is_installed && game.is_game)
-        case 'uninstalled':
-          return library.filter((game) => !game.is_installed && game.is_game)
-        case 'downloading':
-          return library.filter((game) => {
-            const currentApp = this.state.libraryStatus.filter(
-              (app) => app.appName === game.app_name
-            )[0]
-            if (!currentApp || !game.is_game) {
-              return false
-            }
-            return (
-              currentApp.status === 'installing' ||
-              currentApp.status === 'repairing' ||
-              currentApp.status === 'updating' ||
-              currentApp.status === 'moving'
-            )
-          })
-        case 'updates':
-          return library.filter((game) =>
-            this.state.gameUpdates.includes(game.app_name)
-          )
         case 'unreal':
           return library.filter(
             (game) =>


### PR DESCRIPTION
This PR changes the order of the games in the library to display installed games first, then games that are being installed, and then games that are not installed nor installing.

This also removes the selector of All / Ready / Not Ready / Downloading to simplify the UI.

Closes #977 
Closes #878

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
