### PR TITLE
Run game from tray icon directly without using shell

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -212,7 +212,7 @@ const contextMenu = () => {
   const recentsMenu = recentGames.map((game) => {
     return {
       click: function () {
-        openUrlOrFile(`heroic://launch/${game.appName}`)
+        handleProtocol(mainWindow, [`heroic://launch/${game.appName}`])
       },
       label: game.title
     }


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1484 by changing the action executed when a tray icon game is clicked.

Instead of opening the heroic URI using `shell`, now we run the `handleProtocol` function directly, removing that middle man that was not really needed (it had to go to the shell to open that URI and wait for the OS to handle it and pass it back to Heroic).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
