### PR TITLE
Add an option to disable the controller navigation

### DIFF
--- a/electron/types.ts
+++ b/electron/types.ts
@@ -20,6 +20,7 @@ export interface AppSettings {
   customWinePaths: string[]
   darkTrayIcon: boolean
   defaultInstallPath: string
+  disableController: boolean
   discordRPC: boolean
   egsLinkedPath: string
   exitToTray: boolean

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Използване на тъмна иконка за системната област за уведомления",
         "default-install-path": "Папка по подразбиране за инсталации",
         "defaultWinePrefix": "Задаване на папка за нови префикси на Wine",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Включване на актуализирането на присъствието в Дискорд",
         "egs-sync": "Синхронизиране с вече инсталиран Epic Games",
         "enableFSRHack": "Включване на хака FSR (версията на Wine трябва да го поддържа)",

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Emprar la icona fosca al Tray",
         "default-install-path": "Ruta d'instal·lació predefinida",
         "defaultWinePrefix": "Directori de prefixos Wine nous",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Activa la Discord Rich Presence",
         "egs-sync": "Sincronitza amb l'Epic Games instal·lat",
         "enableFSRHack": "Activa el FSR Hack (cal que la versió del Wine en sigui compatible)",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Použít tmavou ikonu v systémové oblasti",
         "default-install-path": "Výchozí cesta pro instalaci",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Povolit Discord Rich Presence",
         "egs-sync": "Synchronizovat s instalovaným Epic Games Store",
         "enableFSRHack": "Povolte FSR Hack (verze Wine jej musí podporovat)",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Dunkles Taskleisten-Icon benutzen",
         "default-install-path": "Standard-Installationspfad",
         "defaultWinePrefix": "Ordner für neue Wine Präfixe festlegen",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Discord Rich Presence aktivieren",
         "egs-sync": "Mit installiertem Epic Games synchronisieren",
         "enableFSRHack": "FSR Hack aktivieren (Wine-Version muss es unterstützen)",

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Χρήση σκοτεινού εικονιδίου",
         "default-install-path": "Προεπιλεγμένη Διαδρομή Εγκατάστασης",
         "defaultWinePrefix": "Καθορισμός Φακέλου για νέα Προθήματα Wine",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Ενεργοποίηση Discord Rich Presence",
         "egs-sync": "Συγχρονισμός με εγκατεστημένο Epic Games",
         "enableFSRHack": "Ενεργοποίηση FSR Hack (Η έκδοση Wine πρέπει να το υποστηρίζει)",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Use Dark Tray Icon",
         "default-install-path": "Default Installation Path",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Enable Discord Rich Presence",
         "egs-sync": "Sync with Installed Epic Games",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Utilice el icono de bandeja oscura",
         "default-install-path": "Ruta de instalación predeterminada",
         "defaultWinePrefix": "Establecer carpeta para nuevos prefijos de Wine",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Activar Discord Rich Presence",
         "egs-sync": "Sincronizar con juegos EGS",
         "enableFSRHack": "Habilitar el hack FSR (La versión de Wine debe soportarlo)",

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Kasuta tumedat süsteemiriiuli ikooni",
         "default-install-path": "Vaikimisi paigaldustee",
         "defaultWinePrefix": "Määrake uute Wine'i prefikside jaoks kaust",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Luba Discord Rich Presence",
         "egs-sync": "Sünkroonimine paigaldatud Epic Games'iga",
         "enableFSRHack": "Luba FSR häkk (Wine'i versioon peab seda toetama)",

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -238,6 +238,7 @@
         "darktray": "استفاده از آیکون میزکار تاریک",
         "default-install-path": "محل پیشفرض نصب",
         "defaultWinePrefix": "تنظیم پوشه برای Wine Prefix جدید",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "فعالسازی Discord Rich Presence",
         "egs-sync": "همگامسازی با بازیهای اپیک نصب شده",
         "enableFSRHack": "فعالسازی FSR Hack (نسخه Wine باید از آن پشتیبانی کند)",

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Käytä tummaa ilmaisinalueen kuvaketta",
         "default-install-path": "Oletus asennussijainti",
         "defaultWinePrefix": "Aseta kansio uusille Winen Prefixeille",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Ota käyttöön Discord Rich Presence",
         "egs-sync": "Synkronoi asennetun Epic Gamesin kanssa",
         "enableFSRHack": "Ota käyttöön FSR Hack (Wine version tulee tukea sitä)",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Utiliser Dark Tray Icon",
         "default-install-path": "Chemin par défaut de l'installation",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Activer Rich Presence dans Discord",
         "egs-sync": "Synchroniser avec l'installation d'Epic Games",
         "enableFSRHack": "Activer FSR Hack (la version de wine doit le prendre en charge)",

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Usar icona escura na bandexa do sistema",
         "default-install-path": "Ruta de instalación predeterminada",
         "defaultWinePrefix": "Estabelecer cartafol para os prefixos de Wine",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Activar a presencia enriquecida de Discord",
         "egs-sync": "Sincronizar cos xogos instalados de Epic",
         "enableFSRHack": "Activar o hack de FSR (A versión de Wine debe soportalo)",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Use Dark Tray Icon",
         "default-install-path": "",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Enable Discord Rich Presence",
         "egs-sync": "",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Sötét tálcaikon használata",
         "default-install-path": "Alapértelmezett telepítési útvonal",
         "defaultWinePrefix": "Mappa beállítása új Wine prefixeknek",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Discord Rich Presence engedélyezése",
         "egs-sync": "Szinkronizálás a telepített Epic Gamesszel",
         "enableFSRHack": "FSR hack engedélyezése (a Wine verziónak támogatnia kell)",

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Gunakan Ikon Baki Gelap",
         "default-install-path": "Lokasi Pemasangan Asali",
         "defaultWinePrefix": "Atur Folder untuk Prefiks Wine baru",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Aktifkan Discord Rich Presence",
         "egs-sync": "Sinkronkan dengan Epic Games yang Terpasang",
         "enableFSRHack": "Aktifkan Peretasan FSR (perlu versi Wine yang mendukung)",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Usa l'icona scura della barra delle applicazioni",
         "default-install-path": "Percorso d'installazione predefinito",
         "defaultWinePrefix": "Imposta cartella per i nuovi prefissi Wine",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Attiva \"Discord Rich Presence\"",
         "egs-sync": "Sincronizza con l'Epic Games già installato",
         "enableFSRHack": "Attiva l'FSR Hack (la versione di Wine deve supportarlo)",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -238,6 +238,7 @@
         "darktray": "ダークトレイアイコンを使用する",
         "default-install-path": "デフォルトのインストールパス",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Discord Rich Presenceを有効にする",
         "egs-sync": "インストールされているEpic Gamesと同期する",
         "enableFSRHack": "FSRハックを有効にする（Wineバージョンはそれをサポートする必要があります）",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -238,6 +238,7 @@
         "darktray": "다크 트레이 아이콘 사용",
         "default-install-path": "기본 설치 경로",
         "defaultWinePrefix": "새로운 Wine 접두사를 위한 폴더 설정",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Discord Rich Presence 활성화",
         "egs-sync": "설치된 Epic Games와 동기화",
         "enableFSRHack": "FSR 활성화 (지원하는 Wine 버전을 사용해야 합니다)",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -238,6 +238,7 @@
         "darktray": "താലത്തില്(ട്രേയില്) ഇരുണ്ട ചിത്രം ഉപയോഗിക്കുക",
         "default-install-path": "തനത് സ്ഥാപനയിടം",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "ഡിസ്കോര്ഡ് റിച്ച് പ്രെസന്സ് വക്കൂ",
         "egs-sync": "സ്ഥാപിച്ച എപിക് ഗെയിംസുമായി ഒന്നിപ്പിക്കുക",
         "enableFSRHack": "എഫ്എസ്ആര് ഹാക്ക് വയ്ക്കൂ (Wine version needs to support it)",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Gebruik donker tray icoon",
         "default-install-path": "Standaard installatie pad",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "\"Discord Rich Presence\" inschakelen",
         "egs-sync": "Synchronisatie met geïnstalleerde Epic Games",
         "enableFSRHack": "FSR Hack inschakelen (Wine versie moet dit ondersteunen)",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Użyj ciemnego motywu ikony",
         "default-install-path": "Domyślna ścieżka instalacyjna",
         "defaultWinePrefix": "Ustaw Folder dla nowych Prefiksów Wine",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Włącz Discord Rich Presence",
         "egs-sync": "Synchronizuj zapisy gier z Epic Games Store",
         "enableFSRHack": "Włącz FSR Hack (Wersja Wine musi to wspierać)",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Usar ícone escuro",
         "default-install-path": "Pasta de instalação padrão",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Habilitar Discord Rich Presence",
         "egs-sync": "Sincronizar com Epic Games Store",
         "enableFSRHack": "Habilitar Hack FSR (Wine precisa supportar a feature)",

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Usar o ícone escuro na barra de tarefas",
         "default-install-path": "Local de instalação padrão",
         "defaultWinePrefix": "Pasta padrão para novos prefixos Wine",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Habilitar o Discord Rich Presence",
         "egs-sync": "Sincronizar com a Epic Games Store",
         "enableFSRHack": "Habilitar Hack FSR (a versão do Wine precisa suportar o recurso)",

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Использовать темную иконку в трее",
         "default-install-path": "Стандартный путь установки",
         "defaultWinePrefix": "Указать папку для новых префиксов Wine",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Включить Discord Rich Presence",
         "egs-sync": "Синхронизировать с установленнными играми EGS",
         "enableFSRHack": "Включить FSR Hack (версия Wine должна поддерживать)",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Använd mörk ikon i systemfältet",
         "default-install-path": "Standard installationssökväg",
         "defaultWinePrefix": "Ange sökväg för nya Wine-prefix",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Aktivera Discord Rich Presence",
         "egs-sync": "Synkronisera med installerade Epic spel",
         "enableFSRHack": "Aktivera FSR Hack (Wine-versionen måste stödja det)",

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -238,6 +238,7 @@
         "darktray": "கணினி தட்டில் இருண்ட சின்னத்தை பயன்படுத்து",
         "default-install-path": "இயல்புநிலை நிறுவல் பாதை",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Enable Discord Rich Presence",
         "egs-sync": "நிறுவப்பட்ட எபிக் விளையாட்டுகளுடன் ஒத்திசை",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Karanlık Tepsi Simgesi Kullan",
         "default-install-path": "Öntanımlı Kurulum Yeri",
         "defaultWinePrefix": "Yeni Wine Prefix'leri için Klasörü Ayarla",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Discord Rich Presence'i Etkinleştir",
         "egs-sync": "Kurulu Epic Games ile Eşzamanla",
         "enableFSRHack": "FSR Hack'i Etkinleştir (Wine sürümünün desteklemesi gerekiyor)",

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Використовувати темну піктограму на панелі",
         "default-install-path": "Стандартний шлях встановлення",
         "defaultWinePrefix": "Обрати теку для нових префіксів Wine",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Ввімкнути Discord Rich Presence",
         "egs-sync": "Синхронізуватися із встановленим Epic Games Launcher",
         "enableFSRHack": "Ввімкнути FSR Hack (версія Wine має це підтримувати)",

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -238,6 +238,7 @@
         "darktray": "Sử dụng icon tối",
         "default-install-path": "Thư mục cài mặc định",
         "defaultWinePrefix": "Đặt thư mục cho prefix mới của Wine",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Bật tính năng Discord Rich Presence",
         "egs-sync": "Đồng bộ với Game Epic đã cài",
         "enableFSRHack": "Bật tính năng FSR hack (Phiên bản Wine cần hỗ trợ tính năng này)",

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -238,6 +238,7 @@
         "darktray": "使用暗色托盘图标",
         "default-install-path": "默认安装路径",
         "defaultWinePrefix": "为新的 WinePrefix设置文件夹",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "启用Discord的Rich Presence（活动状态）",
         "egs-sync": "与已安装的 Epic 游戏同步",
         "enableFSRHack": "启用 FSR（需要支持的WINE版本）",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -238,6 +238,7 @@
         "darktray": "使用暗色系統列圖示",
         "default-install-path": "預設安裝路徑",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
+        "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "啟用Discord的Rich Presence（活動狀態）",
         "egs-sync": "與已安裝的Epic Games同步",
         "enableFSRHack": "啟用FSR（需要支持的WINE版本）",

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -22,6 +22,8 @@ const SCROLL_REPEAT_DELAY = 50
  * For more documentation, check here https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki/Gamepad-Navigation
  */
 
+let controllerIsDisabled = false
+
 export const initGamepad = () => {
   // store the current controllers
   let controllers: number[] = []
@@ -58,6 +60,8 @@ export const initGamepad = () => {
     pressed: boolean,
     controllerIndex: number
   ) {
+    if (controllerIsDisabled) return
+
     if (!heroicIsFocused) {
       // ignore gamepad events if heroic is not the focused app
       //
@@ -294,4 +298,12 @@ export const initGamepad = () => {
 
   window.addEventListener('gamepadconnected', connecthandler)
   window.addEventListener('gamepaddisconnected', disconnecthandler)
+}
+
+export const toggleControllerIsDisabled = (value: boolean | undefined) => {
+  if (value !== undefined) {
+    controllerIsDisabled = value
+  } else {
+    controllerIsDisabled = !controllerIsDisabled
+  }
 }

--- a/src/screens/Settings/components/GeneralSettings/index.tsx
+++ b/src/screens/Settings/components/GeneralSettings/index.tsx
@@ -11,6 +11,7 @@ import classNames from 'classnames'
 import { IpcRenderer } from 'electron'
 import Backspace from '@mui/icons-material/Backspace'
 import CreateNewFolder from '@mui/icons-material/CreateNewFolder'
+import { toggleControllerIsDisabled } from 'src/helpers/gamepad'
 
 const { ipcRenderer } = window.require('electron') as {
   ipcRenderer: IpcRenderer
@@ -21,6 +22,7 @@ const storage: Storage = window.localStorage
 interface Props {
   darkTrayIcon: boolean
   defaultInstallPath: string
+  disableController: boolean
   egsLinkedPath: string
   egsPath: string
   exitToTray: boolean
@@ -35,6 +37,7 @@ interface Props {
   setMaxWorkers: (value: number) => void
   startInTray: boolean
   toggleDarkTrayIcon: () => void
+  toggleDisableController: () => void
   toggleStartInTray: () => void
   toggleTray: () => void
   toggleMinimizeOnLaunch: () => void
@@ -60,8 +63,10 @@ export default function GeneralSettings({
   setMaxWorkers,
   darkTrayIcon,
   toggleDarkTrayIcon,
+  minimizeOnLaunch,
   toggleMinimizeOnLaunch,
-  minimizeOnLaunch
+  disableController,
+  toggleDisableController
 }: Props) {
   const [isSyncing, setIsSyncing] = useState(false)
   const [maxCpus, setMaxCpus] = useState(maxWorkers)
@@ -341,6 +346,27 @@ export default function GeneralSettings({
             title={t('setting.darktray', 'Use Dark Tray Icon (needs restart)')}
           />
           <span>{t('setting.darktray', 'Use Dark Tray Icon')}</span>
+        </label>
+      </span>
+      <span className="setting">
+        <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
+          <ToggleSwitch
+            value={disableController}
+            handleChange={() => {
+              toggleDisableController()
+              toggleControllerIsDisabled(!disableController)
+            }}
+            title={t(
+              'setting.disable_controller',
+              'Disable Heroic navigation using controller'
+            )}
+          />
+          <span>
+            {t(
+              'setting.disable_controller',
+              'Disable Heroic navigation using controller'
+            )}
+          </span>
         </label>
       </span>
       <span className="setting">

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -172,6 +172,11 @@ function Settings() {
     toggle: toggleUnrealMarket,
     setOn: setShowUnrealMarket
   } = useToggle(false)
+  const {
+    on: disableController,
+    toggle: toggleDisableController,
+    setOn: setDisableController
+  } = useToggle(false)
 
   const [autoSyncSaves, setAutoSyncSaves] = useState(false)
   const [altWine, setAltWine] = useState([] as WineInstallation[])
@@ -234,6 +239,8 @@ function Settings() {
       setShowUnrealMarket(config.showUnrealMarket)
       setDefaultWinePrefix(config.defaultWinePrefix)
       setUseSteamRuntime(config.useSteamRuntime || false)
+      setDisableController(config.disableController || false)
+
       if (!isDefault) {
         const {
           title: gameTitle,
@@ -267,6 +274,7 @@ function Settings() {
     darkTrayIcon,
     defaultInstallPath,
     defaultWinePrefix,
+    disableController,
     discordRPC,
     egsLinkedPath,
     enableEsync,
@@ -377,6 +385,8 @@ function Settings() {
               showUnrealMarket={showUnrealMarket}
               minimizeOnLaunch={minimizeOnLaunch}
               toggleMinimizeOnLaunch={toggleMinimizeOnLaunch}
+              disableController={disableController}
+              toggleDisableController={toggleDisableController}
             />
           )}
           {isWineSettings && (

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface AppSettings {
   customWinePaths: Array<string>
   darkTrayIcon: boolean
   defaultInstallPath: string
+  disableController: boolean
   discordRPC: boolean
   egsLinkedPath: string
   exitToTray: boolean


### PR DESCRIPTION
This PR adds a configuration to disable the spatial navigation of Heroic using the gamepad/controller.

It can be problematic if a controller has driffting, so a user can disable the feature to prevent the controller to perfom undesired actions.

Closes #1171 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
