### PR TITLE
[Linux - Fix] Winetricks on Flatpak

### DIFF
--- a/electron/tools.ts
+++ b/electron/tools.ts
@@ -210,7 +210,11 @@ export const Winetricks = {
 
     const { winePrefix, wineBin } = getWineFromProton(wine, isProton, prefix)
 
-    const command = `WINEPREFIX='${winePrefix}' WINE='${wineBin}' ${winetricks} -q`
+    // use wine instead of wine64 since it breaks on flatpak
+    const command = `WINEPREFIX='${winePrefix}' WINE='${wineBin.replace(
+      '64',
+      ''
+    )}' ${winetricks} -q`
 
     logInfo(['trying to run', command], LogPrefix.Backend)
     try {

--- a/electron/tools.ts
+++ b/electron/tools.ts
@@ -210,11 +210,10 @@ export const Winetricks = {
 
     const { winePrefix, wineBin } = getWineFromProton(wine, isProton, prefix)
 
+    const winepath = dirname(wineBin)
+
     // use wine instead of wine64 since it breaks on flatpak
-    const command = `WINEPREFIX='${winePrefix}' WINE='${wineBin.replace(
-      '64',
-      ''
-    )}' ${winetricks} -q`
+    const command = `WINEPREFIX='${winePrefix}' PATH=$PATH:'${winepath}' ${winetricks} -q`
 
     logInfo(['trying to run', command], LogPrefix.Backend)
     try {

--- a/electron/tools.ts
+++ b/electron/tools.ts
@@ -213,7 +213,7 @@ export const Winetricks = {
     const winepath = dirname(wineBin)
 
     // use wine instead of wine64 since it breaks on flatpak
-    const command = `WINEPREFIX='${winePrefix}' PATH=$PATH:'${winepath}' ${winetricks} -q`
+    const command = `WINEPREFIX='${winePrefix}' PATH='${winepath}':$PATH ${winetricks} -q`
 
     logInfo(['trying to run', command], LogPrefix.Backend)
     try {


### PR DESCRIPTION
Changed the `WINE` env var to use `PATH` as suggested by @CommandMC.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
