### PR TITLE
Fix keys in config file for recent games

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -744,7 +744,9 @@ ipcMain.handle(
     logInfo([`launching`, title, game], LogPrefix.Backend)
 
     if (recentGames.length) {
-      let updatedRecentGames = recentGames.filter((a) => a.appName !== game)
+      let updatedRecentGames = recentGames.filter(
+        (a) => a.appName && a.appName !== game
+      )
       if (updatedRecentGames.length > MAX_RECENT_GAMES) {
         const newArr = []
         for (let i = 0; i <= MAX_RECENT_GAMES; i++) {
@@ -758,7 +760,7 @@ ipcMain.handle(
       updatedRecentGames.unshift({ appName: game, title })
       configStore.set('games.recent', updatedRecentGames)
     } else {
-      configStore.set('games.recent', [{ game, title: title }])
+      configStore.set('games.recent', [{ appName: game, title }])
     }
 
     if (minimizeOnLaunch) {


### PR DESCRIPTION
Closes #1000 

The problem was the object set when there's nothing yet in the recent games, the `else` was setting the property `game` instead of `appName`. Check the linked issue for the content of the config with this bug.

I'm also filtering out recent games data with no appName property (to clean that from users with the problem).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
