### PR TITLE
Change Game Language

### DIFF
--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -16,7 +16,8 @@ import {
   isLinux,
   isMac,
   isWindows,
-  installed
+  installed,
+  configStore
 } from '../constants'
 import { logError, logInfo, LogPrefix, logWarning } from '../logger/logger'
 import { spawn } from 'child_process'
@@ -556,6 +557,11 @@ class LegendaryGame extends Game {
 
     const isNative = await this.isNative()
 
+    const languageCode =
+      gameSettings.language || (configStore.get('language', '') as string)
+
+    const languageFlag = languageCode ? ['--language', languageCode] : []
+
     let commandParts = new Array<string>()
     let commandEnv = process.env
     let wrappers = new Array<string>()
@@ -578,6 +584,7 @@ class LegendaryGame extends Game {
       commandParts = [
         'launch',
         gameInfo.app_name,
+        ...languageFlag,
         ...exeOverrideFlag,
         offlineFlag,
         launchArguments
@@ -642,6 +649,7 @@ class LegendaryGame extends Game {
       commandParts = [
         'launch',
         gameInfo.app_name,
+        ...languageFlag,
         ...exeOverrideFlag,
         offlineFlag,
         ...wineFlag,

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -145,6 +145,7 @@ export interface GameSettings {
   enableFsync: boolean
   enableResizableBar: boolean
   maxSharpness: number
+  language: string
   launcherArgs: string
   nvidiaPrime: boolean
   offlineMode: boolean

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Показване на скритите"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Синхронизирайте с EGS, в случай че вече имате работеща инсталация на Epic Games Launcher и искате да внесете игрите си от там, за да избегнете повторното им сваляне.",
         "other": {
             "part1": "Използвайте ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Използване на вградения изпълним файл на GOGDL…",
         "alt-legendary-bin": "Използване на вградения изпълним файл на Legendary…",
-        "egs-prefix": "Префикс, където е инсталиран EGS"
+        "egs-prefix": "Префикс, където е инсталиран EGS",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Линукс",
@@ -305,6 +311,7 @@
         "maxworkers": "Максимален брой работни процеси при сваляне",
         "minimize-on-launch": "Минимизиране на Heroic при пускане на игра",
         "offlinemode": "Пускане на играта в режим „извън линия“",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Използване на отделната видео-карта",
         "resizableBar": "Включване на „Resizable BAR“ (Само за NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Sincronitza amb l'EGL si ja tens instal·lat l'Epic Games Laucher en qualsevol altre lloc i vols importar els jocs sense haver de baixar-los de nou.",
         "other": {
             "part1": "Utilitza les ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "S'està utilitzant el binari integrat del Legendary...",
-        "egs-prefix": "Prefix on l'EGS està instal·lat"
+        "egs-prefix": "Prefix on l'EGS està instal·lat",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "",
@@ -305,6 +311,7 @@
         "maxworkers": "Nombre màxim de Workers en baixar",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Executa el joc sense connexió",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Activa l'Nvidia Prime Render",
         "resizableBar": "Activa el BAR redimensionable (només amb NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Zobrazit skryté"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Synchronizujte s EGL v případě, že máte funkční instalaci Epic Games Launcher jinde a chcete své hry importovat, abyste se vyhnuli jejich opětovnému stahování.",
         "other": {
             "part1": "Použijte ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Pomocí vestavěného GOGDL...",
         "alt-legendary-bin": "Pomocí vestavěného Legendary...",
-        "egs-prefix": "Prefix kde je nainstalován EGS"
+        "egs-prefix": "Prefix kde je nainstalován EGS",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Maximální počet vláken při stahování",
         "minimize-on-launch": "Minimalizujte Heroic po spuštění hry",
         "offlinemode": "Spustit hru offline",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Použít dedikovanou grafickou kartu",
         "resizableBar": "Používat Resizable BAR (pouze s NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Ausgeblendete anzeigen"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Synchronisiere mit EGL, falls du woanders eine funktionierende Installation des Epic Games Launcher hast und deine Spiele importieren möchtest, um ein erneutes Herunterladen zu vermeiden.",
         "other": {
             "part1": "Benutze die ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Nutze eingebaute GOGDL Binary...",
         "alt-legendary-bin": "Benutze eingebaute Legendary Binärdatei...",
-        "egs-prefix": "Prefix, in dem EGS installiert ist"
+        "egs-prefix": "Prefix, in dem EGS installiert ist",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Maximale Anzahl von Prozessen zum gleichzeitigem Herunterladen",
         "minimize-on-launch": "Heroic nach Spielstart minimieren",
         "offlinemode": "Spiel offline ausführen",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Dedizierte Grafikkarte verwenden",
         "resizableBar": "Resizable BAR aktivieren (nur NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Συγχρονίστε με EGL εάν έχετε μια λειτουργική εγκατάσταση Epic Games Launcher κάπου αλλού και θέλετε να εισαγάγετε τα παιχνίδια σας για αποφυγή λήψης ξανά.",
         "other": {
             "part1": "Χρησιμοποιήστε το ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Χρήση ενσωματωμένου δυαδικού αρχείου GOGDL...",
         "alt-legendary-bin": "Χρήση ενσωματωμένου δυαδικού αρχείου Legendary...",
-        "egs-prefix": "Πρόθημα διαδρομής εγκατάστασης EGS"
+        "egs-prefix": "Πρόθημα διαδρομής εγκατάστασης EGS",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Μέγιστος αριθμός εργατών κατά την λήψη",
         "minimize-on-launch": "Ελαχιστοποίηση Heroic Μετά Την 'Εναρξη",
         "offlinemode": "Εκτέλεση Παιχνιδιού Εκτός Δικτύου",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Ενεργοποίηση Nvidia Prime Render",
         "resizableBar": "Ενεργοποίηση Μεταβλητού BAR (NVIDIA RTX 30xx μόνο)",
         "runexe": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Sync with EGL if you have a working installation of the Epic Games Launcher elsewhere and want to import your games to avoid downloading them again.",
         "other": {
             "part1": "Use the ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "Using built-in Legendary binary...",
-        "egs-prefix": "Prefix where EGS is installed"
+        "egs-prefix": "Prefix where EGS is installed",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Maximum Number of Workers when downloading",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Run Game Offline",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Use Dedicated Graphics Card",
         "resizableBar": "Enable Resizable BAR (NVIDIA RTX 30xx only)",
         "runexe": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Mostrar Ocultos"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Sincronice con EGL si tiene una instalación funcional de Epic Games Launcher en otro lugar y desee importar sus juegos para evitar descargarlos nuevamente.",
         "other": {
             "part1": "Utilizar las ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Utilizando el binario incorporado de GOGDL...",
         "alt-legendary-bin": "Usando el binario incorporado de Legendary…",
-        "egs-prefix": "Prefix donde está instalado EGS"
+        "egs-prefix": "Prefix donde está instalado EGS",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Número máximo de procesos al descargar",
         "minimize-on-launch": "Minimizar Heroic al ejecutar un juego",
         "offlinemode": "Ejecutar juego sin conexión",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Utilizar tarjeta de video dedicada",
         "resizableBar": "Habilitar Resizable Bar (NVIDIA RTX 30xx únicamente)",
         "runexe": {

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Näita peidetud"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Sünkroonige EGS-iga, kui teil on Epic Games Store'i töötav installatsioon mujal ja soovite oma mänge importida, et vältida nende uuesti allalaadimist.",
         "other": {
             "part1": "Kasuta ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Kasutusel on sisse-ehitatud GOGDL binaarfaili...",
         "alt-legendary-bin": "Kasutusel on sisse-ehitatud Legendary binaarfail...",
-        "egs-prefix": "Prefiks, kuhu EGS on paigaldatud"
+        "egs-prefix": "Prefiks, kuhu EGS on paigaldatud",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Töötajate maksimaalne arv allalaadimisel",
         "minimize-on-launch": "Minimeeri Heroic pärast mängu käivitamist",
         "offlinemode": "Käivita mäng võrguühenduseta",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Kasuta spetsiaalset graafikakaarti",
         "resizableBar": "Luba muudetav BAR (ainult NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "نمایش موارد پنهان"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "در صورتی که در جایی لانچر اپیک گیمز را به صورت فعال نصب کردهاید و میخواهید بازیهای خود را وارد کنید با EGL همگامسازی کنید تا از دانلود مجدد آنها جلوگیری کنید.",
         "other": {
             "part1": "استفاده از ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "استفاده از باینری GOGDL داخلی...",
         "alt-legendary-bin": "استفاده از باینری Legendary داخلی...",
-        "egs-prefix": "محل نصب شده EGS"
+        "egs-prefix": "محل نصب شده EGS",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "لینوکس",
@@ -305,6 +311,7 @@
         "maxworkers": "بیسترین تعداد ورکر هنگام دانلود",
         "minimize-on-launch": "کوچک کردن Heroic بعد از اجرای بازی",
         "offlinemode": "اجرای آفلاین بازی",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "استفاده از کارت گرافیک اختصاص یافته",
         "resizableBar": "فعالسازی Resizable BAR (فقط محصولات NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Synkronisoi EGL:n kanssa mikäli sinulla on toimiva Epic Games Launcher:in asennus toisaalla ja haluat tuoda pelisi välttääksesi niiden uudelleenlatauksen.",
         "other": {
             "part1": "Käytä ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Käytetään sisäänrakennettua GOGDL-binääriä...",
         "alt-legendary-bin": "Käytetään sisäänrakennettua legendaarista binääriä...",
-        "egs-prefix": "Prefiksi johon EGS on asennettu"
+        "egs-prefix": "Prefiksi johon EGS on asennettu",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "",
@@ -305,6 +311,7 @@
         "maxworkers": "Työntekijöiden enimmäismäärä ladattaessa",
         "minimize-on-launch": "Minimoi Heroic pelin käynnistämisen jälkeen",
         "offlinemode": "Käynnistä peli offline-tilassa",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Ota käyttöön Nvidia Prime Render",
         "resizableBar": "Ota käyttöön Resizable BAR (Vain NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Synchroniser avec le lanceur EG si vous avez un dossier d'installation de l'Epic Games Store ailleurs et que vous voulez importer vos jeux afin d'éviter de les télécharger à nouveau.",
         "other": {
             "part1": "Utilise l' ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "Utilisation du binaire Legendary intégré...",
-        "egs-prefix": "Prefix où EGS est installé"
+        "egs-prefix": "Prefix où EGS est installé",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Nombre Maximum de Workers pendant le téléchargement",
         "minimize-on-launch": "Minimiser Heroic après le lancement du jeu",
         "offlinemode": "Lancer le jeu hors ligne",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Utiliser une carte graphique dédiée",
         "resizableBar": "Activer Resizable BAR (NVIDIA RTX 30xx seulement)",
         "runexe": {

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Sincronizar con EGS no caso que teña unha instalación funcional de Epic Games Launcher noutro lugar e desexa importar os seus xogos para evitar descargalos novamente.",
         "other": {
             "part1": "Utilizar as ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "Usando o binario de Legendary embebeido...",
-        "egs-prefix": "Prefixo onde está instalado EGS"
+        "egs-prefix": "Prefixo onde está instalado EGS",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Número máximo de descargas",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Executar xogo sen conexión",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Activar renderizado de Nvidia Prime",
         "resizableBar": "Activar Resizable Bar (só NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Sinkronizira sa EGL ako imaš instalaciju EpicGames Launcher-a negdje drugdje i želiš uvesti igrice bez ponovnog preuzimanja.",
         "other": {
             "part1": "Koristi ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "Using built-in Legendary binary...",
-        "egs-prefix": "Put gdje je EGS instaliran"
+        "egs-prefix": "Put gdje je EGS instaliran",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Maksimalan broj radnika za preuzimanje",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Pokreni igrice bez pristupa internetu",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Use Dedicated Graphics Card",
         "resizableBar": "Enable Resizable BAR (NVIDIA RTX only)",
         "runexe": {

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Abban az esetben szinkronizálj EGL-lel , ha van egy működő, Epic Games Launcher telepítésed máshol, és importálni szeretnéd a játékaid, hogy elkerüld az újbóli letöltésüket.",
         "other": {
             "part1": "A ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "Beépített Legendary bináris használata...",
-        "egs-prefix": "Prefix ahol telepítve van az EGS"
+        "egs-prefix": "Prefix ahol telepítve van az EGS",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Maximum dolgozók száma letöltéskor",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Játék futtatása offline",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Nvidia Prime Render engedélyezése",
         "resizableBar": "Átméretezhető BAR engedélyezése (csak NVIDIA RTX 30xx kártyáknál)",
         "runexe": {

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Tampilkan yang Disembunyikan"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Sinkronkan dengan EGL jika Anda memiliki instalasi Epic Games Launcher yang berjalan di tempat lain dan ingin mengimpor gim Anda untuk menghindari pengunduhan ulang.",
         "other": {
             "part1": "Gunakan ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Menggunakan GOGDL binary bawaan…",
         "alt-legendary-bin": "Menggunakan Legendary binary bawaan...",
-        "egs-prefix": "Prefiks di mana EGS dipasang"
+        "egs-prefix": "Prefiks di mana EGS dipasang",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Jumlah Maksimum Worker saat mengunduh",
         "minimize-on-launch": "Minimalkan Jendela Heroic Setelah Gim Diluncurkan",
         "offlinemode": "Jalankan Game Secara Luring",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Gunakan Kartu Grafis untuk Rendering",
         "resizableBar": "Aktifkan Resizable BAR (hanya untuk NVIDIA RTX 30xx saja)",
         "runexe": {

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Sincronizza con EGS nel caso tu abbia già un'installazione funzionante con l'Epic Games Store, in modo da importare i giochi senza dover riscaricarli di nuovo.",
         "other": {
             "part1": "Usa le ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "In uso i binari Legendary integrati...",
-        "egs-prefix": "Prefix dove è installato EGS"
+        "egs-prefix": "Prefix dove è installato EGS",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "",
@@ -305,6 +311,7 @@
         "maxworkers": "Numero massimo di connessioni durante il download",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Avvia il gioco in modalità offline",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Attiva Nvidia Prime Render",
         "resizableBar": "Abilita Resizable BAR (solo NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Epic Games Storeが他の場所に正常にインストールされていて、ゲームをインポートして再度ダウンロードしないようにする場合は、EGSと同期します。",
         "other": {
             "part1": "",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "Using built-in Legendary binary...",
-        "egs-prefix": "EGSがインストールされているプレフィックス"
+        "egs-prefix": "EGSがインストールされているプレフィックス",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "",
@@ -305,6 +311,7 @@
         "maxworkers": "ダウンロード時のワーカーの最大数",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "ゲームをオフラインで実行する",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Nvidia Prime Renderを有効にする",
         "resizableBar": "サイズ変更可能なBARを有効にする（NVIDIA RTX 30xxのみ）",
         "runexe": {

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "숨김 표시"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Epic Games Launcher가 다른 곳에 설치되어 있고 게임을 가져와서 다시 다운로드하지 않으려면 Epic Games Launcher와 동기화 하십시오.",
         "other": {
             "part1": "다음 사용 ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "내장된 GOGDL 바이너리 파일 사용...",
         "alt-legendary-bin": "내장된 Legendary 바이너리 파일 사용...",
-        "egs-prefix": "Epic Games Store가 설치된 위치의 접두사"
+        "egs-prefix": "Epic Games Store가 설치된 위치의 접두사",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "다운로드할 때 최대 워커 개수",
         "minimize-on-launch": "게임 실행 후 Heroic 최소화",
         "offlinemode": "게임 오프라인으로 실행",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "외장 그래픽 카드 사용",
         "resizableBar": "Resizable BAR 활성화 (NVIDIA RTX 30xx 전용)",
         "runexe": {

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "എപിക് ഗെയിം കടയുടെ കുഴപ്പമൊന്നുില്ലാത്ത ഒരു നടീല് മറ്റെവിടെയെങ്കിലും ഉണ്ടെങ്കില് നിങ്ങളുടെ കളികള് വീണ്ടും ഇറക്കിയെടുക്കുന്നത് ഒഴിവാക്കാനായി EGSുമായി ഒന്നിപ്പിക്കുക.",
         "other": {
             "part1": "കളി ഓടിക്കുന്നതിനുമുന്പുള്ള വിളികള്ക്കായി ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "തനത് ലെജന്ററി ഈരക്കരേഖ ഉപയോഗിക്കുന്നു...",
-        "egs-prefix": "EGS സ്ഥാപിച്ചയിടം"
+        "egs-prefix": "EGS സ്ഥാപിച്ചയിടം",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "",
@@ -305,6 +311,7 @@
         "maxworkers": "ഇറക്കിയെടുക്കുമ്പോള് പണിയുന്നവരുടെ പരമാവധി എണ്ണം",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "ഓഫ്ലൈനില് കളിക്കുക",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "എന്വിഡിയ പ്രൈം റെന്റര് വയ്ക്കൂ",
         "resizableBar": "വലുപ്പം മാറ്റാവുന്ന BAR വയ്ക്കൂ (എന്വിഡിയ RTX 30xxനു മാത്രം)",
         "runexe": {

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Synchroniseer met EGS als u ergens anders een werkende installatie van de Epic Games Store heeft en u uw games wilt importeren om te vermijden ze opnieuw te downloaden.",
         "other": {
             "part1": "Gebruik de ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "Gebruik built-in Legendary binary...",
-        "egs-prefix": "Prefix waar EGS is geïnstalleerd"
+        "egs-prefix": "Prefix waar EGS is geïnstalleerd",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "",
@@ -305,6 +311,7 @@
         "maxworkers": "Maximale hoeveelheid van werkers tijdens het downloaden",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Spel offline draaien",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Aciveer Nvidia Prime Render",
         "resizableBar": "Resizable BAR inschakelen (Alleen voor NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Pokaż Ukryte"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Synchronizuj z EGS, gdy Epic Games Launcher jest zainstalowane w innym miejscu i chcesz zaimportować swoje gry, aby uniknąć ich ponownego pobierania.",
         "other": {
             "part1": "Użyj ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Używanie wbudowanego pliku binarnego GOGDL...",
         "alt-legendary-bin": "Używanie wbudowanego pliku binarnego Legendary...",
-        "egs-prefix": "Prefiks instalacji EGS"
+        "egs-prefix": "Prefiks instalacji EGS",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Maksymalna liczba wątków przy pobieraniu",
         "minimize-on-launch": "Minimalizuj Heroic Po Uruchomieniu Gry",
         "offlinemode": "Uruchom grę w trybie offline",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Włącz renderowanie Nvidia Prime",
         "resizableBar": "Włącz Resizable BAR (Tylko dla kart NVIDIA RTX)",
         "runexe": {

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Caso você tenha a Epic Games Store instalada em um Prefix Wine, você pode usar a sincronização para importar e exportar jogos entre ela e o Heroic.",
         "other": {
             "part1": "Use as ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "Using built-in Legendary binary...",
-        "egs-prefix": "Prefix onde a Epic Games está instalada"
+        "egs-prefix": "Prefix onde a Epic Games está instalada",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "",
@@ -305,6 +311,7 @@
         "maxworkers": "CPUs máximos utilizados ao baixar jogos",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "Executar o jogo offline",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Habilitar Nvidia Prime Render",
         "resizableBar": "Ativar BARRA redimensionável (apenas NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Mostrar escondidos"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Se você tiver uma instalação funcional da Epic Games Launcher e quiser importar seus jogos, use a sincronização para evitar baixá-los novamente.",
         "other": {
             "part1": "Use o ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Usando binário do GOGDL embutido...",
         "alt-legendary-bin": "Usando o binário embutido do Legendary...",
-        "egs-prefix": "Prefixo onde a EGS está instalada"
+        "egs-prefix": "Prefixo onde a EGS está instalada",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Máximo de núcleos da CPU para utilizar ao fazer baixar jogos",
         "minimize-on-launch": "Minimizar Heroic ao iniciar um jogo",
         "offlinemode": "Iniciar o jogo offline",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Usar placa gráfica dedicada",
         "resizableBar": "Habilitar Resizable BAR (somente NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Показать скрытые"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Синхронизируйте с EGL, если у вас есть работающий Epic Games Launcher в другом месте и вы хотите импортировать свои игры, чтобы избежать их повторного скачивания.",
         "other": {
             "part1": "Используйте ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Используется встроенный GOGDL...",
         "alt-legendary-bin": "Используется встроенный Legendary...",
-        "egs-prefix": "Префикс куда установлен EGS"
+        "egs-prefix": "Префикс куда установлен EGS",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Максимальное количество потоков при скачивании",
         "minimize-on-launch": "Сворачивать Heroic в трей при запуске игры",
         "offlinemode": "Запускать игру офлайн",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Использовать выделенную видеокарту",
         "resizableBar": "Включить Resizable BAR (только NVIDIA RTX)",
         "runexe": {

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Visa dolda"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Synkronisera med EGS om du har en fungerande Epic Games Launcher installation och vill importera spel istället för att ladda ner dem igen.",
         "other": {
             "part1": "Använd ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Använder inbyggd GOGDL version...",
         "alt-legendary-bin": "Använder inbyggd Legendary version...",
-        "egs-prefix": "Prefix för befintlig EGS installation"
+        "egs-prefix": "Prefix för befintlig EGS installation",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Maximalt antal samtida nedladdningar",
         "minimize-on-launch": "Minimera Heroic efter spelstart",
         "offlinemode": "Kör spelet offline",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Använd dedikerat grafikkort",
         "resizableBar": "Aktivera Resizable BAR (NVIDIA RTX endast)",
         "runexe": {

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "நீங்கள் எபிக் கேம்ஸ் ஸ்டோரை வேறு இடத்தில் நிறுவியிருந்தால், அதை மீண்டும் பதிவிறக்குவதைத் தவிர்க்க மற்றும் உங்கள் விளையாட்டுகளை இறக்குமதி செய்ய, EGS உடன் ஒத்திசைக்கவும்.",
         "other": {
             "part1": "Use the ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "Using built-in Legendary binary...",
-        "egs-prefix": "EGS நிறுவப்பட்ட முன்னொட்டு"
+        "egs-prefix": "EGS நிறுவப்பட்ட முன்னொட்டு",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "",
@@ -305,6 +311,7 @@
         "maxworkers": "பதிவிறக்கும் போது வேலையாளிகளின் அதிகபட்ச எண்ணிக்கை",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "இணையத்துடன் இணையாமல் விளையாட்டை துவக்கு",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Nvidia Prime Render ஐ துவக்கு",
         "resizableBar": "Enable Resizable BAR (NVIDIA RTX only)",
         "runexe": {

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Gizlileri Göster"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Başka bir yerde çalışan bir Epic Games Launcher kurulumunuz varsa ve oyunlarınızı tekrar indirmemek için onları içeri aktarmak istiyorsanız EGL ile eşzamanlayın.",
         "other": {
             "part1": "Oyun başlatılmadan önce çağırılması için ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Yerleşik GOGDL çalıştırılabilir dosyasını kullanılıyor...",
         "alt-legendary-bin": "Yerleşik Legendary çalıştırılabilir dosyası kullanılıyor...",
-        "egs-prefix": "EGS'nin kurulu olduğu yer"
+        "egs-prefix": "EGS'nin kurulu olduğu yer",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "İndirirken azami işçi sayısı",
         "minimize-on-launch": "Oyun Başlatıldıktan Sonra Heroic'i Simge Durumuna Küçült",
         "offlinemode": "Oyunu Çevrim Dışı Çalıştır",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Özel Grafik Kartını Kullan",
         "resizableBar": "Resizable BAR'ı etkinleştir (yalnızca NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Показати приховане"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Синхронізувати з EGL якщо ви маєте встановлений Epic Games Launcher і хочете імпортувати ігри уникнувши їх повторного завантаження.",
         "other": {
             "part1": "Використовуйте ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Використання вбудованого GOGDL-файлу...",
         "alt-legendary-bin": "Використовую вбудований двійковий Legendary...",
-        "egs-prefix": "Префікс де встановлено EGS"
+        "egs-prefix": "Префікс де встановлено EGS",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "Максимальна кількість працівників при завантаженні",
         "minimize-on-launch": "Згортати Heroic після запуску гри",
         "offlinemode": "Запустити гру оффлайн",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Використовувати виділену відеокарту",
         "resizableBar": "Ввімкнути Resizable BAR (тільки NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "Đồng bộ với EGL nếu bạn đang cài Epic Games Launcher trên máy và muốn import game của mình để không phải tải lại.",
         "other": {
             "part1": "Sử dụng ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Sử dụng GOGDL binary tích hợp sẵn...",
         "alt-legendary-bin": "Sử dụng Legendary binary tích hợp sẵn...",
-        "egs-prefix": "Prefix nơi EGS được cài đặt"
+        "egs-prefix": "Prefix nơi EGS được cài đặt",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "LInux",
@@ -305,6 +311,7 @@
         "maxworkers": "Số lượng tối đa khi tải xuống",
         "minimize-on-launch": "Thu nhỏ Heroic sau khi khởi chạy trò chơi",
         "offlinemode": "Chạy game oflline",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "Bật Nvidia Prime Render",
         "resizableBar": "Bật tính năng thay đổi kích thước bar (chỉ dùng được với NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "显示隐藏项"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "与 Epic Games 启动器同步，如果你在其他地方安装了Epic Games 启动器，而且想要导入你的游戏，以免再次下载它们。",
         "other": {
             "part1": "使用 ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "使用内置的 GOGDL 二进制文件...",
         "alt-legendary-bin": "使用内置的 Legendary 二进制文件...",
-        "egs-prefix": "Epic 游戏商城安装位置"
+        "egs-prefix": "Epic 游戏商城安装位置",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "Linux",
@@ -305,6 +311,7 @@
         "maxworkers": "下载时的最大线程数量",
         "minimize-on-launch": "游戏启动后最小化 Heroic",
         "offlinemode": "离线运行游戏",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "使用独立显卡",
         "resizableBar": "启动 Resizable BAR (仅限 NVIDIA RTX 30xx)",
         "runexe": {

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -141,6 +141,11 @@
         "show_hidden": "Show Hidden"
     },
     "help": {
+        "game_language": {
+            "fallback": "Leave blank to use Heroic's language.",
+            "in_game_config": "Not all games support this configuration, some have in-game language setting.",
+            "valid_codes": "Valid language codes are game-dependant."
+        },
         "general": "與Epic Games商城同步，如果您在其他地方已經安裝了Epic Games啟動器，可以導入您的遊戲以避免再次下載它們。",
         "other": {
             "part1": "使用 ",
@@ -241,7 +246,8 @@
     "placeholder": {
         "alt-gogdl-bin": "Using built-in GOGDL binary...",
         "alt-legendary-bin": "Using built-in Legendary binary...",
-        "egs-prefix": "Epic Games商城安裝位置"
+        "egs-prefix": "Epic Games商城安裝位置",
+        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
     },
     "platforms": {
         "linux": "",
@@ -305,6 +311,7 @@
         "maxworkers": "下載時的最大Worker數量",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "offlinemode": "離線運行遊戲",
+        "prefered_language": "Prefered Language (Language Code)",
         "primerun": "啟用Nvidia Prime渲染",
         "resizableBar": "啟用 Resizable BAR (僅限 NVIDIA RTX 30xx)",
         "runexe": {

--- a/src/components/UI/LanguageSelector/index.tsx
+++ b/src/components/UI/LanguageSelector/index.tsx
@@ -1,6 +1,7 @@
 import { IpcRenderer } from 'electron'
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
+import { configStore } from 'src/helpers/electronStores'
 import ContextProvider from 'src/state/ContextProvider'
 import { SelectField } from '..'
 
@@ -101,6 +102,7 @@ export default function LanguageSelector({
   const handleChangeLanguage = (newLanguage: string) => {
     ipcRenderer.send('changeLanguage', newLanguage)
     storage.setItem('language', newLanguage)
+    configStore.set('language', newLanguage)
     i18n.changeLanguage(newLanguage)
     setLanguage(newLanguage)
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,13 @@ initShortcuts()
 
 const storage: Storage = window.localStorage
 
+let languageCode = configStore.get('language')
+
+if (!languageCode) {
+  languageCode = storage.getItem('language') || 'en'
+  configStore.set('language', languageCode)
+}
+
 i18next
   // load translation using http -> see /public/locales
   // learn more: https://github.com/i18next/i18next-http-backend
@@ -36,7 +43,7 @@ i18next
     interpolation: {
       escapeValue: false
     },
-    lng: storage.getItem('language') || 'en',
+    lng: languageCode,
     react: {
       useSuspense: true
     },

--- a/src/screens/Settings/components/OtherSettings/index.tsx
+++ b/src/screens/Settings/components/OtherSettings/index.tsx
@@ -23,6 +23,7 @@ interface Props {
   isDefault: boolean
   isMacNative: boolean
   isLinuxNative: boolean
+  languageCode: string
   launcherArgs: string
   canRunOffline: boolean
   offlineMode: boolean
@@ -31,6 +32,7 @@ interface Props {
   addDesktopShortcuts: boolean
   addGamesToStartMenu: boolean
   discordRPC: boolean
+  setLanguageCode: (value: string) => void
   setLauncherArgs: (value: string) => void
   setOtherOptions: (value: string) => void
   setMaxRecentGames: (value: number) => void
@@ -65,6 +67,8 @@ export default function OtherSettings({
   canRunOffline,
   offlineMode,
   toggleOffline,
+  languageCode,
+  setLanguageCode,
   launcherArgs,
   setLauncherArgs,
   audioFix,
@@ -95,6 +99,8 @@ export default function OtherSettings({
     setOtherOptions(event.currentTarget.value)
   const handleLauncherArgs = (event: ChangeEvent<HTMLInputElement>) =>
     setLauncherArgs(event.currentTarget.value)
+  const handleLanguageCode = (event: ChangeEvent<HTMLInputElement>) =>
+    setLanguageCode(event.currentTarget.value)
   const { t } = useTranslation()
   const { platform } = useContext(ContextProvider)
   const isWin = platform === 'win32'
@@ -117,6 +123,25 @@ export default function OtherSettings({
           <strong>{` -nolauncher `}</strong>
           {t('help.other.part7')}
         </span>
+      )}
+    </InfoBox>
+  )
+
+  const languageInfo = (
+    <InfoBox text="infobox.help">
+      {t(
+        'help.game_language.fallback',
+        "Leave blank to use Heroic's language."
+      )}
+      <br />
+      {t(
+        'help.game_language.in_game_config',
+        'Not all games support this configuration, some have in-game language setting.'
+      )}
+      <br />
+      {t(
+        'help.game_language.valid_codes',
+        'Valid language codes are game-dependant.'
       )}
     </InfoBox>
   )
@@ -255,6 +280,22 @@ export default function OtherSettings({
             <option key={n + 1}>{n + 1}</option>
           ))}
         </SelectField>
+      )}
+      {!isDefault && (
+        <TextInputField
+          label={t(
+            'setting.prefered_language',
+            'Prefered Language (Language Code)'
+          )}
+          htmlId="prefered-language"
+          placeholder={t(
+            'placeholder.prefered_language',
+            '2-char code (i.e.: "en" or "fr")'
+          )}
+          value={languageCode}
+          onChange={handleLanguageCode}
+          afterInput={languageInfo}
+        />
       )}
       {!isWin && (
         <TextInputField

--- a/src/screens/Settings/components/OtherSettings/index.tsx
+++ b/src/screens/Settings/components/OtherSettings/index.tsx
@@ -281,22 +281,6 @@ export default function OtherSettings({
           ))}
         </SelectField>
       )}
-      {!isDefault && (
-        <TextInputField
-          label={t(
-            'setting.prefered_language',
-            'Prefered Language (Language Code)'
-          )}
-          htmlId="prefered-language"
-          placeholder={t(
-            'placeholder.prefered_language',
-            '2-char code (i.e.: "en" or "fr")'
-          )}
-          value={languageCode}
-          onChange={handleLanguageCode}
-          afterInput={languageInfo}
-        />
-      )}
       {!isWin && (
         <TextInputField
           label={t('options.advanced.title')}
@@ -315,6 +299,22 @@ export default function OtherSettings({
           value={launcherArgs}
           onChange={handleLauncherArgs}
           afterInput={info}
+        />
+      )}
+      {!isDefault && (
+        <TextInputField
+          label={t(
+            'setting.prefered_language',
+            'Prefered Language (Language Code)'
+          )}
+          htmlId="prefered-language"
+          placeholder={t(
+            'placeholder.prefered_language',
+            '2-char code (i.e.: "en" or "fr")'
+          )}
+          value={languageCode}
+          onChange={handleLanguageCode}
+          afterInput={languageInfo}
         />
       )}
     </>

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -58,6 +58,7 @@ function Settings() {
   const [targetExe, setTargetExe] = useState('')
   const [otherOptions, setOtherOptions] = useState('')
   const [launcherArgs, setLauncherArgs] = useState('')
+  const [languageCode, setLanguageCode] = useState('')
   const [egsLinkedPath, setEgsLinkedPath] = useState('')
   const [title, setTitle] = useState('')
   const [maxWorkers, setMaxWorkers] = useState(0)
@@ -238,6 +239,7 @@ function Settings() {
       setDisableController(config.disableController || false)
 
       if (!isDefault) {
+        setLanguageCode(config.language)
         const { title: gameTitle, canRunOffline: can_run_offline } =
           await getGameInfo(appName, runner)
         setCanRunOffline(can_run_offline)
@@ -298,6 +300,7 @@ function Settings() {
     enableFsync,
     maxSharpness,
     enableResizableBar,
+    language: languageCode,
     launcherArgs,
     nvidiaPrime,
     offlineMode,
@@ -424,6 +427,8 @@ function Settings() {
               setOtherOptions={setOtherOptions}
               launcherArgs={launcherArgs}
               setLauncherArgs={setLauncherArgs}
+              languageCode={languageCode}
+              setLanguageCode={setLanguageCode}
               useGameMode={useGameMode}
               toggleUseGameMode={toggleUseGameMode}
               primeRun={nvidiaPrime}

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,7 @@ export interface GameSettings {
   enableFsync: boolean
   enableResizableBar: boolean
   maxSharpness: number
+  language: string
   launcherArgs: string
   nvidiaPrime: boolean
   offlineMode: boolean


### PR DESCRIPTION
This PR adds the feature to set the game language through Heroic for the games that support it.

Each game now has a `Preferred Language` setting:

![image](https://user-images.githubusercontent.com/188464/172074371-c7cd215b-7cca-402e-b091-41ec8120dd49.png)

Users can set a language code to pass as the `--language` flag to legendary.

Is left empty, the preferred language will fallback to Heroic's language configuration to mimic Epic Games Launcher's behavoir.

This fixes #1391 and fixes #1432

I only know of those 2 games that support this setting (Prey and Wolfenstein The New Order), I tested this with Prey. I couldn't find any place where I could know if a game should/shouldn't support this, I found no flags anywhere in the json files.

Also, I understand there's no equivalent flag for GOG games, so I just implemented this for Epic games, I'm not sure if this should be hidden when the game is from GOG or if there's actually some flag for this (I'll ask over discord). I this this can be reviewed anyway?

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
