### PR TITLE
[macOS & Linux] Wrap game install path in single quotes

### DIFF
--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -392,6 +392,14 @@ class LegendaryGame extends Game {
       ...workers,
       '-y'
     ]
+
+    //Wrap the path in singles quotes for macOS and Linux to avoid errors due to spaces
+    if(platformToInstall == "Linux" || platformToInstall == "Mac"){
+
+      path = "'" + path + "' "
+
+    }
+
     const command = getLegendaryCommand(commandParts)
     logInfo([`Installing ${this.appName} with:`, command], LogPrefix.Legendary)
 

--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -394,7 +394,7 @@ class LegendaryGame extends Game {
     ]
 
     //Wrap the path in singles quotes for macOS and Linux to avoid errors due to spaces
-    if(platformToInstall == "Linux" || platformToInstall == "Mac"){
+    if(platformToInstall === 'Linux' || platformToInstall === 'Mac'){
 
       path = "'" + path + "' "
 


### PR DESCRIPTION
This PR references #1375. The install path may have spaces in between and this leads to errors (the space splits the actual path into separate paths). Thus, it's better to wrap the path in single quotes. This only applies to Linux and macOS.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
