### PR TITLE
[Tech] Refactor game settings with fallbacks 

### DIFF
--- a/electron/game_config.ts
+++ b/electron/game_config.ts
@@ -266,7 +266,7 @@ class GameConfigV0 extends GameConfig {
       defaultSettings.winePrefix = winePrefix || `${userHome}/.wine`
 
       // fix winePrefix if needed
-      if (gameSettings.winePrefix) {
+      if (gameSettings.winePrefix?.includes('~')) {
         gameSettings.winePrefix = gameSettings.winePrefix.replace('~', userHome)
       }
     }

--- a/electron/game_config.ts
+++ b/electron/game_config.ts
@@ -8,6 +8,7 @@ import {
   heroicGamesConfigPath,
   isLinux,
   isMac,
+  isWindows,
   userHome
 } from './constants'
 import { logError, logInfo, LogPrefix } from './logger/logger'
@@ -258,16 +259,22 @@ class GameConfigV0 extends GameConfig {
       gameSettings = settings[this.appName] || ({} as GameSettings)
     }
 
-    // set specific keys depending on the platform
-    if (isMac) {
-      defaultSettings.wineCrossoverBottle = wineCrossoverBottle
-    } else if (isLinux) {
+    if (!isWindows) {
       defaultSettings.wineVersion = wineVersion
-      defaultSettings.winePrefix = winePrefix || `${userHome}/.wine`
 
-      // fix winePrefix if needed
-      if (gameSettings.winePrefix?.includes('~')) {
-        gameSettings.winePrefix = gameSettings.winePrefix.replace('~', userHome)
+      // set specific keys depending on the platform
+      if (isMac) {
+        defaultSettings.wineCrossoverBottle = wineCrossoverBottle
+      } else if (isLinux) {
+        defaultSettings.winePrefix = winePrefix || `${userHome}/.wine`
+
+        // fix winePrefix if needed
+        if (gameSettings.winePrefix?.includes('~')) {
+          gameSettings.winePrefix = gameSettings.winePrefix.replace(
+            '~',
+            userHome
+          )
+        }
       }
     }
 


### PR DESCRIPTION
This PR should fix the 2 issues mentioned here https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1491 by adding more customization around which settings are stored for a game depending on the platform. I think there's still room for improvement there (like... gamemode, mongohud, audio fix, and more can be moved to only linux), but I wanted to fix the issue related to the wine config first before moving more things around and have more tests.

The issues I noticed in the original code:
- we were defaulting to the complete global settings if no config file for a game, this is not necesarilly bad but we just dumped everything there without any sanity check
- we were trying to do a `winePrefix.replace` even on windows on mac, which is not only not needed but also failed in some cases when `winePrefix` was not a string
- we were storing extra information for all platforms, which makes reading logs kinda confusing sometimes

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
