### PR TITLE
Make Shortcuts on the Desktop executable

### DIFF
--- a/electron/shortcuts.ts
+++ b/electron/shortcuts.ts
@@ -41,6 +41,7 @@ Categories=Game;
         writeFile(desktopFile, shortcut, () => {
           logInfo(`Shortcut saved on ${desktopFile}`, LogPrefix.Backend)
         })
+        execAsync(`chmod +x "${desktopFile}"`)
       }
       if (addStartMenuShortcuts || fromMenu) {
         writeFile(menuFile, shortcut, () => {


### PR DESCRIPTION
I don't know why, but KDE shows a Warn symbol if a .desktop file on the Desktop is not executable and it asks if I want to start the Program when i click it. For some reason this is only needed on the Desktop and not the Menu.


Before:
![grafik](https://user-images.githubusercontent.com/15185051/176771007-fccdf363-f11d-459b-8945-460fecdc4de4.png)
![grafik](https://user-images.githubusercontent.com/15185051/176771367-dae4b73b-d24b-451f-bcf8-4027a963aa7a.png)

After:
![grafik](https://user-images.githubusercontent.com/15185051/176771222-72978f12-674f-48ad-830d-e6fcf74e20eb.png)
