### PR TITLE
Dim hidden games

### DIFF
--- a/src/screens/Library/components/GameCard/index.css
+++ b/src/screens/Library/components/GameCard/index.css
@@ -219,6 +219,11 @@
   z-index: 7;
 }
 
+.gameImg,
+.gameLogo {
+  transition: all 0.2s, opacity 0.5s;
+}
+
 .gameImg:not(.installed),
 .gameLogo:not(.installed) {
   filter: grayscale(var(--installing-effect));
@@ -227,7 +232,11 @@
 .gameCard:hover .gameImg:not(.installed),
 .gameCard:hover .gameLogo:not(.installed) {
   filter: grayscale(0);
-  transition-duration: 0.2s;
+}
+
+.gameCard.hidden .gameImg,
+.gameCard.hidden .gameLogo {
+  opacity: 0.2;
 }
 
 .icons {

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -108,12 +108,7 @@ const GameCard = ({
     ? `${125 - getProgress(progress)}%`
     : '100%'
 
-  const instClass = isInstalled ? 'installed' : ''
-  const imgClasses = `gameImg ${isInstalled ? 'installed' : ''}`
-  const logoClasses = `gameLogo ${isInstalled ? 'installed' : ''}`
   const imageSrc = getImageFormatting()
-
-  const wrapperClasses = `${grid ? 'gameCard' : 'gameListItem'}  ${instClass}`
 
   async function handleUpdate() {
     await handleGameStatus({ appName, runner, status: 'updating' })
@@ -288,6 +283,15 @@ const GameCard = ({
       show: isHiddenGame
     }
   ]
+
+  const instClass = isInstalled ? 'installed' : ''
+  const hiddenClass = isHiddenGame ? 'hidden' : ''
+  const imgClasses = `gameImg ${isInstalled ? 'installed' : ''}`
+  const logoClasses = `gameLogo ${isInstalled ? 'installed' : ''}`
+
+  const wrapperClasses = `${
+    grid ? 'gameCard' : 'gameListItem'
+  }  ${instClass} ${hiddenClass}`
 
   return (
     <>


### PR DESCRIPTION
This is an idea by flavio over discord, hidden games have a log opacity so you can indentify them better in the list when showing hidden games.

You can see an example with the second Batman game and with A Short Hike:

![image](https://user-images.githubusercontent.com/188464/166081911-db493c9b-6603-47f5-add3-d58b6382c5cf.png)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
