### PR TITLE
Disable controller on boot

### DIFF
--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -1,5 +1,5 @@
 import { IpcRenderer } from 'electron'
-import { GamepadActionStatus } from 'src/types'
+import { AppSettings, GamepadActionStatus } from 'src/types'
 import {
   checkGameCube,
   checkPS3,
@@ -25,6 +25,12 @@ const SCROLL_REPEAT_DELAY = 50
 let controllerIsDisabled = false
 
 export const initGamepad = () => {
+  ipcRenderer
+    .invoke('requestSettings', 'default')
+    .then(({ disableController }: AppSettings) => {
+      controllerIsDisabled = disableController || false
+    })
+
   // store the current controllers
   let controllers: number[] = []
 
@@ -272,9 +278,9 @@ export const initGamepad = () => {
         console.log(`button ${button} pressed ${buttons[button].value}`)
     }
     for (const axis in axes) {
-      if (axes[axis] < -0.1 && axes[axis] >= -1)
+      if (axes[axis] < -0.2 && axes[axis] >= -1)
         console.log(`axis ${axis} activated negative`)
-      if (axes[axis] > 0.1 && axes[axis] <= 1)
+      if (axes[axis] > 0.2 && axes[axis] <= 1)
         console.log(`axis ${axis} activated positive`)
     }
   }


### PR DESCRIPTION
This PR fixes #1437 . The configuration value was not being read at boot.

I also tweaked the treshold used to detect sticks being moved, it was too sensitive and a small drift or move by mistake was triggering the actions.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
