### PR TITLE
Pass SDL list as multiple arguments

### DIFF
--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -352,13 +352,11 @@ class LegendaryGame extends Game {
   }
 
   private getSdlList(sdlList: Array<string>) {
-    // Legendary needs an empty tag for it to download the other needed files
-    const defaultTag = ' --install-tag=""'
-    return sdlList
-      .map((tag) => `--install-tag ${tag}`)
-      .join(' ')
-      .replaceAll("'", '')
-      .concat(defaultTag)
+    return [
+      // Legendary needs an empty tag for it to download the other needed files
+      '--install-tag=""',
+      ...sdlList.map((tag) => `--install-tag=${tag}`)
+    ]
   }
 
   /**
@@ -377,7 +375,9 @@ class LegendaryGame extends Game {
     )
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
     const withDlcs = installDlcs ? '--with-dlcs' : '--skip-dlcs'
-    const installSdl = sdlList.length ? this.getSdlList(sdlList) : '--skip-sdl'
+    const installSdl = sdlList.length
+      ? this.getSdlList(sdlList)
+      : ['--skip-sdl']
 
     const logPath = join(heroicGamesConfigPath, this.appName + '.log')
 
@@ -389,7 +389,7 @@ class LegendaryGame extends Game {
       '--base-path',
       path,
       withDlcs,
-      installSdl,
+      ...installSdl,
       ...workers,
       '-y'
     ]


### PR DESCRIPTION
Another issue that was originally caused by the launch refactor. Seems to work fine, but I could only try it for one game

Something else I've noticed: The install progress seems to start at 45% for Fortnite for some reason? Legendary is reporting it correctly

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
