### PR TITLE
[Fix] Delete duplicate ThemeSelector element

### DIFF
--- a/src/screens/Settings/components/GeneralSettings/index.tsx
+++ b/src/screens/Settings/components/GeneralSettings/index.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next'
 import ContextProvider from 'src/state/ContextProvider'
 import { InfoBox, SelectField, ToggleSwitch } from 'src/components/UI'
 import LanguageSelector from 'src/components/UI/LanguageSelector'
-import { ThemeSelector } from 'src/components/UI/ThemeSelector'
 
 import { IpcRenderer } from 'electron'
 import Backspace from '@mui/icons-material/Backspace'
@@ -322,8 +321,6 @@ export default function GeneralSettings({
           {t('setting.library_top_option.disabled', 'Disabled')}
         </option>
       </SelectField>
-
-      <ThemeSelector />
 
       <SelectField
         htmlId="max_workers"


### PR DESCRIPTION
I found that ThemeSelector is present in both Accessibility and General Settings screens. Removed the extra one from General Settings.

I can remove it from the Accessibility screen instead. 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
