### PR TITLE
[Fix] "default not writable"/"Path might not be writable" error

### DIFF
--- a/src/screens/Library/components/InstallModal/index.tsx
+++ b/src/screens/Library/components/InstallModal/index.tsx
@@ -253,7 +253,7 @@ export default function InstallModal({
         }
         const { message, free, validPath } = await ipcRenderer.invoke(
           'checkDiskSpace',
-          installPath
+          installPath === 'default' ? config.defaultInstallPath : installPath
         )
         if (gameInstallInfo?.manifest?.disk_size) {
           let notEnoughDiskSpace = free < gameInstallInfo.manifest.disk_size


### PR DESCRIPTION
`installPath` is set to "default" by default. We were calling `setInstallPath` when this was the case, but the rest of the function still continued with the `default` value (according to some googling, this is because states are only updated once per rendering cycle ([SO thread](https://stackoverflow.com/a/58877875)))
This is now fixed by checking `installPath` again right before passing it to 'checkDiskSpace', and swapping in the correct path if it's `default`

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
