### PR TITLE
[Epic] Fix: Pass empty SDL tag properly

### DIFF
--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -354,7 +354,7 @@ class LegendaryGame extends Game {
   private getSdlList(sdlList: Array<string>) {
     return [
       // Legendary needs an empty tag for it to download the other needed files
-      '--install-tag=""',
+      '--install-tag=',
       ...sdlList.map((tag) => `--install-tag=${tag}`)
     ]
   }


### PR DESCRIPTION
Wasn't entirely sure how this worked in #1443, didn't test it enough to find this issue

To test, just install Fortnite (or any other game that supports SDL) and see that important files (like the actual executable) are now getting downloaded

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
