### PR TITLE
Allow specifying wrappers in the env var section again

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -247,12 +247,15 @@ function setupWineEnvVars(gameSettings: GameSettings) {
     ret.VKD3D_CONFIG = 'upload_hvv'
   }
   if (gameSettings.otherOptions) {
-    gameSettings.otherOptions.split(' ').forEach((envKeyAndVar) => {
-      const keyAndValueSplit = envKeyAndVar.split('=')
-      const key = keyAndValueSplit.shift()
-      const value = keyAndValueSplit.join('=')
-      ret[key] = value
-    })
+    gameSettings.otherOptions
+      .split(' ')
+      .filter((val) => val.indexOf('=') !== -1)
+      .forEach((envKeyAndVar) => {
+        const keyAndValueSplit = envKeyAndVar.split('=')
+        const key = keyAndValueSplit.shift()
+        const value = keyAndValueSplit.join('=')
+        ret[key] = value
+      })
   }
   return ret
 }
@@ -264,6 +267,15 @@ function setupWrappers(
   steamRuntime: string
 ): Array<string> {
   const wrappers = Array<string>()
+  // Wrappers could be specified in the environment variable section as well
+  if (gameSettings.otherOptions) {
+    gameSettings.otherOptions
+      .split(' ')
+      .filter((val) => val.indexOf('=') === -1)
+      .forEach((val) => {
+        wrappers.push(val)
+      })
+  }
   if (gameSettings.showMangohud) {
     // Mangohud needs some arguments in addition to the command, so we have to split here
     wrappers.push(...mangoHudBin.split(' '))


### PR DESCRIPTION
With this patch, you can now enter wrappers into the environment variable section of the game settings again & they will be properly executed instead of being added as empty variables

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
