### PR TITLE
Always update Winetricks if we are online

### DIFF
--- a/electron/tools.ts
+++ b/electron/tools.ts
@@ -192,7 +192,7 @@ export const Winetricks = {
     const path = `${heroicToolsPath}/winetricks`
     const downloadCommand = `curl -L ${url} -o ${path} --create-dirs`
 
-    if (existsSync(path)) {
+    if (!isOnline()) {
       return
     }
 


### PR DESCRIPTION
Before, we were not downloading Winetricks if the file already existed. This resulted in very outdated Winetricks versions (for example, I was unknowingly running a version from Feb. 2021)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
