### PR TITLE
Allow installing wine versions using the controller

### DIFF
--- a/src/screens/WineManager/components/WineItem/index.css
+++ b/src/screens/WineManager/components/WineItem/index.css
@@ -24,7 +24,7 @@
 
 .wineManagerListItem {
   display: grid;
-  grid-template-columns: 2fr 1fr 2fr 1fr;
+  grid-template-columns: 2fr 1fr 1fr min-content;
   grid-template-areas: 'name date size action';
   height: 8vh;
   margin: 1em 3em;
@@ -32,7 +32,6 @@
   justify-items: baseline;
   position: relative;
   cursor: default;
-  width: 95%;
   place-self: center;
   border-bottom: 1px solid gray;
 }
@@ -54,11 +53,10 @@
 .wineManagerListItem > .icons {
   display: flex;
   flex-direction: column;
-  height: 100%;
   justify-content: space-around;
-  width: 120px;
+  align-items: flex-end;
   height: 100%;
-  padding: 0 6px;
+  padding: 0 1rem;
 }
 
 .wineManagerListItem > .progress {

--- a/src/screens/WineManager/components/WineItem/index.tsx
+++ b/src/screens/WineManager/components/WineItem/index.tsx
@@ -118,40 +118,46 @@ const WineItem = ({
     return status
   }
 
+  // using one element for the different states so it doesn't
+  // lose focus from the button when using a game controller
+  const handleMainActionClick = () => {
+    if (isInstalled) {
+      remove()
+    } else if (isDownloading || unZipping) {
+      ipcRenderer.send('abortWineInstallation', version)
+    } else {
+      install()
+    }
+  }
+
+  const mainActionIcon = () => {
+    if (isInstalled || isDownloading || unZipping) {
+      return <StopIcon />
+    } else {
+      return <DownIcon className="downIcon" />
+    }
+  }
+
   return (
-    <>
-      <div className="wineManagerListItem">
-        <span className="wineManagerTitleList">{version}</span>
-        <div className="wineManagerListDate">{date}</div>
-        <div className="wineManagerListSize">{renderStatus()}</div>
-        <span className="icons">
-          {!isInstalled && !isDownloading && !unZipping && (
-            <DownIcon className="downIcon" onClick={() => install()} />
-          )}
-          {(isDownloading || unZipping) && (
-            <StopIcon
-              onClick={() => ipcRenderer.send('abortWineInstallation', version)}
-            />
-          )}
-          {isInstalled && (
-            <>
-              <SvgButton
-                className="material-icons settings folder"
-                onClick={() => openInstallDir()}
-              >
-                <FolderOpen data-testid="setinstallpathbutton" />
-              </SvgButton>
-              <SvgButton
-                className="material-icons settings folder"
-                onClick={() => openInstallDir()}
-              >
-                <StopIcon onClick={() => remove()} />
-              </SvgButton>
-            </>
-          )}
-        </span>
-      </div>
-    </>
+    <div className="wineManagerListItem">
+      <span className="wineManagerTitleList">{version}</span>
+      <div className="wineManagerListDate">{date}</div>
+      <div className="wineManagerListSize">{renderStatus()}</div>
+      <span className="icons">
+        {isInstalled && (
+          <SvgButton
+            className="material-icons settings folder"
+            onClick={() => openInstallDir()}
+          >
+            <FolderOpen data-testid="setinstallpathbutton" />
+          </SvgButton>
+        )}
+
+        <SvgButton onClick={handleMainActionClick}>
+          {mainActionIcon()}
+        </SvgButton>
+      </span>
+    </div>
   )
 }
 

--- a/src/screens/WineManager/index.tsx
+++ b/src/screens/WineManager/index.tsx
@@ -33,7 +33,6 @@ export default function WineManager(): JSX.Element | null {
             style={
               !wineVersions.length ? { backgroundColor: 'transparent' } : {}
             }
-            className="gameListLayout"
           >
             {!!wineVersions.length &&
               wineVersions.map((release: WineVersionInfo, key) => (


### PR DESCRIPTION
This fixes #933 

I had to refactor the code to use one single SvgButton because rendering different elements made it lose the focus of the current button and navigating back (to cancel, for example) was really annoying.

I also included a small fix on the responsiveness, on small screens the buttons were outside the viewport.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
