### PR TITLE
Refactor/handle game status update

### DIFF
--- a/electron/gog/games.ts
+++ b/electron/gog/games.ts
@@ -332,6 +332,7 @@ class GOGGame extends Game {
     }
     installedGamesStore.set('installed', array)
     GOGLibrary.get().refreshInstalled()
+    removeShortcuts(this.appName, 'gog')
     return res
   }
 

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -341,6 +341,8 @@ class LegendaryGame extends Game {
         ['Failed to uninstall', `${this.appName}:`, res.error],
         LogPrefix.Legendary
       )
+    } else {
+      removeShortcuts(this.appName, 'legendary')
     }
     return res
   }

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -293,7 +293,7 @@ export class GlobalState extends PureComponent<Props> {
           (game) => game !== appName
         )
         // This avoids calling legendary again before the previous process is killed when canceling
-        await this.refreshLibrary({
+        this.refreshLibrary({
           checkForUpdates: true,
           runInBackground: true
         })
@@ -304,8 +304,8 @@ export class GlobalState extends PureComponent<Props> {
         })
       }
 
-      await this.setState({ libraryStatus: newLibraryStatus })
-      await this.refreshLibrary({ runInBackground: true })
+      this.refreshLibrary({ runInBackground: true })
+      this.setState({ libraryStatus: newLibraryStatus })
     }
   }
 

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -262,8 +262,7 @@ export class GlobalState extends PureComponent<Props> {
     appName,
     status,
     folder,
-    progress,
-    runner
+    progress
   }: GameStatus) => {
     const { libraryStatus, gameUpdates } = this.state
     const currentApp = libraryStatus.filter(
@@ -303,11 +302,6 @@ export class GlobalState extends PureComponent<Props> {
           gameUpdates: updatedGamesUpdates,
           libraryStatus: newLibraryStatus
         })
-      }
-
-      // if the app was uninstalling, remove shortcuts
-      if (currentApp.status === 'uninstalling') {
-        ipcRenderer.send('removeShortcut', appName, runner)
       }
 
       await this.setState({ libraryStatus: newLibraryStatus })

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -286,14 +286,8 @@ export class GlobalState extends PureComponent<Props> {
       (game) => game.appName !== appName
     )
 
-    // if the app was installing and errored, remove it
-    if (currentApp.status === 'installing' && status === 'error') {
-      await this.refresh()
-      return this.setState({ libraryStatus: newLibraryStatus })
-    }
-
-    // if the app is done installing
-    if (status === 'done') {
+    // if the app is done installing or errored
+    if (['error', 'done'].includes(status)) {
       // if the app was updating, remove from the available game updates
       if (currentApp.status === 'updating') {
         const updatedGamesUpdates = gameUpdates.filter(
@@ -316,8 +310,8 @@ export class GlobalState extends PureComponent<Props> {
         ipcRenderer.send('removeShortcut', appName, runner)
       }
 
+      await this.setState({ libraryStatus: newLibraryStatus })
       await this.refreshLibrary({ runInBackground: true })
-      return this.setState({ libraryStatus: newLibraryStatus })
     }
   }
 


### PR DESCRIPTION
This PR is a refactor of the `handleGameStatus` function in the global state:
- there was a lot of repeated code, so I grouped the different conditions to remove conditionals and branching
- I moved the `removeShortcuts` call to the backend so the shortcuts are removed as soon as the backend finishes uninstalling a game instead of calling that method from the frontend
- removed all the setTimeout calls
- removed changing `filter` in different cases (it's useless since the filter select was removed), this allowed it to group setState calls

Testing these changes I found a bug when cancelling the installation of GOG games, the bug is present in the main branch before this refactor so I reported that here #1251, I'm not familiar with the GOG code yet to be able to fix that.

Tested that everything behaves the same as it did before the refactor, would appreciate any feedback by testing these.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
