### PR TITLE
Don't return value in useEffect call in Wine Manager

### DIFF
--- a/src/screens/WineManager/index.tsx
+++ b/src/screens/WineManager/index.tsx
@@ -17,7 +17,7 @@ export default function WineManager(): JSX.Element | null {
     useContext(ContextProvider)
 
   useEffect(() => {
-    return refreshWineVersionInfo(true)
+    refreshWineVersionInfo(true)
   }, [])
 
   if (refreshing) {


### PR DESCRIPTION
This PR fixes #1235. The `useEffect` call was returning a value and that was triggering that React error shown in the issue description.

After the error, the application was broken when changing screens.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
