### PR TITLE
[General] Add cli option "--fullscreen"

### DIFF
--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -32,6 +32,7 @@ const isMac = platform() === 'darwin'
 const isWindows = platform() === 'win32'
 const isLinux = platform() === 'linux'
 const isSteamDeckGameMode = process.env.XDG_CURRENT_DESKTOP === 'gamescope'
+const isCLIFullscreen = process.argv.includes('--fullscreen')
 const isFlatpak = Boolean(env.FLATPAK_ID)
 const currentGameConfigVersion: GameConfigVersion = 'v0'
 const currentGlobalConfigVersion: GlobalConfigVersion = 'v0'
@@ -214,5 +215,6 @@ export {
   tsStore,
   fontsStore,
   isSteamDeckGameMode,
+  isCLIFullscreen,
   runtimePath
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -90,7 +90,8 @@ import {
   fontsStore,
   heroicConfigPath,
   isMac,
-  isSteamDeckGameMode
+  isSteamDeckGameMode,
+  isCLIFullscreen
 } from './constants'
 import { handleProtocol } from './protocol'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
@@ -154,9 +155,14 @@ async function createWindow(): Promise<BrowserWindow> {
     }
   })
 
-  if (isSteamDeckGameMode) {
+  if (isSteamDeckGameMode || isCLIFullscreen) {
     logInfo(
-      'Heroic started via Steam-Deck gamemode. Switching to fullscreen',
+      [
+        isSteamDeckGameMode
+          ? 'Heroic started via Steam-Deck gamemode.'
+          : 'Heroic started with --fullscreen',
+        'Switching to fullscreen'
+      ],
       LogPrefix.Backend
     )
     mainWindow.setFullScreen(true)
@@ -180,7 +186,7 @@ async function createWindow(): Promise<BrowserWindow> {
   mainWindow.on('close', async (e) => {
     e.preventDefault()
 
-    if (!isSteamDeckGameMode) {
+    if (!isCLIFullscreen && !isSteamDeckGameMode) {
       // store windows properties
       configStore.set('window-props', mainWindow.getBounds())
     }
@@ -629,7 +635,7 @@ ipcMain.handle('getMaxCpus', () => cpus().length)
 ipcMain.handle('getHeroicVersion', () => app.getVersion())
 ipcMain.handle('getLegendaryVersion', async () => getLegendaryVersion())
 ipcMain.handle('getGogdlVersion', async () => getGogdlVersion())
-ipcMain.handle('isSteamDeckMode', () => isSteamDeckGameMode)
+ipcMain.handle('isFullscreen', () => isSteamDeckGameMode || isCLIFullscreen)
 
 ipcMain.handle('getPlatform', () => process.platform)
 

--- a/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -50,7 +50,7 @@ export default function SidebarLinks() {
     location.pathname.startsWith('/settings/default')
   )
   const [settingsPath, setSettingsPath] = useState('/settings/default/general')
-  const [isSteamDeckGameMode, setIsSteamDeckGameMode] = useState(false)
+  const [isFullscreen, setIsFullscreen] = useState(false)
 
   const {
     hasCloudSave = false,
@@ -85,8 +85,8 @@ export default function SidebarLinks() {
 
   useEffect(() => {
     ipcRenderer
-      .invoke('isSteamDeckMode')
-      .then((res) => setIsSteamDeckGameMode(res))
+      .invoke('isFullscreen')
+      .then((res) => setIsFullscreen(res))
   }, [])
 
   return (
@@ -368,7 +368,7 @@ export default function SidebarLinks() {
         </div>
         <span>Ko-fi</span>
       </button>
-      {isSteamDeckGameMode && <QuitButton />}
+      {isFullscreen && <QuitButton />}
     </div>
   )
 }

--- a/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -84,9 +84,7 @@ export default function SidebarLinks() {
   }, [location])
 
   useEffect(() => {
-    ipcRenderer
-      .invoke('isFullscreen')
-      .then((res) => setIsFullscreen(res))
+    ipcRenderer.invoke('isFullscreen').then((res) => setIsFullscreen(res))
   }, [])
 
   return (


### PR DESCRIPTION
If passed via cli, heroic will start fullscreen without window decoration. Like on the steam deck game mode, window size is not stored via electron-store.

**Should be merged after beta becomes stable.**

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
