### PR TITLE
Allow game cards to grow to use the complete available horizontal space

### DIFF
--- a/src/screens/Library/components/GameCard/index.css
+++ b/src/screens/Library/components/GameCard/index.css
@@ -1,8 +1,8 @@
 .gameCard {
   background-color: var(--gradient-gamecard);
   text-align: left;
-  width: clamp(130px, 8vw, 200px);
-  height: 12vw;
+  width: 100%;
+  aspect-ratio: 8 / 12;
   max-height: 308px;
   min-height: 182px;
   overflow: hidden;
@@ -57,20 +57,22 @@
 .gameCard > a {
   display: block;
   position: relative;
+  width: 100%;
+  height: 100%;
 }
 
 .gameCard .gameImg {
-  width: clamp(130px, 8vw, 200px);
-  height: clamp(173px, 10vw, 266px);
+  width: 100%;
+  height: 100%;
   object-fit: cover;
 }
 
 .gameCard .gameLogo {
   position: absolute;
-  top: 35%;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
-  width: min(70px, 7vw, 60%);
+  transform: translate(-50%, -100%);
+  width: 50%;
 }
 
 .gameCard .gameListInfo {

--- a/src/screens/Library/index.css
+++ b/src/screens/Library/index.css
@@ -3,7 +3,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
   grid-gap: 1.2rem;
-  padding: 1rem 1rem 2rem;
+  padding: 1rem 1rem 7rem;
 }
 
 .gameListLayout {

--- a/src/screens/Library/index.css
+++ b/src/screens/Library/index.css
@@ -1,7 +1,7 @@
 .gameList {
   color: var(--text-secondary);
   display: grid;
-  grid-template-columns: repeat(auto-fill, clamp(130px, 8vw, 200px));
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
   grid-gap: 1.2rem;
   padding: 1rem 1rem 2rem;
 }


### PR DESCRIPTION
This PR fixes a small visual issue with the game grid leaving some empty space on the right side when wrapping into the next line. Now game cards can grow a bit to use all the space that's available when needed.

Before:
![image](https://user-images.githubusercontent.com/188464/173959153-43d893b7-e05b-43aa-a45f-6b46f5f1683c.png)

After:
![image](https://user-images.githubusercontent.com/188464/173959118-eab953fb-db6a-4861-9006-9c511f4a193a.png)

> Note that I also moved the logos for for images with logos so the title overlay doesn't cover it

I also added some extra padding at the bottom because the `back to top` button was overlapping the last element of the grid.

Before:
![image](https://user-images.githubusercontent.com/188464/173959023-61b1cac4-5e41-4938-8d47-ff96f8553c34.png)

After: (now we can scroll a bit more)
![image](https://user-images.githubusercontent.com/188464/173959058-9642c7e2-c8a2-4ecf-bd63-9fab18b5233f.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
