### PR TITLE
Add new `--no-gui` parameter

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -280,17 +280,7 @@ if (!gotTheLock) {
       mainWindow.show()
     }
 
-    // Figure out which argv element is our protocol
-    let heroicProtocolString = ''
-    argv.forEach((value) => {
-      if (value.startsWith('heroic://')) {
-        heroicProtocolString = value
-      }
-    })
-
-    if (heroicProtocolString) {
-      handleProtocol(mainWindow, heroicProtocolString)
-    }
+    handleProtocol(mainWindow, argv)
   })
   app.whenReady().then(async () => {
     const systemInfo = await getSystemInfo()
@@ -364,7 +354,7 @@ if (!gotTheLock) {
     await createWindow()
 
     protocol.registerStringProtocol('heroic', (request, callback) => {
-      handleProtocol(mainWindow, request.url)
+      handleProtocol(mainWindow, [request.url])
       callback('Operation initiated.')
     })
     if (!app.isDefaultProtocolClient('heroic')) {
@@ -376,10 +366,8 @@ if (!gotTheLock) {
     } else {
       logWarning('Protocol already registered.', LogPrefix.Backend)
     }
-    if (process.argv[1]) {
-      const url = process.argv[1]
-      handleProtocol(mainWindow, url)
-    }
+
+    handleProtocol(mainWindow, process.argv)
 
     // set initial zoom level after a moment, if set in sync the value stays as 1
     setTimeout(() => {
@@ -512,7 +500,7 @@ app.on('window-all-closed', () => {
 
 app.on('open-url', (event, url) => {
   event.preventDefault()
-  handleProtocol(mainWindow, url)
+  handleProtocol(mainWindow, [url])
 })
 
 ipcMain.on('openFolder', async (event, folder) => openUrlOrFile(folder))

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -367,7 +367,7 @@ if (!gotTheLock) {
     }
 
     const { startInTray } = await GlobalConfig.get().getSettings()
-    const headless = process.argv.includes('--no-ui') || startInTray
+    const headless = process.argv.includes('--no-gui') || startInTray
     if (!headless) {
       mainWindow.show()
     }
@@ -890,7 +890,7 @@ Game Settings: ${JSON.stringify(gameSettings, null, '\t')}
         })
 
         // Exit if we've been launched without UI
-        if (process.argv.includes('--no-ui')) {
+        if (process.argv.includes('--no-gui')) {
           app.exit()
         }
       })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -100,7 +100,6 @@ const isWindows = platform() === 'win32'
 let mainWindow: BrowserWindow = null
 
 async function createWindow(): Promise<BrowserWindow> {
-  const { exitToTray, startInTray } = await GlobalConfig.get().getSettings()
   configStore.set('userHome', userHome)
 
   let windowProps: Electron.Rectangle = {
@@ -139,7 +138,7 @@ async function createWindow(): Promise<BrowserWindow> {
     ...windowProps,
     minHeight: 345,
     minWidth: 600,
-    show: !(exitToTray && startInTray),
+    show: false,
     webPreferences: {
       webviewTag: true,
       contextIsolation: false,
@@ -365,6 +364,12 @@ if (!gotTheLock) {
       }
     } else {
       logWarning('Protocol already registered.', LogPrefix.Backend)
+    }
+
+    const { startInTray } = await GlobalConfig.get().getSettings()
+    const headless = process.argv.includes('--no-ui') || startInTray
+    if (!headless) {
+      mainWindow.show()
     }
 
     handleProtocol(mainWindow, process.argv)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -888,6 +888,11 @@ Game Settings: ${JSON.stringify(gameSettings, null, '\t')}
           runner,
           status: 'done'
         })
+
+        // Exit if we've been launched without UI
+        if (process.argv.includes('--no-ui')) {
+          app.exit()
+        }
       })
   }
 )

--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -3,8 +3,17 @@ import { Game, Runner } from './games'
 import { logInfo, LogPrefix } from './logger/logger'
 import i18next from 'i18next'
 
-export async function handleProtocol(window: BrowserWindow, url: string) {
+export async function handleProtocol(window: BrowserWindow, args: string[]) {
   const mainWindow = BrowserWindow.getAllWindows()[0]
+
+  // Figure out which argv element is our protocol
+  let url = ''
+  args.forEach((val) => {
+    if (val.startsWith('heroic://')) {
+      url = val
+    }
+  })
+
   const [scheme, path] = url.split('://')
   if (!url || scheme !== 'heroic' || !path) {
     return


### PR DESCRIPTION
Launching Heroic without the UI is now possible with this parameter. Together with launching a game (`heroic://launch/AppName`), this now allows for a fully headless game launch, similar to HBL (HBL's still faster, since we have to load all of Heroic first)

Closes #1361

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
