### PR TITLE
Store only game setting keys in game config file during installation

### DIFF
--- a/electron/game_config.ts
+++ b/electron/game_config.ts
@@ -203,15 +203,68 @@ class GameConfigV0 extends GameConfig {
     // The settings defined work as overrides.
 
     // fix relative paths
-    const { winePrefix } = (settings[this.appName] as GameSettings) || {}
+    const { winePrefix: gameWinePrefix } =
+      (settings[this.appName] as GameSettings) || {}
 
-    return {
-      ...GlobalConfig.get().config,
+    const defaults = GlobalConfig.get().config
+
+    const {
+      audioFix,
+      autoInstallDxvk,
+      autoInstallVkd3d,
+      autoSyncSaves,
+      enableEsync,
+      enableFSR,
+      enableFsync,
+      maxSharpness,
+      enableResizableBar,
+      launcherArgs,
+      nvidiaPrime,
+      offlineMode,
+      otherOptions,
+      savesPath,
+      showFps,
+      showMangohud,
+      targetExe,
+      useGameMode,
+      winePrefix,
+      wineCrossoverBottle,
+      wineVersion,
+      useSteamRuntime
+    } = defaults
+
+    const settingsToReturn = {
+      audioFix,
+      autoInstallDxvk,
+      autoInstallVkd3d,
+      autoSyncSaves,
+      enableEsync,
+      enableFSR,
+      enableFsync,
+      maxSharpness,
+      enableResizableBar,
+      launcherArgs,
+      nvidiaPrime,
+      offlineMode,
+      otherOptions,
+      savesPath,
+      showFps,
+      showMangohud,
+      targetExe,
+      useGameMode,
+      winePrefix: winePrefix || `${userHome}/.wine`,
+      wineCrossoverBottle,
+      wineVersion,
+      useSteamRuntime,
       ...settings[this.appName],
-      winePrefix: winePrefix
-        ? winePrefix.replace('~', userHome)
-        : `${userHome}/.wine`
+      language: ''
     } as GameSettings
+
+    if (gameWinePrefix) {
+      settingsToReturn.winePrefix = gameWinePrefix.replace('~', userHome)
+    }
+
+    return settingsToReturn
   }
 
   public async resetToDefaults() {

--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -604,7 +604,7 @@ async function callRunner(
  * @param env Enviroment variables to use
  * @param wrappers Wrappers to use (gamemode, steam runtime, etc.)
  * @param runnerPath The full path to the runner executable
- * @returns 
+ * @returns
  */
 function getRunnerCallWithoutCredentials(
   commandParts: string[],

--- a/src/screens/Library/components/InstallModal/index.tsx
+++ b/src/screens/Library/components/InstallModal/index.tsx
@@ -382,12 +382,14 @@ export default function InstallModal({
         )
         if (Array.isArray(newWineList)) {
           setWineVersionList(newWineList)
-          if (
-            !newWineList.some(
-              (newWine) => wineVersion && newWine.bin === wineVersion.bin
-            )
-          ) {
-            setWineVersion(undefined)
+          if (wineVersion?.bin) {
+            if (
+              !newWineList.some(
+                (newWine) => wineVersion && newWine.bin === wineVersion.bin
+              )
+            ) {
+              setWineVersion(undefined)
+            }
           }
         }
       })()


### PR DESCRIPTION
This PR fixes #1465 by using keys that apply only for games when creating the config file for a game during installation instead of copying the complete object.

I understand this should also fix that issue that was reported where the solution was to go to the settings and make one change so the settings got updated with correct data.

This also fixes an issue where all games were created with the current language code in the `language` setting which was unnecessary and broke the language override feature (the `language` setting should be empty by default to fallback to Heroic's setting).

**How to test/QA**

Install a game that you have never configured before (if you want to try with a game that you used, delete the config file first at `~/.config/heroic/GameConfig/`).

Compare the JSON file created before and after this fix, the file will contain only game settings and not all heroic settings.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
