### PR TITLE
[UX] Open main window on tray double click

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -390,6 +390,10 @@ if (!gotTheLock) {
     const trayIcon = darkTrayIcon ? iconDark : iconLight
     appIcon = new Tray(trayIcon)
 
+    appIcon.on('double-click', () => {
+      mainWindow.show()
+    })
+
     appIcon.setContextMenu(contextMenu())
     appIcon.setToolTip('Heroic')
     ipcMain.on('changeLanguage', async (event, language: string) => {


### PR DESCRIPTION
This PR adds the feature of opening the main window when double clicking the icon in the Tray/Taskbar.

This DOES NOT work on linux, the events that we need to listen to only work on window and mac as stated in the Electron docs https://www.electronjs.org/docs/latest/api/tray/#event-double-click-macos-windows

There is no possible workaround for Linux until electron adds support for it.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
