### PR TITLE
Fix: Don't 'handleProtocol' if mainWindow doesn't exist yet

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -205,6 +205,7 @@ async function createWindow(): Promise<BrowserWindow> {
 // Some APIs can only be used after this event occurs.
 let appIcon: Tray = null
 const gotTheLock = app.requestSingleInstanceLock()
+let openUrlArgument = ''
 
 const contextMenu = () => {
   const recentGames: Array<RecentGame> =
@@ -433,7 +434,7 @@ ipcMain.on('Notify', (event, args) => {
 })
 
 ipcMain.on('frontendReady', () => {
-  handleProtocol(mainWindow, process.argv)
+  handleProtocol(mainWindow, [openUrlArgument, ...process.argv])
 })
 
 // Maybe this can help with white screens
@@ -510,7 +511,11 @@ app.on('window-all-closed', () => {
 
 app.on('open-url', (event, url) => {
   event.preventDefault()
-  handleProtocol(mainWindow, [url])
+  if (mainWindow) {
+    handleProtocol(mainWindow, [url])
+  } else {
+    openUrlArgument = url
+  }
 })
 
 ipcMain.on('openFolder', async (event, folder) => openUrlOrFile(folder))


### PR DESCRIPTION
This fixes another issue I found on my jurney to add shortcuts on MacOS. On this pr https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/1501 I was testing opening heroic with arguments, but I didn't test opening heroic by letting the OS handle the `heroic://launch` url.

When I tested that, I notices that the `open-url` event happens before the mainWindow object is even created, and it was trying to `handleProtocol` with no mainWindow object. Then the `process.argv` variable was empty in the other `handleProtocol` in the `frontendReady` callback becuase it was not passed as an argument to the process by the OS.

In this PR I'm checking first if the mainWindow is exists, if it does it just calls `handleProtocol`, it if doesn't then it stores the url somewhere so it can be used in the `frontendReady` callback.

This issue happened only when executing a protocol when heroic was closed.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
