### PR TITLE
Allow for separate library refreshes

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -597,9 +597,13 @@ ipcMain.handle(
 
 /// IPC handlers begin here.
 
-ipcMain.handle('checkGameUpdates', async () => {
-  const legendaryUpdates = await LegendaryLibrary.get().listUpdateableGames()
-  const gogUpdates = await GOGLibrary.get().listUpdateableGames()
+ipcMain.handle('checkGameUpdates', async (event, libraries) => {
+  const legendaryUpdates = libraries.includes('epic')
+    ? await LegendaryLibrary.get().listUpdateableGames()
+    : []
+  const gogUpdates = libraries.includes('gog')
+    ? await GOGLibrary.get().listUpdateableGames()
+    : []
   return [...legendaryUpdates, ...gogUpdates]
 })
 
@@ -754,10 +758,11 @@ if (existsSync(installed)) {
   })
 }
 
-ipcMain.handle('refreshLibrary', async (e, fullRefresh) => {
+ipcMain.handle('refreshLibrary', async (e, fullRefresh, libraries) => {
   await Promise.allSettled([
-    GOGLibrary.get().sync(),
-    LegendaryLibrary.get().getGames('info', fullRefresh)
+    libraries.includes('epic') &&
+      LegendaryLibrary.get().getGames('info', fullRefresh),
+    libraries.includes('gog') && GOGLibrary.get().sync()
   ])
 })
 

--- a/src/components/UI/ActionIcons/index.tsx
+++ b/src/components/UI/ActionIcons/index.tsx
@@ -21,13 +21,15 @@ interface Props {
   sortInstalled: boolean
   toggleSortDescending: () => void
   toggleSortinstalled: () => void
+  category: string
 }
 
 export default function ActionIcons({
   sortDescending,
   toggleSortDescending,
   sortInstalled,
-  toggleSortinstalled
+  toggleSortinstalled,
+  category
 }: Props) {
   const { t } = useTranslation()
   const { refreshLibrary, handleLayout, layout } = useContext(ContextProvider)
@@ -85,7 +87,8 @@ export default function ActionIcons({
             refreshLibrary({
               checkForUpdates: true,
               fullRefresh: true,
-              runInBackground: false
+              runInBackground: false,
+              libraries: [category]
             })
           }
         >

--- a/src/screens/Game/GameSubMenu/index.tsx
+++ b/src/screens/Game/GameSubMenu/index.tsx
@@ -79,7 +79,7 @@ export default function GamesSubmenu({
       })
       if (path) {
         await renderer.invoke('changeInstallPath', [appName, path, runner])
-        await refresh()
+        await refresh([runner])
       }
       return
     }

--- a/src/screens/Library/index.tsx
+++ b/src/screens/Library/index.tsx
@@ -105,6 +105,7 @@ export default function Library(): JSX.Element {
           sortDescending={sortDescending}
           toggleSortDescending={() => handleSortDescending()}
           sortInstalled={sortInstalled}
+          category={category}
           toggleSortinstalled={() => handleSortInstalled()}
         />
       </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export interface ContextType {
   libraryTopSection: string
   handleLibraryTopSection: (value: LibraryTopSectionOptions) => void
   platform: NodeJS.Platform | string
-  refresh: (checkUpdates?: boolean) => Promise<void>
+  refresh: (libraries: string[], checkUpdates?: boolean) => Promise<void>
   refreshLibrary: (options: RefreshOptions) => Promise<void>
   refreshWineVersionInfo: (fetch: boolean) => void
   refreshing: boolean
@@ -267,6 +267,7 @@ export interface Path {
 export type RefreshOptions = {
   checkForUpdates?: boolean
   fullRefresh?: boolean
+  libraries?: string[]
   runInBackground?: boolean
 }
 


### PR DESCRIPTION
This patch, addressing https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1320, adds an additional string[] parameter to GlobalState.refresh and checkGameUpdates, allowing you to update just one library at a time. 

Launching still refreshes both libraries, but logging in or clicking the refresh button in a library only refreshes the corresponding library.

The way I did it, there's some repeated code. There's probably a better way of doing it, especially as more libraries are added, but for now this was the best I could do. Let me know if you have a better idea and I'll happily rewrite it.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
