### PR TITLE
[General] add optional '--no-https' flag for legendary args for LanCache compatibility

### DIFF
--- a/electron/legendary/games.ts
+++ b/electron/legendary/games.ts
@@ -293,12 +293,14 @@ class LegendaryGame extends Game {
       runner: 'legendary',
       status: 'updating'
     })
-    const { maxWorkers } = await GlobalConfig.get().getSettings()
+    const { maxWorkers, downloadNoHttps } =
+      await GlobalConfig.get().getSettings()
     const info = await Game.get(this.appName, 'legendary').getInstallInfo()
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
+    const noHttps = downloadNoHttps ? ['--no-https'] : []
     const logPath = join(heroicGamesConfigPath, this.appName + '.log')
 
-    const commandParts = ['update', this.appName, ...workers, '-y']
+    const commandParts = ['update', this.appName, ...workers, ...noHttps, '-y']
 
     const onOutput = (data: string) => {
       this.onInstallOrUpdateOutput(
@@ -368,11 +370,13 @@ class LegendaryGame extends Game {
     sdlList,
     platformToInstall
   }: InstallArgs): Promise<{ status: 'done' | 'error' }> {
-    const { maxWorkers } = await GlobalConfig.get().getSettings()
+    const { maxWorkers, downloadNoHttps } =
+      await GlobalConfig.get().getSettings()
     const info = await Game.get(this.appName, 'legendary').getInstallInfo(
       platformToInstall
     )
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
+    const noHttps = downloadNoHttps ? ['--no-https'] : []
     const withDlcs = installDlcs ? '--with-dlcs' : '--skip-dlcs'
     const installSdl = sdlList.length
       ? this.getSdlList(sdlList)
@@ -390,6 +394,7 @@ class LegendaryGame extends Game {
       withDlcs,
       ...installSdl,
       ...workers,
+      ...noHttps,
       '-y'
     ]
 
@@ -454,12 +459,14 @@ class LegendaryGame extends Game {
    */
   public async repair(): Promise<ExecResult> {
     // this.state.status = 'repairing'
-    const { maxWorkers } = await GlobalConfig.get().getSettings()
+    const { maxWorkers, downloadNoHttps } =
+      await GlobalConfig.get().getSettings()
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
+    const noHttps = downloadNoHttps ? ['--no-https'] : []
 
     const logPath = join(heroicGamesConfigPath, this.appName + '.log')
 
-    const commandParts = ['repair', this.appName, ...workers, '-y']
+    const commandParts = ['repair', this.appName, ...workers, ...noHttps, '-y']
 
     const res = await runLegendaryCommand(commandParts, {
       logFile: logPath,

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -22,6 +22,7 @@ export interface AppSettings {
   defaultInstallPath: string
   disableController: boolean
   discordRPC: boolean
+  downloadNoHttps: boolean
   egsLinkedPath: string
   exitToTray: boolean
   enableEsync: boolean

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Задаване на папка за нови префикси на Wine",
         "disable_controller": "Изключване на навигирането в Heroic посредством контролер",
         "discordRPC": "Включване на актуализирането на присъствието в Дискорд",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Синхронизиране с вече инсталиран Epic Games",
         "enableFSRHack": "Включване на хака FSR (версията на Wine трябва да го поддържа)",
         "esync": "Включване на Esync",

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Directori de prefixos Wine nous",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Activa la Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Sincronitza amb l'Epic Games instal·lat",
         "enableFSRHack": "Activa el FSR Hack (cal que la versió del Wine en sigui compatible)",
         "esync": "Activa l'Esync",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Nastavit složku pro nové Prefixy Wine",
         "disable_controller": "Zakázat navigaci v Heroic pomocí ovladače",
         "discordRPC": "Povolit Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Synchronizovat s instalovaným Epic Games Store",
         "enableFSRHack": "Povolte FSR Hack (verze Wine jej musí podporovat)",
         "esync": "Povolit Esync",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Ordner für neue Wine Präfixe festlegen",
         "disable_controller": "Heroic Navigation mit Controller deaktivieren",
         "discordRPC": "Discord Rich Presence aktivieren",
+        "download-no-https": "Spiele ohne HTTPS herunterladen (nützlich für CDNs z.B. LanCache)",
         "egs-sync": "Mit installiertem Epic Games synchronisieren",
         "enableFSRHack": "FSR Hack aktivieren (Wine-Version muss es unterstützen)",
         "esync": "Esync aktivieren",

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Καθορισμός Φακέλου για νέα Προθήματα Wine",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Ενεργοποίηση Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Συγχρονισμός με εγκατεστημένο Epic Games",
         "enableFSRHack": "Ενεργοποίηση FSR Hack (Η έκδοση Wine πρέπει να το υποστηρίζει)",
         "esync": "Ενεργοποίηση Esync",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Enable Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Sync with Installed Epic Games",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Establecer carpeta para nuevos prefijos de Wine",
         "disable_controller": "Desactivar la navegación de Heroic usando el controlador",
         "discordRPC": "Activar Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Sincronizar con juegos EGS",
         "enableFSRHack": "Habilitar el hack FSR (La versión de Wine debe soportarlo)",
         "esync": "Activar Esync",

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Määrake uute Wine'i prefikside jaoks kaust",
         "disable_controller": "Keela Heroic'u mängupuldiga navigeerimine",
         "discordRPC": "Luba Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Sünkroonimine paigaldatud Epic Games'iga",
         "enableFSRHack": "Luba FSR häkk (Wine'i versioon peab seda toetama)",
         "esync": "Luba Esync",

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "تنظیم پوشه برای Wine Prefix جدید",
         "disable_controller": "غیر فعال کردن کنترل Heroic با استفاده از دسته",
         "discordRPC": "فعالسازی Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "همگامسازی با بازیهای اپیک نصب شده",
         "enableFSRHack": "فعالسازی FSR Hack (نسخه Wine باید از آن پشتیبانی کند)",
         "esync": "فعالسازی Esync",

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Aseta kansio uusille Winen Prefixeille",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Ota käyttöön Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Synkronoi asennetun Epic Gamesin kanssa",
         "enableFSRHack": "Ota käyttöön FSR Hack (Wine version tulee tukea sitä)",
         "esync": "Ota Esync käyttöön",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Activer Rich Presence dans Discord",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Synchroniser avec l'installation d'Epic Games",
         "enableFSRHack": "Activer FSR Hack (la version de wine doit le prendre en charge)",
         "esync": "Activer Esync",

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Estabelecer cartafol para os prefixos de Wine",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Activar a presencia enriquecida de Discord",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Sincronizar cos xogos instalados de Epic",
         "enableFSRHack": "Activar o hack de FSR (A versión de Wine debe soportalo)",
         "esync": "Activar Esync",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Enable Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Sinkroniziraj sa instaliranim Epic Games",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Mappa beállítása új Wine prefixeknek",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Discord Rich Presence engedélyezése",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Szinkronizálás a telepített Epic Gamesszel",
         "enableFSRHack": "FSR hack engedélyezése (a Wine verziónak támogatnia kell)",
         "esync": "Esync engedélyezése",

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Atur Folder untuk Prefiks Wine baru",
         "disable_controller": "Nonaktifkan navigasi Heroic menggunakan pengontrol",
         "discordRPC": "Aktifkan Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Sinkronkan dengan Epic Games yang Terpasang",
         "enableFSRHack": "Aktifkan Peretasan FSR (perlu versi Wine yang mendukung)",
         "esync": "Aktifkan Esync",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Imposta cartella per i nuovi prefissi Wine",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Attiva \"Discord Rich Presence\"",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Sincronizza con l'Epic Games già installato",
         "enableFSRHack": "Attiva l'FSR Hack (la versione di Wine deve supportarlo)",
         "esync": "Abilita l'Esync",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Discord Rich Presenceを有効にする",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "インストールされているEpic Gamesと同期する",
         "enableFSRHack": "FSRハックを有効にする（Wineバージョンはそれをサポートする必要があります）",
         "esync": "Esyncを有効にする",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "새로운 Wine 접두사를 위한 폴더 설정",
         "disable_controller": "컨트롤러를 이용한 Heroic 탐색 비활성화",
         "discordRPC": "Discord Rich Presence 활성화",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "설치된 Epic Games와 동기화",
         "enableFSRHack": "FSR 활성화 (지원하는 Wine 버전을 사용해야 합니다)",
         "esync": "Esync 활성화",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "ഡിസ്കോര്ഡ് റിച്ച് പ്രെസന്സ് വക്കൂ",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "സ്ഥാപിച്ച എപിക് ഗെയിംസുമായി ഒന്നിപ്പിക്കുക",
         "enableFSRHack": "എഫ്എസ്ആര് ഹാക്ക് വയ്ക്കൂ (Wine version needs to support it)",
         "esync": "Esync വയ്ക്കൂ",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "\"Discord Rich Presence\" inschakelen",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Synchronisatie met geïnstalleerde Epic Games",
         "enableFSRHack": "FSR Hack inschakelen (Wine versie moet dit ondersteunen)",
         "esync": "Esync inschakelen",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Ustaw Folder dla nowych Prefiksów Wine",
         "disable_controller": "Wyłącz nawigację Heroic przy użyciu kontrolera",
         "discordRPC": "Włącz Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Synchronizuj z zainstalowanym Epic Games",
         "enableFSRHack": "Włącz FSR Hack (Wersja Wine musi to wspierać)",
         "esync": "Włącz Esync",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Habilitar Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Sincronizar com Epic Games Store",
         "enableFSRHack": "Habilitar Hack FSR (Wine precisa supportar a feature)",
         "esync": "Enable Esync",

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Pasta padrão para novos prefixos Wine",
         "disable_controller": "Desabilitar navegação por controle no Heroic",
         "discordRPC": "Habilitar o Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Sincronizar com a Epic Games Store",
         "enableFSRHack": "Habilitar Hack FSR (a versão do Wine precisa suportar o recurso)",
         "esync": "Habilitar Esync",

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Указать папку для новых префиксов Wine",
         "disable_controller": "Отключить навигацию в Heroic с помощью контроллера",
         "discordRPC": "Включить Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Синхронизировать с установленнными играми EGS",
         "enableFSRHack": "Включить FSR Hack (версия Wine должна поддерживать)",
         "esync": "Включить Esync",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Ange sökväg för nya Wine-prefix",
         "disable_controller": "Deaktivera navigering via handkontroll",
         "discordRPC": "Aktivera Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Synkronisera med installerade Epic spel",
         "enableFSRHack": "Aktivera FSR Hack (Wine-versionen måste stödja det)",
         "esync": "Aktivera Esync",

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Enable Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "நிறுவப்பட்ட எபிக் விளையாட்டுகளுடன் ஒத்திசை",
         "enableFSRHack": "Enable FSR Hack (Wine version needs to support it)",
         "esync": "Enable Esync",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Yeni Wine Prefix'leri için Klasörü Ayarla",
         "disable_controller": "Denetleyiciyi kullanarak Heroic gezinmesini devre dışı bırak",
         "discordRPC": "Discord Rich Presence'i Etkinleştir",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Kurulu Epic Games ile Eşzamanla",
         "enableFSRHack": "FSR Hack'i Etkinleştir (Wine sürümünün desteklemesi gerekiyor)",
         "esync": "Esync'i Etkinleştir",

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Обрати теку для нових префіксів Wine",
         "disable_controller": "Вимкнути навігацію Heroic за допомогою контролера",
         "discordRPC": "Ввімкнути Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Синхронізуватися із встановленим Epic Games Launcher",
         "enableFSRHack": "Ввімкнути FSR Hack (версія Wine має це підтримувати)",
         "esync": "Ввімкнути Esync",

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Đặt thư mục cho prefix mới của Wine",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "Bật tính năng Discord Rich Presence",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "Đồng bộ với Game Epic đã cài",
         "enableFSRHack": "Bật tính năng FSR hack (Phiên bản Wine cần hỗ trợ tính năng này)",
         "esync": "Bật Esync",

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "为新的 WinePrefix设置文件夹",
         "disable_controller": "使用控制器禁止 Heroic 导航",
         "discordRPC": "启用Discord的Rich Presence（活动状态）",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "与已安装的 Epic 游戏同步",
         "enableFSRHack": "启用 FSR（需要支持的WINE版本）",
         "esync": "启用 Esync",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -288,6 +288,7 @@
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
         "disable_controller": "Disable Heroic navigation using controller",
         "discordRPC": "啟用Discord的Rich Presence（活動狀態）",
+        "download-no-https": "Download games without HTTPS (useful for CDNs e.g. LanCache)",
         "egs-sync": "與已安裝的Epic Games同步",
         "enableFSRHack": "啟用FSR（需要支持的WINE版本）",
         "esync": "Enable Esync",

--- a/src/screens/Settings/components/AdvancedSettings/index.tsx
+++ b/src/screens/Settings/components/AdvancedSettings/index.tsx
@@ -7,6 +7,7 @@ import {
 import classNames from 'classnames'
 import { IpcRenderer, Clipboard } from 'electron'
 import { useTranslation } from 'react-i18next'
+import { ToggleSwitch } from 'src/components/UI'
 import React, { useEffect, useState } from 'react'
 import { AppSettings, Path } from 'src/types'
 import { configStore } from 'src/helpers/electronStores'
@@ -24,16 +25,20 @@ const { ipcRenderer, clipboard } = window.require('electron') as ElectronProps
 interface Props {
   altLegendaryBin: string
   altGogdlBin: string
+  downloadNoHttps: boolean
   setAltLegendaryBin: (value: string) => void
   setAltGogdlBin: (value: string) => void
+  toggleDownloadNoHttps: () => void
   settingsToSave: AppSettings
 }
 
 export const AdvancedSettings = ({
   altLegendaryBin,
   altGogdlBin,
+  downloadNoHttps,
   setAltLegendaryBin,
   setAltGogdlBin,
+  toggleDownloadNoHttps,
   settingsToSave
 }: Props) => {
   const [legendaryVersion, setLegendaryVersion] = useState('')
@@ -208,6 +213,16 @@ export const AdvancedSettings = ({
             {gogdlVersion}
           </span>
         }
+      />
+
+      <ToggleSwitch
+        htmlId="downloadNoHttps"
+        value={downloadNoHttps}
+        handleChange={toggleDownloadNoHttps}
+        title={t(
+          'setting.download-no-https',
+          'Download games without HTTPS (useful for CDNs e.g. LanCache)'
+        )}
       />
 
       <div className="footerFlex">

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -177,6 +177,11 @@ function Settings() {
     toggle: toggleDisableController,
     setOn: setDisableController
   } = useToggle(false)
+  const {
+    on: downloadNoHttps,
+    toggle: toggleDownloadNoHttps,
+    setOn: setDownloadNoHttps
+  } = useToggle(false)
 
   const [autoSyncSaves, setAutoSyncSaves] = useState(false)
   const [altWine, setAltWine] = useState([] as WineInstallation[])
@@ -244,6 +249,7 @@ function Settings() {
         setDefaultWinePrefix(config.defaultWinePrefix)
         setUseSteamRuntime(config.useSteamRuntime)
         setDisableController(config.disableController || false)
+        setDownloadNoHttps(config.downloadNoHttps)
 
         if (!isDefault) {
           setLanguageCode(config.language)
@@ -357,6 +363,7 @@ function Settings() {
     defaultWinePrefix,
     disableController,
     discordRPC,
+    downloadNoHttps,
     egsLinkedPath,
     enableEsync,
     enableFsync,
@@ -545,6 +552,8 @@ function Settings() {
               setAltLegendaryBin={setAltLegendaryBin}
               altGogdlBin={altGogdlBin}
               setAltGogdlBin={setAltGogdlBin}
+              downloadNoHttps={downloadNoHttps}
+              toggleDownloadNoHttps={toggleDownloadNoHttps}
               settingsToSave={settingsToSave}
             />
           )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface AppSettings {
   defaultInstallPath: string
   disableController: boolean
   discordRPC: boolean
+  downloadNoHttps: boolean
   egsLinkedPath: string
   exitToTray: boolean
   enableEsync: boolean


### PR DESCRIPTION
fixes issue #1032 
Epic Games uses also only http for downloads.
This flag is default disabled, can be enabled via the advanced settings and gets applied to the uses of legendary commands "install", "update" and "repair".
New settings option has translations for english and german. Other languages are missing.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
