### PR TITLE
Run GOG setup again + don't skip Wineboot for Proton

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -291,15 +291,8 @@ export async function verifyWinePrefix(
     return { res: { stdout: '', stderr: '' }, updated: false }
   }
 
-  let didCreateFolder = false
-
   if (!existsSync(winePrefix)) {
     mkdirSync(winePrefix, { recursive: true })
-    didCreateFolder = true
-  }
-
-  if (wineVersion.type === 'proton') {
-    return { res: { stdout: '', stderr: '' }, updated: didCreateFolder }
   }
 
   // If the registry isn't available yet, things like DXVK installers might fail. So we have to wait on wineboot then

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -166,7 +166,7 @@ async function prepareWineLaunch(game: LegendaryGame | GOGGame): Promise<{
       ['Created/Updated Wineprefix at', gameSettings.winePrefix],
       LogPrefix.Backend
     )
-    setup(game.appName)
+    await setup(game.appName)
   }
 
   // If DXVK/VKD3D installation is enabled, install it

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -296,7 +296,11 @@ export async function verifyWinePrefix(
   }
 
   // If the registry isn't available yet, things like DXVK installers might fail. So we have to wait on wineboot then
-  const haveToWait = !existsSync(join(winePrefix, 'system.reg'))
+  const systemRegPath =
+    wineVersion.type === 'proton'
+      ? join(winePrefix, 'pfx', 'system.reg')
+      : join(winePrefix, 'system.reg')
+  const haveToWait = !existsSync(systemRegPath)
 
   return game
     .runWineCommand('wineboot --init', '', haveToWait)


### PR DESCRIPTION
GOG Setup instructions were not ran due to a missing `await`
I've also reverted the changes about not running Wineboot since otherwise, a Proton prefix would only count as "updated" if the root folder was created by Heroic (so if the user deletes all files inside it, it would still not run the setup instructions)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
