### PR TITLE
Set Steam App ID variables when using the Runtime on Proton + fixup setting user-defined env vars on native games

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -266,8 +266,12 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
     // This sets the name of the log file given when setting PROTON_LOG=1
     ret.SteamGameId = `heroic-${gameId}`
     ret.PROTON_LOG_DIR = flatPakHome
-    // Stop Proton from overriding WINEDEBUG; this prevents logs growing to a few GB for some games
-    ret.WINEDEBUG = 'timestamp'
+
+    // Only set WINEDEBUG if PROTON_LOG is set since Proton will also log if just WINEDEBUG is set
+    if (gameSettings.otherOptions.includes('PROTON_LOG=')) {
+      // Stop Proton from overriding WINEDEBUG; this prevents logs growing to a few GB for some games
+      ret.WINEDEBUG = 'timestamp'
+    }
   }
   return ret
 }

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -263,7 +263,7 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
     // If we don't set this, GE-Proton tries to guess the AppID from the prefix path, which doesn't work in our case
     ret.STEAM_COMPAT_APP_ID = '0'
     ret.SteamAppId = ret.STEAM_COMPAT_APP_ID
-    // This sets the name of the log file given when settings PROTON_LOG=1
+    // This sets the name of the log file given when setting PROTON_LOG=1
     ret.SteamGameId = `heroic-${gameId}`
     ret.PROTON_LOG_DIR = flatPakHome
   }

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -209,6 +209,17 @@ function setupEnvVars(gameSettings: GameSettings) {
   if (gameSettings.audioFix) {
     ret.PULSE_LATENCY_MSEC = '60'
   }
+  if (gameSettings.otherOptions) {
+    gameSettings.otherOptions
+      .split(' ')
+      .filter((val) => val.indexOf('=') !== -1)
+      .forEach((envKeyAndVar) => {
+        const keyAndValueSplit = envKeyAndVar.split('=')
+        const key = keyAndValueSplit.shift()
+        const value = keyAndValueSplit.join('=')
+        ret[key] = value
+      })
+  }
 
   return ret
 }
@@ -250,17 +261,6 @@ function setupWineEnvVars(gameSettings: GameSettings) {
     // If we don't set this, GE-Proton tries to guess the AppID from the prefix path, which doesn't work in our case
     ret.STEAM_COMPAT_APP_ID = '0'
     ret.SteamAppId = ret.STEAM_COMPAT_APP_ID
-  }
-  if (gameSettings.otherOptions) {
-    gameSettings.otherOptions
-      .split(' ')
-      .filter((val) => val.indexOf('=') !== -1)
-      .forEach((envKeyAndVar) => {
-        const keyAndValueSplit = envKeyAndVar.split('=')
-        const key = keyAndValueSplit.shift()
-        const value = keyAndValueSplit.join('=')
-        ret[key] = value
-      })
   }
   return ret
 }

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -189,7 +189,8 @@ async function prepareWineLaunch(game: LegendaryGame | GOGGame): Promise<{
     }
   }
 
-  const envVars = setupWineEnvVars(gameSettings)
+  const installFolderName = (await game.getGameInfo()).folder_name
+  const envVars = setupWineEnvVars(gameSettings, installFolderName)
 
   return { success: true, envVars: envVars }
 }
@@ -227,9 +228,10 @@ function setupEnvVars(gameSettings: GameSettings) {
 /**
  * Maps Wine-related settings to environment variables
  * @param gameSettings The GameSettings to get the environment variables for
+ * @param gameId If Proton and the Steam Runtime are used, the SteamGameId variable will be set to `heroic-gameId`
  * @returns A Record that can be passed to execAsync/spawn
  */
-function setupWineEnvVars(gameSettings: GameSettings) {
+function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
   const { wineVersion } = gameSettings
 
   // Add WINEPREFIX / STEAM_COMPAT_DATA_PATH / CX_BOTTLE
@@ -261,7 +263,9 @@ function setupWineEnvVars(gameSettings: GameSettings) {
     // If we don't set this, GE-Proton tries to guess the AppID from the prefix path, which doesn't work in our case
     ret.STEAM_COMPAT_APP_ID = '0'
     ret.SteamAppId = ret.STEAM_COMPAT_APP_ID
-    ret.SteamGameId = ret.STEAM_COMPAT_APP_ID
+    // This sets the name of the log file given when settings PROTON_LOG=1
+    ret.SteamGameId = `heroic-${gameId}`
+    // ret.PROTON_LOG_DIR = flatPakHome
   }
   return ret
 }

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -246,6 +246,11 @@ function setupWineEnvVars(gameSettings: GameSettings) {
   if (gameSettings.enableResizableBar) {
     ret.VKD3D_CONFIG = 'upload_hvv'
   }
+  if (gameSettings.useSteamRuntime) {
+    // If we don't set this, GE-Proton tries to guess the AppID from the prefix path, which doesn't work in our case
+    ret.STEAM_COMPAT_APP_ID = '0'
+    ret.SteamAppId = ret.STEAM_COMPAT_APP_ID
+  }
   if (gameSettings.otherOptions) {
     gameSettings.otherOptions
       .split(' ')

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -261,6 +261,7 @@ function setupWineEnvVars(gameSettings: GameSettings) {
     // If we don't set this, GE-Proton tries to guess the AppID from the prefix path, which doesn't work in our case
     ret.STEAM_COMPAT_APP_ID = '0'
     ret.SteamAppId = ret.STEAM_COMPAT_APP_ID
+    ret.SteamGameId = ret.STEAM_COMPAT_APP_ID
   }
   return ret
 }

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -266,6 +266,8 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
     // This sets the name of the log file given when setting PROTON_LOG=1
     ret.SteamGameId = `heroic-${gameId}`
     ret.PROTON_LOG_DIR = flatPakHome
+    // Stop Proton from overriding WINEDEBUG; this prevents logs growing to a few GB for some games
+    ret.WINEDEBUG = 'timestamp'
   }
   return ret
 }

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -265,7 +265,7 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
     ret.SteamAppId = ret.STEAM_COMPAT_APP_ID
     // This sets the name of the log file given when settings PROTON_LOG=1
     ret.SteamGameId = `heroic-${gameId}`
-    // ret.PROTON_LOG_DIR = flatPakHome
+    ret.PROTON_LOG_DIR = flatPakHome
   }
   return ret
 }

--- a/flatpak/local.heroic.yml
+++ b/flatpak/local.heroic.yml
@@ -124,8 +124,8 @@ modules:
   - name: heroic
     buildsystem: simple
     build-commands:
-      - unappimage Heroic-2.3.1.AppImage
-      - rm Heroic-2.3.1.AppImage
+      - unappimage Heroic-2.3.3.AppImage
+      - rm Heroic-2.3.3.AppImage
       - mv squashfs-root /app/bin/heroic
       - install -D heroic-run -t /app/bin
     sources:
@@ -135,9 +135,9 @@ modules:
           - zypak-wrapper /app/bin/heroic/heroic "$@"
 
       - type: file
-        filename: Heroic-2.3.1.AppImage
+        filename: Heroic-2.3.3.AppImage
         # put right path here
-        path: ../dist/Heroic-2.3.1.AppImage
+        path: ../dist/Heroic-2.3.3.AppImage
 
   - name: platform-bootstrap
     buildsystem: simple


### PR DESCRIPTION
- When the Steam Runtime is used for Proton, `STEAM_COMPAT_APP_ID` and `SteamAppId` are set to 0. This avoids a ProtonFix crash for GE-Proton
- User-defined environment variables are now set in `setupEnvVars` (they were in `setupWineEnvVars` before). Not sure why I did it that way back then. Because of that, setting these variables on native games works again now.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
