### PR TITLE
[Fix] Check for game updates before launch

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -280,7 +280,7 @@ async function verifyWinePrefix(
 ): Promise<{ res: ExecResult; updated: boolean }> {
   const { winePrefix, wineVersion } = await game.getSettings()
 
-  if (wineVersion.type === 'crossover') {
+  if (!(wineVersion.type === 'wine')) {
     return { res: { stdout: '', stderr: '' }, updated: false }
   }
 
@@ -363,7 +363,7 @@ async function runWineCommand(
     // Can't wait if we don't have a Wineserver
     if (wait) {
       if (wineVersion.wineserver) {
-        additional_command = `${wineVersion.wineserver} --wait`
+        additional_command = `"${wineVersion.wineserver}" --wait`
       } else {
         logWarning(
           'Unable to wait on Wine command, no Wineserver!',

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -373,7 +373,7 @@ async function runWineCommand(
     }
   }
 
-  let finalCommand = `${wineBin} ${command}`
+  let finalCommand = `"${wineBin}" ${command}`
   if (additional_command) {
     finalCommand += ` && ${additional_command}`
   }
@@ -385,7 +385,7 @@ async function runWineCommand(
       return response
     })
     .catch((error) => {
-      logError(['Error running Wine command:', error], LogPrefix.Legendary)
+      logError(['Error running Wine command:', error], LogPrefix.Backend)
       return { stderr: error, stdout: '' }
     })
 }

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -522,8 +522,6 @@ class LegendaryGame extends Game {
   }
 
   public async launch(launchArguments: string): Promise<LaunchResult> {
-    console.log('launch', { launchArguments })
-
     const gameSettings =
       GameConfig.get(this.appName).config ||
       (await GameConfig.get(this.appName).getSettings())

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -521,7 +521,9 @@ class LegendaryGame extends Game {
     return res
   }
 
-  public async launch(launchArguments = ''): Promise<LaunchResult> {
+  public async launch(launchArguments: string): Promise<LaunchResult> {
+    console.log('launch', { launchArguments })
+
     const gameSettings =
       GameConfig.get(this.appName).config ||
       (await GameConfig.get(this.appName).getSettings())
@@ -572,6 +574,7 @@ class LegendaryGame extends Game {
           steamRuntime
         )
       }
+
       // These options are required on both Windows and Mac
       commandParts = [
         'launch',
@@ -623,7 +626,8 @@ class LegendaryGame extends Game {
         offlineFlag,
         ...wineFlag,
         ...winePrefixFlag,
-        launcherArgs
+        launcherArgs,
+        launchArguments
       ]
     }
     const command = getLegendaryCommand(commandParts, commandEnv, wrappers)

--- a/src/helpers/library.ts
+++ b/src/helpers/library.ts
@@ -275,7 +275,7 @@ const launch = async ({
     return ipcRenderer.invoke('launch', {
       appName,
       runner,
-      launchArguments: runner === 'legendary' ? '--skip-version-check' : ''
+      launchArguments: '--skip-version-check'
     })
   }
 

--- a/src/screens/Game/GamePage/index.tsx
+++ b/src/screens/Game/GamePage/index.tsx
@@ -536,7 +536,13 @@ export default function GamePage(): JSX.Element | null {
         await syncSaves(savesPath, appName)
         setIsSyncing(false)
       }
-      await launch({ appName, t, launchArguments, runner: gameInfo.runner })
+      await launch({
+        appName,
+        t,
+        launchArguments,
+        runner: gameInfo.runner,
+        hasUpdate
+      })
 
       if (autoSyncSaves) {
         setIsSyncing(true)

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -361,7 +361,7 @@ const GameCard = ({
       return sendKill(appName, runner)
     }
     if (isInstalled) {
-      return launch({ appName, t, runner })
+      return launch({ appName, t, runner, hasUpdate })
     }
     return
   }

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -454,7 +454,8 @@ export class GlobalState extends PureComponent<Props> {
       )[0]
       if (!currentApp) {
         // Add finding a runner for games
-        return launch({ appName, t, runner })
+        const hasUpdate = this.state.gameUpdates?.includes(appName)
+        return launch({ appName, t, runner, hasUpdate })
       }
     })
 


### PR DESCRIPTION
This fixes the issue we are having now where it is not possible to skip an update when launching a game.
I changed the logic to check the update on frontend and show the message before even launching the game instead of waiting for an error from Legendary.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
