### PR TITLE
[Windows] Prompt for Visual C++ Runtime installation when not found

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -65,7 +65,8 @@ import {
   getLegendaryBin,
   getGOGdlBin,
   showErrorBoxModal,
-  getFileSize
+  getFileSize,
+  detectVCRedist
 } from './utils'
 import {
   configStore,
@@ -187,11 +188,16 @@ async function createWindow(): Promise<BrowserWindow> {
     const { exitToTray } = GlobalConfig.get().config
 
     if (exitToTray) {
+      logInfo('Exitting to tray instead of quitting', LogPrefix.Backend)
       return mainWindow.hide()
     }
 
     handleExit(mainWindow)
   })
+
+  if (isWindows) {
+    detectVCRedist(mainWindow)
+  }
 
   if (!app.isPackaged) {
     /* eslint-disable @typescript-eslint/ban-ts-comment */


### PR DESCRIPTION
On Startup, we now check if the 64- and 32-bit-versions of the [Visual C++ Runtime](https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#visual-studio-2015-2017-2019-and-2022) are installed and display a message if they aren't. These runtimes are required for a few games (Fall Guys for example), but they're expected to already be installed (*I think* the EGL installs them when it's installed?)

Some remarks:
- The way I'm checking for the runtimes can probably have false positives (for example if someone has the actual development environment installed), although I don't think that's too big of an issue since you should still be fine if you have *more* than just the runtimes
- The messages in the dialog boxes could be improved a bit (which is why I didn't run `yarn i18next` yet)
- Displaying the message on each launch might be a little annoying, although I'd say the runtimes are important enough that everyone should have them installed

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
