### PR TITLE
[Fix] Quote environment variables in generated command

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -616,7 +616,7 @@ function getLegendaryOrGogdlCommand(
         continue
       }
     }
-    formattedEnvVars.push(`${key}=${value}`)
+    formattedEnvVars.push(`${key}=${quoteIfNecessary(value)}`)
   }
 
   return [

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -543,7 +543,11 @@ const formatEpicStoreUrl = (title: string) => {
 }
 
 function quoteIfNecessary(stringToQuote: string) {
-  if (stringToQuote.includes(' ')) {
+  if (
+    (stringToQuote.charAt(0) !== '"' ||
+      stringToQuote.charAt(stringToQuote.length - 1) !== '"') &&
+    stringToQuote.includes(' ')
+  ) {
     return `"${stringToQuote}"`
   }
   return stringToQuote


### PR DESCRIPTION
Small thing, but we weren't quoting environment variables in the getCommand function, leading to commands like this:
```
WINEPREFIX=/home/commandmc/Games/Heroic/Prefixes/Akalabeth - World of Doom WINEFSYNC=1 ...
```
That's now fixed:
```
WINEPREFIX="/home/commandmc/Games/Heroic/Prefixes/Akalabeth - World of Doom" WINEFSYNC=1 ...
```
This is *not* a change relating to how commands are ran, this is just how they're represented

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
