### PR TITLE
Change Steam Runtime search path

### DIFF
--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -451,12 +451,12 @@ async function searchForExecutableOnPath(executable: string): Promise<string> {
 function getSteamRuntime(version: 'scout' | 'soldier'): SteamRuntime {
   const possibleRuntimes: Array<SteamRuntime> = [
     {
-      path: `${userHome}/.local/share/Steam/steamapps/common/SteamLinuxRuntime_soldier/_v2-entry-point`,
+      path: `${userHome}/.steam/root/steamapps/common/SteamLinuxRuntime_soldier/_v2-entry-point`,
       type: 'unpackaged',
       version: 'soldier'
     },
     {
-      path: `${userHome}/.local/share/Steam/ubuntu12_32/steam-runtime/run.sh`,
+      path: `${userHome}/.steam/root/ubuntu12_32/steam-runtime/run.sh`,
       type: 'unpackaged',
       version: 'scout'
     },


### PR DESCRIPTION
This changes the Steam Runtime path from `~/.local/share/Steam/...` to `~/.steam/root/...`. This makes the Steam Runtime work on Ubuntu-based distributions

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
