### PR TITLE
[macOS] Check for CX bottle existence before launching a game

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -1,11 +1,15 @@
-import { appendFileSync, writeFileSync } from 'graceful-fs'
 // This handles launching games, prefix creation etc..
 
 import i18next from 'i18next'
-import { existsSync, mkdirSync } from 'graceful-fs'
+import {
+  existsSync,
+  mkdirSync,
+  appendFileSync,
+  writeFileSync
+} from 'graceful-fs'
 import { join } from 'path'
 
-import { flatPakHome, isLinux } from './constants'
+import { flatPakHome, isLinux, isMac, userHome } from './constants'
 import {
   constructAndUpdateRPC,
   execAsync,
@@ -158,6 +162,32 @@ async function prepareWineLaunch(game: LegendaryGame | GOGGame): Promise<{
       'You are using Proton, this can lead to some bugs. Please do not open issues with bugs related to games',
       LogPrefix.Backend
     )
+  }
+
+  // Verify that the CrossOver bottle exists
+  if (isMac && gameSettings.wineVersion.type === 'crossover') {
+    const bottleExists = existsSync(
+      join(
+        userHome,
+        'Library/Application Support/CrossOver/Bottles',
+        gameSettings.wineCrossoverBottle,
+        'cxbottle.conf'
+      )
+    )
+    if (!bottleExists) {
+      showErrorBoxModalAuto(
+        i18next.t(
+          'box.error.cx-bottle-not-found.title',
+          'CrossOver bottle not found'
+        ),
+        i18next.t(
+          'box.error.cx-bottle-not-found.message',
+          `The CrossOver bottle "{{bottle_name}}" does not exist, can't launch!`,
+          { bottle_name: gameSettings.wineCrossoverBottle }
+        )
+      )
+      return { success: false }
+    }
   }
 
   const { updated: winePrefixUpdated } = await verifyWinePrefix(game)

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Данните Ви за удостоверяване са изтекли. Излезте и влезте отново."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Няма достатъчно свободно място на диска",
                 "title": "Недостатъчно място"

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Les teves credencials han caducat, tanca la sessió i inicia-la de nou."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "No hi ha prou espai al disc",
                 "title": "No hi ha espai"

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Vaše přihlašovací údaje vypršeli, odhlaste se a přihlašte se znovu prosím."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Nedostatek místa na disku",
                 "title": "Nedostatek místa"

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Deine Anmeldedaten sind abgelaufen, bitte logge dich aus und melde dich erneut an."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Nicht genügend freier Speicherplatz",
                 "title": "Kein Speicherplatz"

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Τα διαπιστευτήριά σας έληξαν, παρακαλώ αποσυνδεθείτε και επανασυνδεθείτε εκ νέου."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Δεν υπάρχει αρκετός διαθέσιμος χώρος στο δίσκο",
                 "title": "Ανεπαρκής χώρος"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Your credentials have expired, please log out and log in again."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Not enough available disk space",
                 "title": "No Space"

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Tus credenciales han expirado, por favor, inicia sesión nuevamente."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "No hay suficiente espacio disponible en disco",
                 "title": "Sin espacio"

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Teie kasutaja andmed on aegunud, palun logige välja ja logige uuesti sisse."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Ei ole piisavalt vaba kettaruumi",
                 "title": "Ei ole ruumi"

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "اعتبار ورود شما منقضی شده است، لطفا دوباره خارج شده و داخل شوید."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "فضای ذخیره سازی کافی موجود نیست",
                 "title": "فضایی موجود نیست"

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Kirjautumistietosi ovat vanhentuneet, ole hyvä ja kirjaudu uudelleen sisään."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Ei tarpeeksi tilaa levyllä",
                 "title": "Ei ole tilaa levyllä"

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Vos informations d'identification ont expiré, veuillez vous reconnecter."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Espace disque nécessaire insuffisant",
                 "title": "Pas de place"

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "As túas credenciais expiraron, pecha sesión e iníciaa de novo."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Non hai suficiente espacio dispoñíbel no disco",
                 "title": "Sen espacio"

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Vaša prijava je istekla, ponovno se prijavite."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Nema dovoljno slobodnog prostora na disku",
                 "title": "Nema Prostora"
@@ -369,9 +373,9 @@
     "userselector": {
         "discord": "Discord",
         "logout": "Logout",
+        "logout_confirmation": "Jeste li sigurni da se želite odjaviti?",
         "manageaccounts": "Manage Accounts",
-        "quit": "Quit",
-        "logout_confirmation": "Jeste li sigurni da se želite odjaviti?"
+        "quit": "Quit"
     },
     "webview": {
         "controls": {

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Lejártak a hitelesítő adataid, jelentkezz ki, majd jelentkezz be újra."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Nincs elég elérhető lemezterület",
                 "title": "Nincs hely"

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Kredensial Anda telah kedaluwarsa, silakan keluar dan masuk lagi."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Ruang penyimpanan tidak cukup",
                 "title": "Tidak Ada Ruang"

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Le tue credenziali non sono più valide, per favore rifai il login."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Spazio su disco insufficiente",
                 "title": "Spazio insufficiente"

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "クレデンシャルの有効期限が切れています。ログアウトしてから再度ログインしてください。"
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "使用可能なディスク容量が不足しています",
                 "title": "ディスク容量がありません"

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "사용자의 인증서가 만료되었습니다, 로그아웃 한 뒤 다시 로그인 해주세요."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "사용 가능한 디스크 공간이 충분하지 않습니다",
                 "title": "공간 없음"

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "നിങ്ങളെക്കുറിച്ചുള്ള വിവരങ്ങള് പഴകിയിരിക്കുന്നു, പുറത്തുകടന്ന് വീണ്ടും കയറിനോക്കൂ."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "തകിടില്(disk) ആവശ്യത്തിന് സ്ഥലമില്ലല്ലോ",
                 "title": "സ്ഥലമില്ല"

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Uw inloggegevens zijn verlopen, gelieven uit te loggen en weer inloggen."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Niet genoeg ruimte beschikbaar op de harde schijf",
                 "title": "Niet genoeg opslag"

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Twoje dane uwierzytelniające wygasły, wyloguj się i zaloguj ponownie."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Za mało miejsca na dysku",
                 "title": "Brak miejsca"

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Suas credenciais expiraram, por favor faça logout e login novamente."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Sem espaço disponível no disco",
                 "title": "Sem Espaço"

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Suas credenciais expiraram, por favor desconecte sua conta e entre novamente."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Sem espaço suficiente disponível no disco",
                 "title": "Sem Espaço"

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Срок действия ваших учетных данных истек. Пожалуйста, выйдите из системы и войдите снова."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Недостаточно свободного места на диске",
                 "title": "Нет места"

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Autentisering har utgått, logga ut och logga sedan in igen."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Otillräckligt ledigt hårdiskutrymme",
                 "title": "Otillräckligt utrymme"

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "உங்கள் சான்றிதழ்கள் காலாவதியாகிவிட்டன, தயவுசெய்து வெளியேறி மீண்டும் உள்நுழைக."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "போதுமான இடம் இல்லை",
                 "title": "இடம் இல்லை"

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Kimlik bilgilerinizin süresi doldu, lütfen oturumunuzu kapatın ve tekrar oturum açın."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Yeterli kullanılabilir disk alanı yok",
                 "title": "Alan Yok"

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Термін дії ваших облікових даних скінчився, будь ласка вийдіть і увійдіть знову."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Недостатньо місця на диску",
                 "title": "Немає місця"

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "Thông tin đăng nhập hết hạn, vui lòng đăng xuất rồi đăng nhập lại."
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "Không đủ bộ nhớ trống",
                 "title": "Không đủ bộ nhớ"

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "你的凭据已过期，请注销并重新登录。"
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "没有足够的可用磁盘空间",
                 "title": "没有空间"

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -24,6 +24,10 @@
             "credentials": {
                 "message": "您的憑據已過期，請登出並重新登入。"
             },
+            "cx-bottle-not-found": {
+                "message": "The CrossOver bottle \"{{bottle_name}}\" does not exist, can't launch!",
+                "title": "CrossOver bottle not found"
+            },
             "diskspace": {
                 "message": "磁碟空間不足",
                 "title": "空間不足"


### PR DESCRIPTION
We had a lot of people that didn't realize that they actually had to create the CX bottle themselves. With this, a message is now displayed when the bottle doesn't exist, and the game launch is aborted

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
