### PR TITLE
[UI] Match Toggle Helper Icon with Theme Color

### DIFF
--- a/src/screens/Settings/components/OtherSettings/index.css
+++ b/src/screens/Settings/components/OtherSettings/index.css
@@ -6,4 +6,5 @@
 
 .helpIcon {
   padding-left: 5px;
+  color: var(--accent);
 }

--- a/src/screens/Settings/components/WineSettings/index.css
+++ b/src/screens/Settings/components/WineSettings/index.css
@@ -6,4 +6,5 @@
 
 .helpIcon {
   padding-left: 5px;
+  color: var(--accent);
 }


### PR DESCRIPTION
The color for Helper Icons for Toggles will now complement the selected theme.

**Classic:**
![toggle_helpericon_theme_color1](https://user-images.githubusercontent.com/74495920/178652251-7a58652d-cd94-4a27-a526-d6a32e5d3028.png)

**Zombie Classic:**
![toggle_helpericon_theme_color2](https://user-images.githubusercontent.com/74495920/178652274-c7874588-f124-473d-84d9-c66771ea5a8f.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
