### PR TITLE
Refactor/fix: Wait until frontend is ready before processing protocol/args

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -375,8 +375,6 @@ if (!gotTheLock) {
       mainWindow.show()
     }
 
-    handleProtocol(mainWindow, process.argv)
-
     // set initial zoom level after a moment, if set in sync the value stays as 1
     setTimeout(() => {
       const zoomFactor =
@@ -432,6 +430,10 @@ function notify({ body, title }: NotifyType) {
 
 ipcMain.on('Notify', (event, args) => {
   notify({ body: args[1], title: args[0] })
+})
+
+ipcMain.on('frontendReady', () => {
+  handleProtocol(mainWindow, process.argv)
 })
 
 // Maybe this can help with white screens

--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -4,8 +4,6 @@ import { logInfo, LogPrefix } from './logger/logger'
 import i18next from 'i18next'
 
 export async function handleProtocol(window: BrowserWindow, args: string[]) {
-  const mainWindow = BrowserWindow.getAllWindows()[0]
-
   // Figure out which argv element is our protocol
   let url = ''
   args.forEach((val) => {
@@ -23,10 +21,13 @@ export async function handleProtocol(window: BrowserWindow, args: string[]) {
     command = path
     arg = null
   }
+
   logInfo(`received '${url}'`, LogPrefix.ProtocolHandler)
+
   if (command === 'ping') {
     return logInfo(['Received ping! Arg:', arg], LogPrefix.ProtocolHandler)
   }
+
   if (command === 'launch') {
     let runner: Runner = 'legendary'
     let game = await Game.get(arg, runner).getGameInfo()
@@ -35,42 +36,39 @@ export async function handleProtocol(window: BrowserWindow, args: string[]) {
       game = await Game.get(arg, runner).getGameInfo()
     }
     const { is_installed, title, app_name } = game
-    setTimeout(async () => {
-      // wait for the frontend to be ready
-      if (!is_installed) {
-        logInfo(`"${arg}" not installed.`, LogPrefix.ProtocolHandler)
-        const { response } = await dialog.showMessageBox(window, {
-          buttons: [i18next.t('box.yes'), i18next.t('box.no')],
-          cancelId: 1,
-          message: `${title} ${i18next.t(
-            'box.protocol.install.not_installed',
-            'Is Not Installed, do you wish to Install it?'
-          )}`,
-          title: title
+    if (!is_installed) {
+      logInfo(`"${arg}" not installed.`, LogPrefix.ProtocolHandler)
+      const { response } = await dialog.showMessageBox(window, {
+        buttons: [i18next.t('box.yes'), i18next.t('box.no')],
+        cancelId: 1,
+        message: `${title} ${i18next.t(
+          'box.protocol.install.not_installed',
+          'Is Not Installed, do you wish to Install it?'
+        )}`,
+        title: title
+      })
+      if (response === 0) {
+        const { filePaths, canceled } = await dialog.showOpenDialog({
+          buttonLabel: i18next.t('box.choose'),
+          properties: ['openDirectory'],
+          title: i18next.t('install.path', 'Select Install Path')
         })
-        if (response === 0) {
-          const { filePaths, canceled } = await dialog.showOpenDialog({
-            buttonLabel: i18next.t('box.choose'),
-            properties: ['openDirectory'],
-            title: i18next.t('install.path', 'Select Install Path')
-          })
-          if (canceled) {
-            return
-          }
-          if (filePaths[0]) {
-            return window.webContents.send('installGame', {
-              appName: app_name,
-              runner,
-              installPath: filePaths[0]
-            })
-          }
+        if (canceled) {
+          return
         }
-        if (response === 1) {
-          return logInfo('Not installing game', LogPrefix.ProtocolHandler)
+        if (filePaths[0]) {
+          return window.webContents.send('installGame', {
+            appName: app_name,
+            runner,
+            installPath: filePaths[0]
+          })
         }
       }
-      mainWindow.hide()
-      window.webContents.send('launchGame', arg, runner)
-    }, 3000)
+      if (response === 1) {
+        return logInfo('Not installing game', LogPrefix.ProtocolHandler)
+      }
+    }
+    window.hide()
+    window.webContents.send('launchGame', arg, runner)
   }
 }

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -575,6 +575,8 @@ export class GlobalState extends PureComponent<Props> {
         runInBackground: Boolean(epic.library.length)
       })
     }
+
+    ipcRenderer.send('frontendReady')
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
With the current code, we process the protocol/args 3s after Heroic starts, this value is sometimes too much (if heroic starts really fast) and sometimes not enough (in slow computers like my Mac it takes more than those 3 second for the frontend to be ready).

Instead of having that delay, with this PR I added a message from the frontend to the backend to tell it it's ready, and then we process the protocol.

This will also help with issue I had with the desktop shortcut feature on Mac, since I think this was causing the problem described in my comment (my mac being slow taking more than 3 seconds to have the frontend ready) https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/723

**How to Test/QA:**

Change the `electron` script in package.json to be something like:
```
"electron": "yarn build-electron && electron . heroic://launch/Fortnite --trace-warnings",
```

Or any installed game, run `yarn electron`.

You can set a really small timeout to show what happens if that runs before the frontend is ready in the code without this fix.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
