### PR TITLE
Some UI fixes for long strings on translations

### DIFF
--- a/src/components/UI/Header/index.css
+++ b/src/components/UI/Header/index.css
@@ -3,7 +3,7 @@
   top: 0;
   z-index: 7;
   display: grid;
-  grid-template-columns: 330px 50%;
+  grid-template-columns: minmax(min-content, 350px) 1fr;
   grid-template-areas: 'filters search';
   grid-gap: 8px;
   align-items: start;

--- a/src/components/UI/Sidebar/index.css
+++ b/src/components/UI/Sidebar/index.css
@@ -40,6 +40,7 @@
   font-size: 18px;
   color: var(--navbar-accent);
   transition: color 250ms;
+  text-align: start;
 }
 
 .Sidebar__item:focus-visible {
@@ -67,6 +68,7 @@
   display: inline-flex;
   justify-content: center;
   color: var(--accent);
+  flex-shrink: 0;
 }
 
 .currentDownloads {

--- a/src/components/UI/ToggleSwitch/index.css
+++ b/src/components/UI/ToggleSwitch/index.css
@@ -4,6 +4,7 @@
   grid-template-columns: min-content 1fr;
   align-items: center;
   justify-items: flex-start;
+  text-align: start;
   cursor: pointer;
 }
 

--- a/src/screens/Settings/index.css
+++ b/src/screens/Settings/index.css
@@ -213,7 +213,7 @@ a {
 }
 
 .settingsWrapper .button {
-  max-height: auto;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
 }


### PR DESCRIPTION
This PR fixes a few issues found when testing Heroic with some languages. It fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1502 and also:

Note the sidebar item and the toggle text here with Ukranian:
![image](https://user-images.githubusercontent.com/188464/178640161-f4397d4a-0e6a-4de3-9d98-ec0656134e9e.png)

After:
![image](https://user-images.githubusercontent.com/188464/178640268-497d69fb-af7c-42b5-8d1d-37651373e0b0.png)

And now the Header buttons can grow more if the translation for `ALL` is longer:
![image](https://user-images.githubusercontent.com/188464/178640364-ecc2cde1-5ab0-439f-804d-4991bfb3a9fb.png)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
