### PR TITLE
Fix toggle switch ids in install dialog

### DIFF
--- a/src/screens/Library/components/InstallModal/index.tsx
+++ b/src/screens/Library/components/InstallModal/index.tsx
@@ -608,13 +608,13 @@ export default function InstallModal({
               )}
               {haveSDL && (
                 <div className="InstallModal__sdls">
-                  {sdls.map((sdl: SelectiveDownload) => (
+                  {sdls.map((sdl: SelectiveDownload, idx: number) => (
                     <label
                       key={sdl.name}
                       className="InstallModal__toggle toggleWrapper"
                     >
                       <ToggleSwitch
-                        htmlId="sdls"
+                        htmlId={`sdls-${idx}`}
                         title={sdl.name}
                         value={
                           !!sdl.mandatory || !!selectedSdls[getUniqueKey(sdl)]


### PR DESCRIPTION
This PR fixes #1446 by using different ids for each ToggleSwitch element.

Tested it with Fortnite.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
