### PR TITLE
Fix detection of search bar focus to open virtual keyboard

### DIFF
--- a/src/components/UI/SearchBar/index.tsx
+++ b/src/components/UI/SearchBar/index.tsx
@@ -42,7 +42,7 @@ export default function SearchBar() {
           ref={input}
           data-testid="searchInput"
           placeholder={t('search')}
-          id="search"
+          id="search" // this id is used for the virtualkeyboard, don't change it
           className="FormControl__input"
         />
       </FormControl>

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -175,7 +175,7 @@ export const initGamepad = () => {
     const el = currentElement()
     if (!el) return false
 
-    return el.classList.contains('searchInput')
+    return el.id === 'search'
   }
 
   function playable() {


### PR DESCRIPTION
This PR fixes the detection of the searchbar to know if the virtual keyboard should be open when using gamepad navigation.

Added a comment in the search component to prevent this from happening again since it depends on the element's id.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
