### PR TITLE
[Fix] System Libs Helper icon spacing

### DIFF
--- a/src/screens/Settings/components/WineSettings/index.tsx
+++ b/src/screens/Settings/components/WineSettings/index.tsx
@@ -366,7 +366,11 @@ export default function WineSettings({
               )}
             />
           </div>
+        </div>
+      )}
 
+      {isLinux && !isProton && (
+        <div>
           <div className="toggleRow">
             <ToggleSwitch
               htmlId="systemLibsToggle"


### PR DESCRIPTION
Eliminate the odd spacing between the toggle text and helper icon

**Before:**
![fix-systemlib-help-icon](https://user-images.githubusercontent.com/74495920/178892086-b1c2f3a4-eae0-48e0-baae-c9dc3d63b714.png)


**After:**
![fix-systemlib-help-icon-new](https://user-images.githubusercontent.com/74495920/178892096-287528b7-77db-480c-9f32-d9211bcd7372.png)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
