### PR TITLE
[UX] Use better paths on open dialog

### DIFF
--- a/src/helpers/library.ts
+++ b/src/helpers/library.ts
@@ -71,10 +71,15 @@ async function install({
   }
 
   if (installPath === 'import' && is_game) {
+    const { defaultInstallPath }: AppSettings = await ipcRenderer.invoke(
+      'requestSettings',
+      'default'
+    )
     const args = {
       buttonLabel: t('gamepage:box.choose'),
       properties: ['openDirectory'],
-      title: t('gamepage:box.importpath')
+      title: t('gamepage:box.importpath'),
+      defaultPath: defaultInstallPath
     }
     const { path, canceled } = await ipcRenderer.invoke('openDialog', args)
 

--- a/src/screens/Game/GameSubMenu/index.tsx
+++ b/src/screens/Game/GameSubMenu/index.tsx
@@ -52,10 +52,15 @@ export default function GamesSubmenu({
       title: t('box.move.title')
     })
     if (response === 0) {
+      const { defaultInstallPath }: AppSettings = await ipcRenderer.invoke(
+        'requestSettings',
+        'default'
+      )
       const { path } = await ipcRenderer.invoke('openDialog', {
         buttonLabel: t('box.choose'),
         properties: ['openDirectory'],
-        title: t('box.move.path')
+        title: t('box.move.path'),
+        defaultPath: defaultInstallPath
       })
       if (path) {
         await handleGameStatus({ appName, runner, status: 'moving' })
@@ -72,10 +77,15 @@ export default function GamesSubmenu({
       title: t('box.change.title')
     })
     if (response === 0) {
+      const { defaultInstallPath }: AppSettings = await ipcRenderer.invoke(
+        'requestSettings',
+        'default'
+      )
       const { path } = await ipcRenderer.invoke('openDialog', {
         buttonLabel: t('box.choose'),
         properties: ['openDirectory'],
-        title: t('box.change.path')
+        title: t('box.change.path'),
+        defaultPath: defaultInstallPath
       })
       if (path) {
         await renderer.invoke('changeInstallPath', [appName, path, runner])

--- a/src/screens/Library/components/InstallModal/index.tsx
+++ b/src/screens/Library/components/InstallModal/index.tsx
@@ -503,7 +503,8 @@ export default function InstallModal({
                     .invoke('openDialog', {
                       buttonLabel: t('box.choose'),
                       properties: ['openDirectory'],
-                      title: t('install.path')
+                      title: t('install.path'),
+                      defaultPath: defaultPath
                     })
                     .then(({ path }: Path) =>
                       setInstallPath(path ? path : defaultPath)

--- a/src/screens/Settings/components/GeneralSettings/index.tsx
+++ b/src/screens/Settings/components/GeneralSettings/index.tsx
@@ -156,7 +156,8 @@ export default function GeneralSettings({
             .invoke('openDialog', {
               buttonLabel: t('box.choose'),
               properties: ['openDirectory'],
-              title: t('box.default-install-path')
+              title: t('box.default-install-path'),
+              defaultPath: defaultInstallPath
             })
             .then(({ path }: Path) =>
               setDefaultInstallPath(path ? `${path}` : defaultInstallPath)

--- a/src/screens/Settings/components/OtherSettings/index.tsx
+++ b/src/screens/Settings/components/OtherSettings/index.tsx
@@ -51,6 +51,7 @@ interface Props {
   useSteamRuntime: boolean
   toggleUseSteamRuntime: () => void
   isProton: boolean
+  defaultInstallPath: string
 }
 
 export default function OtherSettings({
@@ -86,7 +87,8 @@ export default function OtherSettings({
   isLinuxNative,
   toggleUseSteamRuntime,
   useSteamRuntime,
-  isProton
+  isProton,
+  defaultInstallPath
 }: Props) {
   const handleOtherOptions = (event: ChangeEvent<HTMLInputElement>) =>
     setOtherOptions(event.currentTarget.value)
@@ -145,7 +147,8 @@ export default function OtherSettings({
                     .invoke('openDialog', {
                       buttonLabel: t('box.select.button', 'Select'),
                       properties: ['openFile'],
-                      title: t('box.select.exe', 'Select EXE')
+                      title: t('box.select.exe', 'Select EXE'),
+                      defaultPath: defaultInstallPath
                     })
                     .then(({ path }: Path) => setTargetExe(path || targetExe))
               : () => setTargetExe('')

--- a/src/screens/Settings/components/Tools/index.tsx
+++ b/src/screens/Settings/components/Tools/index.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react'
 import { IpcRenderer } from 'electron'
 import { WineInstallation } from 'src/types'
 import { useTranslation } from 'react-i18next'
+import { getGameInfo } from 'src/helpers'
 
 const { ipcRenderer } = window.require('electron') as {
   ipcRenderer: IpcRenderer
@@ -43,10 +44,12 @@ export default function Tools({ wineVersion, winePrefix, appName }: Props) {
 
   const handleRunExe = async () => {
     let exe = ''
+    const gameinfo = await getGameInfo(appName)
     const { path } = await ipcRenderer.invoke('openDialog', {
       buttonLabel: t('box.select.button', 'Select'),
       properties: ['openFile'],
-      title: t('box.runexe.title')
+      title: t('box.runexe.title'),
+      defaultPath: gameinfo.install.install_path
     })
     if (path) {
       exe = path

--- a/src/screens/Settings/components/WineSettings/index.tsx
+++ b/src/screens/Settings/components/WineSettings/index.tsx
@@ -158,7 +158,8 @@ export default function WineSettings({
               .invoke('openDialog', {
                 buttonLabel: t('box.choose'),
                 properties: ['openDirectory'],
-                title: t('box.wineprefix')
+                title: t('box.wineprefix'),
+                defaultPath: defaultWinePrefix
               })
               .then(({ path }: Path) =>
                 setDefaultWinePrefix(path ? `${path}` : defaultWinePrefix)

--- a/src/screens/Settings/components/WineSettings/index.tsx
+++ b/src/screens/Settings/components/WineSettings/index.tsx
@@ -188,7 +188,8 @@ export default function WineSettings({
               .invoke('openDialog', {
                 buttonLabel: t('box.choose'),
                 properties: ['openDirectory'],
-                title: t('box.wineprefix')
+                title: t('box.wineprefix'),
+                defaultPath: defaultWinePrefix
               })
               .then(({ path }: Path) =>
                 setWinePrefix(path ? `${path}` : winePrefix)

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -459,6 +459,7 @@ function Settings() {
               isMacNative={isMacNative}
               isLinuxNative={isLinuxNative}
               isProton={wineVersion.type === 'proton'}
+              defaultInstallPath={defaultInstallPath}
             />
           )}
           {isSyncSettings && (

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -417,7 +417,7 @@ function Settings() {
               toggleResizableBar={toggleResizableBar}
             />
           )}
-          {isWineSettings && (
+          {isWineSettings && !isDefault && (
             <Tools
               winePrefix={winePrefix}
               wineVersion={wineVersion}
@@ -459,7 +459,7 @@ function Settings() {
               isMacNative={isMacNative}
               isLinuxNative={isLinuxNative}
               isProton={wineVersion.type === 'proton'}
-              defaultInstallPath={defaultInstallPath}
+              appName={appName}
             />
           )}
           {isSyncSettings && (


### PR DESCRIPTION
This is a small quality of life improvement. 
When opening dialogs, the starting folder will be more specific to the setting instead of being generic and opening the recent files.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
