### PR TITLE
[UI / Linux] Prevent wine manager list overflow

### DIFF
--- a/src/screens/WineManager/components/WineItem/index.css
+++ b/src/screens/WineManager/components/WineItem/index.css
@@ -26,7 +26,7 @@
   display: grid;
   grid-template-columns: 2fr 1fr 1fr min-content;
   grid-template-areas: 'name date size action';
-  height: 8vh;
+  height: fit-content;
   margin: 1em 3em;
   align-items: center;
   justify-items: baseline;


### PR DESCRIPTION
Found a small display bug where the row text would overflow it's container.

Before:
![Screenshot from 2022-06-22 21-50-03](https://user-images.githubusercontent.com/47540781/175201612-6b3a3dc3-9663-4a5d-ad80-ade816971e1d.png)

After:
![Screenshot from 2022-06-22 21-58-19](https://user-images.githubusercontent.com/47540781/175202117-46125f43-6672-4752-8249-27fdd8b1332e.png)


