### PR TITLE
[General] Fix: No longer replace token/sid with redacted

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -597,6 +597,15 @@ async function callRunner(
     })
 }
 
+/**
+ * Generates a formatted, safe command that can be logged
+ * @param commandParts The runner command that's executed, e. g. install, list, etc.
+ * Note that this will be modified, so pass a copy of your actual command parts
+ * @param env Enviroment variables to use
+ * @param wrappers Wrappers to use (gamemode, steam runtime, etc.)
+ * @param runnerPath The full path to the runner executable
+ * @returns 
+ */
 function getRunnerCallWithoutCredentials(
   commandParts: string[],
   env: Record<string, string> = {},

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -487,7 +487,7 @@ async function callRunner(
   // TypeError is triggered
   commandParts = commandParts.filter(Boolean)
   const safeCommand = getRunnerCallWithoutCredentials(
-    commandParts,
+    [...commandParts],
     options?.env,
     options?.wrappers,
     fullRunnerPath


### PR DESCRIPTION
It seems like arrays are passed by reference in JS, which means the getRunnerCallWithoutCredentials function was altering the actual commandParts passed to Legendary/GOGDL. By copying the array before passing it, this no longer happens

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
