### PR TITLE
[FIX] Use ELECTRON_IS_DEV for dev environments with devtools

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -179,7 +179,8 @@ async function createWindow(): Promise<BrowserWindow> {
     handleExit(mainWindow)
   })
 
-  if (!app.isPackaged) {
+  const isDevEnvSet = (process.env?.ELECTRON_IS_DEV ?? '0') === '1'
+  if (isDevEnvSet && !app.isPackaged) {
     /* eslint-disable @typescript-eslint/ban-ts-comment */
     //@ts-ignore
     import('electron-devtools-installer').then((devtools) => {


### PR DESCRIPTION
When using HGL as an unpackaged Electron application (much like `code` from Arch or `zulip-desktop-electron` from AUR) the dev environment is loaded by default and it fails to import `electron-devtools-installer` if a production build was used.
So instead of adding `electron-is-dev` again let's just add `ELECTRON_IS_DEV` with a default value of `0`. Otherwise, if the value is `1` then the dev environment is loaded as desired.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
