### PR TITLE
Fetch libraries in the background after login

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -710,8 +710,10 @@ if (existsSync(installed)) {
 }
 
 ipcMain.handle('refreshLibrary', async (e, fullRefresh) => {
-  await GOGLibrary.get().sync()
-  return await LegendaryLibrary.get().getGames('info', fullRefresh)
+  await Promise.allSettled([
+    GOGLibrary.get().sync(),
+    LegendaryLibrary.get().getGames('info', fullRefresh)
+  ])
 })
 
 ipcMain.on('logError', (e, err) => logError(`${err}`, LogPrefix.Frontend))

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -99,7 +99,7 @@
         "yes": "ДА"
     },
     "button": {
-        "continue": "Продължаване",
+        "go_to_library": "Go to Library",
         "login": "Влизане",
         "sync": "Синхронизиране",
         "syncing": "Синхронизиране",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Настройките се запазват автоматично"
     },
     "infobox": {

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -99,7 +99,7 @@
         "yes": "SÍ"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Inicia la sessió",
         "sync": "Sincronitza",
         "syncing": "S'està sincronitzant",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "La configuració es desa automàticament"
     },
     "infobox": {

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -99,7 +99,7 @@
         "yes": "ANO"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Login",
         "sync": "Synchronizovat",
         "syncing": "Synchronizuji",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Nastavení se ukládají automaticky"
     },
     "infobox": {

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -99,7 +99,7 @@
         "yes": "JA"
     },
     "button": {
-        "continue": "Fortsetzen",
+        "go_to_library": "Go to Library",
         "login": "Anmelden",
         "sync": "Synchronisieren",
         "syncing": "Synchronisiere",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Einstellungen werden automatisch gespeichert"
     },
     "infobox": {

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -99,7 +99,7 @@
         "yes": "ΝΑΙ"
     },
     "button": {
-        "continue": "Συνέχεια",
+        "go_to_library": "Go to Library",
         "login": "Σύνδεση",
         "sync": "Συγχρονισμός",
         "syncing": "Συγχρονισμός",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Οι ρυθμίσεις αποθηκεύονται αυτομάτως"
     },
     "infobox": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -99,7 +99,7 @@
         "yes": "YES"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Log in",
         "sync": "Sync",
         "syncing": "Syncing",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Settings are saved automatically"
     },
     "infobox": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -99,7 +99,7 @@
         "yes": "SÍ"
     },
     "button": {
-        "continue": "Continuar",
+        "go_to_library": "Go to Library",
         "login": "Iniciar sesión",
         "sync": "Sincronizar",
         "syncing": "Sincronizando",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Los ajustes se guardan automáticamente"
     },
     "infobox": {

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -99,7 +99,7 @@
         "yes": "JAH"
     },
     "button": {
-        "continue": "Jätka",
+        "go_to_library": "Go to Library",
         "login": "Logi sisse",
         "sync": "Sünkrooni",
         "syncing": "Sünkroonimine",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Seaded salvestatakse automaatselt"
     },
     "infobox": {

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -99,7 +99,7 @@
         "yes": "بله"
     },
     "button": {
-        "continue": "ادامه",
+        "go_to_library": "Go to Library",
         "login": "ورود",
         "sync": "همگام سازی",
         "syncing": "در حال همگام سازی",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "تنظیمات به صورت خودکار ذخیره شدند"
     },
     "infobox": {

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -99,7 +99,7 @@
         "yes": "KYLLÄ"
     },
     "button": {
-        "continue": "Jatka",
+        "go_to_library": "Go to Library",
         "login": "Kirjaudu sisään",
         "sync": "Synkronoi",
         "syncing": "Synkronoidaan",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Asetukset tallennetaan automaattisesti"
     },
     "infobox": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -99,7 +99,7 @@
         "yes": "OUI"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Connexion",
         "sync": "Synchroniser",
         "syncing": "Synchronisation en cours",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Les options sont sauvegardées automatiquement"
     },
     "infobox": {

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -99,7 +99,7 @@
         "yes": "Sí"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Iniciar sesión",
         "sync": "Sincronizar",
         "syncing": "Sincronizando",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Preferencias gardadas automaticamente"
     },
     "infobox": {

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -99,7 +99,7 @@
         "yes": ""
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Login",
         "sync": "",
         "syncing": "",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": ""
     },
     "infobox": {

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -99,7 +99,7 @@
         "yes": "IGEN"
     },
     "button": {
-        "continue": "Letöltés folytatása",
+        "go_to_library": "Go to Library",
         "login": "Bejelentkezés",
         "sync": "Szinkronizálás",
         "syncing": "Szinkronizálás folyamatban",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "A beállítások automatikusan mentődnek"
     },
     "infobox": {

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -99,7 +99,7 @@
         "yes": "YA"
     },
     "button": {
-        "continue": "Lanjutkan",
+        "go_to_library": "Go to Library",
         "login": "Log Masuk",
         "sync": "Sinkronkan",
         "syncing": "Menyinkronkan",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Pengaturan disimpan secara otomatis"
     },
     "infobox": {

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -99,7 +99,7 @@
         "yes": "SI"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Accedi",
         "sync": "Sincronizza",
         "syncing": "Sincronizzazione in corso",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Le impostazioni sono salvate automaticamente"
     },
     "infobox": {

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -99,7 +99,7 @@
         "yes": "はい"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Login",
         "sync": "同期",
         "syncing": "同期しています",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "設定は自動的に保存されます"
     },
     "infobox": {

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -99,7 +99,7 @@
         "yes": "예"
     },
     "button": {
-        "continue": "계속",
+        "go_to_library": "Go to Library",
         "login": "로그인",
         "sync": "싱크",
         "syncing": "싱크중",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "설정은 자동으로 저장됩니다"
     },
     "infobox": {

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -99,7 +99,7 @@
         "yes": "ശരി"
     },
     "button": {
-        "continue": "തുടരുക",
+        "go_to_library": "Go to Library",
         "login": "അകത്ത് കയറുക",
         "sync": "ഒന്നിപ്പിക്കൂ",
         "syncing": "ഒന്നിപ്പിക്കുന്നു",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "ക്രമീകരണങ്ങള് താനെ സൂക്ഷിക്കപ്പെട്ടിരിക്കുന്നു"
     },
     "infobox": {

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -99,7 +99,7 @@
         "yes": "JA"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Login",
         "sync": "Synchroniseer",
         "syncing": "Synchroniseren",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Instellingen worden automatisch opgeslagen"
     },
     "infobox": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -99,7 +99,7 @@
         "yes": "TAK"
     },
     "button": {
-        "continue": "Kontynuuj",
+        "go_to_library": "Go to Library",
         "login": "Zaloguj",
         "sync": "Synchronizuj",
         "syncing": "Synchronizacja",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Ustawienia są zapisywane automatycznie"
     },
     "infobox": {

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -99,7 +99,7 @@
         "yes": "SIM"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Entrar",
         "sync": "Sincronizar",
         "syncing": "Sincronizando",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "As configurações são salvas automaticamente"
     },
     "infobox": {

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -99,7 +99,7 @@
         "yes": "SIM"
     },
     "button": {
-        "continue": "Continuar",
+        "go_to_library": "Go to Library",
         "login": "Conecte-se",
         "sync": "Sincronizar",
         "syncing": "Sincronizando",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "As configurações são salvas automaticamente"
     },
     "infobox": {

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -99,7 +99,7 @@
         "yes": "ДА"
     },
     "button": {
-        "continue": "Продолжить",
+        "go_to_library": "Go to Library",
         "login": "Вход",
         "sync": "Синхронизировать",
         "syncing": "Синхронизация",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Настройки сохраняются автоматически"
     },
     "infobox": {

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -99,7 +99,7 @@
         "yes": "Ja"
     },
     "button": {
-        "continue": "Fortsätt",
+        "go_to_library": "Go to Library",
         "login": "Logga in",
         "sync": "Synkronisering",
         "syncing": "Synkroniserar",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Inställningar sparas automatiskt"
     },
     "infobox": {

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -99,7 +99,7 @@
         "yes": "ஆம்"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Login",
         "sync": "ஒத்திசைவு செய்",
         "syncing": "ஒத்திசைவு செய்யப்படுகிறது",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "அமைப்புகள் தானாகவே சேமிக்கப்படும்"
     },
     "infobox": {

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -99,7 +99,7 @@
         "yes": "EVET"
     },
     "button": {
-        "continue": "Devam et",
+        "go_to_library": "Go to Library",
         "login": "Oturum Aç",
         "sync": "Eşzamanla",
         "syncing": "Eşzamanlanıyor",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Ayarlar otomatik kaydedilir"
     },
     "infobox": {

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -99,7 +99,7 @@
         "yes": "ТАК"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Увійти",
         "sync": "Синхронізувати",
         "syncing": "Синхронізую",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Налаштування збережені автоматично"
     },
     "infobox": {

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -99,7 +99,7 @@
         "yes": "Có"
     },
     "button": {
-        "continue": "Tiếp tục",
+        "go_to_library": "Go to Library",
         "login": "Đăng nhập",
         "sync": "Đồng bộ",
         "syncing": "Đang đồng bộ",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "Cài đặt được tự đông lưu"
     },
     "infobox": {

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -99,7 +99,7 @@
         "yes": "是"
     },
     "button": {
-        "continue": "继续",
+        "go_to_library": "Go to Library",
         "login": "登录",
         "sync": "同步",
         "syncing": "正在同步",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "设置会自动保存"
     },
     "infobox": {

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -99,7 +99,7 @@
         "yes": "是"
     },
     "button": {
-        "continue": "Continue",
+        "go_to_library": "Go to Library",
         "login": "Login",
         "sync": "同步",
         "syncing": "正在同步",
@@ -141,6 +141,9 @@
         }
     },
     "info": {
+        "heroic": {
+            "version": "Heroic Version"
+        },
         "settings": "設定會自動保存"
     },
     "infobox": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,9 @@ import React, { lazy } from 'react'
 
 import './App.css'
 import { HashRouter, Route, Switch } from 'react-router-dom'
-import ElectronStore from 'electron-store'
 import Sidebar from 'src/components/UI/Sidebar'
 import Login from './screens/Login'
 import WebView from './screens/WebView'
-
-const Store = window.require('electron-store')
 
 const Library = lazy(() => import('./screens/Library'))
 const Settings = lazy(() => import('./screens/Settings'))
@@ -15,24 +12,13 @@ const GamePage = lazy(() => import('./screens/Game/GamePage'))
 const WineManager = lazy(() => import('./screens/WineManager'))
 
 function App() {
-  const configStore: ElectronStore = new Store({
-    cwd: 'store'
-  })
-  const gogStore: ElectronStore = new Store({
-    cwd: 'gog_store'
-  })
-
-  const user = configStore.has('userInfo') || gogStore.has('credentials')
-
   return (
     <div className="App">
       <HashRouter>
         <Sidebar />
         <main className="content">
           <Switch>
-            <Route exact path="/">
-              {user && <Library />}
-            </Route>
+            <Route exact path="/" component={Library} />
             <Route exact path="/login" component={Login} />
             <Route exact path="/epicstore" component={WebView} />
             <Route exact path="/gogstore" component={WebView} />

--- a/src/screens/Login/index.css
+++ b/src/screens/Login/index.css
@@ -34,7 +34,7 @@
   flex-wrap: wrap;
 }
 
-.continueLogin {
+.goToLibrary {
   position: relative;
   font-family: var(--font-primary-bold);
   top: 10%;
@@ -50,11 +50,11 @@
   backdrop-filter: blur(var(--blur-light));
 }
 
-.continueLogin:hover {
+.goToLibrary:hover {
   color: var(--text-hover);
 }
 
-.continueLogin.disabled {
+.goToLibrary.disabled {
   cursor: default;
   color: var(--text-default);
   display: none;

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -1,13 +1,11 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import './index.css'
 import EpicLogo from '../../assets/epic-logo.svg'
 import Runner from './components/Runner'
 import ElectronStore from 'electron-store'
 import { useTranslation } from 'react-i18next'
-import cx from 'classnames'
 import { useHistory } from 'react-router'
 
-import ContextProvider from 'src/state/ContextProvider'
 import GOGLogo from 'src/assets/gog-logo.svg'
 import { LanguageSelector, UpdateComponent } from 'src/components/UI'
 import { FlagPosition } from 'src/components/UI/LanguageSelector'
@@ -25,7 +23,6 @@ export default function NewLogin() {
     i18n.changeLanguage(language)
   }
   const history = useHistory()
-  const { refreshLibrary, handleCategory } = useContext(ContextProvider)
   const [epicLogin, setEpicLogin] = useState({})
   const [gogLogin, setGOGLogin] = useState({})
   const [loading, setLoading] = useState(true)
@@ -57,17 +54,7 @@ export default function NewLogin() {
       ipcRenderer.removeListener('updateLoginState', () => eventHandler)
     }
   }, [])
-  async function continueLogin() {
-    setLoading(true)
-    await refreshLibrary({
-      fullRefresh: true,
-      runInBackground: false
-    })
-    //Make sure we cannot get to library that we can't see
-    handleCategory(epicLogin ? 'epic' : 'gog')
-    setLoading(false)
-    history.push('/')
-  }
+
   return (
     <div className="loginPage">
       {loading && (
@@ -124,14 +111,11 @@ export default function NewLogin() {
             }}
           />
         </div>
-        <button
-          onClick={continueLogin}
-          className={cx('continueLogin', {
-            ['disabled']: !epicLogin && !gogLogin
-          })}
-        >
-          {t('button.continue', 'Continue')}
-        </button>
+        {(epicLogin || gogLogin) && (
+          <button onClick={() => history.push('/')} className="goToLibrary">
+            {t('button.go_to_library', 'Go to Library')}
+          </button>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
This PR makes the app fetch the library immediately after loging in a user in either epic or gog without the need of clicking `Continue` in the Log in screen.

The library shows the loading animation while this is happening.

I replaced the `Continue` button with a `Go to Library` button

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
