### PR TITLE
Add favourites feature and library top section config

### DIFF
--- a/public/locales/bg/gamepage.json
+++ b/public/locales/bg/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "ДА"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Пауза/Отказ",
         "continue": "Продължаване на свалянето",
         "hide_game": "Hide Game",
         "import": "Внасяне на игра",
         "install": "Инсталиране",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Деинсталиране",
         "update": "Обновяване"

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Глобални настройки",
     "GOG": "GOG",
     "gog-store": "Магазин на GOG",
@@ -250,6 +251,12 @@
         "fsync": "Включване на Fsync",
         "gamemode": "Използване на „GameMode“ („Feral Game Mode“ трябва да е инсталирано)",
         "language": "Изберете езика на приложението",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Копиране на съдържанието на журнала в буфера за обмен",
             "current-log": "Текущ журнал",

--- a/public/locales/ca/gamepage.json
+++ b/public/locales/ca/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "SÍ"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Pausa/Cancel·la",
         "continue": "Continua la baixada",
         "hide_game": "Hide Game",
         "import": "Importa el joc",
         "install": "Instal·la",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Desinstal·la",
         "update": "Actualitza"

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "fora de línia"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Configuració global",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Activa l'Fsync",
         "gamemode": "Utilitza el GameMode (cal que el Feral Game Mode estigui instal·lat)",
         "language": "Tria la llengua de l'aplicació",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copia el registre al porta-retalls",
             "current-log": "Registre actual",

--- a/public/locales/cs/gamepage.json
+++ b/public/locales/cs/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "ANO"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Zrušit",
         "continue": "Pokračovat ve stahování",
         "hide_game": "Hide Game",
         "import": "Importovat",
         "install": "Instalovat",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Odinstalovat",
         "update": "Update"

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Globální nastavení",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Enable Fsync",
         "gamemode": "Použít GameMode (Feral GameMode musí být nainstalován)",
         "language": "Vybrat jazyk aplikace",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",

--- a/public/locales/de/gamepage.json
+++ b/public/locales/de/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "JA"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Pausieren/Abbrechen",
         "continue": "Download fortsetzen",
         "hide_game": "Hide Game",
         "import": "Spiel importieren",
         "install": "Installieren",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Deinstallieren",
         "update": "Update"

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Globale Einstellungen",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Fsync aktivieren",
         "gamemode": "GameMode benutzen (Feral Game Mode muss installiert sein)",
         "language": "App Sprache auswählen",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Log-Inhalt in Zwischenablage kopieren",
             "current-log": "Aktueller Log",

--- a/public/locales/el/gamepage.json
+++ b/public/locales/el/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "ΝΑΙ"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Παύση/Ακύρωση",
         "continue": "Συνέχιση λήψης",
         "hide_game": "Hide Game",
         "import": "Εισαγωγή Παιχνιδιού",
         "install": "Εγκατάσταση",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Απεγκατάσταση",
         "update": "Ενημέρωση"

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "Εκτός Σύνδεσης"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Καθολικές Ρυθμίσεις",
     "GOG": "GOG",
     "gog-store": "Κατάστημα GOG",
@@ -250,6 +251,12 @@
         "fsync": "Ενεργοποίηση Fsync",
         "gamemode": "Χρήση λειτουργίας παιχνιδιού (απαραίτητη η εγκατάσταση του Feral Game Mode)",
         "language": "Διαλέξτε γλώσσα εφαρμογής",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Αντιγραφή αρχείου καταγραφής στο πρόχειρο",
             "current-log": "Τρέχων Αρχείο Καταγραφής",

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "YES"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Pause/Cancel",
         "continue": "Continue Download",
         "hide_game": "Hide Game",
         "import": "Import Game",
         "install": "Install",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Uninstall",
         "update": "Update"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Global Settings",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Enable Fsync",
         "gamemode": "Use GameMode (Feral Game Mode needs to be installed)",
         "language": "Choose App Language",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",

--- a/public/locales/es/gamepage.json
+++ b/public/locales/es/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "SÍ"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Pausar/Cancelar",
         "continue": "Seguir descargando",
         "hide_game": "Hide Game",
         "import": "Importar juego",
         "install": "Instalar",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Desinstalar",
         "update": "Actualizar"

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Ajustes globales",
     "GOG": "GOG",
     "gog-store": "Tienda de GOG",
@@ -250,6 +251,12 @@
         "fsync": "Habilitar Fsync",
         "gamemode": "Usar GameMode (Feral Game Mode debe estar instalado)",
         "language": "Elija el idioma de la aplicación",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copiar el contenido del registro en el portapapeles",
             "current-log": "Registro actual",

--- a/public/locales/et/gamepage.json
+++ b/public/locales/et/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "JAH"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Peata/Tühista",
         "continue": "Jätka allalaadimist",
         "hide_game": "Hide Game",
         "import": "Impordi mäng",
         "install": "Paigalda",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Eemalda",
         "update": "Uuenda"

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Globaalsed seaded",
     "GOG": "GOG",
     "gog-store": "GOG Pood",
@@ -250,6 +251,12 @@
         "fsync": "Luba Fsync",
         "gamemode": "Kasuta GameMode'i (Feral Game Mode peab olema paigaldatud)",
         "language": "Valige rakenduse keel",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Kopeeri logi sisu lõikelauale",
             "current-log": "Praegune logi",

--- a/public/locales/fa/gamepage.json
+++ b/public/locales/fa/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "بله"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "توقف/انصراف",
         "continue": "ادامه بارگیری",
         "hide_game": "Hide Game",
         "import": "وارد کردن بازی",
         "install": "نصب",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "حذف",
         "update": "بهروزرسانی"

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "اپیک گیمز",
+    "favourites": "Favourites",
     "globalSettings": "تنظیمات عمومی",
     "GOG": "GOG",
     "gog-store": "فروشگاه GOG",
@@ -250,6 +251,12 @@
         "fsync": "فعالسازی Fsync",
         "gamemode": "استفاده از GameMode (Feral Game Mode باید نصب شده باشد)",
         "language": "انتخاب زبان نرمافزار",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "کپی کردن محتوای لاگ در کليپ بورد",
             "current-log": "لاگ اخیر",

--- a/public/locales/fi/gamepage.json
+++ b/public/locales/fi/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "KYLLÄ"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Pysäytä/Peruuta",
         "continue": "Jatka lataamista",
         "hide_game": "Hide Game",
         "import": "Tuo peli",
         "install": "Asenna",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Poista",
         "update": "Päivitä"

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Globaalit asetukset",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Ota Fsync käyttöön",
         "gamemode": "Käytä GameModea (Feral Game Mode tulee olla asennettu)",
         "language": "Valitse applikaation kieli",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Kopioi lokin sisältö leikepöydälle",
             "current-log": "Nykyinen loki",

--- a/public/locales/fr/gamepage.json
+++ b/public/locales/fr/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "OUI"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Suspendre/Annuler",
         "continue": "Continuer le téléchargement",
         "hide_game": "Hide Game",
         "import": "Importer le jeu",
         "install": "Installer",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Désinstaller",
         "update": "Mise à jour"

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Paramètres généraux",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Activer Fsync",
         "gamemode": "Utiliser GameMode (Feral Game Mode doit être installé)",
         "language": "Choix de la langue",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",

--- a/public/locales/gl/gamepage.json
+++ b/public/locales/gl/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "Sí"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Pausar/Cancelar",
         "continue": "Continuar descarga",
         "hide_game": "Hide Game",
         "import": "Importar xogo",
         "install": "Instalar",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Desinstalar",
         "update": "Actualizar"

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Preferencias globais",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Activar Fsync",
         "gamemode": "Usar GameMode (Feral Game Mode debe estar instalado)",
         "language": "Seleccionar o idioma da aplicación",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",

--- a/public/locales/hr/gamepage.json
+++ b/public/locales/hr/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "DA"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Otkaži/Prekini",
         "continue": "Nastavi preuzimanje",
         "hide_game": "Hide Game",
         "import": "Uvezi igru",
         "install": "Instaliraj",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Deinstaliraj",
         "update": "Ažuriraj"

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Global Settings",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Enable Fsync",
         "gamemode": "",
         "language": "",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard.",
             "current-log": "Current log",

--- a/public/locales/hu/gamepage.json
+++ b/public/locales/hu/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "IGEN"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Szüneteltetés/mégse",
         "continue": "Letöltés folytatása",
         "hide_game": "Hide Game",
         "import": "Játék importálása",
         "install": "Telepítés",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Eltávolítás",
         "update": "Frissítés"

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Globális beállítások",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Fsync engedélyezése",
         "gamemode": "GameMode használata (a Feral Game Mode-nak telepítve kell lennie)",
         "language": "Alkalmazás nyelvének kiválasztása",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Napló tartalmának vágólapra másolása",
             "current-log": "Jelenlegi napló",

--- a/public/locales/id/gamepage.json
+++ b/public/locales/id/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "YA"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Jeda/Batal",
         "continue": "Lanjutkan Unduhan",
         "hide_game": "Hide Game",
         "import": "Impor Gim",
         "install": "Pasang",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Copot",
         "update": "Perbarui"

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "luring"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Pengaturan Global",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Aktifkan Fsync",
         "gamemode": "Gunakan GameMode (Feral Game Mode perlu dipasang)",
         "language": "Pilih Bahasa",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Salin konten log ke papan klip",
             "current-log": "Log Saat Ini",

--- a/public/locales/it/gamepage.json
+++ b/public/locales/it/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "SI"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Pausa/Annulla",
         "continue": "Continua Download",
         "hide_game": "Hide Game",
         "import": "Importa gioco",
         "install": "Installa",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Disinstalla",
         "update": "Update"

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Impostazioni globali",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Abilita Fsync",
         "gamemode": "Usa GameMode (Feral Game Mode necessita di essere installato)",
         "language": "Seleziona il linguaggio dell'app",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",

--- a/public/locales/ja/gamepage.json
+++ b/public/locales/ja/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "はい"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "一時停止/キャンセル",
         "continue": "ダウンロードを続ける",
         "hide_game": "Hide Game",
         "import": "インポート",
         "install": "インストール",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "アンインストール",
         "update": "アップデート"

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "全体設定",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Fsyncを有効にする",
         "gamemode": "GameModeを使用する（Feral Game Modeをインストールする必要があります）",
         "language": "アプリの言語を選択",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",

--- a/public/locales/ko/gamepage.json
+++ b/public/locales/ko/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "예"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "일시정지/취소",
         "continue": "계속 다운로드",
         "hide_game": "Hide Game",
         "import": "게임 들여오기",
         "install": "설치",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "설치 제거",
         "update": "업데이트"

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "글로벌 설정",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Fsync 활성화",
         "gamemode": "GameMode 사용 (Feral Game Mode가 설치되어 있어야 합니다)",
         "language": "앱 언어 선택",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "로그 내용을 클립보드에 복사",
             "current-log": "현재 로그",

--- a/public/locales/ml/gamepage.json
+++ b/public/locales/ml/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "ശരി"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "നിര്ത്തൂ/റദ്ദാക്കൂ",
         "continue": "ഇറക്കൽ തുടരൂ",
         "hide_game": "Hide Game",
         "import": "കളി ഇറക്കുമതി ചെയ്യൂ",
         "install": "നടൂ",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "എടുത്തുനീക്കൂ",
         "update": "പുതുക്കൂ"

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "എപിക് ഗെയിംസ്",
+    "favourites": "Favourites",
     "globalSettings": "ആഗോള ക്രമീകരണങ്ങള്",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Fsync വയ്ക്കൂ",
         "gamemode": "ഗെയിംമോഡ് ഉപയോഗിക്കൂ (ഫെറലിന്റെ ഗെയിംമോഡ് ഇന്സ്റ്റാള് ചെയ്തിരിക്കണം)",
         "language": "ആപ്പിന്റെ ഭാഷ",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",

--- a/public/locales/nl/gamepage.json
+++ b/public/locales/nl/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "JA"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Pauzeren/Annuleren",
         "continue": "Doorgaan met Download",
         "hide_game": "Hide Game",
         "import": "Importeren",
         "install": "Installeren",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Verwijderen",
         "update": "Update"

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Algemene instellingen",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Fsync inschakelen",
         "gamemode": "Gebruik GameMode (Feral Game Mode moet geïnstalleerd zijn)",
         "language": "Selecteer een App taal",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",

--- a/public/locales/pl/gamepage.json
+++ b/public/locales/pl/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "TAK"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Wstrzymaj/Anuluj",
         "continue": "Kontynuuj pobieranie",
         "hide_game": "Hide Game",
         "import": "Importuj Grę",
         "install": "Instaluj",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Odinstaluj",
         "update": "Update"

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Ustawienia Globalne",
     "GOG": "GOG",
     "gog-store": "Sklep GOG",
@@ -250,6 +251,12 @@
         "fsync": "Włącz Fsync",
         "gamemode": "Użyj GameMode (Feral Game Mode musi być zainstalowane)",
         "language": "Wybierz język",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Skopiuj zawartość logu do schowka",
             "current-log": "Obecny Log",

--- a/public/locales/pt/gamepage.json
+++ b/public/locales/pt/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "SIM"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Pausar/Cancelar",
         "continue": "Continuar Download",
         "hide_game": "Hide Game",
         "import": "Importar Jogo",
         "install": "Instalar",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Desinstalar",
         "update": "Update"

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Configurações Globais",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Enable Fsync",
         "gamemode": "Usar modo Jogo (Necessita gamemode instalado)",
         "language": "Selecionar idioma",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",

--- a/public/locales/pt_BR/gamepage.json
+++ b/public/locales/pt_BR/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "SIM"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Pausar/Cancelar",
         "continue": "Continuar baixando",
         "hide_game": "Hide Game",
         "import": "Importar Jogo",
         "install": "Instalar",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Desinstalar",
         "update": "Update"

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Configurações globais",
     "GOG": "GOG",
     "gog-store": "Loja GOG",
@@ -250,6 +251,12 @@
         "fsync": "Habilitar Fsync",
         "gamemode": "Usar o GameMode (precisa do gamemode instalado)",
         "language": "Selecione o idioma do app",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copiar log para a área de transferência",
             "current-log": "Log atual",

--- a/public/locales/ru/gamepage.json
+++ b/public/locales/ru/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "ДА"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Пауза/Отмена",
         "continue": "Продолжить загрузку",
         "hide_game": "Hide Game",
         "import": "Импортировать игру",
         "install": "Установить",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Удалить",
         "update": "Обновить"

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Глобальные настройки",
     "GOG": "GOG",
     "gog-store": "Магазин GOG",
@@ -250,6 +251,12 @@
         "fsync": "Включить Fsync",
         "gamemode": "Использовать GameMode (Нужен Feral GameMode)",
         "language": "Выберите язык приложения",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Копировать содержимое журнала в буфер обмена",
             "current-log": "Текущий журнал",

--- a/public/locales/sv/gamepage.json
+++ b/public/locales/sv/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "Ja"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Paus/Avbryt",
         "continue": "Fortsätt nedladdning",
         "hide_game": "Hide Game",
         "import": "Importera spel",
         "install": "Installera",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Avinstallera",
         "update": "Update"

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "Offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Globala inställningar",
     "GOG": "GOG",
     "gog-store": "GOG Butik",
@@ -250,6 +251,12 @@
         "fsync": "Aktivera Fsync",
         "gamemode": "Använd GameMode (Feral Game Mode måste vara installerat)",
         "language": "Välj språk",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Kopiera loggen till urklipp/klippbord",
             "current-log": "Aktuell logg",

--- a/public/locales/ta/gamepage.json
+++ b/public/locales/ta/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "ஆம்"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "ரத்துசெய்",
         "continue": "பதிவிறக்கத்தை தொடரு",
         "hide_game": "Hide Game",
         "import": "இறக்குமதி செய்",
         "install": "நிறுவு",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "நிறுவல் நீக்கு",
         "update": "Update"

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "உலகளாவிய விருப்பத்தேர்வுகள்",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Enable Fsync",
         "gamemode": "GameMode ஐ பயன்படுது (Feral விளையாட்டு பயன்முறையை நிறுவப்பட்டிருக்க வேண்டும்)",
         "language": "பயன்பாட்டின் மொழியை தேர்வுசெய்",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",

--- a/public/locales/tr/gamepage.json
+++ b/public/locales/tr/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "EVET"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Duraklat/İptal",
         "continue": "İndirmeye Devam Et",
         "hide_game": "Hide Game",
         "import": "Oyunu İçe Aktar",
         "install": "Kur",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Kaldır",
         "update": "Güncelle"

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "çevrim dışı"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Genel Ayarlar",
     "GOG": "GOG",
     "gog-store": "GOG Mağazası",
@@ -250,6 +251,12 @@
         "fsync": "Fsync'i Etkinleştir",
         "gamemode": "Oyun Modu Kullan (Feral Game Mode yüklü olmalıdır)",
         "language": "Uygulama Dilini Seç",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Günlük içeriğini panoya kopyala",
             "current-log": "Geçerli Günlük",

--- a/public/locales/uk/gamepage.json
+++ b/public/locales/uk/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "ТАК"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Призупинити/Скасувати",
         "continue": "Продовжити завантаження",
         "hide_game": "Hide Game",
         "import": "Імпортувати гру",
         "install": "Встановити",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Видалити",
         "update": "Оновити"

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "офлайн"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "Глобальні налаштування",
     "GOG": "GOG",
     "gog-store": "Магазин GOG",
@@ -250,6 +251,12 @@
         "fsync": "Ввімкнути Fsync",
         "gamemode": "Використовувати GameMode (Feral Game Mode має бути встановлений)",
         "language": "Оберіть мову застосунка",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Копіювати вміст логу в сховище обміну",
             "current-log": "Поточний лог",

--- a/public/locales/vi/gamepage.json
+++ b/public/locales/vi/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "Có"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "Tạm dừng/Huỷ",
         "continue": "Tiếp tục tải",
         "hide_game": "Hide Game",
         "import": "Import Game",
         "install": "Cài đặt",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "Gỡ cài đặt",
         "update": "Cập nhật"

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Game",
+    "favourites": "Favourites",
     "globalSettings": "Cài đặt chung",
     "GOG": "GOG",
     "gog-store": "Cửa hàng GOG",
@@ -250,6 +251,12 @@
         "fsync": "Bật Fsync",
         "gamemode": "Sử dụng GameMode (Cần cài đặt Feral Game Mode)",
         "language": "Chọn ngôn ngữ của ứng dụng",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Sao chép nội dung log vào bộ nhớ tạm",
             "current-log": "Log hiện tại",

--- a/public/locales/zh_Hans/gamepage.json
+++ b/public/locales/zh_Hans/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "是"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "暂停/取消",
         "continue": "继续下载",
         "hide_game": "Hide Game",
         "import": "导入游戏",
         "install": "安装",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "卸载",
         "update": "更新"

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "离线"
     },
     "Epic Games": "Epic 游戏",
+    "favourites": "Favourites",
     "globalSettings": "全局设置",
     "GOG": "GOG",
     "gog-store": "GOG 商店",
@@ -250,6 +251,12 @@
         "fsync": "启用 Fsync",
         "gamemode": "使用 GameMode（需要已安装 Feral Game Mode）",
         "language": "选择应用语言",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "复制日志内容到剪贴板",
             "current-log": "当前日志",

--- a/public/locales/zh_Hant/gamepage.json
+++ b/public/locales/zh_Hant/gamepage.json
@@ -36,11 +36,13 @@
         "yes": "是"
     },
     "button": {
+        "add_to_favourites": "Add To Favourites",
         "cancel": "取消",
         "continue": "繼續下載",
         "hide_game": "Hide Game",
         "import": "導入",
         "install": "安裝",
+        "remove_from_favourites": "Remove From Favourites",
         "unhide_game": "Unhide Game",
         "uninstall": "解除安裝",
         "update": "更新"

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -110,6 +110,7 @@
         "offline-notification-title": "offline"
     },
     "Epic Games": "Epic Games",
+    "favourites": "Favourites",
     "globalSettings": "全域設定",
     "GOG": "GOG",
     "gog-store": "GOG Store",
@@ -250,6 +251,12 @@
         "fsync": "Enable Fsync",
         "gamemode": "使用GameMode（需要已安裝Feral Game Mode）",
         "language": "選擇應用語言",
+        "library_top_option": {
+            "disabled": "Disabled",
+            "favourites": "Favourite Games",
+            "recently_played": "Recently Played Games"
+        },
+        "library_top_section": "Library Top Section",
         "log": {
             "copy-to-clipboard": "Copy log content to clipboard",
             "current-log": "Current Log",

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -75,8 +75,14 @@ const GameCard = ({
 
   const { t } = useTranslation('gamepage')
 
-  const { libraryStatus, layout, handleGameStatus, platform, hiddenGames } =
-    useContext(ContextProvider)
+  const {
+    libraryStatus,
+    layout,
+    handleGameStatus,
+    platform,
+    hiddenGames,
+    favouriteGames
+  } = useContext(ContextProvider)
   const history = useHistory()
   const isWin = platform === 'win32'
 
@@ -221,6 +227,7 @@ const GameCard = ({
   }, [isInstalling, appName])
 
   const [isHiddenGame, setIsHiddenGame] = useState(false)
+  const [isFavouriteGame, setIsFavouriteGame] = useState(false)
 
   useEffect(() => {
     const found = !!hiddenGames.list.find(
@@ -229,6 +236,14 @@ const GameCard = ({
 
     setIsHiddenGame(found)
   }, [hiddenGames, appName])
+
+  useEffect(() => {
+    const found = !!favouriteGames.list.find(
+      (favouriteGame) => favouriteGame.appName === appName
+    )
+
+    setIsFavouriteGame(found)
+  }, [favouriteGames, appName])
 
   const items: Item[] = [
     {
@@ -286,6 +301,16 @@ const GameCard = ({
       label: t('button.unhide_game', 'Unhide Game'),
       onclick: () => hiddenGames.remove(appName),
       show: isHiddenGame
+    },
+    {
+      label: t('button.add_to_favourites', 'Add To Favourites'),
+      onclick: () => favouriteGames.add(appName, title),
+      show: !isFavouriteGame
+    },
+    {
+      label: t('button.remove_from_favourites', 'Remove From Favourites'),
+      onclick: () => favouriteGames.remove(appName),
+      show: isFavouriteGame
     }
   ]
 

--- a/src/screens/Library/index.tsx
+++ b/src/screens/Library/index.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next'
 import { getLibraryTitle } from './constants'
 import ActionIcons from 'src/components/UI/ActionIcons'
 import { GamesList } from './components/GamesList'
-import { Runner } from 'src/types'
+import { GameInfo, Runner } from 'src/types'
 
 const InstallModal = lazy(
   () => import('src/screens/Library/components/InstallModal')
@@ -25,7 +25,9 @@ export default function Library(): JSX.Element {
     filter,
     epicLibrary,
     gogLibrary,
-    recentGames
+    recentGames,
+    favouriteGames,
+    libraryTopSection
   } = useContext(ContextProvider)
 
   const [showModal, setShowModal] = useState({
@@ -97,7 +99,29 @@ export default function Library(): JSX.Element {
     return 1
   })
 
-  const showRecentGames = !!recentGames.length && category !== 'unreal'
+  const showRecentGames =
+    libraryTopSection === 'recently_played' &&
+    !!recentGames.length &&
+    category !== 'unreal'
+
+  const showFavourites =
+    libraryTopSection === 'favourites' &&
+    !!favouriteGames.list.length &&
+    category !== 'unreal'
+
+  const favourites: GameInfo[] = []
+
+  if (showFavourites) {
+    const favouriteAppNames = favouriteGames.list.map(
+      (favourite) => favourite.appName
+    )
+    epicLibrary.forEach((game) => {
+      if (favouriteAppNames.includes(game.app_name)) favourites.push(game)
+    })
+    gogLibrary.forEach((game) => {
+      if (favouriteAppNames.includes(game.app_name)) favourites.push(game)
+    })
+  }
 
   const dlcCount = epicLibrary.filter((lib) => lib.install.is_dlc)
   const numberOfGames =
@@ -118,6 +142,13 @@ export default function Library(): JSX.Element {
               library={recentGames}
               handleGameCardClick={handleModal}
             />
+          </>
+        )}
+
+        {showFavourites && (
+          <>
+            <h3 className="libraryHeader">{t('favourites', 'Favourites')}</h3>
+            <GamesList library={favourites} handleGameCardClick={handleModal} />
           </>
         )}
 

--- a/src/screens/Settings/components/GeneralSettings/index.tsx
+++ b/src/screens/Settings/components/GeneralSettings/index.tsx
@@ -376,7 +376,7 @@ export default function GeneralSettings({
         </label>
       </span>
 
-      <span className="setting" data-testid="generalSettings">
+      <span className="setting">
         <label
           className={classNames('settingText', { isRTL: isRTL })}
           htmlFor="library_top_section_selector"

--- a/src/screens/Settings/components/GeneralSettings/index.tsx
+++ b/src/screens/Settings/components/GeneralSettings/index.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react'
 
-import { Path } from 'src/types'
+import { LibraryTopSectionOptions, Path } from 'src/types'
 import { useTranslation } from 'react-i18next'
 import ContextProvider from 'src/state/ContextProvider'
 import { InfoBox, SvgButton } from 'src/components/UI'
@@ -70,7 +70,13 @@ export default function GeneralSettings({
 }: Props) {
   const [isSyncing, setIsSyncing] = useState(false)
   const [maxCpus, setMaxCpus] = useState(maxWorkers)
-  const { platform, refreshLibrary, isRTL } = useContext(ContextProvider)
+  const {
+    platform,
+    refreshLibrary,
+    isRTL,
+    libraryTopSection,
+    handleLibraryTopSection
+  } = useContext(ContextProvider)
   const { t, i18n } = useTranslation()
   const isLinked = Boolean(egsLinkedPath.length)
   const isWindows = platform === 'win32'
@@ -386,6 +392,29 @@ export default function GeneralSettings({
           </select>
           <span>{t('setting.maxworkers')}</span>
         </label>
+      </span>
+
+      <span className="setting" data-testid="generalSettings">
+        <label
+          className={classNames('settingText', { isRTL: isRTL })}
+          htmlFor="library_top_section_selector"
+        >
+          {t('setting.library_top_section', 'Library Top Section')}
+        </label>
+        <select
+          id="library_top_section_selector"
+          onChange={(event) =>
+            handleLibraryTopSection(
+              event.target.value as LibraryTopSectionOptions
+            )
+          }
+          value={libraryTopSection}
+          className="settingSelect is-drop-down"
+        >
+          <option value="disabled">Disabled</option>
+          <option value="recently_played">Recently Played Games</option>
+          <option value="favourites">Favourite Games</option>
+        </select>
       </span>
     </>
   )

--- a/src/screens/Settings/components/GeneralSettings/index.tsx
+++ b/src/screens/Settings/components/GeneralSettings/index.tsx
@@ -375,24 +375,6 @@ export default function GeneralSettings({
           </span>
         </label>
       </span>
-      <span className="setting">
-        <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
-          <select
-            data-testid="setMaxWorkers"
-            onChange={(event) => setMaxWorkers(Number(event.target.value))}
-            value={maxWorkers}
-            className="settingSelect smaller is-drop-down"
-          >
-            {Array.from(Array(maxCpus).keys()).map((n) => (
-              <option key={n + 1}>{n + 1}</option>
-            ))}
-            <option key={0} value={0}>
-              Max
-            </option>
-          </select>
-          <span>{t('setting.maxworkers')}</span>
-        </label>
-      </span>
 
       <span className="setting" data-testid="generalSettings">
         <label
@@ -411,10 +393,38 @@ export default function GeneralSettings({
           value={libraryTopSection}
           className="settingSelect is-drop-down"
         >
-          <option value="disabled">Disabled</option>
-          <option value="recently_played">Recently Played Games</option>
-          <option value="favourites">Favourite Games</option>
+          <option value="recently_played">
+            {t(
+              'setting.library_top_option.recently_played',
+              'Recently Played Games'
+            )}
+          </option>
+          <option value="favourites">
+            {t('setting.library_top_option.favourites', 'Favourite Games')}
+          </option>
+          <option value="disabled">
+            {t('setting.library_top_option.disabled', 'Disabled')}
+          </option>
         </select>
+      </span>
+
+      <span className="setting">
+        <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
+          <select
+            data-testid="setMaxWorkers"
+            onChange={(event) => setMaxWorkers(Number(event.target.value))}
+            value={maxWorkers}
+            className="settingSelect smaller is-drop-down"
+          >
+            {Array.from(Array(maxCpus).keys()).map((n) => (
+              <option key={n + 1}>{n + 1}</option>
+            ))}
+            <option key={0} value={0}>
+              Max
+            </option>
+          </select>
+          <span>{t('setting.maxworkers')}</span>
+        </label>
       </span>
     </>
   )

--- a/src/state/ContextProvider.tsx
+++ b/src/state/ContextProvider.tsx
@@ -20,6 +20,8 @@ const initialContext: ContextType = {
   handleSearch: () => null,
   layout: 'grid',
   libraryStatus: [],
+  libraryTopSection: 'disabled',
+  handleLibraryTopSection: () => null,
   platform: 'unknown',
   refresh: () => Promise.resolve(),
   recentGames: [],
@@ -33,7 +35,12 @@ const initialContext: ContextType = {
     remove: () => null
   },
   showHidden: false,
-  setShowHidden: () => null
+  setShowHidden: () => null,
+  favouriteGames: {
+    list: [],
+    add: () => null,
+    remove: () => null
+  }
 }
 
 export default React.createContext(initialContext)

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -396,7 +396,7 @@ export class GlobalState extends PureComponent<Props> {
     const language = storage.getItem('language') || 'en'
     const showHidden = JSON.parse(storage.getItem('show_hidden') || 'false')
     const libraryTopSection =
-      storage.getItem('library_top_section') || 'disabled'
+      storage.getItem('library_top_section') || 'recently_played'
 
     if (!legendaryUser) {
       await ipcRenderer.invoke('getUserInfo')

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -1,10 +1,12 @@
 import React, { PureComponent } from 'react'
 
 import {
+  FavouriteGame,
   GameInfo,
   GameStatus,
   HiddenGame,
   InstalledInfo,
+  LibraryTopSectionOptions,
   RefreshOptions,
   WineVersionInfo
 } from 'src/types'
@@ -50,10 +52,12 @@ interface StateProps {
   language: string
   layout: string
   libraryStatus: GameStatus[]
+  libraryTopSection: string
   platform: string
   refreshing: boolean
   hiddenGames: HiddenGame[]
   showHidden: boolean
+  favouriteGames: FavouriteGame[]
 }
 
 export class GlobalState extends PureComponent<Props> {
@@ -91,10 +95,13 @@ export class GlobalState extends PureComponent<Props> {
     language: '',
     layout: 'grid',
     libraryStatus: [],
+    libraryTopSection: 'disabled',
     platform: '',
     refreshing: false,
     hiddenGames: (configStore.get('games.hidden') as Array<HiddenGame>) || [],
-    showHidden: false
+    showHidden: false,
+    favouriteGames:
+      (configStore.get('games.favourites') as Array<FavouriteGame>) || []
   }
 
   setShowHidden = (value: boolean) => {
@@ -122,6 +129,35 @@ export class GlobalState extends PureComponent<Props> {
       hiddenGames: newHiddenGames
     })
     configStore.set('games.hidden', newHiddenGames)
+  }
+
+  addGameToFavourites = (appNameToAdd: string, appTitle: string) => {
+    const newFavouriteGames = [
+      ...this.state.favouriteGames.filter(
+        (fav) => fav.appName !== appNameToAdd
+      ),
+      { appName: appNameToAdd, title: appTitle }
+    ]
+
+    this.setState({
+      favouriteGames: newFavouriteGames
+    })
+    configStore.set('games.favourites', newFavouriteGames)
+  }
+
+  removeGameFromFavourites = (appNameToRemove: string) => {
+    const newFavouriteGames = this.state.favouriteGames.filter(
+      ({ appName }) => appName !== appNameToRemove
+    )
+
+    this.setState({
+      favouriteGames: newFavouriteGames
+    })
+    configStore.set('games.favourites', newFavouriteGames)
+  }
+
+  handleLibraryTopSection = (value: LibraryTopSectionOptions) => {
+    this.setState({ libraryTopSection: value })
   }
 
   refresh = async (checkUpdates?: boolean): Promise<void> => {
@@ -426,6 +462,8 @@ export class GlobalState extends PureComponent<Props> {
     const layout = storage.getItem('layout') || 'grid'
     const language = storage.getItem('language') || 'en'
     const showHidden = JSON.parse(storage.getItem('show_hidden') || 'false')
+    const libraryTopSection =
+      storage.getItem('library_top_section') || 'disabled'
 
     if (!legendaryUser) {
       await ipcRenderer.invoke('getUserInfo')
@@ -437,7 +475,15 @@ export class GlobalState extends PureComponent<Props> {
     }
 
     i18n.changeLanguage(language)
-    this.setState({ category, filter, language, layout, platform, showHidden })
+    this.setState({
+      category,
+      filter,
+      language,
+      layout,
+      platform,
+      showHidden,
+      libraryTopSection
+    })
 
     if (legendaryUser || gogUser) {
       this.refreshLibrary({
@@ -449,14 +495,22 @@ export class GlobalState extends PureComponent<Props> {
   }
 
   componentDidUpdate() {
-    const { filter, gameUpdates, libraryStatus, layout, category, showHidden } =
-      this.state
+    const {
+      filter,
+      gameUpdates,
+      libraryStatus,
+      layout,
+      category,
+      showHidden,
+      libraryTopSection
+    } = this.state
 
     storage.setItem('category', category)
     storage.setItem('filter', filter)
     storage.setItem('layout', layout)
     storage.setItem('updates', JSON.stringify(gameUpdates))
     storage.setItem('show_hidden', JSON.stringify(showHidden))
+    storage.setItem('library_top_section', libraryTopSection)
 
     const pendingOps = libraryStatus.filter(
       (game) => game.status !== 'playing'
@@ -546,7 +600,13 @@ export class GlobalState extends PureComponent<Props> {
             add: this.hideGame,
             remove: this.unhideGame
           },
-          setShowHidden: this.setShowHidden
+          setShowHidden: this.setShowHidden,
+          favouriteGames: {
+            list: this.state.favouriteGames,
+            add: this.addGameToFavourites,
+            remove: this.removeGameFromFavourites
+          },
+          handleLibraryTopSection: this.handleLibraryTopSection
         }}
       >
         {children}

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,8 @@ export interface ContextType {
   handleSearch: (input: string) => void
   layout: string
   libraryStatus: GameStatus[]
+  libraryTopSection: string
+  handleLibraryTopSection: (value: LibraryTopSectionOptions) => void
   platform: NodeJS.Platform | string
   refresh: (checkUpdates?: boolean) => Promise<void>
   refreshLibrary: (options: RefreshOptions) => Promise<void>
@@ -77,9 +79,19 @@ export interface ContextType {
     add: (appNameToHide: string, appTitle: string) => void
     remove: (appNameToUnhide: string) => void
   }
+  favouriteGames: {
+    list: HiddenGame[]
+    add: (appNameToAdd: string, appTitle: string) => void
+    remove: (appNameToRemove: string) => void
+  }
   showHidden: boolean
   setShowHidden: (value: boolean) => void
 }
+
+export type LibraryTopSectionOptions =
+  | 'disabled'
+  | 'recently_played'
+  | 'favourites'
 
 interface ExtraInfo {
   about: About
@@ -116,6 +128,8 @@ export interface HiddenGame {
   appName: string
   title: string
 }
+
+export type FavouriteGame = HiddenGame
 
 export interface GameSettings {
   audioFix: boolean


### PR DESCRIPTION
This PR uses a similar pattern used for the feature to hide games but to implement the feature of marking games as Favourites. As discussed in Discord, I also added a configuration in the General Settings to configure what is displayed at the top of the Library (nothing / recently played / favourites).

https://user-images.githubusercontent.com/188464/165879423-c48f2664-5e63-4858-8aab-42150d127bfe.mp4

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
