### PR TITLE
Add option to hide games from the library

### DIFF
--- a/public/locales/bg/gamepage.json
+++ b/public/locales/bg/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Пауза/Отказ",
         "continue": "Продължаване на свалянето",
+        "hide_game": "Hide Game",
         "import": "Внасяне на игра",
         "install": "Инсталиране",
+        "unhide_game": "Unhide Game",
         "uninstall": "Деинсталиране",
         "update": "Обновяване"
     },

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "Магазин на GOG",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Платформа",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Синхронизиране",
         "unsync": "Десинхронизиране"
     },
-    "Downloading": "Сваляне",
     "epic": {
         "offline-notification-body": "Услугите, зависещи от Интернет, може да не работят изцяло, тъй като сървърите на Epic Games не са достъпни!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "Глобални настройки",
     "GOG": "GOG",
     "gog-store": "Магазин на GOG",
     "header": {
-        "platform": "Платформа"
+        "platform": "Платформа",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Синхронизирайте с EGS, в случай че вече имате работеща инсталация на Epic Games Launcher и искате да внесете игрите си от там, за да избегнете повторното им сваляне.",
@@ -170,7 +167,6 @@
         "unsync": "Десинхронизацията е завършена"
     },
     "nogames": "Няма намерени игри",
-    "Not Ready": "Не е готово",
     "notify": {
         "error": {
             "move": "Грешка при преместването на играта",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Добавки",
     "Projects": "Проекти",
-    "Ready": "Готово",
     "Recent": "Играно наскоро",
     "search": "Въведете името на играта...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Всички игри",
         "allUnreal": "Unreal – Всичко",
-        "downloading": "Сваляне",
-        "installedGames": "Инсталирани игри",
-        "notInstalledGames": "Не инсталирани",
         "unrealAssets": "Unreal – Ресурси",
         "unrealPlugins": "Unreal – Добавки",
-        "unrealProjects": "Unreal – Проекти",
-        "updates": "Изчакващи обновления"
+        "unrealProjects": "Unreal – Проекти"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Показване"
     },
     "Unreal Marketplace": "Пазар на Unreal",
-    "Updates": "Обновления",
     "userselector": {
         "discord": "Дискорд",
         "logout": "Излизане",

--- a/public/locales/ca/gamepage.json
+++ b/public/locales/ca/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Pausa/Cancel·la",
         "continue": "Continua la baixada",
+        "hide_game": "Hide Game",
         "import": "Importa el joc",
         "install": "Instal·la",
+        "unhide_game": "Unhide Game",
         "uninstall": "Desinstal·la",
         "update": "Actualitza"
     },

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -105,20 +105,17 @@
         "syncing": "S'està sincronitzant",
         "unsync": "Dessincronitza"
     },
-    "Downloading": "S'està baixant",
     "epic": {
         "offline-notification-body": "L'Heroic probablement no funcionarà.",
         "offline-notification-title": "fora de línia"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Cap filtre"
-    },
     "globalSettings": "Configuració global",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Sincronitza amb l'EGL si ja tens instal·lat l'Epic Games Laucher en qualsevol altre lloc i vols importar els jocs sense haver de baixar-los de nou.",
@@ -170,7 +167,6 @@
         "unsync": "S'ha completat la dessincronització"
     },
     "nogames": "No s'ha trobat cap joc",
-    "Not Ready": "No preparats",
     "notify": {
         "error": {
             "move": "Error en desplaçar el joc",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Extensions",
     "Projects": "Projectes",
-    "Ready": "Preparats",
     "Recent": "Jugats fa poc",
     "search": "Introdueix el nom del joc...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Tots els jocs",
         "allUnreal": "Unreal - Tot",
-        "downloading": "S'està baixant",
-        "installedGames": "Jocs instal·lats",
-        "notInstalledGames": "No instal·lats",
         "unrealAssets": "Unreal - Recursos",
         "unrealPlugins": "Unreal - Extensions",
-        "unrealProjects": "Unreal - Projectes",
-        "updates": "Actualitzacions pendents"
+        "unrealProjects": "Unreal - Projectes"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Mostra"
     },
     "Unreal Marketplace": "Llibreria d'Unreal",
-    "Updates": "Actualitzacions",
     "userselector": {
         "discord": "Discord",
         "logout": "Tanca la sessió",

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/cs/gamepage.json
+++ b/public/locales/cs/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Zrušit",
         "continue": "Pokračovat ve stahování",
+        "hide_game": "Hide Game",
         "import": "Importovat",
         "install": "Instalovat",
+        "unhide_game": "Unhide Game",
         "uninstall": "Odinstalovat",
         "update": "Update"
     },

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Synchronizuji",
         "unsync": "Desynchroniozovat"
     },
-    "Downloading": "Stahování",
     "epic": {
         "offline-notification-body": "Heroic will not work probably!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "Globální nastavení",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Synchronizujte s EGS v případě, že máte funkční instalaci Epic Games Store jinde a chcete své hry importovat, abyste se vyhnuli jejich opětovnému stahování.",
@@ -170,7 +167,6 @@
         "unsync": "Desynchronizace dokončena"
     },
     "nogames": "Žádné hry nebyly nalezeny",
-    "Not Ready": "Není připraveno",
     "notify": {
         "error": {
             "move": "Error Moving the Game",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Projekty",
-    "Ready": "Připraveno",
     "Recent": "Recently Played",
     "search": "Zde zadejte název hry...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "All Games",
         "allUnreal": "Unreal - Everything",
-        "downloading": "Downloading",
-        "installedGames": "Installed Games",
-        "notInstalledGames": "Not Installed",
         "unrealAssets": "Unreal - Assets",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projects",
-        "updates": "Pending Updates"
+        "unrealProjects": "Unreal - Projects"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Zobrazit"
     },
     "Unreal Marketplace": "Unreal Marketplace",
-    "Updates": "Aktualizace",
     "userselector": {
         "discord": "Discord",
         "logout": "Odhlásit",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/de/gamepage.json
+++ b/public/locales/de/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Pausieren/Abbrechen",
         "continue": "Download fortsetzen",
+        "hide_game": "Hide Game",
         "import": "Spiel importieren",
         "install": "Installieren",
+        "unhide_game": "Unhide Game",
         "uninstall": "Deinstallieren",
         "update": "Update"
     },

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Plattform",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Synchronisiere",
         "unsync": "Nicht mehr synchronisieren"
     },
-    "Downloading": "Am Herunterladen",
     "epic": {
         "offline-notification-body": "Online-Dienste funktionieren möglicherweise nicht vollständig, da die Server von Epic Games offline sind!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Kein Filter"
-    },
     "globalSettings": "Globale Einstellungen",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": "Plattform"
+        "platform": "Plattform",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Synchronisiere mit EGL, falls du woanders eine funktionierende Installation des Epic Games Launcher hast und deine Spiele importieren möchtest, um ein erneutes Herunterladen zu vermeiden.",
@@ -170,7 +167,6 @@
         "unsync": "Synchronisation erfolgreich aufgehoben"
     },
     "nogames": "Keine Spiele gefunden",
-    "Not Ready": "Nicht installiert",
     "notify": {
         "error": {
             "move": "Fehler beim Verschieben des Spiels",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Projekte",
-    "Ready": "Installiert",
     "Recent": "Zuletzt gespielte Spiele",
     "search": "Gebe hier den Namen des Spiels ein...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Alle Spiele",
         "allUnreal": "Unreal - Alles",
-        "downloading": "wird heruntergeladen",
-        "installedGames": "Installierte Spiele",
-        "notInstalledGames": "Nicht installiert",
         "unrealAssets": "Unreal - Assets",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projekte",
-        "updates": "Ausstehende Aktualisierungen"
+        "unrealProjects": "Unreal - Projekte"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Anzeigen"
     },
     "Unreal Marketplace": "Unreal Marketplace",
-    "Updates": "Aktualisierungen",
     "userselector": {
         "discord": "Discord",
         "logout": "Abmelden",

--- a/public/locales/el/gamepage.json
+++ b/public/locales/el/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Παύση/Ακύρωση",
         "continue": "Συνέχιση λήψης",
+        "hide_game": "Hide Game",
         "import": "Εισαγωγή Παιχνιδιού",
         "install": "Εγκατάσταση",
+        "unhide_game": "Unhide Game",
         "uninstall": "Απεγκατάσταση",
         "update": "Ενημέρωση"
     },

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "Κατάστημα GOG",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Πλατφόρμα",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Συγχρονισμός",
         "unsync": "Αποσυγχρονισμός"
     },
-    "Downloading": "Λήψη",
     "epic": {
         "offline-notification-body": "Οι διαδικτυακές υπηρεσίες πιθανό να μη λειτουργούν πλήρως καθώς οι διακομιστές Epic Games ειναι εκτός σύνδεσης!",
         "offline-notification-title": "Εκτός Σύνδεσης"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Χωρίς Φίλτρο"
-    },
     "globalSettings": "Καθολικές Ρυθμίσεις",
     "GOG": "GOG",
     "gog-store": "Κατάστημα GOG",
     "header": {
-        "platform": "Πλατφόρμα"
+        "platform": "Πλατφόρμα",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Συγχρονίστε με EGL εάν έχετε μια λειτουργική εγκατάσταση Epic Games Launcher κάπου αλλού και θέλετε να εισαγάγετε τα παιχνίδια σας για αποφυγή λήψης ξανά.",
@@ -170,7 +167,6 @@
         "unsync": "Ο αποσυγχρονισμός ολοκληρώθηκε"
     },
     "nogames": "Δεν βρέθηκαν παιχνίδια",
-    "Not Ready": "Δεν είναι έτοιμο",
     "notify": {
         "error": {
             "move": "Σφάλμα μετακίνησης του Παιχνιδιού",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Πρότζεκτ",
-    "Ready": "Έτοιμο",
     "Recent": "Παίχτηκε Πρόσφατα",
     "search": "Εισαγάγετε το όνομα παιχνιδιού εδώ...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Όλα τα παιχνίδια",
         "allUnreal": "Unreal - Όλα",
-        "downloading": "Γίνεται λήψη",
-        "installedGames": "Εγκατεστημένα Παιχνίδια",
-        "notInstalledGames": "Μη Εγκατεστημένο",
         "unrealAssets": "Unreal - Στοιχεία",
         "unrealPlugins": "Unreal - Πρόσθετα",
-        "unrealProjects": "Unreal - Πρότζεκτ",
-        "updates": "Εκκρεμής Ενημερώσεις"
+        "unrealProjects": "Unreal - Πρότζεκτ"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Εμφάνιση"
     },
     "Unreal Marketplace": "Κατάστημα Unreal",
-    "Updates": "Ενημερώσεις",
     "userselector": {
         "discord": "Discord",
         "logout": "Αποσύνδεση",

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Pause/Cancel",
         "continue": "Continue Download",
+        "hide_game": "Hide Game",
         "import": "Import Game",
         "install": "Install",
+        "unhide_game": "Unhide Game",
         "uninstall": "Uninstall",
         "update": "Update"
     },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Platform",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Syncing",
         "unsync": "Unsync"
     },
-    "Downloading": "Downloading",
     "epic": {
         "offline-notification-body": "Online services may not work fully as Epic Games servers are offline!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "Global Settings",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": "Platform"
+        "platform": "Platform",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Sync with EGL if you have a working installation of the Epic Games Launcher elsewhere and want to import your games to avoid downloading them again.",
@@ -170,7 +167,6 @@
         "unsync": "Unsync Complete"
     },
     "nogames": "No Games Found",
-    "Not Ready": "Not Ready",
     "notify": {
         "error": {
             "move": "Error Moving the Game",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Projects",
-    "Ready": "Ready",
     "Recent": "Played Recently",
     "search": "Enter the game name here...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "All Games",
         "allUnreal": "Unreal - Everything",
-        "downloading": "Downloading",
-        "installedGames": "Installed Games",
-        "notInstalledGames": "Not Installed",
         "unrealAssets": "Unreal - Assets",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projects",
-        "updates": "Pending Updates"
+        "unrealProjects": "Unreal - Projects"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Show"
     },
     "Unreal Marketplace": "Unreal Marketplace",
-    "Updates": "Updates",
     "userselector": {
         "discord": "Discord",
         "logout": "Log out",

--- a/public/locales/es/gamepage.json
+++ b/public/locales/es/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Pausar/Cancelar",
         "continue": "Seguir descargando",
+        "hide_game": "Hide Game",
         "import": "Importar juego",
         "install": "Instalar",
+        "unhide_game": "Unhide Game",
         "uninstall": "Desinstalar",
         "update": "Actualizar"
     },

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "Tienda de GOG",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Plataforma",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Sincronizando",
         "unsync": "Desincronizar"
     },
-    "Downloading": "Descargando",
     "epic": {
         "offline-notification-body": "¡Puede que algunos servicios no funcionen correctamente si no estás conectado a los servidores de Epic Games!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Sin filtrar"
-    },
     "globalSettings": "Ajustes globales",
     "GOG": "GOG",
     "gog-store": "Tienda de GOG",
     "header": {
-        "platform": "Plataforma"
+        "platform": "Plataforma",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Sincronice con EGL si tiene una instalación funcional de Epic Games Launcher en otro lugar y desee importar sus juegos para evitar descargarlos nuevamente.",
@@ -170,7 +167,6 @@
         "unsync": "Desincronizacion completa"
     },
     "nogames": "No se han encontrado juegos",
-    "Not Ready": "No está listo",
     "notify": {
         "error": {
             "move": "Error al mover el juego",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Proyectos",
-    "Ready": "Listo",
     "Recent": "Jugado recientemente",
     "search": "Ingrese el nombre del juego aquí…",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Todos los juegos",
         "allUnreal": "Unreal - Todo",
-        "downloading": "Descargando",
-        "installedGames": "Juegos instalados",
-        "notInstalledGames": "No instalado",
         "unrealAssets": "Unreal - Recursos",
         "unrealPlugins": "Unreal - Plug-ins",
-        "unrealProjects": "Unreal - Proyectos",
-        "updates": "Actualizaciones pendientes"
+        "unrealProjects": "Unreal - Proyectos"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Mostrar"
     },
     "Unreal Marketplace": "Tienda de Unreal",
-    "Updates": "Actualizaciones",
     "userselector": {
         "discord": "Discord",
         "logout": "Cerrar sesión",

--- a/public/locales/et/gamepage.json
+++ b/public/locales/et/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Peata/Tühista",
         "continue": "Jätka allalaadimist",
+        "hide_game": "Hide Game",
         "import": "Impordi mäng",
         "install": "Paigalda",
+        "unhide_game": "Unhide Game",
         "uninstall": "Eemalda",
         "update": "Uuenda"
     },

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Pood",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Platvorm",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Sünkroonimine",
         "unsync": "Mittesünkroniseerimine"
     },
-    "Downloading": "Allalaadimine",
     "epic": {
         "offline-notification-body": "Võrguteenused ei pruugi täielikult töötada, kuna Epic Gamesi serverid on võrguühenduseta!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Filtreerimata"
-    },
     "globalSettings": "Globaalsed seaded",
     "GOG": "GOG",
     "gog-store": "GOG Pood",
     "header": {
-        "platform": "Platvorm"
+        "platform": "Platvorm",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Sünkroonige EGS-iga, kui teil on Epic Games Store'i töötav installatsioon mujal ja soovite oma mänge importida, et vältida nende uuesti allalaadimist.",
@@ -170,7 +167,6 @@
         "unsync": "Mittesünkroniseerimine lõpetatud"
     },
     "nogames": "Mänge ei leitud",
-    "Not Ready": "Pole valmis",
     "notify": {
         "error": {
             "move": "Viga mängu liigutamisel",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Pluginad",
     "Projects": "Projektid",
-    "Ready": "Valmis",
     "Recent": "Hiljuti mängitud",
     "search": "Sisestage mängu nimi siia...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Kõik mängud",
         "allUnreal": "Unreal - Kõik",
-        "downloading": "Allalaadimine",
-        "installedGames": "Paigaldatud mängud",
-        "notInstalledGames": "Pole installitud",
         "unrealAssets": "Unreal - varamu",
         "unrealPlugins": "Unreal - pluginad",
-        "unrealProjects": "Unreal - Projektid",
-        "updates": "Ootel olevad uuendused"
+        "unrealProjects": "Unreal - Projektid"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Näita"
     },
     "Unreal Marketplace": "Unreal'i Marketplace",
-    "Updates": "Uuendused",
     "userselector": {
         "discord": "Discord",
         "logout": "Logi välja",

--- a/public/locales/fa/gamepage.json
+++ b/public/locales/fa/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "توقف/انصراف",
         "continue": "ادامه بارگیری",
+        "hide_game": "Hide Game",
         "import": "وارد کردن بازی",
         "install": "نصب",
+        "unhide_game": "Unhide Game",
         "uninstall": "حذف",
         "update": "بهروزرسانی"
     },

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "فروشگاه GOG",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "پلتفرم",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -105,20 +105,17 @@
         "syncing": "در حال همگام سازی",
         "unsync": "عدم همگام سازی"
     },
-    "Downloading": "در حال دانلود",
     "epic": {
         "offline-notification-body": "به علت آفلاین بودن سرورهای اپیک گیمز سرویسهای آنلاین ممکن است کار نکنند!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "اپیک گیمز",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "تنظیمات عمومی",
     "GOG": "GOG",
     "gog-store": "فروشگاه GOG",
     "header": {
-        "platform": "پلتفرم"
+        "platform": "پلتفرم",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "در صورتی که در جایی لانچر اپیک گیمز را به صورت فعال نصب کردهاید و میخواهید بازیهای خود را وارد کنید با EGL همگامسازی کنید تا از دانلود مجدد آنها جلوگیری کنید.",
@@ -170,7 +167,6 @@
         "unsync": "عدم همگامسازی کامل شد"
     },
     "nogames": "بازی یافت نشد",
-    "Not Ready": "آماده نمیباشد",
     "notify": {
         "error": {
             "move": "خطا در جابهجا کردن بازی",
@@ -221,7 +217,6 @@
     },
     "Plugins": "افزونهها",
     "Projects": "پروژهها",
-    "Ready": "آماده",
     "Recent": "اخیرا بازی شده",
     "search": "نام بازی را اینجا وارد کنید...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "همه بازیها",
         "allUnreal": "Unreal - همهچیز",
-        "downloading": "در حال دانلود",
-        "installedGames": "بازیهای نصب شده",
-        "notInstalledGames": "نصب نشده",
         "unrealAssets": "Unreal - مهرهها",
         "unrealPlugins": "Unreal - افزونهها",
-        "unrealProjects": "Unreal - پروژهها",
-        "updates": "آپدیتهای در حال انتظار"
+        "unrealProjects": "Unreal - پروژهها"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "نمایش"
     },
     "Unreal Marketplace": "بازار Unreal",
-    "Updates": "بهروزرسانیها",
     "userselector": {
         "discord": "Discord",
         "logout": "خروج از حساب",

--- a/public/locales/fi/gamepage.json
+++ b/public/locales/fi/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Pysäytä/Peruuta",
         "continue": "Jatka lataamista",
+        "hide_game": "Hide Game",
         "import": "Tuo peli",
         "install": "Asenna",
+        "unhide_game": "Unhide Game",
         "uninstall": "Poista",
         "update": "Päivitä"
     },

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Synkronoidaan",
         "unsync": "Älä synkronoi"
     },
-    "Downloading": "Ladataan",
     "epic": {
         "offline-notification-body": "Verkkopalvelut eivät välttämättä toimi kokonaisuudessaan Epic Games:in palvelinten ollessa vailla verkkoyhteyttä!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "Globaalit asetukset",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Synkronisoi EGL:n kanssa mikäli sinulla on toimiva Epic Games Launcher:in asennus toisaalla ja haluat tuoda pelisi välttääksesi niiden uudelleenlatauksen.",
@@ -170,7 +167,6 @@
         "unsync": "Synkronoinnin poisto valmis"
     },
     "nogames": "Pelejä ei löydetty",
-    "Not Ready": "Ei valmis",
     "notify": {
         "error": {
             "move": "Virhe pelin siirtämisessä",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Laajennukset",
     "Projects": "Projektit",
-    "Ready": "Valmis",
     "Recent": "Viimeksi pelatut",
     "search": "Kirjoita tähän pelin nimi...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Kaikki pelit",
         "allUnreal": "Unreal - Kaikki",
-        "downloading": "Ladataan",
-        "installedGames": "Asennetut pelit",
-        "notInstalledGames": "Ei asennettu",
         "unrealAssets": "Unreal - Assets",
         "unrealPlugins": "Unreal - Liitännäiset",
-        "unrealProjects": "Unreal - Projektit",
-        "updates": "Odottavat päivitykset"
+        "unrealProjects": "Unreal - Projektit"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Näytä"
     },
     "Unreal Marketplace": "Unreal Marketplace",
-    "Updates": "Päivitykset",
     "userselector": {
         "discord": "Discord",
         "logout": "Kirjaudu ulos",

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/fr/gamepage.json
+++ b/public/locales/fr/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Suspendre/Annuler",
         "continue": "Continuer le téléchargement",
+        "hide_game": "Hide Game",
         "import": "Importer le jeu",
         "install": "Installer",
+        "unhide_game": "Unhide Game",
         "uninstall": "Désinstaller",
         "update": "Mise à jour"
     },

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Synchronisation en cours",
         "unsync": "Désynchroniser"
     },
-    "Downloading": "Téléchargement en cours",
     "epic": {
         "offline-notification-body": "Heroic will not work probably!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "Paramètres généraux",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Synchronisation avec EGS si vous avez un dossier d'installation de l'Epic Games Store ailleurs et que vous voulez importer vos jeux, afin d'éviter de les retélécharger.",
@@ -170,7 +167,6 @@
         "unsync": "Désynchronisation Complète"
     },
     "nogames": "Aucun jeu trouvé",
-    "Not Ready": "Non installé",
     "notify": {
         "error": {
             "move": "Erreur lors du déplacement des fichiers du jeu",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Projets",
-    "Ready": "Prêt",
     "Recent": "Joué récemment",
     "search": "Insérez le nom du jeu ici...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Tous les jeux",
         "allUnreal": "Unreal - Tout",
-        "downloading": "Téléchargement en cours",
-        "installedGames": "Jeux installés",
-        "notInstalledGames": "Non installés",
         "unrealAssets": "Unreal - Ressources",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projets",
-        "updates": "Mises à jour en attente"
+        "unrealProjects": "Unreal - Projets"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Montrer"
     },
     "Unreal Marketplace": "Marché Unreal",
-    "Updates": "Mises à jour",
     "userselector": {
         "discord": "Discord",
         "logout": "Déconnexion",

--- a/public/locales/gl/gamepage.json
+++ b/public/locales/gl/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Pausar/Cancelar",
         "continue": "Continuar descarga",
+        "hide_game": "Hide Game",
         "import": "Importar xogo",
         "install": "Instalar",
+        "unhide_game": "Unhide Game",
         "uninstall": "Desinstalar",
         "update": "Actualizar"
     },

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Sincronizando",
         "unsync": "Desincronizar"
     },
-    "Downloading": "Descargando",
     "epic": {
         "offline-notification-body": "Os servizos en liña podería non funcionar correctamente xa que os servidores de Epic Games están sen conexión!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Non hai filtro"
-    },
     "globalSettings": "Preferencias globais",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": "Plataforma"
+        "platform": "Plataforma",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Sincronizar con EGS no caso que teña unha instalación funcional de Epic Games Launcher noutro lugar e desexa importar os seus xogos para evitar descargalos novamente.",
@@ -170,7 +167,6 @@
         "unsync": "Desincronización completa"
     },
     "nogames": "Non se atoparon xogos",
-    "Not Ready": "Non está listo",
     "notify": {
         "error": {
             "move": "Erro ao mover o xogo",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Engadidos",
     "Projects": "Proxectos",
-    "Ready": "Listo",
     "Recent": "Xogado recentemente",
     "search": "Escribe o nome do xogo aquí...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Todos os xogos",
         "allUnreal": "Unreal - Todo",
-        "downloading": "Descargando",
-        "installedGames": "Xogos instalados",
-        "notInstalledGames": "Non instalados",
         "unrealAssets": "Unreal - Recursos",
         "unrealPlugins": "Recursos - Engadidos",
-        "unrealProjects": "Unreal - Proxectos",
-        "updates": "Actualizacións pendentes"
+        "unrealProjects": "Unreal - Proxectos"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Mostrar"
     },
     "Unreal Marketplace": "Tenda de Unreal",
-    "Updates": "Actualizacións",
     "userselector": {
         "discord": "Discord",
         "logout": "Pechar sesión",

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Plataforma",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/hr/gamepage.json
+++ b/public/locales/hr/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Otkaži/Prekini",
         "continue": "Nastavi preuzimanje",
+        "hide_game": "Hide Game",
         "import": "Uvezi igru",
         "install": "Instaliraj",
+        "unhide_game": "Unhide Game",
         "uninstall": "Deinstaliraj",
         "update": "Ažuriraj"
     },

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -105,20 +105,17 @@
         "syncing": "",
         "unsync": ""
     },
-    "Downloading": "",
     "epic": {
         "offline-notification-body": "Heroic will maybe not work probably!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "Global Settings",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "",
@@ -170,7 +167,6 @@
         "unsync": ""
     },
     "nogames": "",
-    "Not Ready": "",
     "notify": {
         "error": {
             "move": "Error Moving the Game",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Projects",
-    "Ready": "",
     "Recent": "Played Recently",
     "search": "",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "All Games",
         "allUnreal": "Unreal - Everything",
-        "downloading": "Downloading",
-        "installedGames": "Installed Games",
-        "notInstalledGames": "Not Installed",
         "unrealAssets": "Unreal - Assets",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projects",
-        "updates": "Pending Updates"
+        "unrealProjects": "Unreal - Projects"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": ""
     },
     "Unreal Marketplace": "Unreal Marketplace",
-    "Updates": "Updates",
     "userselector": {
         "discord": "Discord",
         "logout": "Logout",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/hu/gamepage.json
+++ b/public/locales/hu/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Szüneteltetés/mégse",
         "continue": "Letöltés folytatása",
+        "hide_game": "Hide Game",
         "import": "Játék importálása",
         "install": "Telepítés",
+        "unhide_game": "Unhide Game",
         "uninstall": "Eltávolítás",
         "update": "Frissítés"
     },

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Platform",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Szinkronizálás folyamatban",
         "unsync": "Deszinkronizálás"
     },
-    "Downloading": "Letöltés",
     "epic": {
         "offline-notification-body": "Az online szolgáltatások lehet, hogy nem működnek teljesen, mert az Epic Games szerverek offline vannak!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Nincs szűrő"
-    },
     "globalSettings": "Globális beállítások",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": "Platform"
+        "platform": "Platform",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Abban az esetben szinkronizálj EGL-lel , ha van egy működő, Epic Games Launcher telepítésed máshol, és importálni szeretnéd a játékaid, hogy elkerüld az újbóli letöltésüket.",
@@ -170,7 +167,6 @@
         "unsync": "Deszinkronizálás befejezve"
     },
     "nogames": "Nem található játék",
-    "Not Ready": "Nincs kész",
     "notify": {
         "error": {
             "move": "Hiba a játék áthelyezésekor",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Beépülők",
     "Projects": "Projektek",
-    "Ready": "Kész",
     "Recent": "Nemrég játszott",
     "search": "Add meg itt a játék nevét...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Összes játék",
         "allUnreal": "Unreal - Minden",
-        "downloading": "Letöltés",
-        "installedGames": "Telepített játékok",
-        "notInstalledGames": "Nincs telepítve",
         "unrealAssets": "Unreal - Eszközök",
         "unrealPlugins": "Unreal - Bővítmények",
-        "unrealProjects": "Unreal - Projektek",
-        "updates": "Függőben lévő frissítések"
+        "unrealProjects": "Unreal - Projektek"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Megjelenítés"
     },
     "Unreal Marketplace": "Unreal piactér",
-    "Updates": "Frissítések",
     "userselector": {
         "discord": "Discord",
         "logout": "Kijelentkezés",

--- a/public/locales/id/gamepage.json
+++ b/public/locales/id/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Jeda/Batal",
         "continue": "Lanjutkan Unduhan",
+        "hide_game": "Hide Game",
         "import": "Impor Gim",
         "install": "Pasang",
+        "unhide_game": "Unhide Game",
         "uninstall": "Copot",
         "update": "Perbarui"
     },

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Platform",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Menyinkronkan",
         "unsync": "Batalkan sinkronisasi"
     },
-    "Downloading": "Mengunduh",
     "epic": {
         "offline-notification-body": "Layanan daring mungkin tidak akan bekerja sepenuhnya karena server Epic Games sedang luring!",
         "offline-notification-title": "luring"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Tidak Ada Filter"
-    },
     "globalSettings": "Pengaturan Global",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": "Platform"
+        "platform": "Platform",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Sinkronkan dengan EGL jika Anda memiliki instalasi Epic Games Launcher yang berjalan di tempat lain dan ingin mengimpor gim Anda untuk menghindari pengunduhan ulang.",
@@ -170,7 +167,6 @@
         "unsync": "Pembatalan Sinkronisasi Selesai"
     },
     "nogames": "Tidak Ada Gim yang Ditemukan",
-    "Not Ready": "Belum Siap",
     "notify": {
         "error": {
             "move": "Galat dalam Memindahkan Gim",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugin",
     "Projects": "Proyek",
-    "Ready": "Siap",
     "Recent": "Dimainkan Baru-Baru Ini",
     "search": "Masukkan nama gim di sini...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Semua Gim",
         "allUnreal": "Unreal - Semuanya",
-        "downloading": "Mengunduh",
-        "installedGames": "Gim Terpasang",
-        "notInstalledGames": "Tidak Terpasang",
         "unrealAssets": "Unreal - Aset",
         "unrealPlugins": "Unreal - Plugin",
-        "unrealProjects": "Unreal - Proyek",
-        "updates": "Pembaruan Tertunda"
+        "unrealProjects": "Unreal - Proyek"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Tampilkan"
     },
     "Unreal Marketplace": "Unreal Marketplace",
-    "Updates": "Pembaruan",
     "userselector": {
         "discord": "Discord",
         "logout": "Log keluar",

--- a/public/locales/it/gamepage.json
+++ b/public/locales/it/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Pausa/Annulla",
         "continue": "Continua Download",
+        "hide_game": "Hide Game",
         "import": "Importa gioco",
         "install": "Installa",
+        "unhide_game": "Unhide Game",
         "uninstall": "Disinstalla",
         "update": "Update"
     },

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Sincronizzazione in corso",
         "unsync": "Annulla sincronizzazione"
     },
-    "Downloading": "Download in corso",
     "epic": {
         "offline-notification-body": "Heroic will not work probably!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "Impostazioni globali",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Sincronizza con EGS nel caso tu abbia già un'installazione funzionante con l'Epic Games Store, in modo da importare i giochi senza dover riscaricarli di nuovo.",
@@ -170,7 +167,6 @@
         "unsync": "Annullamento sincronizzazione completato"
     },
     "nogames": "Nessun gioco trovato",
-    "Not Ready": "Non ancora pronto",
     "notify": {
         "error": {
             "move": "Errore nello spostamento del gioco",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Progetti",
-    "Ready": "Pronto",
     "Recent": "Giocato di recente",
     "search": "Inserisci qui il nome del gioco...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Tutti i giochi",
         "allUnreal": "Unreal - Tutto",
-        "downloading": "Download in corso",
-        "installedGames": "Giochi installati",
-        "notInstalledGames": "Non installato",
         "unrealAssets": "Unreal - Risorse",
         "unrealPlugins": "Unreal - Plugin",
-        "unrealProjects": "Unreal - Progetti",
-        "updates": "Aggiornamenti in sospeso"
+        "unrealProjects": "Unreal - Progetti"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Mostra"
     },
     "Unreal Marketplace": "Mercato Unreal",
-    "Updates": "Aggiornamenti",
     "userselector": {
         "discord": "Discord",
         "logout": "Disconnetti",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/ja/gamepage.json
+++ b/public/locales/ja/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "一時停止/キャンセル",
         "continue": "ダウンロードを続ける",
+        "hide_game": "Hide Game",
         "import": "インポート",
         "install": "インストール",
+        "unhide_game": "Unhide Game",
         "uninstall": "アンインストール",
         "update": "アップデート"
     },

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -105,20 +105,17 @@
         "syncing": "同期しています",
         "unsync": "非同期"
     },
-    "Downloading": "ダウンロードしています",
     "epic": {
         "offline-notification-body": "Heroic will not work probably!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "全体設定",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Epic Games Storeが他の場所に正常にインストールされていて、ゲームをインポートして再度ダウンロードしないようにする場合は、EGSと同期します。",
@@ -170,7 +167,6 @@
         "unsync": "非同期が完了しました"
     },
     "nogames": "ゲームが見つかりません",
-    "Not Ready": "準備ができていません",
     "notify": {
         "error": {
             "move": "Error Moving the Game",
@@ -221,7 +217,6 @@
     },
     "Plugins": "プラグイン",
     "Projects": "プロジェクト",
-    "Ready": "準備",
     "Recent": "最近のゲーム",
     "search": "ここにゲーム名を入力してください...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "All Games",
         "allUnreal": "Unreal - Everything",
-        "downloading": "Downloading",
-        "installedGames": "Installed Games",
-        "notInstalledGames": "Not Installed",
         "unrealAssets": "Unreal - Assets",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projects",
-        "updates": "Pending Updates"
+        "unrealProjects": "Unreal - Projects"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "表示する"
     },
     "Unreal Marketplace": "Unreal マーケットプレイス",
-    "Updates": "更新",
     "userselector": {
         "discord": "Discord",
         "logout": "ログアウト",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/ko/gamepage.json
+++ b/public/locales/ko/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "일시정지/취소",
         "continue": "계속 다운로드",
+        "hide_game": "Hide Game",
         "import": "게임 들여오기",
         "install": "설치",
+        "unhide_game": "Unhide Game",
         "uninstall": "설치 제거",
         "update": "업데이트"
     },

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "플랫폼",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -105,20 +105,17 @@
         "syncing": "싱크중",
         "unsync": "싱크 해제"
     },
-    "Downloading": "다운로드 중",
     "epic": {
         "offline-notification-body": "Epic Games 서버가 오프라인 상태이므로 온라인 서비스가 완전히 작동하지 않을 수 있습니다!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "글로벌 설정",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": "플랫폼"
+        "platform": "플랫폼",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Epic Games Launcher가 다른 곳에 설치되어 있고 게임을 가져와서 다시 다운로드하지 않으려면 Epic Games Launcher와 동기화 하십시오.",
@@ -170,7 +167,6 @@
         "unsync": "동기화 해제 완료"
     },
     "nogames": "게임이 발견되지 않았습니다",
-    "Not Ready": "준비되지 않음",
     "notify": {
         "error": {
             "move": "게임 이동 중 오류 발생",
@@ -221,7 +217,6 @@
     },
     "Plugins": "플러그인",
     "Projects": "프로젝트",
-    "Ready": "준비됨",
     "Recent": "최근 플레이한 게임",
     "search": "여기에 게임 이름을 입력 ...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "모든 게임",
         "allUnreal": "Unreal - Everything",
-        "downloading": "다운로드 중",
-        "installedGames": "설치된 게임",
-        "notInstalledGames": "설치되지 않음",
         "unrealAssets": "Unreal - 에셋",
         "unrealPlugins": "Unreal - 플러그인",
-        "unrealProjects": "Unreal - 프로젝트",
-        "updates": "보류 중인 업데이트"
+        "unrealProjects": "Unreal - 프로젝트"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "표시"
     },
     "Unreal Marketplace": "Unreal 마켓플레이스",
-    "Updates": "업데이트",
     "userselector": {
         "discord": "Discord",
         "logout": "로그아웃",

--- a/public/locales/ml/gamepage.json
+++ b/public/locales/ml/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "നിര്ത്തൂ/റദ്ദാക്കൂ",
         "continue": "ഇറക്കൽ തുടരൂ",
+        "hide_game": "Hide Game",
         "import": "കളി ഇറക്കുമതി ചെയ്യൂ",
         "install": "നടൂ",
+        "unhide_game": "Unhide Game",
         "uninstall": "എടുത്തുനീക്കൂ",
         "update": "പുതുക്കൂ"
     },

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -105,20 +105,17 @@
         "syncing": "ഒന്നിപ്പിക്കുന്നു",
         "unsync": "പിരിക്കൂ"
     },
-    "Downloading": "ഇറക്കുന്നവ",
     "epic": {
         "offline-notification-body": "Heroic will not work probably!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "എപിക് ഗെയിംസ്",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "ആഗോള ക്രമീകരണങ്ങള്",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "എപിക് ഗെയിം കടയുടെ കുഴപ്പമൊന്നുില്ലാത്ത ഒരു നടീല് മറ്റെവിടെയെങ്കിലും ഉണ്ടെങ്കില് നിങ്ങളുടെ കളികള് വീണ്ടും ഇറക്കിയെടുക്കുന്നത് ഒഴിവാക്കാനായി EGSുമായി ഒന്നിപ്പിക്കുക.",
@@ -170,7 +167,6 @@
         "unsync": "പിരിച്ചു"
     },
     "nogames": "കളികളൊന്നും കണ്ടെത്തിയില്ല",
-    "Not Ready": "സജ്ജമല്ലാത്തവ",
     "notify": {
         "error": {
             "move": "കളി നീക്കുന്നതില് പിഴവു പറ്റി",
@@ -221,7 +217,6 @@
     },
     "Plugins": "കൂടുതലുകള്",
     "Projects": "ഏര്പാടുകള്",
-    "Ready": "തയ്യാറായവ",
     "Recent": "പതിവ് കളികള്",
     "search": "കളിയുടെ പേര് ഇവിടെ എഴുതൂ...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "മൊത്തം കളികള്",
         "allUnreal": "അണ്റിയല് - എല്ലാം",
-        "downloading": "ഇറക്കുന്നു",
-        "installedGames": "നട്ട കളികള്",
-        "notInstalledGames": "നടാത്തവ",
         "unrealAssets": "അണ്റിയല് - വകകള്",
         "unrealPlugins": "അണ്റിയല് - Plugins",
-        "unrealProjects": "അണ്റിയല് - പണികള്",
-        "updates": "നടക്കേണ്ട പുതുക്കലുകള്"
+        "unrealProjects": "അണ്റിയല് - പണികള്"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "കാണിക്കൂ"
     },
     "Unreal Marketplace": "അണ്റിയല് ചന്ത",
-    "Updates": "പുതുക്കലുകള്",
     "userselector": {
         "discord": "ഡിസ്കോഡ഻്",
         "logout": "ഇറങ്ങൂ(ലോഗൌട്ട്)",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/nl/gamepage.json
+++ b/public/locales/nl/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Pauzeren/Annuleren",
         "continue": "Doorgaan met Download",
+        "hide_game": "Hide Game",
         "import": "Importeren",
         "install": "Installeren",
+        "unhide_game": "Unhide Game",
         "uninstall": "Verwijderen",
         "update": "Update"
     },

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Synchroniseren",
         "unsync": "De-synchroniseren"
     },
-    "Downloading": "Aan het downloaden",
     "epic": {
         "offline-notification-body": "Heroic will not work probably!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "Algemene instellingen",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Synchroniseer met EGS als u ergens anders een werkende installatie van de Epic Games Store heeft en u uw games wilt importeren om te vermijden ze opnieuw te downloaden.",
@@ -170,7 +167,6 @@
         "unsync": "De-synchronisatie compleet"
     },
     "nogames": "Geen spellen gevonden",
-    "Not Ready": "Niet klaar",
     "notify": {
         "error": {
             "move": "Error Moving the Game",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Projecten",
-    "Ready": "Gereed",
     "Recent": "Recente Spellen",
     "search": "Voor je spel naam hier in...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "All Games",
         "allUnreal": "Unreal - Everything",
-        "downloading": "Downloading",
-        "installedGames": "Installed Games",
-        "notInstalledGames": "Not Installed",
         "unrealAssets": "Unreal - Assets",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projects",
-        "updates": "Pending Updates"
+        "unrealProjects": "Unreal - Projects"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Tonen"
     },
     "Unreal Marketplace": "Unreal Marktplaats",
-    "Updates": "Updates",
     "userselector": {
         "discord": "Discord",
         "logout": "Log uit",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/pl/gamepage.json
+++ b/public/locales/pl/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Wstrzymaj/Anuluj",
         "continue": "Kontynuuj pobieranie",
+        "hide_game": "Hide Game",
         "import": "Importuj Grę",
         "install": "Instaluj",
+        "unhide_game": "Unhide Game",
         "uninstall": "Odinstaluj",
         "update": "Update"
     },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "Sklep GOG",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Synchronizacja",
         "unsync": "Desynchronizacja"
     },
-    "Downloading": "Pobieranie",
     "epic": {
         "offline-notification-body": "Serwisy Online mogą nie działać w pełni, ponieważ serwery Epic Games są offline!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "Ustawienia Globalne",
     "GOG": "GOG",
     "gog-store": "Sklep GOG",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Synchronizuj z EGS, gdy Epic Games Launcher jest zainstalowane w innym miejscu i chcesz zaimportować swoje gry, aby uniknąć ich ponownego pobierania.",
@@ -170,7 +167,6 @@
         "unsync": "Desynchronizacja zakończona"
     },
     "nogames": "Nie znaleziono żadnej gry",
-    "Not Ready": "Dostępne",
     "notify": {
         "error": {
             "move": "Błąd podczas Przenoszenia Gry",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Rozszerzenia",
     "Projects": "Projekty",
-    "Ready": "Zainstalowane",
     "Recent": "Ostatnio Grane",
     "search": "Wpisz nazwę gry...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Wszystkie Gry",
         "allUnreal": "Unreal - Wszystko",
-        "downloading": "Pobieranie",
-        "installedGames": "Zainstalowane Gry",
-        "notInstalledGames": "Nie Zainstalowane",
         "unrealAssets": "Unreal - Assety",
         "unrealPlugins": "Unreal - Pluginy",
-        "unrealProjects": "Unreal - Projekty",
-        "updates": "Oczekujące Aktualizacje"
+        "unrealProjects": "Unreal - Projekty"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Pokaż"
     },
     "Unreal Marketplace": "Sklep Assetów dla Unreal",
-    "Updates": "Aktualizacje",
     "userselector": {
         "discord": "Discord",
         "logout": "Wyloguj",

--- a/public/locales/pt/gamepage.json
+++ b/public/locales/pt/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Pausar/Cancelar",
         "continue": "Continuar Download",
+        "hide_game": "Hide Game",
         "import": "Importar Jogo",
         "install": "Instalar",
+        "unhide_game": "Unhide Game",
         "uninstall": "Desinstalar",
         "update": "Update"
     },

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Sincronizando",
         "unsync": "Dessincronizar"
     },
-    "Downloading": "Baixando",
     "epic": {
         "offline-notification-body": "Heroic will not work probably!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "Configurações Globais",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Caso você tenha a Epic Games Store instalada em um Prefix Wine, você pode usar a sincronização para importar e exportar jogos entre ela e o Heroic.",
@@ -170,7 +167,6 @@
         "unsync": "Unsync Concluído"
     },
     "nogames": "Nenhum Jogo Encontrado",
-    "Not Ready": "Não Baixados",
     "notify": {
         "error": {
             "move": "Error Moving the Game",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Projetos",
-    "Ready": "Baixados",
     "Recent": "Played Recently",
     "search": "Digite o nome do jogo...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "All Games",
         "allUnreal": "Unreal - Everything",
-        "downloading": "Downloading",
-        "installedGames": "Installed Games",
-        "notInstalledGames": "Not Installed",
         "unrealAssets": "Unreal - Assets",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projects",
-        "updates": "Pending Updates"
+        "unrealProjects": "Unreal - Projects"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Mostrar"
     },
     "Unreal Marketplace": "Loja Unreal",
-    "Updates": "Atualizações",
     "userselector": {
         "discord": "Discord",
         "logout": "Sair",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/pt_BR/gamepage.json
+++ b/public/locales/pt_BR/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Pausar/Cancelar",
         "continue": "Continuar baixando",
+        "hide_game": "Hide Game",
         "import": "Importar Jogo",
         "install": "Instalar",
+        "unhide_game": "Unhide Game",
         "uninstall": "Desinstalar",
         "update": "Update"
     },

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "Loja GOG",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Plataforma",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Sincronizando",
         "unsync": "Dessincronizar"
     },
-    "Downloading": "Baixando",
     "epic": {
         "offline-notification-body": "Serviços online podem não funcionar totalmente, os servidores da Epic Games estão offline!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Sem Filtro"
-    },
     "globalSettings": "Configurações globais",
     "GOG": "GOG",
     "gog-store": "Loja GOG",
     "header": {
-        "platform": "Plataforma"
+        "platform": "Plataforma",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Se você tiver uma instalação funcional da Epic Games Launcher e quiser importar seus jogos, use a sincronização para evitar baixá-los novamente.",
@@ -170,7 +167,6 @@
         "unsync": "Dessincronização Completa"
     },
     "nogames": "Nenhum Jogo Encontrado",
-    "Not Ready": "Não Instalados",
     "notify": {
         "error": {
             "move": "Error ao mover o jogo",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Projetos",
-    "Ready": "Instalados",
     "Recent": "Jogados Recentemente",
     "search": "Insira o nome do jogo aqui…",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Todos os Jogos",
         "allUnreal": "Unreal - Tudo",
-        "downloading": "Baixando",
-        "installedGames": "Jogos Instalados",
-        "notInstalledGames": "Não instalados",
         "unrealAssets": "Unreal - Recursos",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projetos",
-        "updates": "Atualizações pendentes"
+        "unrealProjects": "Unreal - Projetos"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Mostrar"
     },
     "Unreal Marketplace": "Loja Unreal",
-    "Updates": "Atualizações",
     "userselector": {
         "discord": "Discord",
         "logout": "Sair",

--- a/public/locales/ru/gamepage.json
+++ b/public/locales/ru/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Пауза/Отмена",
         "continue": "Продолжить загрузку",
+        "hide_game": "Hide Game",
         "import": "Импортировать игру",
         "install": "Установить",
+        "unhide_game": "Unhide Game",
         "uninstall": "Удалить",
         "update": "Обновить"
     },

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "Магазин GOG",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Платформа",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Синхронизация",
         "unsync": "Рассинхронизировать"
     },
-    "Downloading": "Скачивается",
     "epic": {
         "offline-notification-body": "Онлайн-сервисы могут работать не полностью, так как серверы Epic Games отключены!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Без фильтра"
-    },
     "globalSettings": "Глобальные настройки",
     "GOG": "GOG",
     "gog-store": "Магазин GOG",
     "header": {
-        "platform": "Платформа"
+        "platform": "Платформа",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Синхронизируйте с EGL, если у вас есть работающий Epic Games Launcher в другом месте и вы хотите импортировать свои игры, чтобы избежать их повторного скачивания.",
@@ -170,7 +167,6 @@
         "unsync": "Рассинхронизация завершена"
     },
     "nogames": "Игры не найдены",
-    "Not Ready": "Не готово",
     "notify": {
         "error": {
             "move": "Ошибка при перемещении игры",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Плагины",
     "Projects": "Проекты",
-    "Ready": "Готово",
     "Recent": "Запускались недавно",
     "search": "Введите здесь название игры...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Все игры",
         "allUnreal": "Unreal - Все",
-        "downloading": "Скачивание",
-        "installedGames": "Установленные игры",
-        "notInstalledGames": "Не установлено",
         "unrealAssets": "Unreal - Ресурсы",
         "unrealPlugins": "Unreal - Плагины",
-        "unrealProjects": "Unreal - Проекты",
-        "updates": "Ожидаемые обновления"
+        "unrealProjects": "Unreal - Проекты"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Показать"
     },
     "Unreal Marketplace": "Unreal Marketplace",
-    "Updates": "Обновления",
     "userselector": {
         "discord": "Дискорд",
         "logout": "Выйти из аккаунта",

--- a/public/locales/sv/gamepage.json
+++ b/public/locales/sv/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Paus/Avbryt",
         "continue": "Fortsätt nedladdning",
+        "hide_game": "Hide Game",
         "import": "Importera spel",
         "install": "Installera",
+        "unhide_game": "Unhide Game",
         "uninstall": "Avinstallera",
         "update": "Update"
     },

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Synkroniserar",
         "unsync": "Avbryt synkronisering"
     },
-    "Downloading": "Laddar ner",
     "epic": {
         "offline-notification-body": "Onlinetjänster kanske inte fungerar korrekt då Epics servrar är nere för tillfället!",
         "offline-notification-title": "Offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Inga filter"
-    },
     "globalSettings": "Globala inställningar",
     "GOG": "GOG",
     "gog-store": "GOG Butik",
     "header": {
-        "platform": "Plattform"
+        "platform": "Plattform",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Synkronisera med EGS om du har en fungerande Epic Games Launcher installation och vill importera spel istället för att ladda ner dem igen.",
@@ -170,7 +167,6 @@
         "unsync": "Avbryt synkronisering slutfört"
     },
     "nogames": "Inga spel hittades",
-    "Not Ready": "Ej redo att spelas",
     "notify": {
         "error": {
             "move": "Problem vid flytt av spel",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugins",
     "Projects": "Projekt",
-    "Ready": "Redo",
     "Recent": "Nyligen spelat",
     "search": "Ange spelets titel här...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Alla spel",
         "allUnreal": "Unreal - allt",
-        "downloading": "Laddar ner",
-        "installedGames": "Installerade spel",
-        "notInstalledGames": "Ej installerade",
         "unrealAssets": "Unreal - Tillgångar",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projekt",
-        "updates": "Tillgängliga uppdateringar"
+        "unrealProjects": "Unreal - Projekt"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Visa"
     },
     "Unreal Marketplace": "Unreal marknadsplats",
-    "Updates": "Uppdateringar",
     "userselector": {
         "discord": "Discord",
         "logout": "Logga ut",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Butik",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Plattform",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/ta/gamepage.json
+++ b/public/locales/ta/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "ரத்துசெய்",
         "continue": "பதிவிறக்கத்தை தொடரு",
+        "hide_game": "Hide Game",
         "import": "இறக்குமதி செய்",
         "install": "நிறுவு",
+        "unhide_game": "Unhide Game",
         "uninstall": "நிறுவல் நீக்கு",
         "update": "Update"
     },

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -105,20 +105,17 @@
         "syncing": "ஒத்திசைவு செய்யப்படுகிறது",
         "unsync": "ஒத்திசைவை செயல்தவிர்"
     },
-    "Downloading": "பதிவிறக்கப்படுகிறது",
     "epic": {
         "offline-notification-body": "Heroic will not work probably!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "உலகளாவிய விருப்பத்தேர்வுகள்",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "நீங்கள் எபிக் கேம்ஸ் ஸ்டோரை வேறு இடத்தில் நிறுவியிருந்தால், அதை மீண்டும் பதிவிறக்குவதைத் தவிர்க்க மற்றும் உங்கள் விளையாட்டுகளை இறக்குமதி செய்ய, EGS உடன் ஒத்திசைக்கவும்.",
@@ -170,7 +167,6 @@
         "unsync": "ஒத்திசைவு செயல்தவிர் நிறைப்படைந்தது"
     },
     "nogames": "விளையாட்டுகள் எதுவும் காணப்படவில்லை",
-    "Not Ready": "தயார் இல்லை",
     "notify": {
         "error": {
             "move": "Error Moving the Game",
@@ -221,7 +217,6 @@
     },
     "Plugins": "செருகுநிரல்கள்",
     "Projects": "செயல்திட்டம்",
-    "Ready": "தயார்",
     "Recent": "சமீபத்திய விளையாட்டுகள்",
     "search": "விளையாட்டின் பெயரை இங்கே உள்ளிடு...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "All Games",
         "allUnreal": "Unreal - Everything",
-        "downloading": "Downloading",
-        "installedGames": "Installed Games",
-        "notInstalledGames": "Not Installed",
         "unrealAssets": "Unreal - Assets",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projects",
-        "updates": "Pending Updates"
+        "unrealProjects": "Unreal - Projects"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "காட்டு"
     },
     "Unreal Marketplace": "Unreal விற்பனைக்கூடம்",
-    "Updates": "புதுப்பிப்புகள்",
     "userselector": {
         "discord": "டிஸ்கார்ட் (Discord)",
         "logout": "வெளியேறு",

--- a/public/locales/tr/gamepage.json
+++ b/public/locales/tr/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Duraklat/İptal",
         "continue": "İndirmeye Devam Et",
+        "hide_game": "Hide Game",
         "import": "Oyunu İçe Aktar",
         "install": "Kur",
+        "unhide_game": "Unhide Game",
         "uninstall": "Kaldır",
         "update": "Güncelle"
     },

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Eşzamanlanıyor",
         "unsync": "Eşzamanlamayı kaldır"
     },
-    "Downloading": "İndiriliyor",
     "epic": {
         "offline-notification-body": "Epic Games sunucuları çevrim dışı olduğundan çevrim içi hizmetler tam olarak çalışmayabilir!",
         "offline-notification-title": "çevrim dışı"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Filtre Yok"
-    },
     "globalSettings": "Genel Ayarlar",
     "GOG": "GOG",
     "gog-store": "GOG Mağazası",
     "header": {
-        "platform": "Platform"
+        "platform": "Platform",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Başka bir yerde çalışan bir Epic Games Launcher kurulumunuz varsa ve oyunlarınızı tekrar indirmemek için onları içeri aktarmak istiyorsanız EGL ile eşzamanlayın.",
@@ -170,7 +167,6 @@
         "unsync": "Eşzamanlamayı Kaldırma Tamamlandı"
     },
     "nogames": "Oyun Bulunamadı",
-    "Not Ready": "Hazır Değil",
     "notify": {
         "error": {
             "move": "Oyunu Taşıma Hatası",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Eklentiler",
     "Projects": "Projeler",
-    "Ready": "Hazır",
     "Recent": "Son Oynanan",
     "search": "Buraya oyun adı girin...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Tüm Oyunlar",
         "allUnreal": "Unreal - Her şey",
-        "downloading": "İndiriliyor",
-        "installedGames": "Yüklü Oyunlar",
-        "notInstalledGames": "Yüklü değil",
         "unrealAssets": "Unreal - Varlıklar",
         "unrealPlugins": "Unreal - Eklentiler",
-        "unrealProjects": "Unreal - Projeler",
-        "updates": "Bekleyen Güncellemeler"
+        "unrealProjects": "Unreal - Projeler"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Göster"
     },
     "Unreal Marketplace": "Unreal Mağazası",
-    "Updates": "Güncellemeler",
     "userselector": {
         "discord": "Discord",
         "logout": "Oturumu kapat",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Mağazası",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Platform",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/uk/gamepage.json
+++ b/public/locales/uk/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Призупинити/Скасувати",
         "continue": "Продовжити завантаження",
+        "hide_game": "Hide Game",
         "import": "Імпортувати гру",
         "install": "Встановити",
+        "unhide_game": "Unhide Game",
         "uninstall": "Видалити",
         "update": "Оновити"
     },

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Синхронізую",
         "unsync": "Десинхронізувати"
     },
-    "Downloading": "Завантажую",
     "epic": {
         "offline-notification-body": "Heroic ймовірно не працюватиме!",
         "offline-notification-title": "офлайн"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "Без фільтра"
-    },
     "globalSettings": "Глобальні налаштування",
     "GOG": "GOG",
     "gog-store": "Магазин GOG",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Синхронізувати з EGL якщо ви маєте встановлений Epic Games Launcher і хочете імпортувати ігри уникнувши їх повторного завантаження.",
@@ -170,7 +167,6 @@
         "unsync": "Десинхронізація завершена"
     },
     "nogames": "Не знайдено ігор",
-    "Not Ready": "Неготові",
     "notify": {
         "error": {
             "move": "Помилка під час переміщення гри",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Плаґіни",
     "Projects": "Проєкти",
-    "Ready": "Готові",
     "Recent": "Нещодавно зіграні",
     "search": "Вкажіть тут назву гри...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Всі ігри",
         "allUnreal": "Unreal - Все",
-        "downloading": "Завантажую",
-        "installedGames": "Встановлені ігри",
-        "notInstalledGames": "Невстановлені",
         "unrealAssets": "Unreal - Ассети",
         "unrealPlugins": "Unreal - плаґіни",
-        "unrealProjects": "Unreal - проєкти",
-        "updates": "Очікувані оновлення"
+        "unrealProjects": "Unreal - проєкти"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Показати"
     },
     "Unreal Marketplace": "Торговий майданчик Unreal",
-    "Updates": "Оновлення",
     "userselector": {
         "discord": "Діскорд",
         "logout": "Вийти",

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "Магазин GOG",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/vi/gamepage.json
+++ b/public/locales/vi/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "Tạm dừng/Huỷ",
         "continue": "Tiếp tục tải",
+        "hide_game": "Hide Game",
         "import": "Import Game",
         "install": "Cài đặt",
+        "unhide_game": "Unhide Game",
         "uninstall": "Gỡ cài đặt",
         "update": "Cập nhật"
     },

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "Cửa hàng GOG",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "Nền tảng",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -105,20 +105,17 @@
         "syncing": "Đang đồng bộ",
         "unsync": "Hủy đồng bộ"
     },
-    "Downloading": "Đang tải",
     "epic": {
         "offline-notification-body": "Các dịch vụ trực tuyến có thể không hoạt động đầy đủ vì máy chủ của Epic Games đang ngoại tuyến!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Game",
-    "filter": {
-        "noFilter": "Không lọc"
-    },
     "globalSettings": "Cài đặt chung",
     "GOG": "GOG",
     "gog-store": "Cửa hàng GOG",
     "header": {
-        "platform": "Nền tảng"
+        "platform": "Nền tảng",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "Đồng bộ với EGL nếu bạn đang cài Epic Games Launcher trên máy và muốn import game của mình để không phải tải lại.",
@@ -170,7 +167,6 @@
         "unsync": "Hoàn tất quá trình hủy đồng bộ"
     },
     "nogames": "Không tìm thấy game nào",
-    "Not Ready": "Chưa sẵn sàng",
     "notify": {
         "error": {
             "move": "Gặp lỗi khi di chuyển game",
@@ -221,7 +217,6 @@
     },
     "Plugins": "Plugin",
     "Projects": "Project",
-    "Ready": "Sẵn sàng",
     "Recent": "Chơi gần đây",
     "search": "Nhập tên game ở đây...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "Tất cả game",
         "allUnreal": "Unreal - Tất cả",
-        "downloading": "Đang tải",
-        "installedGames": "Game đã cài",
-        "notInstalledGames": "Chưa cài",
         "unrealAssets": "Unreal - Asset",
         "unrealPlugins": "Unreal - Plugin",
-        "unrealProjects": "Unreal - Project",
-        "updates": "Đang chờ cập nhật"
+        "unrealProjects": "Unreal - Project"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "Hiển thị"
     },
     "Unreal Marketplace": "Unreal Marketplace",
-    "Updates": "Cập nhật",
     "userselector": {
         "discord": "Discord",
         "logout": "Đăng xuất",

--- a/public/locales/zh_Hans/gamepage.json
+++ b/public/locales/zh_Hans/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "暂停/取消",
         "continue": "继续下载",
+        "hide_game": "Hide Game",
         "import": "导入游戏",
         "install": "安装",
+        "unhide_game": "Unhide Game",
         "uninstall": "卸载",
         "update": "更新"
     },

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG 商店",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "平台",
         "show_hidden": "Show Hidden"
     },

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -105,20 +105,17 @@
         "syncing": "正在同步",
         "unsync": "不同步"
     },
-    "Downloading": "正在下载",
     "epic": {
         "offline-notification-body": "在线服务可能无法完全工作，因为 Epic Games 服务器离线！",
         "offline-notification-title": "离线"
     },
     "Epic Games": "Epic 游戏",
-    "filter": {
-        "noFilter": "全部"
-    },
     "globalSettings": "全局设置",
     "GOG": "GOG",
     "gog-store": "GOG 商店",
     "header": {
-        "platform": "平台"
+        "platform": "平台",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "与 Epic Games 启动器同步，如果你在其他地方安装了Epic Games 启动器，而且想要导入你的游戏，以免再次下载它们。",
@@ -170,7 +167,6 @@
         "unsync": "取消同步完成"
     },
     "nogames": "未找到游戏",
-    "Not Ready": "尚未就绪",
     "notify": {
         "error": {
             "move": "移动游戏时出错",
@@ -221,7 +217,6 @@
     },
     "Plugins": "插件",
     "Projects": "项目",
-    "Ready": "准备就绪",
     "Recent": "最近玩过",
     "search": "在此处输入游戏名称…",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "所有游戏",
         "allUnreal": "虚幻 - 所有",
-        "downloading": "下载中",
-        "installedGames": "已安装的游戏",
-        "notInstalledGames": "未安装",
         "unrealAssets": "虚幻 - 素材",
         "unrealPlugins": "虚幻 - 插件",
-        "unrealProjects": "虚幻 - 项目",
-        "updates": "待更新"
+        "unrealProjects": "虚幻 - 项目"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "显示"
     },
     "Unreal Marketplace": "虚幻商城",
-    "Updates": "更新",
     "userselector": {
         "discord": "Discord",
         "logout": "退出登录",

--- a/public/locales/zh_Hant/gamepage.json
+++ b/public/locales/zh_Hant/gamepage.json
@@ -38,8 +38,10 @@
     "button": {
         "cancel": "取消",
         "continue": "繼續下載",
+        "hide_game": "Hide Game",
         "import": "導入",
         "install": "安裝",
+        "unhide_game": "Unhide Game",
         "uninstall": "解除安裝",
         "update": "更新"
     },

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -105,20 +105,17 @@
         "syncing": "正在同步",
         "unsync": "不同步"
     },
-    "Downloading": "正在下載",
     "epic": {
         "offline-notification-body": "Heroic will not work probably!",
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
-    "filter": {
-        "noFilter": "No Filter"
-    },
     "globalSettings": "全域設定",
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
-        "platform": ""
+        "platform": "",
+        "show_hidden": "Show Hidden"
     },
     "help": {
         "general": "與Epic Games商城同步，如果您在其他地方已經安裝了Epic Games啟動器，可以導入您的遊戲以避免再次下載它們。",
@@ -170,7 +167,6 @@
         "unsync": "取消同步完成"
     },
     "nogames": "未找到遊戲",
-    "Not Ready": "尚未就緒",
     "notify": {
         "error": {
             "move": "Error Moving the Game",
@@ -221,7 +217,6 @@
     },
     "Plugins": "外掛插件",
     "Projects": "專案",
-    "Ready": "準備就緒",
     "Recent": "最近的遊戲",
     "search": "在此處輸入遊戲名稱...",
     "setting": {
@@ -314,13 +309,9 @@
     "title": {
         "allGames": "All Games",
         "allUnreal": "Unreal - Everything",
-        "downloading": "Downloading",
-        "installedGames": "Installed Games",
-        "notInstalledGames": "Not Installed",
         "unrealAssets": "Unreal - Assets",
         "unrealPlugins": "Unreal - Plugins",
-        "unrealProjects": "Unreal - Projects",
-        "updates": "Pending Updates"
+        "unrealProjects": "Unreal - Projects"
     },
     "toolbox": {
         "settings": {
@@ -340,7 +331,6 @@
         "show": "顯示"
     },
     "Unreal Marketplace": "虛幻商城",
-    "Updates": "更新",
     "userselector": {
         "discord": "Discord",
         "logout": "登出",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -114,6 +114,7 @@
     "GOG": "GOG",
     "gog-store": "GOG Store",
     "header": {
+        "ignore_hidden": "Ignore Hidden",
         "platform": "",
         "show_hidden": "Show Hidden"
     },

--- a/src/components/UI/FormControl/index.css
+++ b/src/components/UI/FormControl/index.css
@@ -93,6 +93,10 @@
   border-bottom-right-radius: 0;
 }
 
+.FormControl--segmented > button > svg {
+  display: block;
+}
+
 .FormControl__segmentedFaIcon {
   font-size: 20px;
   outline: none;

--- a/src/components/UI/Header/index.css
+++ b/src/components/UI/Header/index.css
@@ -3,8 +3,8 @@
   top: 0;
   z-index: 7;
   display: grid;
-  grid-template-columns: 3fr 4fr 3fr;
-  grid-template-areas: 'filters search summary';
+  grid-template-columns: min-content 1fr 4fr 2fr;
+  grid-template-areas: 'hidden filters search summary';
   grid-gap: 8px;
   align-items: center;
   margin: 0 32px;
@@ -12,19 +12,13 @@
   background: var(--gradient-body-background);
   color: var(--text-secondary);
 }
-@media (max-width: 1400px) {
-  .Header {
-    grid-template-columns: 3fr 4fr 2fr;
-  }
-}
 
-@media screen and (max-width: 1200px) {
+@media screen and (max-width: 1000px) {
   .Header {
-    grid-template-columns: 1fr auto;
-    grid-template-rows: 1fr 1fr;
+    grid-template-columns: min-content 1fr min-content;
     grid-template-areas:
-      'search search'
-      'filters summary';
+      'search search search'
+      'hidden filters summary';
   }
 }
 
@@ -32,10 +26,17 @@
   grid-area: filters;
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .Header__filters .FormControl {
   margin-right: 8px;
+}
+
+.Header__toggleHidden {
+  grid-area: hidden;
+  margin-right: 8px;
+  white-space: nowrap;
 }
 
 .Header__search {
@@ -49,6 +50,8 @@
 .Header__summary {
   grid-area: summary;
   text-align: right;
+  white-space: nowrap;
+  margin-left: 8px;
 }
 
 /* TODO move following styles to the components which use them */

--- a/src/components/UI/Header/index.css
+++ b/src/components/UI/Header/index.css
@@ -3,8 +3,8 @@
   top: 0;
   z-index: 7;
   display: grid;
-  grid-template-columns: min-content 1fr 4fr 2fr;
-  grid-template-areas: 'hidden filters search summary';
+  grid-template-columns: 1fr 4fr 1fr min-content;
+  grid-template-areas: 'filters search summary hidden';
   grid-gap: 8px;
   align-items: center;
   margin: 0 32px;
@@ -31,12 +31,6 @@
 
 .Header__filters .FormControl {
   margin-right: 8px;
-}
-
-.Header__toggleHidden {
-  grid-area: hidden;
-  margin-right: 8px;
-  white-space: nowrap;
 }
 
 .Header__search {

--- a/src/components/UI/Header/index.css
+++ b/src/components/UI/Header/index.css
@@ -15,10 +15,10 @@
 
 @media screen and (max-width: 1000px) {
   .Header {
-    grid-template-columns: min-content 1fr min-content;
+    grid-template-columns: 1fr min-content min-content;
     grid-template-areas:
       'search search search'
-      'hidden filters summary';
+      'filters summary hidden';
   }
 }
 

--- a/src/components/UI/Header/index.tsx
+++ b/src/components/UI/Header/index.tsx
@@ -6,8 +6,8 @@ import { useTranslation } from 'react-i18next'
 import { SearchBar } from 'src/components/UI'
 import ContextProvider from 'src/state/ContextProvider'
 import FormControl from '../FormControl'
-import ToggleSwitch from '../ToggleSwitch'
 import { UE_VERSIONS } from './constants'
+import { Visibility, VisibilityOff } from '@mui/icons-material'
 import './index.css'
 
 export interface HeaderProps {
@@ -33,6 +33,10 @@ export default function Header({ numberOfGames }: HeaderProps) {
   const toggleShowHidden = () => {
     setShowHidden(!showHidden)
   }
+
+  const showHiddenTitle = showHidden
+    ? t('header.ignore_hidden', 'Ignore Hidden')
+    : t('header.show_hidden', 'Show Hidden')
 
   return (
     <div className="Header">
@@ -144,14 +148,15 @@ export default function Header({ numberOfGames }: HeaderProps) {
           ? `${t('Total Games')}: ${numberOfGames}`
           : `${t('nogames')}`}
       </div>
-      <label className="Header__toggleHidden">
-        {t('header.show_hidden', 'Show Hidden')}
-        <ToggleSwitch
-          title={t('header.show_hidden', 'Show Hidden')}
-          handleChange={toggleShowHidden}
-          value={showHidden}
-        />
-      </label>
+      <FormControl segmented>
+        <button
+          className="FormControl__button"
+          title={showHiddenTitle}
+          onClick={toggleShowHidden}
+        >
+          {showHidden ? <Visibility /> : <VisibilityOff />}
+        </button>
+      </FormControl>
     </div>
   )
 }

--- a/src/components/UI/Header/index.tsx
+++ b/src/components/UI/Header/index.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { SearchBar } from 'src/components/UI'
 import ContextProvider from 'src/state/ContextProvider'
 import FormControl from '../FormControl'
+import ToggleSwitch from '../ToggleSwitch'
 import { UE_VERSIONS } from './constants'
 import './index.css'
 
@@ -21,11 +22,17 @@ export default function Header({ numberOfGames }: HeaderProps) {
     handleFilter,
     filterPlatform,
     handlePlatformFilter,
-    platform
+    platform,
+    showHidden,
+    setShowHidden
   } = useContext(ContextProvider)
 
   const isMac = platform === 'darwin'
   const isLinux = platform === 'linux'
+
+  const toggleShowHidden = () => {
+    setShowHidden(!showHidden)
+  }
 
   return (
     <div className="Header">
@@ -137,6 +144,14 @@ export default function Header({ numberOfGames }: HeaderProps) {
           ? `${t('Total Games')}: ${numberOfGames}`
           : `${t('nogames')}`}
       </div>
+      <label className="Header__toggleHidden">
+        {t('header.show_hidden', 'Show Hidden')}
+        <ToggleSwitch
+          title={t('header.show_hidden', 'Show Hidden')}
+          handleChange={toggleShowHidden}
+          value={showHidden}
+        />
+      </label>
     </div>
   )
 }

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -51,7 +51,8 @@ export const initGamepad = () => {
     rightStickRight: { triggeredAt: {}, repeatDelay: SCROLL_REPEAT_DELAY },
     mainAction: { triggeredAt: {}, repeatDelay: false },
     back: { triggeredAt: {}, repeatDelay: false },
-    altAction: { triggeredAt: {}, repeatDelay: false }
+    altAction: { triggeredAt: {}, repeatDelay: false },
+    rightClick: { triggeredAt: {}, repeatDelay: false }
   }
 
   // check if an action should be triggered

--- a/src/helpers/gamepad_layouts/genius.ts
+++ b/src/helpers/gamepad_layouts/genius.ts
@@ -10,7 +10,7 @@ export function checkGenius1(
 ) {
   const one = buttons[0],
     two = buttons[1],
-    // three = buttons[2],
+    three = buttons[2],
     four = buttons[3],
     // L1 = buttons[4],
     // R1 = buttons[5],
@@ -42,4 +42,5 @@ export function checkGenius1(
   checkAction('mainAction', one.pressed, controllerIndex)
   checkAction('back', two.pressed, controllerIndex)
   checkAction('altAction', four.pressed, controllerIndex)
+  checkAction('rightClick', three.pressed, controllerIndex)
 }

--- a/src/helpers/gamepad_layouts/nintendo.ts
+++ b/src/helpers/gamepad_layouts/nintendo.ts
@@ -7,7 +7,7 @@ export function checkGameCube(
   checkAction: (action: string, pressed: boolean, ctrlIdx: number) => void
 ) {
   const A = buttons[0],
-    // X = buttons[1],
+    X = buttons[1],
     Y = buttons[2],
     B = buttons[3],
     // LT = buttons[4],
@@ -38,6 +38,7 @@ export function checkGameCube(
   checkAction('mainAction', A.pressed, controllerIndex)
   checkAction('back', B.pressed, controllerIndex)
   checkAction('altAction', Y.pressed, controllerIndex)
+  checkAction('rightClick', X.pressed, controllerIndex)
 }
 
 // Generic USB Joystick (Vendor: 0079 Product: 0006)
@@ -54,7 +55,7 @@ export function checkN64Clone1(
     // L = buttons[4],
     // R = buttons[5],
     A = buttons[6],
-    // Z = buttons[7],
+    Z = buttons[7],
     B = buttons[8],
     // Start = buttons[9],
     axisX = axes[0],
@@ -89,4 +90,5 @@ export function checkN64Clone1(
   checkAction('mainAction', A.pressed, controllerIndex)
   checkAction('back', B.pressed, controllerIndex)
   checkAction('altAction', CDown.pressed, controllerIndex)
+  checkAction('rightClick', Z.pressed, controllerIndex)
 }

--- a/src/helpers/gamepad_layouts/ps.ts
+++ b/src/helpers/gamepad_layouts/ps.ts
@@ -8,7 +8,7 @@ export function checkPS3(
 ) {
   const X = buttons[0],
     Circle = buttons[1],
-    // Square = buttons[2],
+    Square = buttons[2],
     Triangle = buttons[3],
     // LB = buttons[4],
     // RB = buttons[5],
@@ -43,6 +43,7 @@ export function checkPS3(
   checkAction('mainAction', X.pressed, controllerIndex)
   checkAction('back', Circle.pressed, controllerIndex)
   checkAction('altAction', Triangle.pressed, controllerIndex)
+  checkAction('rightClick', Square.pressed, controllerIndex)
 }
 
 export function checkPS5(
@@ -54,7 +55,7 @@ export function checkPS5(
   const Circle = buttons[0],
     Triangle = buttons[1],
     X = buttons[2],
-    // Square = buttons[3],
+    Square = buttons[3],
     // LB = buttons[4],
     // RB = buttons[5],
     rightAxisX = buttons[6],
@@ -83,6 +84,7 @@ export function checkPS5(
   checkAction('mainAction', X.pressed, controllerIndex)
   checkAction('back', Circle.pressed, controllerIndex)
   checkAction('altAction', Triangle.pressed, controllerIndex)
+  checkAction('rightClick', Square.pressed, controllerIndex)
 }
 
 // Vendor: 2563, Product: 0523
@@ -95,7 +97,7 @@ export function checkPS3Clone1(
   const Triangle = buttons[0],
     Circle = buttons[1],
     X = buttons[2],
-    // Square = buttons[3],
+    Square = buttons[3],
     // LB = buttons[4],
     // RB = buttons[5],
     // LT = buttons[6],
@@ -124,4 +126,5 @@ export function checkPS3Clone1(
   checkAction('mainAction', X.pressed, controllerIndex)
   checkAction('back', Circle.pressed, controllerIndex)
   checkAction('altAction', Triangle.pressed, controllerIndex)
+  checkAction('rightClick', Square.pressed, controllerIndex)
 }

--- a/src/helpers/gamepad_layouts/xbox.ts
+++ b/src/helpers/gamepad_layouts/xbox.ts
@@ -10,7 +10,7 @@ export function checkXbox(
 ) {
   const A = buttons[0],
     B = buttons[1],
-    // X = buttons[2],
+    X = buttons[2],
     Y = buttons[3],
     // LB = buttons[4],
     // RB = buttons[5],
@@ -47,4 +47,5 @@ export function checkXbox(
   checkAction('padDown', down?.pressed, controllerIndex)
   checkAction('padLeft', left?.pressed, controllerIndex)
   checkAction('padRight', right?.pressed, controllerIndex)
+  checkAction('rightClick', X?.pressed, controllerIndex)
 }

--- a/src/helpers/library.ts
+++ b/src/helpers/library.ts
@@ -297,17 +297,17 @@ type RecentGame = {
   title: string
 }
 
+const Store = window.require('electron-store')
+const configStore: ElectronStore = new Store({
+  cwd: 'store'
+})
+
 function getRecentGames(library: GameInfo[]) {
-  return library.filter((game) => {
-    const Store = window.require('electron-store')
-    const configStore: ElectronStore = new Store({
-      cwd: 'store'
-    })
-    const recentGames: Array<RecentGame> =
-      (configStore.get('games.recent') as Array<RecentGame>) || []
-    const recentGamesList = recentGames.map((a) => a.appName) as string[]
-    return recentGamesList.includes(game.app_name)
-  })
+  const recentGames =
+    (configStore.get('games.recent') as Array<RecentGame>) || []
+  const recentGamesList = recentGames.map((a) => a.appName) as string[]
+
+  return library.filter((game) => recentGamesList.includes(game.app_name))
 }
 
 export {

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -75,7 +75,7 @@ const GameCard = ({
 
   const { t } = useTranslation('gamepage')
 
-  const { libraryStatus, layout, handleGameStatus, platform } =
+  const { libraryStatus, layout, handleGameStatus, platform, hiddenGames } =
     useContext(ContextProvider)
   const history = useHistory()
   const isWin = platform === 'win32'
@@ -220,6 +220,16 @@ const GameCard = ({
     return () => clearInterval(progressInterval)
   }, [isInstalling, appName])
 
+  const [isHiddenGame, setIsHiddenGame] = useState(false)
+
+  useEffect(() => {
+    const found = !!hiddenGames.list.find(
+      (hiddenGame) => hiddenGame.appName === appName
+    )
+
+    setIsHiddenGame(found)
+  }, [hiddenGames, appName])
+
   const items: Item[] = [
     {
       label: t('label.playing.start'),
@@ -266,6 +276,16 @@ const GameCard = ({
       label: t('button.cancel'),
       onclick: () => handlePlay(runner),
       show: isInstalling
+    },
+    {
+      label: t('button.hide_game', 'Hide Game'),
+      onclick: () => hiddenGames.add(appName, title),
+      show: !isHiddenGame
+    },
+    {
+      label: t('button.unhide_game', 'Unhide Game'),
+      onclick: () => hiddenGames.remove(appName),
+      show: isHiddenGame
     }
   ]
 

--- a/src/state/ContextProvider.tsx
+++ b/src/state/ContextProvider.tsx
@@ -26,7 +26,14 @@ const initialContext: ContextType = {
   refreshLibrary: () => Promise.resolve(),
   refreshWineVersionInfo: () => Promise.resolve(),
   refreshing: false,
-  isRTL: false
+  isRTL: false,
+  hiddenGames: {
+    list: [],
+    add: () => null,
+    remove: () => null
+  },
+  showHidden: false,
+  setShowHidden: () => null
 }
 
 export default React.createContext(initialContext)

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -105,8 +105,8 @@ export class GlobalState extends PureComponent<Props> {
     libraryStatus: [],
     platform: '',
     refreshing: false,
-    hiddenGames: [],
-    showHidden: true
+    hiddenGames: (configStore.get('games.hidden') as Array<HiddenGame>) || [],
+    showHidden: false
   }
 
   setShowHidden = (value: boolean) => {
@@ -161,15 +161,11 @@ export class GlobalState extends PureComponent<Props> {
       ipcRenderer.send('logError', error)
     }
 
-    const hiddenGames =
-      (configStore.get('games.hidden') as Array<HiddenGame>) || []
-
     this.setState({
       epicLibrary,
       gogLibrary,
       gameUpdates: updates,
-      refreshing: false,
-      hiddenGames
+      refreshing: false
     })
 
     if (currentLibraryLength !== epicLibrary.length) {
@@ -435,6 +431,7 @@ export class GlobalState extends PureComponent<Props> {
     const filter = storage.getItem('filter') || 'all'
     const layout = storage.getItem('layout') || 'grid'
     const language = storage.getItem('language') || 'en'
+    const showHidden = JSON.parse(storage.getItem('show_hidden') || 'false')
 
     if (!legendaryUser) {
       await ipcRenderer.invoke('getUserInfo')
@@ -446,7 +443,7 @@ export class GlobalState extends PureComponent<Props> {
     }
 
     i18n.changeLanguage(language)
-    this.setState({ category, filter, language, layout, platform })
+    this.setState({ category, filter, language, layout, platform, showHidden })
 
     if (legendaryUser || gogUser) {
       this.refreshLibrary({
@@ -458,12 +455,14 @@ export class GlobalState extends PureComponent<Props> {
   }
 
   componentDidUpdate() {
-    const { filter, gameUpdates, libraryStatus, layout, category } = this.state
+    const { filter, gameUpdates, libraryStatus, layout, category, showHidden } =
+      this.state
 
     storage.setItem('category', category)
     storage.setItem('filter', filter)
     storage.setItem('layout', layout)
     storage.setItem('updates', JSON.stringify(gameUpdates))
+    storage.setItem('show_hidden', JSON.stringify(showHidden))
 
     const pendingOps = libraryStatus.filter(
       (game) => game.status !== 'playing'

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react'
 import {
   GameInfo,
   GameStatus,
+  HiddenGame,
   InstalledInfo,
   RefreshOptions,
   WineVersionInfo
@@ -63,6 +64,8 @@ interface StateProps {
   libraryStatus: GameStatus[]
   platform: string
   refreshing: boolean
+  hiddenGames: HiddenGame[]
+  showHidden: boolean
 }
 
 export class GlobalState extends PureComponent<Props> {
@@ -101,7 +104,36 @@ export class GlobalState extends PureComponent<Props> {
     layout: 'grid',
     libraryStatus: [],
     platform: '',
-    refreshing: false
+    refreshing: false,
+    hiddenGames: [],
+    showHidden: true
+  }
+
+  setShowHidden = (value: boolean) => {
+    this.setState({ showHidden: value })
+  }
+
+  hideGame = (appNameToHide: string, appTitle: string) => {
+    const newHiddenGames = [
+      ...this.state.hiddenGames,
+      { appName: appNameToHide, title: appTitle }
+    ]
+
+    this.setState({
+      hiddenGames: newHiddenGames
+    })
+    configStore.set('games.hidden', newHiddenGames)
+  }
+
+  unhideGame = (appNameToUnhide: string) => {
+    const newHiddenGames = this.state.hiddenGames.filter(
+      ({ appName }) => appName !== appNameToUnhide
+    )
+
+    this.setState({
+      hiddenGames: newHiddenGames
+    })
+    configStore.set('games.hidden', newHiddenGames)
   }
 
   refresh = async (checkUpdates?: boolean): Promise<void> => {
@@ -129,11 +161,15 @@ export class GlobalState extends PureComponent<Props> {
       ipcRenderer.send('logError', error)
     }
 
+    const hiddenGames =
+      (configStore.get('games.hidden') as Array<HiddenGame>) || []
+
     this.setState({
       epicLibrary,
       gogLibrary,
       gameUpdates: updates,
-      refreshing: false
+      refreshing: false,
+      hiddenGames
     })
 
     if (currentLibraryLength !== epicLibrary.length) {
@@ -480,6 +516,19 @@ export class GlobalState extends PureComponent<Props> {
       recentGames = [...recentGames, ...getRecentGames(gogLibrary)]
     }
 
+    const hiddenGamesAppNames = this.state.hiddenGames.map(
+      (hidden) => hidden.appName
+    )
+
+    if (!this.state.showHidden) {
+      filteredEpicLibrary = filteredEpicLibrary.filter(
+        (game) => !hiddenGamesAppNames.includes(game.app_name)
+      )
+      filteredGOGLibrary = filteredGOGLibrary.filter(
+        (game) => !hiddenGamesAppNames.includes(game.app_name)
+      )
+    }
+
     return (
       <ContextProvider.Provider
         value={{
@@ -498,7 +547,13 @@ export class GlobalState extends PureComponent<Props> {
           refresh: this.refresh,
           refreshLibrary: this.refreshLibrary,
           refreshWineVersionInfo: this.refreshWineVersionInfo,
-          recentGames
+          recentGames,
+          hiddenGames: {
+            list: this.state.hiddenGames,
+            add: this.hideGame,
+            remove: this.unhideGame
+          },
+          setShowHidden: this.setShowHidden
         }}
       >
         {children}

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,13 @@ export interface ContextType {
   refreshLibrary: (options: RefreshOptions) => Promise<void>
   refreshWineVersionInfo: (fetch: boolean) => void
   refreshing: boolean
+  hiddenGames: {
+    list: HiddenGame[]
+    add: (appNameToHide: string, appTitle: string) => void
+    remove: (appNameToUnhide: string) => void
+  }
+  showHidden: boolean
+  setShowHidden: (value: boolean) => void
 }
 
 interface ExtraInfo {
@@ -103,6 +110,11 @@ export interface GameInfo {
   save_folder: string
   title: string
   canRunOffline: boolean
+}
+
+export interface HiddenGame {
+  appName: string
+  title: string
 }
 
 export interface GameSettings {


### PR DESCRIPTION
This PR adds a the ability to mark games from the library as `hidden` so they don't show up by default. This can be toggled on/off with the new checkbox.

Games can be hid/unhid using the right click context menu.

You can see it working in this video with the game A Short Hike (second to last, bottom right)

https://user-images.githubusercontent.com/188464/164943074-053065f1-bd62-4cd4-bc65-a77fa2344db6.mp4

(The total games counter changes by more than 1 because I have other hidden games outside the viewport)

This I tried and was not happy with (but accept any feedback):
- using an icon for the `Show hidden` toggle instead of text, it didn't look clear at least to me
- adding an icon in the game card to toggle the hide/unhide, it added noise for an action that's probably done only once or twice ever for a game

Haven't tested with Unreal Market (I don't use it, I don't know if this is expected to work there too? I understand it works but I don't know if we should ignore this feature there).

Closes #948

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
