### PR TITLE
Fixup verifyWinePrefix for Proton... again

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -323,6 +323,10 @@ export async function verifyWinePrefix(
     mkdirSync(winePrefix, { recursive: true })
   }
 
+  if (wineVersion.type === 'proton' && existsSync(join(winePrefix, 'pfx'))) {
+    return { res: { stdout: '', stderr: '' }, updated: false }
+  }
+
   // If the registry isn't available yet, things like DXVK installers might fail. So we have to wait on wineboot then
   const systemRegPath =
     wineVersion.type === 'proton'
@@ -333,6 +337,9 @@ export async function verifyWinePrefix(
   return game
     .runWineCommand('wineboot --init', '', haveToWait)
     .then((result) => {
+      if (wineVersion.type === 'proton') {
+        return { res: result, updated: true }
+      }
       // This is kinda hacky
       const wasUpdated = result.stderr.includes('has been updated')
       return { res: result, updated: wasUpdated }


### PR DESCRIPTION
Proton copies over a ready-made default prefix when it detects that it needs to update, so running `wineboot` afterwards will always say that it wasn't updated. This changes `verifyWinePrefix` so it (1) returns early if a Proton prefix is already present & (2) returns true if Proton created a prefix

This is still somewhat naive since it relies on the `pfx` directory (not) being present, but it's still better than not working at all

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
