### PR TITLE
fix: undefined install path passed to install func

### DIFF
--- a/src/screens/Library/components/InstallModal/index.tsx
+++ b/src/screens/Library/components/InstallModal/index.tsx
@@ -159,6 +159,8 @@ export default function InstallModal({
   }
 
   async function handleInstall(path?: string) {
+    // If path provided by user is empty, use default path (as shown in placeholder; $HOME/Games/Heroic)
+    if (!path || path == '') path = defaultPath
     backdropClick()
 
     // Write Default game config with prefix on linux
@@ -542,7 +544,7 @@ export default function InstallModal({
                 {t('button.import')}
               </button>
               <button
-                onClick={() => handleInstall()}
+                onClick={() => handleInstall(installPath)}
                 className={`button is-secondary`}
               >
                 {previousProgress.folder === installPath


### PR DESCRIPTION
The install button wasn't passing the user selected path to the install function and would just crash and die.

+Install button properly passes install path to the function, and uses the default in empty/undef

Use the following Checklist if you have changed something on the Backend or Frontend:

- [Y] Tested the feature and it's working on a current and clean install.
- [Y] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [N] Created / Updated Tests (If necessary)
- [N] Created / Updated documentation (If necessary)
