### PR TITLE
[UI] Add accessibility option to show all game tiles in color

### DIFF
--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Семейство на шрифта за действията (по подразбиране: „Rubik“)",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Семейство на шрифта за съдържанието (по подразбиране: „Cabin“)",
         "fonts": "Fonts",
         "title": "Достъпност",
@@ -257,6 +258,7 @@
         "enableFSRHack": "Включване на хака FSR (версията на Wine трябва да го поддържа)",
         "esync": "Включване на Esync",
         "exit-to-tray": "Затваряне в системната област за уведомления",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Включване на Fsync",
         "gamemode": "Използване на „GameMode“ („Feral Game Mode“ трябва да е инсталирано)",
         "language": "Изберете езика на приложението",
@@ -285,6 +287,7 @@
             "title": "Ръчно синхронизиране на запазените файлове",
             "upload": "Качване"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Максимален брой работни процеси при сваляне",
         "minimize-on-launch": "Минимизиране на Heroic при пускане на игра",
         "offlinemode": "Пускане на играта в режим „извън линия“",

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Семейство на шрифта за действията (по подразбиране: „Rubik“)",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Семейство на шрифта за съдържанието (по подразбиране: „Cabin“)",
         "fonts": "Fonts",
         "title": "Достъпност",

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Семейство на шрифта за действията (по подразбиране: „Rubik“)",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Семейство на шрифта за съдържанието (по подразбиране: „Cabin“)",
         "fonts": "Fonts",
         "title": "Достъпност",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Включване на хака FSR (версията на Wine трябва да го поддържа)",
         "esync": "Включване на Esync",
         "exit-to-tray": "Затваряне в системната област за уведомления",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "Сила на остротата на FSR",
         "fsync": "Включване на Fsync",
         "gamemode": "Използване на „GameMode“ („Feral Game Mode“ трябва да е инсталирано)",
         "language": "Изберете езика на приложението",
@@ -287,7 +286,7 @@
             "title": "Ръчно синхронизиране на запазените файлове",
             "upload": "Качване"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Играно наскоро за показване",
         "maxworkers": "Максимален брой работни процеси при сваляне",
         "minimize-on-launch": "Минимизиране на Heroic при пускане на игра",
         "offlinemode": "Пускане на играта в режим „извън линия“",

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -197,6 +197,9 @@
             "startInstall": "Инсталацията е започната"
         },
         "moved": "Преместването е завършено",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Деинсталирано",
         "update": {
             "canceled": "Обновяването е преустановено",
@@ -253,7 +256,6 @@
         "enableFSRHack": "Включване на хака FSR (версията на Wine трябва да го поддържа)",
         "esync": "Включване на Esync",
         "exit-to-tray": "Затваряне в системната област за уведомления",
-        "FsrSharpnessStrenght": "Сила на остротата на FSR",
         "fsync": "Включване на Fsync",
         "gamemode": "Използване на „GameMode“ („Feral Game Mode“ трябва да е инсталирано)",
         "language": "Изберете езика на приложението",
@@ -282,7 +284,6 @@
             "title": "Ръчно синхронизиране на запазените файлове",
             "upload": "Качване"
         },
-        "maxRecentGames": "Играно наскоро за показване",
         "maxworkers": "Максимален брой работни процеси при сваляне",
         "minimize-on-launch": "Минимизиране на Heroic при пускане на игра",
         "offlinemode": "Пускане на играта в режим „извън линия“",

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Activa el FSR Hack (cal que la versió del Wine en sigui compatible)",
         "esync": "Activa l'Esync",
         "exit-to-tray": "Surt a la safata del sistema",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "Força de la nitidesa de l'FSR",
         "fsync": "Activa l'Fsync",
         "gamemode": "Utilitza el GameMode (cal que el Feral Game Mode estigui instal·lat)",
         "language": "Tria la llengua de l'aplicació",
@@ -287,7 +286,7 @@
             "title": "Sincronització manual de partides desades",
             "upload": "Puja"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Jugats recentment a mostrar",
         "maxworkers": "Nombre màxim de Workers en baixar",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Executa el joc sense connexió",

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "S'ha iniciat la instal·lació"
         },
         "moved": "Ha finalitzat el desplaçament",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Desinstal·lat",
         "update": {
             "canceled": "S'ha cancel·lat l'actualització",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Activa el FSR Hack (cal que la versió del Wine en sigui compatible)",
         "esync": "Activa l'Esync",
         "exit-to-tray": "Surt a la safata del sistema",
-        "FsrSharpnessStrenght": "Força de la nitidesa de l'FSR",
         "fsync": "Activa l'Fsync",
         "gamemode": "Utilitza el GameMode (cal que el Feral Game Mode estigui instal·lat)",
         "language": "Tria la llengua de l'aplicació",
@@ -282,7 +286,6 @@
             "title": "Sincronització manual de partides desades",
             "upload": "Puja"
         },
-        "maxRecentGames": "Jugats recentment a mostrar",
         "maxworkers": "Nombre màxim de Workers en baixar",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Executa el joc sense connexió",

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Activa el FSR Hack (cal que la versió del Wine en sigui compatible)",
         "esync": "Activa l'Esync",
         "exit-to-tray": "Surt a la safata del sistema",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Activa l'Fsync",
         "gamemode": "Utilitza el GameMode (cal que el Feral Game Mode estigui instal·lat)",
         "language": "Tria la llengua de l'aplicació",
@@ -286,6 +287,7 @@
             "title": "Sincronització manual de partides desades",
             "upload": "Puja"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Nombre màxim de Workers en baixar",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Executa el joc sense connexió",

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Písmo pro Akce (Výchozí: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Písmo pro Obsah (Výchozí: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Přístupnost",
@@ -286,6 +287,7 @@
             "title": "Ručně synchronizovat uložené soubory",
             "upload": "Nahrát"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Maximální počet vláken při stahování",
         "minimize-on-launch": "Minimalizujte Heroic po spuštění hry",
         "offlinemode": "Spustit hru offline",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -197,6 +197,9 @@
             "startInstall": "Instalace zahájena"
         },
         "moved": "Přesun dokončen",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Odinstalováno",
         "update": {
             "canceled": "Aktualizace zrušena",
@@ -282,7 +285,6 @@
             "title": "Ručně synchronizovat uložené soubory",
             "upload": "Nahrát"
         },
-        "maxRecentGames": "Max. nedávno hraných her k zobrazení",
         "maxworkers": "Maximální počet vláken při stahování",
         "minimize-on-launch": "Minimalizujte Heroic po spuštění hry",
         "offlinemode": "Spustit hru offline",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Písmo pro Akce (Výchozí: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Písmo pro Obsah (Výchozí: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Přístupnost",
@@ -287,7 +286,7 @@
             "title": "Ručně synchronizovat uložené soubory",
             "upload": "Nahrát"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Max. nedávno hraných her k zobrazení",
         "maxworkers": "Maximální počet vláken při stahování",
         "minimize-on-launch": "Minimalizujte Heroic po spuštění hry",
         "offlinemode": "Spustit hru offline",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Písmo pro Akce (Výchozí: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Písmo pro Obsah (Výchozí: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Přístupnost",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "FSR Hack aktivieren (Wine-Version muss es unterstützen)",
         "esync": "Esync aktivieren",
         "exit-to-tray": "Beim Beenden in die Taskleiste minimieren",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Fsync aktivieren",
         "gamemode": "GameMode benutzen (Feral Game Mode muss installiert sein)",
         "language": "App Sprache auswählen",
@@ -286,6 +287,7 @@
             "title": "Spielstände manuell synchronisieren",
             "upload": "Upload"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Maximale Anzahl von Prozessen zum gleichzeitigem Herunterladen",
         "minimize-on-launch": "Heroic nach Spielstart minimieren",
         "offlinemode": "Spiel offline ausführen",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "FSR Hack aktivieren (Wine-Version muss es unterstützen)",
         "esync": "Esync aktivieren",
         "exit-to-tray": "Beim Beenden in die Taskleiste minimieren",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR Schärfestärke",
         "fsync": "Fsync aktivieren",
         "gamemode": "GameMode benutzen (Feral Game Mode muss installiert sein)",
         "language": "App Sprache auswählen",
@@ -287,7 +286,7 @@
             "title": "Spielstände manuell synchronisieren",
             "upload": "Upload"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Zuletzt gespielte Spiele anzeigen",
         "maxworkers": "Maximale Anzahl von Prozessen zum gleichzeitigem Herunterladen",
         "minimize-on-launch": "Heroic nach Spielstart minimieren",
         "offlinemode": "Spiel offline ausführen",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Installation gestartet"
         },
         "moved": "Verschieben abgeschlossen",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Deinstalliert",
         "update": {
             "canceled": "Update abgebrochen",
@@ -253,7 +258,6 @@
         "enableFSRHack": "FSR Hack aktivieren (Wine-Version muss es unterstützen)",
         "esync": "Esync aktivieren",
         "exit-to-tray": "Beim Beenden in die Taskleiste minimieren",
-        "FsrSharpnessStrenght": "FSR Schärfestärke",
         "fsync": "Fsync aktivieren",
         "gamemode": "GameMode benutzen (Feral Game Mode muss installiert sein)",
         "language": "App Sprache auswählen",
@@ -282,7 +286,6 @@
             "title": "Spielstände manuell synchronisieren",
             "upload": "Upload"
         },
-        "maxRecentGames": "Zuletzt gespielte Spiele anzeigen",
         "maxworkers": "Maximale Anzahl von Prozessen zum gleichzeitigem Herunterladen",
         "minimize-on-launch": "Heroic nach Spielstart minimieren",
         "offlinemode": "Spiel offline ausführen",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Ενεργοποίηση FSR Hack (Η έκδοση Wine πρέπει να το υποστηρίζει)",
         "esync": "Ενεργοποίηση Esync",
         "exit-to-tray": "Έξοδος σε Μπάρα Εργαλειών",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Ενεργοποίηση Fsync",
         "gamemode": "Χρήση λειτουργίας παιχνιδιού (απαραίτητη η εγκατάσταση του Feral Game Mode)",
         "language": "Διαλέξτε γλώσσα εφαρμογής",
@@ -286,6 +287,7 @@
             "title": "Δεδομένα Χειροκίνητου Συγχρονισμού",
             "upload": "Μεταφόρτωση"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Μέγιστος αριθμός εργατών κατά την λήψη",
         "minimize-on-launch": "Ελαχιστοποίηση Heroic Μετά Την 'Εναρξη",
         "offlinemode": "Εκτέλεση Παιχνιδιού Εκτός Δικτύου",

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Η Εγκατάσταση έχει ξεκινήσει"
         },
         "moved": "Η μετακίνηση ολοκληρώθηκε",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Απεγκαταστάθηκε",
         "update": {
             "canceled": "Η ενημέρωση ακυρώθηκε",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Ενεργοποίηση FSR Hack (Η έκδοση Wine πρέπει να το υποστηρίζει)",
         "esync": "Ενεργοποίηση Esync",
         "exit-to-tray": "Έξοδος σε Μπάρα Εργαλειών",
-        "FsrSharpnessStrenght": "Βαθμός οξύτητας FSR",
         "fsync": "Ενεργοποίηση Fsync",
         "gamemode": "Χρήση λειτουργίας παιχνιδιού (απαραίτητη η εγκατάσταση του Feral Game Mode)",
         "language": "Διαλέξτε γλώσσα εφαρμογής",
@@ -282,7 +286,6 @@
             "title": "Δεδομένα Χειροκίνητου Συγχρονισμού",
             "upload": "Μεταφόρτωση"
         },
-        "maxRecentGames": "Παίχτηκε Πρόσφατα για Προβολή",
         "maxworkers": "Μέγιστος αριθμός εργατών κατά την λήψη",
         "minimize-on-launch": "Ελαχιστοποίηση Heroic Μετά Την 'Εναρξη",
         "offlinemode": "Εκτέλεση Παιχνιδιού Εκτός Δικτύου",

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Ενεργοποίηση FSR Hack (Η έκδοση Wine πρέπει να το υποστηρίζει)",
         "esync": "Ενεργοποίηση Esync",
         "exit-to-tray": "Έξοδος σε Μπάρα Εργαλειών",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "Βαθμός οξύτητας FSR",
         "fsync": "Ενεργοποίηση Fsync",
         "gamemode": "Χρήση λειτουργίας παιχνιδιού (απαραίτητη η εγκατάσταση του Feral Game Mode)",
         "language": "Διαλέξτε γλώσσα εφαρμογής",
@@ -287,7 +286,7 @@
             "title": "Δεδομένα Χειροκίνητου Συγχρονισμού",
             "upload": "Μεταφόρτωση"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Παίχτηκε Πρόσφατα για Προβολή",
         "maxworkers": "Μέγιστος αριθμός εργατών κατά την λήψη",
         "minimize-on-launch": "Ελαχιστοποίηση Heroic Μετά Την 'Εναρξη",
         "offlinemode": "Εκτέλεση Παιχνιδιού Εκτός Δικτύου",

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Installation Started"
         },
         "moved": "Finished Moving",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Uninstalled",
         "update": {
             "canceled": "Updated Canceled",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",
         "exit-to-tray": "Exit to System Tray",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Enable Fsync",
         "gamemode": "Use GameMode (Feral Game Mode needs to be installed)",
         "language": "Choose App Language",
@@ -282,7 +286,6 @@
             "title": "Manual Sync Saves",
             "upload": "Upload"
         },
-        "maxRecentGames": "Played Recently to Show",
         "maxworkers": "Maximum Number of Workers when downloading",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Run Game Offline",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",
         "exit-to-tray": "Exit to System Tray",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Enable Fsync",
         "gamemode": "Use GameMode (Feral Game Mode needs to be installed)",
         "language": "Choose App Language",
@@ -286,6 +287,7 @@
             "title": "Manual Sync Saves",
             "upload": "Upload"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Maximum Number of Workers when downloading",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Run Game Offline",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -287,7 +286,7 @@
             "title": "Manual Sync Saves",
             "upload": "Upload"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Played Recently to Show",
         "maxworkers": "Maximum Number of Workers when downloading",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Run Game Offline",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Habilitar el hack FSR (La versión de Wine debe soportarlo)",
         "esync": "Activar Esync",
         "exit-to-tray": "Salir a la bandeja del sistema",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Habilitar Fsync",
         "gamemode": "Usar GameMode (Feral Game Mode debe estar instalado)",
         "language": "Elija el idioma de la aplicación",
@@ -286,6 +287,7 @@
             "title": "Guardado de sincronización manual",
             "upload": "Subida"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Número máximo de descargas",
         "minimize-on-launch": "Minimizar Heroic al ejecutar un juego",
         "offlinemode": "Ejecutar juego sin conexión",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Habilitar el hack FSR (La versión de Wine debe soportarlo)",
         "esync": "Activar Esync",
         "exit-to-tray": "Salir a la bandeja del sistema",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR Fuerza de Nitidez",
         "fsync": "Habilitar Fsync",
         "gamemode": "Usar GameMode (Feral Game Mode debe estar instalado)",
         "language": "Elija el idioma de la aplicación",
@@ -287,7 +286,7 @@
             "title": "Guardado de sincronización manual",
             "upload": "Subida"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Jugado recientemente para mostrar",
         "maxworkers": "Número máximo de descargas",
         "minimize-on-launch": "Minimizar Heroic al ejecutar un juego",
         "offlinemode": "Ejecutar juego sin conexión",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Instalación iniciada"
         },
         "moved": "Movimiento terminado",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Desinstalado",
         "update": {
             "canceled": "Actualización cancelada",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Habilitar el hack FSR (La versión de Wine debe soportarlo)",
         "esync": "Activar Esync",
         "exit-to-tray": "Salir a la bandeja del sistema",
-        "FsrSharpnessStrenght": "FSR Fuerza de Nitidez",
         "fsync": "Habilitar Fsync",
         "gamemode": "Usar GameMode (Feral Game Mode debe estar instalado)",
         "language": "Elija el idioma de la aplicación",
@@ -282,7 +286,6 @@
             "title": "Guardado de sincronización manual",
             "upload": "Subida"
         },
-        "maxRecentGames": "Jugado recientemente para mostrar",
         "maxworkers": "Número máximo de descargas",
         "minimize-on-launch": "Minimizar Heroic al ejecutar un juego",
         "offlinemode": "Ejecutar juego sin conexión",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Luba FSR häkk (Wine'i versioon peab seda toetama)",
         "esync": "Luba Esync",
         "exit-to-tray": "Välju süsteemiriiulisse",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Luba Fsync",
         "gamemode": "Kasuta GameMode'i (Feral Game Mode peab olema paigaldatud)",
         "language": "Valige rakenduse keel",
@@ -286,6 +287,7 @@
             "title": "Käsitsi salvestuste sünkroonimine",
             "upload": "Laadi üles"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Töötajate maksimaalne arv allalaadimisel",
         "minimize-on-launch": "Minimeeri Heroic pärast mängu käivitamist",
         "offlinemode": "Käivita mäng võrguühenduseta",

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Paigaldamine algas"
         },
         "moved": "Teisaldamine on lõpule viidud",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Eemaldatud",
         "update": {
             "canceled": "Uuendatud tühistatud",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Luba FSR häkk (Wine'i versioon peab seda toetama)",
         "esync": "Luba Esync",
         "exit-to-tray": "Välju süsteemiriiulisse",
-        "FsrSharpnessStrenght": "FSR teravuse tugevus",
         "fsync": "Luba Fsync",
         "gamemode": "Kasuta GameMode'i (Feral Game Mode peab olema paigaldatud)",
         "language": "Valige rakenduse keel",
@@ -282,7 +286,6 @@
             "title": "Käsitsi salvestuste sünkroonimine",
             "upload": "Laadi üles"
         },
-        "maxRecentGames": "Hiljuti mängitud mänge, mida näidata",
         "maxworkers": "Töötajate maksimaalne arv allalaadimisel",
         "minimize-on-launch": "Minimeeri Heroic pärast mängu käivitamist",
         "offlinemode": "Käivita mäng võrguühenduseta",

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Luba FSR häkk (Wine'i versioon peab seda toetama)",
         "esync": "Luba Esync",
         "exit-to-tray": "Välju süsteemiriiulisse",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR teravuse tugevus",
         "fsync": "Luba Fsync",
         "gamemode": "Kasuta GameMode'i (Feral Game Mode peab olema paigaldatud)",
         "language": "Valige rakenduse keel",
@@ -287,7 +286,7 @@
             "title": "Käsitsi salvestuste sünkroonimine",
             "upload": "Laadi üles"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Hiljuti mängitud mänge, mida näidata",
         "maxworkers": "Töötajate maksimaalne arv allalaadimisel",
         "minimize-on-launch": "Minimeeri Heroic pärast mängu käivitamist",
         "offlinemode": "Käivita mäng võrguühenduseta",

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -163,7 +162,7 @@
         "path": "انتخاب محل نصب"
     },
     "library": {
-        "gridView": "نمای شبکه ای",
+        "gridView": "نمای شبکه\u200cای",
         "listView": "نمای لیستی",
         "refresh": "تازه کردن",
         "sortAscending": "Sort Ascending",
@@ -258,7 +257,7 @@
         "enableFSRHack": "فعالسازی FSR Hack (نسخه Wine باید از آن پشتیبانی کند)",
         "esync": "فعالسازی Esync",
         "exit-to-tray": "خروج به میزکار سیستم",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "قدرت تیزی FSR",
         "fsync": "فعالسازی Fsync",
         "gamemode": "استفاده از GameMode (Feral Game Mode باید نصب شده باشد)",
         "language": "انتخاب زبان نرمافزار",
@@ -287,7 +286,7 @@
             "title": "همگامسازی دستی ذخیرهها",
             "upload": "آپلود"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "اخیرا بازی شده برای نمایش",
         "maxworkers": "بیسترین تعداد ورکر هنگام دانلود",
         "minimize-on-launch": "کوچک کردن Heroic بعد از اجرای بازی",
         "offlinemode": "اجرای آفلاین بازی",

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "فعالسازی FSR Hack (نسخه Wine باید از آن پشتیبانی کند)",
         "esync": "فعالسازی Esync",
         "exit-to-tray": "خروج به میزکار سیستم",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "فعالسازی Fsync",
         "gamemode": "استفاده از GameMode (Feral Game Mode باید نصب شده باشد)",
         "language": "انتخاب زبان نرمافزار",
@@ -286,6 +287,7 @@
             "title": "همگامسازی دستی ذخیرهها",
             "upload": "آپلود"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "بیسترین تعداد ورکر هنگام دانلود",
         "minimize-on-launch": "کوچک کردن Heroic بعد از اجرای بازی",
         "offlinemode": "اجرای آفلاین بازی",

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -163,7 +163,7 @@
         "path": "انتخاب محل نصب"
     },
     "library": {
-        "gridView": "نمای شبکه\u200cای",
+        "gridView": "نمای شبکه ای",
         "listView": "نمای لیستی",
         "refresh": "تازه کردن",
         "sortAscending": "Sort Ascending",

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "زوم"
     },
@@ -161,7 +163,7 @@
         "path": "انتخاب محل نصب"
     },
     "library": {
-        "gridView": "نمای شبکه‌ای",
+        "gridView": "نمای شبکه\u200cای",
         "listView": "نمای لیستی",
         "refresh": "تازه کردن",
         "sortAscending": "Sort Ascending",
@@ -197,6 +199,9 @@
             "startInstall": "نصب آغاز شد"
         },
         "moved": "انتقال کامل شد",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "حذف شد",
         "update": {
             "canceled": "بهروزرسانی لغو شد",
@@ -253,7 +258,6 @@
         "enableFSRHack": "فعالسازی FSR Hack (نسخه Wine باید از آن پشتیبانی کند)",
         "esync": "فعالسازی Esync",
         "exit-to-tray": "خروج به میزکار سیستم",
-        "FsrSharpnessStrenght": "قدرت تیزی FSR",
         "fsync": "فعالسازی Fsync",
         "gamemode": "استفاده از GameMode (Feral Game Mode باید نصب شده باشد)",
         "language": "انتخاب زبان نرمافزار",
@@ -282,7 +286,6 @@
             "title": "همگامسازی دستی ذخیرهها",
             "upload": "آپلود"
         },
-        "maxRecentGames": "اخیرا بازی شده برای نمایش",
         "maxworkers": "بیسترین تعداد ورکر هنگام دانلود",
         "minimize-on-launch": "کوچک کردن Heroic بعد از اجرای بازی",
         "offlinemode": "اجرای آفلاین بازی",

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Ota käyttöön FSR Hack (Wine version tulee tukea sitä)",
         "esync": "Ota Esync käyttöön",
         "exit-to-tray": "Sulje ilmaisinalueelle",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR terävyyden voimakkuus",
         "fsync": "Ota Fsync käyttöön",
         "gamemode": "Käytä GameModea (Feral Game Mode tulee olla asennettu)",
         "language": "Valitse applikaation kieli",
@@ -287,7 +286,7 @@
             "title": "Manuaalinen tallennusten synkronointi",
             "upload": "Lähetä"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Viimeksi pelatut näkyvillä",
         "maxworkers": "Työntekijöiden enimmäismäärä ladattaessa",
         "minimize-on-launch": "Minimoi Heroic pelin käynnistämisen jälkeen",
         "offlinemode": "Käynnistä peli offline-tilassa",

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Asennus aloitettu"
         },
         "moved": "Siirto valmis",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Poistettu",
         "update": {
             "canceled": "Päivitys peruutettu",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Ota käyttöön FSR Hack (Wine version tulee tukea sitä)",
         "esync": "Ota Esync käyttöön",
         "exit-to-tray": "Sulje ilmaisinalueelle",
-        "FsrSharpnessStrenght": "FSR terävyyden voimakkuus",
         "fsync": "Ota Fsync käyttöön",
         "gamemode": "Käytä GameModea (Feral Game Mode tulee olla asennettu)",
         "language": "Valitse applikaation kieli",
@@ -282,7 +286,6 @@
             "title": "Manuaalinen tallennusten synkronointi",
             "upload": "Lähetä"
         },
-        "maxRecentGames": "Viimeksi pelatut näkyvillä",
         "maxworkers": "Työntekijöiden enimmäismäärä ladattaessa",
         "minimize-on-launch": "Minimoi Heroic pelin käynnistämisen jälkeen",
         "offlinemode": "Käynnistä peli offline-tilassa",

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Ota käyttöön FSR Hack (Wine version tulee tukea sitä)",
         "esync": "Ota Esync käyttöön",
         "exit-to-tray": "Sulje ilmaisinalueelle",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Ota Fsync käyttöön",
         "gamemode": "Käytä GameModea (Feral Game Mode tulee olla asennettu)",
         "language": "Valitse applikaation kieli",
@@ -286,6 +287,7 @@
             "title": "Manuaalinen tallennusten synkronointi",
             "upload": "Lähetä"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Työntekijöiden enimmäismäärä ladattaessa",
         "minimize-on-launch": "Minimoi Heroic pelin käynnistämisen jälkeen",
         "offlinemode": "Käynnistä peli offline-tilassa",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Activer FSR Hack (la version de wine doit le prendre en charge)",
         "esync": "Activer Esync",
         "exit-to-tray": "Quitter vers System Tray",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "Niveau de netteté pour FSR (FSR Sharpness Strength)",
         "fsync": "Activer Fsync",
         "gamemode": "Utiliser GameMode (Feral Game Mode doit être installé)",
         "language": "Choix de la langue",
@@ -287,7 +286,7 @@
             "title": "Synchronisation manuelle des auvegardes",
             "upload": "Upload"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Jeux récents à afficher",
         "maxworkers": "Nombre Maximum de Workers pendant le téléchargement",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Lancer le jeu hors ligne",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Activer FSR Hack (la version de wine doit le prendre en charge)",
         "esync": "Activer Esync",
         "exit-to-tray": "Quitter vers System Tray",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Activer Fsync",
         "gamemode": "Utiliser GameMode (Feral Game Mode doit être installé)",
         "language": "Choix de la langue",
@@ -286,6 +287,7 @@
             "title": "Synchronisation manuelle des auvegardes",
             "upload": "Upload"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Nombre Maximum de Workers pendant le téléchargement",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Lancer le jeu hors ligne",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Installation commencée"
         },
         "moved": "Déplacement Terminé",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Désinstallé",
         "update": {
             "canceled": "Mise à jour Annulée",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Activer FSR Hack (la version de wine doit le prendre en charge)",
         "esync": "Activer Esync",
         "exit-to-tray": "Quitter vers System Tray",
-        "FsrSharpnessStrenght": "Niveau de netteté pour FSR (FSR Sharpness Strength)",
         "fsync": "Activer Fsync",
         "gamemode": "Utiliser GameMode (Feral Game Mode doit être installé)",
         "language": "Choix de la langue",
@@ -282,7 +286,6 @@
             "title": "Synchronisation manuelle des auvegardes",
             "upload": "Upload"
         },
-        "maxRecentGames": "Jeux récents à afficher",
         "maxworkers": "Nombre Maximum de Workers pendant le téléchargement",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Lancer le jeu hors ligne",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Activar o hack de FSR (A versión de Wine debe soportalo)",
         "esync": "Activar Esync",
         "exit-to-tray": "Saír á bandexa do sistema",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR forza de nitidez",
         "fsync": "Activar Fsync",
         "gamemode": "Usar GameMode (Feral Game Mode debe estar instalado)",
         "language": "Seleccionar o idioma da aplicación",

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Activar o hack de FSR (A versión de Wine debe soportalo)",
         "esync": "Activar Esync",
         "exit-to-tray": "Saír á bandexa do sistema",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Activar Fsync",
         "gamemode": "Usar GameMode (Feral Game Mode debe estar instalado)",
         "language": "Seleccionar o idioma da aplicación",
@@ -286,6 +287,7 @@
             "title": "Sincronización manual de partidas gardadas",
             "upload": "Subir"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Número máximo de descargas",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Executar xogo sen conexión",

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Instalación iniciada"
         },
         "moved": "Movemento rematado",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Desintalado",
         "update": {
             "canceled": "Actualización cancelada",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Activar o hack de FSR (A versión de Wine debe soportalo)",
         "esync": "Activar Esync",
         "exit-to-tray": "Saír á bandexa do sistema",
-        "FsrSharpnessStrenght": "FSR forza de nitidez",
         "fsync": "Activar Fsync",
         "gamemode": "Usar GameMode (Feral Game Mode debe estar instalado)",
         "language": "Seleccionar o idioma da aplicación",
@@ -282,7 +286,6 @@
             "title": "Sincronización manual de partidas gardadas",
             "upload": "Subir"
         },
-        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Número máximo de descargas",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Executar xogo sen conexión",

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Installation Started"
         },
         "moved": "",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "",
         "update": {
             "canceled": "",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",
         "exit-to-tray": "",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Enable Fsync",
         "gamemode": "",
         "language": "",
@@ -282,7 +286,6 @@
             "title": "",
             "upload": ""
         },
-        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",
         "exit-to-tray": "",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Enable Fsync",
         "gamemode": "",
         "language": "",
@@ -286,6 +287,7 @@
             "title": "",
             "upload": ""
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "",

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "FSR hack engedélyezése (a Wine verziónak támogatnia kell)",
         "esync": "Esync engedélyezése",
         "exit-to-tray": "Kilépés a rendszertálcára",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Fsync engedélyezése",
         "gamemode": "GameMode használata (a Feral Game Mode-nak telepítve kell lennie)",
         "language": "Alkalmazás nyelvének kiválasztása",
@@ -286,6 +287,7 @@
             "title": "Mentések manuális szinkronizálása",
             "upload": "Feltöltés"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Maximum dolgozók száma letöltéskor",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Játék futtatása offline",

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Telepítés elindult"
         },
         "moved": "Áthelyezés befejezve",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Eltávolítva",
         "update": {
             "canceled": "Frissítés visszavonva",
@@ -253,7 +258,6 @@
         "enableFSRHack": "FSR hack engedélyezése (a Wine verziónak támogatnia kell)",
         "esync": "Esync engedélyezése",
         "exit-to-tray": "Kilépés a rendszertálcára",
-        "FsrSharpnessStrenght": "FSR élesség erőssége",
         "fsync": "Fsync engedélyezése",
         "gamemode": "GameMode használata (a Feral Game Mode-nak telepítve kell lennie)",
         "language": "Alkalmazás nyelvének kiválasztása",
@@ -282,7 +286,6 @@
             "title": "Mentések manuális szinkronizálása",
             "upload": "Feltöltés"
         },
-        "maxRecentGames": "Nemrég játszottak megjelenítése",
         "maxworkers": "Maximum dolgozók száma letöltéskor",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Játék futtatása offline",

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "FSR hack engedélyezése (a Wine verziónak támogatnia kell)",
         "esync": "Esync engedélyezése",
         "exit-to-tray": "Kilépés a rendszertálcára",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR élesség erőssége",
         "fsync": "Fsync engedélyezése",
         "gamemode": "GameMode használata (a Feral Game Mode-nak telepítve kell lennie)",
         "language": "Alkalmazás nyelvének kiválasztása",
@@ -287,7 +286,7 @@
             "title": "Mentések manuális szinkronizálása",
             "upload": "Feltöltés"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Nemrég játszottak megjelenítése",
         "maxworkers": "Maximum dolgozók száma letöltéskor",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Játék futtatása offline",

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Aksesibilitas",

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Aktifkan Peretasan FSR (perlu versi Wine yang mendukung)",
         "esync": "Aktifkan Esync",
         "exit-to-tray": "Keluar ke Baki Sistem",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Aktifkan Fsync",
         "gamemode": "Gunakan GameMode (Feral Game Mode perlu dipasang)",
         "language": "Pilih Bahasa",
@@ -286,6 +287,7 @@
             "title": "Sinkronisasi Penyimpanan Secara Manual",
             "upload": "Unggah"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Jumlah Maksimum Worker saat mengunduh",
         "minimize-on-launch": "Minimalkan Jendela Heroic Setelah Gim Diluncurkan",
         "offlinemode": "Jalankan Game Secara Luring",

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Aksesibilitas",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Aktifkan Peretasan FSR (perlu versi Wine yang mendukung)",
         "esync": "Aktifkan Esync",
         "exit-to-tray": "Keluar ke Baki Sistem",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "Kekuatan Ketajaman FSR",
         "fsync": "Aktifkan Fsync",
         "gamemode": "Gunakan GameMode (Feral Game Mode perlu dipasang)",
         "language": "Pilih Bahasa",
@@ -287,7 +286,7 @@
             "title": "Sinkronisasi Penyimpanan Secara Manual",
             "upload": "Unggah"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Gim yang Dimainkan Baru-Baru Ini",
         "maxworkers": "Jumlah Maksimum Worker saat mengunduh",
         "minimize-on-launch": "Minimalkan Jendela Heroic Setelah Gim Diluncurkan",
         "offlinemode": "Jalankan Game Secara Luring",

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "title": "Aksesibilitas",
         "zoom": "Zoom"
@@ -197,6 +198,9 @@
             "startInstall": "Pemasangan Dimulai"
         },
         "moved": "Selesai Memindahkan",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Dihapus",
         "update": {
             "canceled": "Pembaruan Dibatalkan",
@@ -253,7 +257,6 @@
         "enableFSRHack": "Aktifkan Peretasan FSR (perlu versi Wine yang mendukung)",
         "esync": "Aktifkan Esync",
         "exit-to-tray": "Keluar ke Baki Sistem",
-        "FsrSharpnessStrenght": "Kekuatan Ketajaman FSR",
         "fsync": "Aktifkan Fsync",
         "gamemode": "Gunakan GameMode (Feral Game Mode perlu dipasang)",
         "language": "Pilih Bahasa",
@@ -282,7 +285,6 @@
             "title": "Sinkronisasi Penyimpanan Secara Manual",
             "upload": "Unggah"
         },
-        "maxRecentGames": "Gim yang Dimainkan Baru-Baru Ini",
         "maxworkers": "Jumlah Maksimum Worker saat mengunduh",
         "minimize-on-launch": "Minimalkan Jendela Heroic Setelah Gim Diluncurkan",
         "offlinemode": "Jalankan Game Secara Luring",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Attiva l'FSR Hack (la versione di Wine deve supportarlo)",
         "esync": "Abilita l'Esync",
         "exit-to-tray": "Riduci ad icona nell'area di notifica",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "Forza della nitidezza dell'FSR",
         "fsync": "Abilita Fsync",
         "gamemode": "Usa GameMode (Feral Game Mode necessita di essere installato)",
         "language": "Seleziona il linguaggio dell'app",
@@ -287,7 +286,7 @@
             "title": "Sincronizza i salvataggi manualmente",
             "upload": "Upload"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Giocati di recente da mostrare",
         "maxworkers": "Numero massimo di connessioni durante il download",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Avvia il gioco in modalità offline",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Installazione avviata"
         },
         "moved": "Spostamento completato",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Disinstallazione completata",
         "update": {
             "canceled": "Aggiornamento annullato",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Attiva l'FSR Hack (la versione di Wine deve supportarlo)",
         "esync": "Abilita l'Esync",
         "exit-to-tray": "Riduci ad icona nell'area di notifica",
-        "FsrSharpnessStrenght": "Forza della nitidezza dell'FSR",
         "fsync": "Abilita Fsync",
         "gamemode": "Usa GameMode (Feral Game Mode necessita di essere installato)",
         "language": "Seleziona il linguaggio dell'app",
@@ -282,7 +286,6 @@
             "title": "Sincronizza i salvataggi manualmente",
             "upload": "Upload"
         },
-        "maxRecentGames": "Giocati di recente da mostrare",
         "maxworkers": "Numero massimo di connessioni durante il download",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Avvia il gioco in modalità offline",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Attiva l'FSR Hack (la versione di Wine deve supportarlo)",
         "esync": "Abilita l'Esync",
         "exit-to-tray": "Riduci ad icona nell'area di notifica",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Abilita Fsync",
         "gamemode": "Usa GameMode (Feral Game Mode necessita di essere installato)",
         "language": "Seleziona il linguaggio dell'app",
@@ -286,6 +287,7 @@
             "title": "Sincronizza i salvataggi manualmente",
             "upload": "Upload"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Numero massimo di connessioni durante il download",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Avvia il gioco in modalità offline",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "FSRハックを有効にする（Wineバージョンはそれをサポートする必要があります）",
         "esync": "Esyncを有効にする",
         "exit-to-tray": "システムトレイに戻る",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSRシャープネス強度",
         "fsync": "Fsyncを有効にする",
         "gamemode": "GameModeを使用する（Feral Game Modeをインストールする必要があります）",
         "language": "アプリの言語を選択",
@@ -287,7 +286,7 @@
             "title": "手動同期保存",
             "upload": "アップロード"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "表示する最近のゲーム",
         "maxworkers": "ダウンロード時のワーカーの最大数",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "ゲームをオフラインで実行する",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Installation Started"
         },
         "moved": "移動が完了しました",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "アンインストールしました",
         "update": {
             "canceled": "更新がキャンセルされました",
@@ -253,7 +258,6 @@
         "enableFSRHack": "FSRハックを有効にする（Wineバージョンはそれをサポートする必要があります）",
         "esync": "Esyncを有効にする",
         "exit-to-tray": "システムトレイに戻る",
-        "FsrSharpnessStrenght": "FSRシャープネス強度",
         "fsync": "Fsyncを有効にする",
         "gamemode": "GameModeを使用する（Feral Game Modeをインストールする必要があります）",
         "language": "アプリの言語を選択",
@@ -282,7 +286,6 @@
             "title": "手動同期保存",
             "upload": "アップロード"
         },
-        "maxRecentGames": "表示する最近のゲーム",
         "maxworkers": "ダウンロード時のワーカーの最大数",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "ゲームをオフラインで実行する",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "FSRハックを有効にする（Wineバージョンはそれをサポートする必要があります）",
         "esync": "Esyncを有効にする",
         "exit-to-tray": "システムトレイに戻る",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Fsyncを有効にする",
         "gamemode": "GameModeを使用する（Feral Game Modeをインストールする必要があります）",
         "language": "アプリの言語を選択",
@@ -286,6 +287,7 @@
             "title": "手動同期保存",
             "upload": "アップロード"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "ダウンロード時のワーカーの最大数",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "ゲームをオフラインで実行する",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "FSR 활성화 (지원하는 Wine 버전을 사용해야 합니다)",
         "esync": "Esync 활성화",
         "exit-to-tray": "시스템 트레이로 나가기",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Fsync 활성화",
         "gamemode": "GameMode 사용 (Feral Game Mode가 설치되어 있어야 합니다)",
         "language": "앱 언어 선택",
@@ -286,6 +287,7 @@
             "title": "세이브 수동 동기화",
             "upload": "업로드"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "다운로드할 때 최대 워커 개수",
         "minimize-on-launch": "게임 실행 후 Heroic 최소화",
         "offlinemode": "게임 오프라인으로 실행",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "FSR 활성화 (지원하는 Wine 버전을 사용해야 합니다)",
         "esync": "Esync 활성화",
         "exit-to-tray": "시스템 트레이로 나가기",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR 선명도 강도",
         "fsync": "Fsync 활성화",
         "gamemode": "GameMode 사용 (Feral Game Mode가 설치되어 있어야 합니다)",
         "language": "앱 언어 선택",
@@ -287,7 +286,7 @@
             "title": "세이브 수동 동기화",
             "upload": "업로드"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "표시할 최근 플레이한 게임",
         "maxworkers": "다운로드할 때 최대 워커 개수",
         "minimize-on-launch": "게임 실행 후 Heroic 최소화",
         "offlinemode": "게임 오프라인으로 실행",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "설치 시작됨"
         },
         "moved": "이동 완료됨",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "설치 제거됨",
         "update": {
             "canceled": "업데이트 취소됨",
@@ -253,7 +258,6 @@
         "enableFSRHack": "FSR 활성화 (지원하는 Wine 버전을 사용해야 합니다)",
         "esync": "Esync 활성화",
         "exit-to-tray": "시스템 트레이로 나가기",
-        "FsrSharpnessStrenght": "FSR 선명도 강도",
         "fsync": "Fsync 활성화",
         "gamemode": "GameMode 사용 (Feral Game Mode가 설치되어 있어야 합니다)",
         "language": "앱 언어 선택",
@@ -282,7 +286,6 @@
             "title": "세이브 수동 동기화",
             "upload": "업로드"
         },
-        "maxRecentGames": "표시할 최근 플레이한 게임",
         "maxworkers": "다운로드할 때 최대 워커 개수",
         "minimize-on-launch": "게임 실행 후 Heroic 최소화",
         "offlinemode": "게임 오프라인으로 실행",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "എഫ്എസ്ആര് ഹാക്ക് വയ്ക്കൂ (Wine version needs to support it)",
         "esync": "Esync വയ്ക്കൂ",
         "exit-to-tray": "സംവിധാന താലത്തിലേക്ക്(സിസ്റ്റം ട്രേ) ചുരുക്കുക",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "എഫ്എസ്ആര് ഷാര്പ്പ്നെസ്സ് സ്ട്രെങ്ത്",
         "fsync": "Fsync വയ്ക്കൂ",
         "gamemode": "ഗെയിംമോഡ് ഉപയോഗിക്കൂ (ഫെറലിന്റെ ഗെയിംമോഡ് ഇന്സ്റ്റാള് ചെയ്തിരിക്കണം)",
         "language": "ആപ്പിന്റെ ഭാഷ",
@@ -287,7 +286,7 @@
             "title": "നിങ്ങള് സൂക്ഷിച്ച ഒന്നിപ്പിക്കലുകള്",
             "upload": "കയറ്റിവയ്ക്കുൂ"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "അടുത്തിടെയുള്ള പതിവ് കളികള്",
         "maxworkers": "ഇറക്കിയെടുക്കുമ്പോള് പണിയുന്നവരുടെ പരമാവധി എണ്ണം",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "ഓഫ്ലൈനില് കളിക്കുക",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "എഫ്എസ്ആര് ഹാക്ക് വയ്ക്കൂ (Wine version needs to support it)",
         "esync": "Esync വയ്ക്കൂ",
         "exit-to-tray": "സംവിധാന താലത്തിലേക്ക്(സിസ്റ്റം ട്രേ) ചുരുക്കുക",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Fsync വയ്ക്കൂ",
         "gamemode": "ഗെയിംമോഡ് ഉപയോഗിക്കൂ (ഫെറലിന്റെ ഗെയിംമോഡ് ഇന്സ്റ്റാള് ചെയ്തിരിക്കണം)",
         "language": "ആപ്പിന്റെ ഭാഷ",
@@ -286,6 +287,7 @@
             "title": "നിങ്ങള് സൂക്ഷിച്ച ഒന്നിപ്പിക്കലുകള്",
             "upload": "കയറ്റിവയ്ക്കുൂ"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "ഇറക്കിയെടുക്കുമ്പോള് പണിയുന്നവരുടെ പരമാവധി എണ്ണം",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "ഓഫ്ലൈനില് കളിക്കുക",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "നടീല് തുടങ്ങി"
         },
         "moved": "മാറ്റിക്കഴിഞ്ഞു",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "എടുത്തുനീക്കി",
         "update": {
             "canceled": "പുതുക്കല് റദ്ദാക്കി",
@@ -253,7 +258,6 @@
         "enableFSRHack": "എഫ്എസ്ആര് ഹാക്ക് വയ്ക്കൂ (Wine version needs to support it)",
         "esync": "Esync വയ്ക്കൂ",
         "exit-to-tray": "സംവിധാന താലത്തിലേക്ക്(സിസ്റ്റം ട്രേ) ചുരുക്കുക",
-        "FsrSharpnessStrenght": "എഫ്എസ്ആര് ഷാര്പ്പ്നെസ്സ് സ്ട്രെങ്ത്",
         "fsync": "Fsync വയ്ക്കൂ",
         "gamemode": "ഗെയിംമോഡ് ഉപയോഗിക്കൂ (ഫെറലിന്റെ ഗെയിംമോഡ് ഇന്സ്റ്റാള് ചെയ്തിരിക്കണം)",
         "language": "ആപ്പിന്റെ ഭാഷ",
@@ -282,7 +286,6 @@
             "title": "നിങ്ങള് സൂക്ഷിച്ച ഒന്നിപ്പിക്കലുകള്",
             "upload": "കയറ്റിവയ്ക്കുൂ"
         },
-        "maxRecentGames": "അടുത്തിടെയുള്ള പതിവ് കളികള്",
         "maxworkers": "ഇറക്കിയെടുക്കുമ്പോള് പണിയുന്നവരുടെ പരമാവധി എണ്ണം",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "ഓഫ്ലൈനില് കളിക്കുക",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Installation Started"
         },
         "moved": "Klaar met verplaatsing",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Verwijderd",
         "update": {
             "canceled": "Update geannuleerd",
@@ -253,7 +258,6 @@
         "enableFSRHack": "FSR Hack inschakelen (Wine versie moet dit ondersteunen)",
         "esync": "Esync inschakelen",
         "exit-to-tray": "Afsluiten naar systeemvak",
-        "FsrSharpnessStrenght": "FSR Sharpness Sterkte",
         "fsync": "Fsync inschakelen",
         "gamemode": "Gebruik GameMode (Feral Game Mode moet geïnstalleerd zijn)",
         "language": "Selecteer een App taal",
@@ -282,7 +286,6 @@
             "title": "Handmatige synchronisatie van saves",
             "upload": "Upload"
         },
-        "maxRecentGames": "Recente spellen om te tonen",
         "maxworkers": "Maximale hoeveelheid van werkers tijdens het downloaden",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Spel offline draaien",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "FSR Hack inschakelen (Wine versie moet dit ondersteunen)",
         "esync": "Esync inschakelen",
         "exit-to-tray": "Afsluiten naar systeemvak",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR Sharpness Sterkte",
         "fsync": "Fsync inschakelen",
         "gamemode": "Gebruik GameMode (Feral Game Mode moet geïnstalleerd zijn)",
         "language": "Selecteer een App taal",
@@ -287,7 +286,7 @@
             "title": "Handmatige synchronisatie van saves",
             "upload": "Upload"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Recente spellen om te tonen",
         "maxworkers": "Maximale hoeveelheid van werkers tijdens het downloaden",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Spel offline draaien",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "FSR Hack inschakelen (Wine versie moet dit ondersteunen)",
         "esync": "Esync inschakelen",
         "exit-to-tray": "Afsluiten naar systeemvak",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Fsync inschakelen",
         "gamemode": "Gebruik GameMode (Feral Game Mode moet geïnstalleerd zijn)",
         "language": "Selecteer een App taal",
@@ -286,6 +287,7 @@
             "title": "Handmatige synchronisatie van saves",
             "upload": "Upload"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Maximale hoeveelheid van werkers tijdens het downloaden",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Spel offline draaien",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Włącz FSR Hack (Wersja Wine musi to wspierać)",
         "esync": "Włącz Esync",
         "exit-to-tray": "Wyjście do tacki systemowej",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Włącz Fsync",
         "gamemode": "Użyj GameMode (Feral Game Mode musi być zainstalowane)",
         "language": "Wybierz język",
@@ -286,6 +287,7 @@
             "title": "Manualnie synchronizuj zapisy",
             "upload": "Upload"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Maksymalna liczba wątków przy pobieraniu",
         "minimize-on-launch": "Minimalizuj Heroic Po Uruchomieniu Gry",
         "offlinemode": "Uruchom grę w trybie offline",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Włącz FSR Hack (Wersja Wine musi to wspierać)",
         "esync": "Włącz Esync",
         "exit-to-tray": "Wyjście do tacki systemowej",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "Ostrość FSR",
         "fsync": "Włącz Fsync",
         "gamemode": "Użyj GameMode (Feral Game Mode musi być zainstalowane)",
         "language": "Wybierz język",
@@ -287,7 +286,7 @@
             "title": "Manualnie synchronizuj zapisy",
             "upload": "Upload"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Ostatnio Grane do Pokazania",
         "maxworkers": "Maksymalna liczba wątków przy pobieraniu",
         "minimize-on-launch": "Minimalizuj Heroic Po Uruchomieniu Gry",
         "offlinemode": "Uruchom grę w trybie offline",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Instalacja Rozpoczęta"
         },
         "moved": "Przenoszenie zakończone",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Odinstalowane",
         "update": {
             "canceled": "Aktualizacja przerwana",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Włącz FSR Hack (Wersja Wine musi to wspierać)",
         "esync": "Włącz Esync",
         "exit-to-tray": "Wyjście do tacki systemowej",
-        "FsrSharpnessStrenght": "Ostrość FSR",
         "fsync": "Włącz Fsync",
         "gamemode": "Użyj GameMode (Feral Game Mode musi być zainstalowane)",
         "language": "Wybierz język",
@@ -282,7 +286,6 @@
             "title": "Manualnie synchronizuj zapisy",
             "upload": "Upload"
         },
-        "maxRecentGames": "Ostatnio Grane do Pokazania",
         "maxworkers": "Maksymalna liczba wątków przy pobieraniu",
         "minimize-on-launch": "Minimalizuj Heroic Po Uruchomieniu Gry",
         "offlinemode": "Uruchom grę w trybie offline",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Habilitar Hack FSR (Wine precisa supportar a feature)",
         "esync": "Enable Esync",
         "exit-to-tray": "Sair para a área de noticação",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "Intensidade do filtro de nitidez do FSR",
         "fsync": "Enable Fsync",
         "gamemode": "Usar modo Jogo (Necessita gamemode instalado)",
         "language": "Selecionar idioma",
@@ -287,7 +286,7 @@
             "title": "Sincronização manual",
             "upload": "Upload"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Número de jogos recents a mostrar",
         "maxworkers": "CPUs máximos utilizados ao baixar jogos",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Executar o jogo offline",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Habilitar Hack FSR (Wine precisa supportar a feature)",
         "esync": "Enable Esync",
         "exit-to-tray": "Sair para a área de noticação",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Enable Fsync",
         "gamemode": "Usar modo Jogo (Necessita gamemode instalado)",
         "language": "Selecionar idioma",
@@ -286,6 +287,7 @@
             "title": "Sincronização manual",
             "upload": "Upload"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "CPUs máximos utilizados ao baixar jogos",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Executar o jogo offline",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Installation Started"
         },
         "moved": "Movido com sucesso",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Desinstalado",
         "update": {
             "canceled": "Updated Cancelado",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Habilitar Hack FSR (Wine precisa supportar a feature)",
         "esync": "Enable Esync",
         "exit-to-tray": "Sair para a área de noticação",
-        "FsrSharpnessStrenght": "Intensidade do filtro de nitidez do FSR",
         "fsync": "Enable Fsync",
         "gamemode": "Usar modo Jogo (Necessita gamemode instalado)",
         "language": "Selecionar idioma",
@@ -282,7 +286,6 @@
             "title": "Sincronização manual",
             "upload": "Upload"
         },
-        "maxRecentGames": "Número de jogos recents a mostrar",
         "maxworkers": "CPUs máximos utilizados ao baixar jogos",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Executar o jogo offline",

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Fonte para ações (Padrão: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Fonte para conteúdo (Padrão: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibilidade",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Habilitar Hack FSR (a versão do Wine precisa suportar o recurso)",
         "esync": "Habilitar Esync",
         "exit-to-tray": "Fechar para a barra de tarefas",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR Força de nitidez",
         "fsync": "Habilitar Fsync",
         "gamemode": "Usar o GameMode (precisa do gamemode instalado)",
         "language": "Selecione o idioma do app",
@@ -287,7 +286,7 @@
             "title": "Sincronizar manualmente os saves",
             "upload": "Upload"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Máximo de jogos em Jogados Recentemente",
         "maxworkers": "Máximo de núcleos da CPU para utilizar ao fazer baixar jogos",
         "minimize-on-launch": "Minimizar Heroic ao iniciar um jogo",
         "offlinemode": "Iniciar o jogo offline",

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Fonte para ações (Padrão: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Fonte para conteúdo (Padrão: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibilidade",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Instalação iniciada"
         },
         "moved": "Movido com sucesso",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Desinstalado",
         "update": {
             "canceled": "Atualização cancelada",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Habilitar Hack FSR (a versão do Wine precisa suportar o recurso)",
         "esync": "Habilitar Esync",
         "exit-to-tray": "Fechar para a barra de tarefas",
-        "FsrSharpnessStrenght": "FSR Força de nitidez",
         "fsync": "Habilitar Fsync",
         "gamemode": "Usar o GameMode (precisa do gamemode instalado)",
         "language": "Selecione o idioma do app",
@@ -282,7 +286,6 @@
             "title": "Sincronizar manualmente os saves",
             "upload": "Upload"
         },
-        "maxRecentGames": "Máximo de jogos em Jogados Recentemente",
         "maxworkers": "Máximo de núcleos da CPU para utilizar ao fazer baixar jogos",
         "minimize-on-launch": "Minimizar Heroic ao iniciar um jogo",
         "offlinemode": "Iniciar o jogo offline",

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Habilitar Hack FSR (a versão do Wine precisa suportar o recurso)",
         "esync": "Habilitar Esync",
         "exit-to-tray": "Fechar para a barra de tarefas",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Habilitar Fsync",
         "gamemode": "Usar o GameMode (precisa do gamemode instalado)",
         "language": "Selecione o idioma do app",
@@ -286,6 +287,7 @@
             "title": "Sincronizar manualmente os saves",
             "upload": "Upload"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Máximo de núcleos da CPU para utilizar ao fazer baixar jogos",
         "minimize-on-launch": "Minimizar Heroic ao iniciar um jogo",
         "offlinemode": "Iniciar o jogo offline",

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Fonte para ações (Padrão: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Fonte para conteúdo (Padrão: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibilidade",

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Семейство шрифтов для действий (По умолчанию: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Семейство шрифтов для содержания (По умолчанию: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Доступность",
@@ -257,6 +258,7 @@
         "enableFSRHack": "Включить FSR Hack (версия Wine должна поддерживать)",
         "esync": "Включить Esync",
         "exit-to-tray": "Сворачивать в системный трей",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Включить Fsync",
         "gamemode": "Использовать GameMode (Нужен Feral GameMode)",
         "language": "Выберите язык приложения",
@@ -285,6 +287,7 @@
             "title": "Ручная синхронизация сохранений",
             "upload": "Загрузить"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Максимальное количество потоков при скачивании",
         "minimize-on-launch": "Сворачивать Heroic в трей при запуске игры",
         "offlinemode": "Запускать игру офлайн",

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -197,6 +197,9 @@
             "startInstall": "Установка началась"
         },
         "moved": "Перемещение завершено",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Удалено",
         "update": {
             "canceled": "Обновление прервано",
@@ -253,7 +256,6 @@
         "enableFSRHack": "Включить FSR Hack (версия Wine должна поддерживать)",
         "esync": "Включить Esync",
         "exit-to-tray": "Сворачивать в системный трей",
-        "FsrSharpnessStrenght": "Усиление резкости FSR",
         "fsync": "Включить Fsync",
         "gamemode": "Использовать GameMode (Нужен Feral GameMode)",
         "language": "Выберите язык приложения",
@@ -282,7 +284,6 @@
             "title": "Ручная синхронизация сохранений",
             "upload": "Загрузить"
         },
-        "maxRecentGames": "Показывать недавно запускавшихся игр",
         "maxworkers": "Максимальное количество потоков при скачивании",
         "minimize-on-launch": "Сворачивать Heroic в трей при запуске игры",
         "offlinemode": "Запускать игру офлайн",

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Семейство шрифтов для действий (По умолчанию: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Семейство шрифтов для содержания (По умолчанию: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Доступность",

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Семейство шрифтов для действий (По умолчанию: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Семейство шрифтов для содержания (По умолчанию: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Доступность",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Включить FSR Hack (версия Wine должна поддерживать)",
         "esync": "Включить Esync",
         "exit-to-tray": "Сворачивать в системный трей",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "Усиление резкости FSR",
         "fsync": "Включить Fsync",
         "gamemode": "Использовать GameMode (Нужен Feral GameMode)",
         "language": "Выберите язык приложения",
@@ -287,7 +286,7 @@
             "title": "Ручная синхронизация сохранений",
             "upload": "Загрузить"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Показывать недавно запускавшихся игр",
         "maxworkers": "Максимальное количество потоков при скачивании",
         "minimize-on-launch": "Сворачивать Heroic в трей при запуске игры",
         "offlinemode": "Запускать игру офлайн",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Installation påbörjad"
         },
         "moved": "Spelflytt slutförd",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Avinstallerat",
         "update": {
             "canceled": "Uppdatering avbröts",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Aktivera FSR Hack (Wine-versionen måste stödja det)",
         "esync": "Aktivera Esync",
         "exit-to-tray": "Minimera till systemfältet",
-        "FsrSharpnessStrenght": "FSR skärpningsnivå",
         "fsync": "Aktivera Fsync",
         "gamemode": "Använd GameMode (Feral Game Mode måste vara installerat)",
         "language": "Välj språk",
@@ -282,7 +286,6 @@
             "title": "Synkronisera sparfiler manuellt",
             "upload": "Ladda upp"
         },
-        "maxRecentGames": "Visa nyligen spelat",
         "maxworkers": "Maximalt antal samtida nedladdningar",
         "minimize-on-launch": "Minimera Heroic efter spelstart",
         "offlinemode": "Kör spelet offline",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Aktivera FSR Hack (Wine-versionen måste stödja det)",
         "esync": "Aktivera Esync",
         "exit-to-tray": "Minimera till systemfältet",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR skärpningsnivå",
         "fsync": "Aktivera Fsync",
         "gamemode": "Använd GameMode (Feral Game Mode måste vara installerat)",
         "language": "Välj språk",
@@ -287,7 +286,7 @@
             "title": "Synkronisera sparfiler manuellt",
             "upload": "Ladda upp"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Visa nyligen spelat",
         "maxworkers": "Maximalt antal samtida nedladdningar",
         "minimize-on-launch": "Minimera Heroic efter spelstart",
         "offlinemode": "Kör spelet offline",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Aktivera FSR Hack (Wine-versionen måste stödja det)",
         "esync": "Aktivera Esync",
         "exit-to-tray": "Minimera till systemfältet",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Aktivera Fsync",
         "gamemode": "Använd GameMode (Feral Game Mode måste vara installerat)",
         "language": "Välj språk",
@@ -286,6 +287,7 @@
             "title": "Synkronisera sparfiler manuellt",
             "upload": "Ladda upp"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Maximalt antal samtida nedladdningar",
         "minimize-on-launch": "Minimera Heroic efter spelstart",
         "offlinemode": "Kör spelet offline",

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Installation Started"
         },
         "moved": "நகர்தல் முடிவடைந்தது",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "நிறுவல் நீக்கப்பட்டது",
         "update": {
             "canceled": "புதுப்பிப்பு ரத்து செய்யப்பட்டது",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",
         "exit-to-tray": "கணினி தட்டிற்கு வெளியேறு",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Enable Fsync",
         "gamemode": "GameMode ஐ பயன்படுது (Feral விளையாட்டு பயன்முறையை நிறுவப்பட்டிருக்க வேண்டும்)",
         "language": "பயன்பாட்டின் மொழியை தேர்வுசெய்",
@@ -282,7 +286,6 @@
             "title": "கைமுறை ஒத்திசைவு சேமிப்புகள்",
             "upload": "பதிவேற்றம்"
         },
-        "maxRecentGames": "Played Recently to Show",
         "maxworkers": "பதிவிறக்கும் போது வேலையாளிகளின் அதிகபட்ச எண்ணிக்கை",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "இணையத்துடன் இணையாமல் விளையாட்டை துவக்கு",

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -287,7 +286,7 @@
             "title": "கைமுறை ஒத்திசைவு சேமிப்புகள்",
             "upload": "பதிவேற்றம்"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Played Recently to Show",
         "maxworkers": "பதிவிறக்கும் போது வேலையாளிகளின் அதிகபட்ச எண்ணிக்கை",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "இணையத்துடன் இணையாமல் விளையாட்டை துவக்கு",

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",
         "exit-to-tray": "கணினி தட்டிற்கு வெளியேறு",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Enable Fsync",
         "gamemode": "GameMode ஐ பயன்படுது (Feral விளையாட்டு பயன்முறையை நிறுவப்பட்டிருக்க வேண்டும்)",
         "language": "பயன்பாட்டின் மொழியை தேர்வுசெய்",
@@ -286,6 +287,7 @@
             "title": "கைமுறை ஒத்திசைவு சேமிப்புகள்",
             "upload": "பதிவேற்றம்"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "பதிவிறக்கும் போது வேலையாளிகளின் அதிகபட்ச எண்ணிக்கை",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "இணையத்துடன் இணையாமல் விளையாட்டை துவக்கு",

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Eylemler Yazı Tipi Ailesi (Öntanımlı: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "İçerik Yazı Tipi Ailesi (Öntanımlı: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Erişilebilirlik",
@@ -257,6 +258,7 @@
         "enableFSRHack": "FSR Hack'i Etkinleştir (Wine sürümünün desteklemesi gerekiyor)",
         "esync": "Esync'i Etkinleştir",
         "exit-to-tray": "Sistem Tepsisine Küçült",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Fsync'i Etkinleştir",
         "gamemode": "Oyun Modu Kullan (Feral Game Mode yüklü olmalıdır)",
         "language": "Uygulama Dilini Seç",
@@ -285,6 +287,7 @@
             "title": "Kayıtları Elle Eşzamanla",
             "upload": "Karşıya Yükle"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "İndirirken azami işçi sayısı",
         "minimize-on-launch": "Oyun Başlatıldıktan Sonra Heroic'i Simge Durumuna Küçült",
         "offlinemode": "Oyunu Çevrim Dışı Çalıştır",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -197,6 +197,9 @@
             "startInstall": "Kurulum Başladı"
         },
         "moved": "Taşıma Tamamlandı",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Kaldırıldı",
         "update": {
             "canceled": "Güncelleme İptal Edildi",
@@ -253,7 +256,6 @@
         "enableFSRHack": "FSR Hack'i Etkinleştir (Wine sürümünün desteklemesi gerekiyor)",
         "esync": "Esync'i Etkinleştir",
         "exit-to-tray": "Sistem Tepsisine Küçült",
-        "FsrSharpnessStrenght": "FSR Keskinlik Gücü",
         "fsync": "Fsync'i Etkinleştir",
         "gamemode": "Oyun Modu Kullan (Feral Game Mode yüklü olmalıdır)",
         "language": "Uygulama Dilini Seç",
@@ -282,7 +284,6 @@
             "title": "Kayıtları Elle Eşzamanla",
             "upload": "Karşıya Yükle"
         },
-        "maxRecentGames": "Gösterilecek Son Oynananlar",
         "maxworkers": "İndirirken azami işçi sayısı",
         "minimize-on-launch": "Oyun Başlatıldıktan Sonra Heroic'i Simge Durumuna Küçült",
         "offlinemode": "Oyunu Çevrim Dışı Çalıştır",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Eylemler Yazı Tipi Ailesi (Öntanımlı: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "İçerik Yazı Tipi Ailesi (Öntanımlı: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Erişilebilirlik",
@@ -258,7 +257,7 @@
         "enableFSRHack": "FSR Hack'i Etkinleştir (Wine sürümünün desteklemesi gerekiyor)",
         "esync": "Esync'i Etkinleştir",
         "exit-to-tray": "Sistem Tepsisine Küçült",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR Keskinlik Gücü",
         "fsync": "Fsync'i Etkinleştir",
         "gamemode": "Oyun Modu Kullan (Feral Game Mode yüklü olmalıdır)",
         "language": "Uygulama Dilini Seç",
@@ -287,7 +286,7 @@
             "title": "Kayıtları Elle Eşzamanla",
             "upload": "Karşıya Yükle"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Gösterilecek Son Oynananlar",
         "maxworkers": "İndirirken azami işçi sayısı",
         "minimize-on-launch": "Oyun Başlatıldıktan Sonra Heroic'i Simge Durumuna Küçült",
         "offlinemode": "Oyunu Çevrim Dışı Çalıştır",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Eylemler Yazı Tipi Ailesi (Öntanımlı: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "İçerik Yazı Tipi Ailesi (Öntanımlı: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Erişilebilirlik",

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Розпочалось встановлення"
         },
         "moved": "Переміщення завершене",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Видалено",
         "update": {
             "canceled": "Оновлення скасовано",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Ввімкнути FSR Hack (версія Wine має це підтримувати)",
         "esync": "Ввімкнути Esync",
         "exit-to-tray": "Вийти до системної панелі",
-        "FsrSharpnessStrenght": "Посилення різкості FSR",
         "fsync": "Ввімкнути Fsync",
         "gamemode": "Використовувати GameMode (Feral Game Mode має бути встановлений)",
         "language": "Оберіть мову застосунка",
@@ -282,7 +286,6 @@
             "title": "Синхронізувати збереження власноруч",
             "upload": "Вивантажити"
         },
-        "maxRecentGames": "Скільки показувати нещодавно зіграних ігор",
         "maxworkers": "Максимальна кількість працівників при завантаженні",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Запустити гру оффлайн",

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Ввімкнути FSR Hack (версія Wine має це підтримувати)",
         "esync": "Ввімкнути Esync",
         "exit-to-tray": "Вийти до системної панелі",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Ввімкнути Fsync",
         "gamemode": "Використовувати GameMode (Feral Game Mode має бути встановлений)",
         "language": "Оберіть мову застосунка",
@@ -286,6 +287,7 @@
             "title": "Синхронізувати збереження власноруч",
             "upload": "Вивантажити"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Максимальна кількість працівників при завантаженні",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Запустити гру оффлайн",

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Ввімкнути FSR Hack (версія Wine має це підтримувати)",
         "esync": "Ввімкнути Esync",
         "exit-to-tray": "Вийти до системної панелі",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "Посилення різкості FSR",
         "fsync": "Ввімкнути Fsync",
         "gamemode": "Використовувати GameMode (Feral Game Mode має бути встановлений)",
         "language": "Оберіть мову застосунка",
@@ -287,7 +286,7 @@
             "title": "Синхронізувати збереження власноруч",
             "upload": "Вивантажити"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Скільки показувати нещодавно зіграних ігор",
         "maxworkers": "Максимальна кількість працівників при завантаженні",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Запустити гру оффлайн",

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "Bật tính năng FSR hack (Phiên bản Wine cần hỗ trợ tính năng này)",
         "esync": "Bật Esync",
         "exit-to-tray": "Thoát ra khay hệ thống",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "Độ sắc nét FSR",
         "fsync": "Bật Fsync",
         "gamemode": "Sử dụng GameMode (Cần cài đặt Feral Game Mode)",
         "language": "Chọn ngôn ngữ của ứng dụng",
@@ -287,7 +286,7 @@
             "title": "Đồng bộ thủ công bản sao lưu",
             "upload": "Tải lên"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "Hiển thị số game đã chơi gần đây",
         "maxworkers": "Số lượng tối đa khi tải xuống",
         "minimize-on-launch": "Thu nhỏ Heroic sau khi khởi chạy trò chơi",
         "offlinemode": "Chạy game oflline",

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "Bật tính năng FSR hack (Phiên bản Wine cần hỗ trợ tính năng này)",
         "esync": "Bật Esync",
         "exit-to-tray": "Thoát ra khay hệ thống",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Bật Fsync",
         "gamemode": "Sử dụng GameMode (Cần cài đặt Feral Game Mode)",
         "language": "Chọn ngôn ngữ của ứng dụng",
@@ -286,6 +287,7 @@
             "title": "Đồng bộ thủ công bản sao lưu",
             "upload": "Tải lên"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "Số lượng tối đa khi tải xuống",
         "minimize-on-launch": "Thu nhỏ Heroic sau khi khởi chạy trò chơi",
         "offlinemode": "Chạy game oflline",

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Quá trình cài đặt đã bắt đầu"
         },
         "moved": "Di chuyển hoàn tất",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "Gỡ cài đặt",
         "update": {
             "canceled": "Quá trình cập nhật đã hủy",
@@ -253,7 +258,6 @@
         "enableFSRHack": "Bật tính năng FSR hack (Phiên bản Wine cần hỗ trợ tính năng này)",
         "esync": "Bật Esync",
         "exit-to-tray": "Thoát ra khay hệ thống",
-        "FsrSharpnessStrenght": "Độ sắc nét FSR",
         "fsync": "Bật Fsync",
         "gamemode": "Sử dụng GameMode (Cần cài đặt Feral Game Mode)",
         "language": "Chọn ngôn ngữ của ứng dụng",
@@ -282,7 +286,6 @@
             "title": "Đồng bộ thủ công bản sao lưu",
             "upload": "Tải lên"
         },
-        "maxRecentGames": "Hiển thị số game đã chơi gần đây",
         "maxworkers": "Số lượng tối đa khi tải xuống",
         "minimize-on-launch": "Thu nhỏ Heroic sau khi khởi chạy trò chơi",
         "offlinemode": "Chạy game oflline",

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "操作字族 (默认: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "内容字族 (默认: \"Cabin\")",
         "title": "辅助",
         "zoom": "缩放"
@@ -197,6 +198,9 @@
             "startInstall": "安装已开始"
         },
         "moved": "移动完成",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "已卸载",
         "update": {
             "canceled": "已取消更新",
@@ -253,7 +257,6 @@
         "enableFSRHack": "启用 FSR（需要支持的WINE版本）",
         "esync": "启用 Esync",
         "exit-to-tray": "退出到系统托盘",
-        "FsrSharpnessStrenght": "FSR 锐化度",
         "fsync": "启用 Fsync",
         "gamemode": "使用 GameMode（需要已安装 Feral Game Mode）",
         "language": "选择应用语言",
@@ -282,7 +285,6 @@
             "title": "手动同步存档",
             "upload": "上传"
         },
-        "maxRecentGames": "要显示的最近玩过的游戏",
         "maxworkers": "下载时的最大线程数量",
         "minimize-on-launch": "游戏启动后最小化 Heroic",
         "offlinemode": "离线运行游戏",

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "操作字族 (默认: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "内容字族 (默认: \"Cabin\")",
         "fonts": "Fonts",
         "title": "辅助",

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "操作字族 (默认: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "内容字族 (默认: \"Cabin\")",
         "fonts": "Fonts",
         "title": "辅助",
@@ -258,7 +257,7 @@
         "enableFSRHack": "启用 FSR（需要支持的WINE版本）",
         "esync": "启用 Esync",
         "exit-to-tray": "退出到系统托盘",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR 锐化度",
         "fsync": "启用 Fsync",
         "gamemode": "使用 GameMode（需要已安装 Feral Game Mode）",
         "language": "选择应用语言",
@@ -287,7 +286,7 @@
             "title": "手动同步存档",
             "upload": "上传"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "要显示的最近玩过的游戏",
         "maxworkers": "下载时的最大线程数量",
         "minimize-on-launch": "游戏启动后最小化 Heroic",
         "offlinemode": "离线运行游戏",

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "启用 FSR（需要支持的WINE版本）",
         "esync": "启用 Esync",
         "exit-to-tray": "退出到系统托盘",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "启用 Fsync",
         "gamemode": "使用 GameMode（需要已安装 Feral Game Mode）",
         "language": "选择应用语言",
@@ -286,6 +287,7 @@
             "title": "手动同步存档",
             "upload": "上传"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "下载时的最大线程数量",
         "minimize-on-launch": "游戏启动后最小化 Heroic",
         "offlinemode": "离线运行游戏",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -1,7 +1,9 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
+        "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"
     },
@@ -197,6 +199,9 @@
             "startInstall": "Installation Started"
         },
         "moved": "移動完成",
+        "refresh": {
+            "error": "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
+        },
         "uninstalled": "已解除安裝",
         "update": {
             "canceled": "已取消更新",
@@ -253,7 +258,6 @@
         "enableFSRHack": "啟用FSR（需要支持的WINE版本）",
         "esync": "Enable Esync",
         "exit-to-tray": "退出到系統列",
-        "FsrSharpnessStrenght": "FSR 銳化度",
         "fsync": "Enable Fsync",
         "gamemode": "使用GameMode（需要已安裝Feral Game Mode）",
         "language": "選擇應用語言",
@@ -282,7 +286,6 @@
             "title": "手動同步存檔",
             "upload": "上傳"
         },
-        "maxRecentGames": "最近要展示的遊戲",
         "maxworkers": "下載時的最大Worker數量",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "離線運行遊戲",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -258,6 +258,7 @@
         "enableFSRHack": "啟用FSR（需要支持的WINE版本）",
         "esync": "Enable Esync",
         "exit-to-tray": "退出到系統列",
+        "FsrSharpnessStrenght": "FSR Sharpness Strength",
         "fsync": "Enable Fsync",
         "gamemode": "使用GameMode（需要已安裝Feral Game Mode）",
         "language": "選擇應用語言",
@@ -286,6 +287,7 @@
             "title": "手動同步存檔",
             "upload": "上傳"
         },
+        "maxRecentGames": "Recent Games to Show",
         "maxworkers": "下載時的最大Worker數量",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "離線運行遊戲",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -1,7 +1,6 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
-        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",
@@ -258,7 +257,7 @@
         "enableFSRHack": "啟用FSR（需要支持的WINE版本）",
         "esync": "Enable Esync",
         "exit-to-tray": "退出到系統列",
-        "FsrSharpnessStrenght": "FSR Sharpness Strength",
+        "FsrSharpnessStrenght": "FSR 銳化度",
         "fsync": "Enable Fsync",
         "gamemode": "使用GameMode（需要已安裝Feral Game Mode）",
         "language": "選擇應用語言",
@@ -287,7 +286,7 @@
             "title": "手動同步存檔",
             "upload": "上傳"
         },
-        "maxRecentGames": "Recent Games to Show",
+        "maxRecentGames": "最近要展示的遊戲",
         "maxworkers": "下載時的最大Worker數量",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "離線運行遊戲",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -1,6 +1,7 @@
 {
     "accessibility": {
         "actions_font_family": "Actions Font Family (Default: \"Rubik\")",
+        "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family": "Content Font Family (Default: \"Cabin\")",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/src/screens/Accessibility/index.tsx
+++ b/src/screens/Accessibility/index.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next'
 import ContextProvider from 'src/state/ContextProvider'
 import classNames from 'classnames'
 import { ThemeSelector } from 'src/components/UI/ThemeSelector'
+import ToggleSwitch from 'src/components/UI/ToggleSwitch'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSyncAlt } from '@fortawesome/free-solid-svg-icons'
 const { ipcRenderer } = window.require('electron')
@@ -24,7 +25,9 @@ export default function Accessibility() {
     contentFontFamily,
     setContentFontFamily,
     actionsFontFamily,
-    setActionsFontFamily
+    setActionsFontFamily,
+    allTilesInColor,
+    setAllTilesInColor
   } = useContext(ContextProvider)
 
   const [fonts, setFonts] = useState<string[]>(['Cabin', 'Rubik'])
@@ -162,6 +165,20 @@ export default function Accessibility() {
         </span>
 
         <ThemeSelector />
+        <span className="setting">
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <ToggleSwitch
+              value={allTilesInColor}
+              handleChange={() => {
+                setAllTilesInColor(!allTilesInColor)
+              }}
+              title={t(
+                'accessibility.allTilesInColor',
+                'Show all game tiles in color'
+              )}
+            />
+          </label>
+        </span>
       </div>
     </div>
   )

--- a/src/screens/Accessibility/index.tsx
+++ b/src/screens/Accessibility/index.tsx
@@ -173,7 +173,7 @@ export default function Accessibility() {
                 setAllTilesInColor(!allTilesInColor)
               }}
               title={t(
-                'accessibility.allTilesInColor',
+                'accessibility.all_tiles_in_color',
                 'Show all game tiles in color'
               )}
             />

--- a/src/screens/Game/GamePage/index.tsx
+++ b/src/screens/Game/GamePage/index.tsx
@@ -45,7 +45,7 @@ const { ipcRenderer } = window.require('electron') as {
 export default function GamePage(): JSX.Element | null {
   const { appName } = useParams() as { appName: string }
   const { t } = useTranslation('gamepage')
-  const { t: t2 } = useTranslation('translation')
+  const { t: t2 } = useTranslation()
 
   const [tabToShow, setTabToShow] = useState('infoTab')
   const [showModal, setShowModal] = useState({ game: '', show: false })

--- a/src/screens/Library/components/GameCard/index.css
+++ b/src/screens/Library/components/GameCard/index.css
@@ -230,7 +230,9 @@
 }
 
 .gameCard:hover .gameImg:not(.installed),
-.gameCard:hover .gameLogo:not(.installed) {
+.gameCard:hover .gameLogo:not(.installed),
+.gameImg.allTilesInColor,
+.gameLogo.allTilesInColor {
   filter: grayscale(0);
 }
 

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -66,7 +66,8 @@ const GameCard = ({
     handleGameStatus,
     platform,
     hiddenGames,
-    favouriteGames
+    favouriteGames,
+    allTilesInColor
   } = useContext(ContextProvider)
 
   const isWin = platform === 'win32'
@@ -288,8 +289,12 @@ const GameCard = ({
 
   const instClass = isInstalled ? 'installed' : ''
   const hiddenClass = isHiddenGame ? 'hidden' : ''
-  const imgClasses = `gameImg ${isInstalled ? 'installed' : ''}`
-  const logoClasses = `gameLogo ${isInstalled ? 'installed' : ''}`
+  const imgClasses = `gameImg ${isInstalled ? 'installed' : ''} ${
+    allTilesInColor && 'allTilesInColor'
+  }`
+  const logoClasses = `gameLogo ${isInstalled ? 'installed' : ''} ${
+    allTilesInColor && 'allTilesInColor'
+  }`
 
   const wrapperClasses = `${
     grid ? 'gameCard' : 'gameListItem'

--- a/src/state/ContextProvider.tsx
+++ b/src/state/ContextProvider.tsx
@@ -58,7 +58,9 @@ const initialContext: ContextType = {
   contentFontFamily: "'Cabin', sans-serif",
   setContentFontFamily: () => null,
   actionsFontFamily: "'Rubik', sans-serif",
-  setActionsFontFamily: () => null
+  setActionsFontFamily: () => null,
+  allTilesInColor: false,
+  setAllTilesInColor: () => null
 }
 
 export default React.createContext(initialContext)

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -74,6 +74,7 @@ interface StateProps {
   zoomPercent: number
   contentFontFamily: string
   actionsFontFamily: string
+  allTilesInColor: boolean
 }
 
 export class GlobalState extends PureComponent<Props> {
@@ -129,7 +130,8 @@ export class GlobalState extends PureComponent<Props> {
     contentFontFamily:
       (configStore.get('contentFontFamily') as string) || "'Cabin', sans-serif",
     actionsFontFamily:
-      (configStore.get('actionsFontFamily') as string) || "'Rubik', sans-serif"
+      (configStore.get('actionsFontFamily') as string) || "'Rubik', sans-serif",
+    allTilesInColor: (configStore.get('allTilesInColor') as boolean) || false
   }
 
   setTheme = (newThemeName: string) => {
@@ -158,6 +160,11 @@ export class GlobalState extends PureComponent<Props> {
   setActionsFontFamily = (newFontFamily: string) => {
     configStore.set('actionsFontFamily', newFontFamily)
     this.setState({ actionsFontFamily: newFontFamily })
+  }
+
+  setAllTilesInColor = (value: boolean) => {
+    configStore.set('allTilesInColor', value)
+    this.setState({ allTilesInColor: value })
   }
 
   setShowHidden = (value: boolean) => {
@@ -707,7 +714,8 @@ export class GlobalState extends PureComponent<Props> {
           setTheme: this.setTheme,
           setZoomPercent: this.setZoomPercent,
           setContentFontFamily: this.setContentFontFamily,
-          setActionsFontFamily: this.setActionsFontFamily
+          setActionsFontFamily: this.setActionsFontFamily,
+          setAllTilesInColor: this.setAllTilesInColor
         }}
       >
         {children}

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,8 @@ export interface ContextType {
     login: (token: string) => Promise<string>
     logout: () => void
   }
+  allTilesInColor: boolean
+  setAllTilesInColor: (value: boolean) => void
 }
 
 export type LibraryTopSectionOptions =


### PR DESCRIPTION
Patch to address feature request https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1301

This adds an option in accessibility settings that, when enabled, adds the `allTilesInColor` class to the GameCard component, making all tiles show in color. 

![image](https://user-images.githubusercontent.com/65339198/168468045-f1ee8b36-3827-4445-a831-bf85ff40f89d.png)
![image](https://user-images.githubusercontent.com/65339198/168468121-be7cb592-0d56-4641-8f6b-efdbe228bf00.png)

Just wanted to get this out there and get some feedback. Will do checklist soon!

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
