### PR TITLE
Don't show update notification after uninstalling a game with available updates

### DIFF
--- a/electron/gog/library.ts
+++ b/electron/gog/library.ts
@@ -412,7 +412,7 @@ export class GOGLibrary {
   }
 
   // This checks for updates of Windows and Mac titles
-  // Linux installers need to be checked differenly
+  // Linux installers need to be checked differently
   public async listUpdateableGames(): Promise<string[]> {
     const installed = Array.from(this.installedGames.values())
     const updateable: Array<string> = []

--- a/src/screens/Game/GamePage/index.tsx
+++ b/src/screens/Game/GamePage/index.tsx
@@ -147,7 +147,7 @@ export default function GamePage(): JSX.Element | null {
     setShowModal({ game: appName, show: true })
   }
 
-  const hasUpdate = gameUpdates?.includes(appName)
+  let hasUpdate = false
 
   if (gameInfo && gameInfo.install) {
     const {
@@ -168,6 +168,9 @@ export default function GamePage(): JSX.Element | null {
       cloud_save_enabled,
       canRunOffline
     }: GameInfo = gameInfo
+
+    hasUpdate = is_installed && gameUpdates?.includes(appName)
+
     const downloadSize =
       gameInstallInfo?.manifest?.download_size &&
       size(Number(gameInstallInfo?.manifest?.download_size))

--- a/src/screens/Library/components/GamesList/index.tsx
+++ b/src/screens/Library/components/GamesList/index.tsx
@@ -55,7 +55,7 @@ export const GamesList = ({
             if (is_dlc) {
               return null
             }
-            const hasUpdate = gameUpdates?.includes(app_name)
+            const hasUpdate = is_installed && gameUpdates?.includes(app_name)
             return (
               <GameCard
                 key={app_name}


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1578 by checking if a game is installed to set the hasUpdate variables and not just the statuses array.

Before:
![image](https://user-images.githubusercontent.com/188464/179631806-a8fb38b1-01b9-4c6f-9939-604270ba6200.png)
![image](https://user-images.githubusercontent.com/188464/179631830-224b78f7-cff5-41aa-ab55-79b422165b04.png)

After:
![image](https://user-images.githubusercontent.com/188464/179631865-492c4614-d50d-460c-a272-09b580a49149.png)
![image](https://user-images.githubusercontent.com/188464/179631891-b5f21d9f-7ce4-464b-b387-fa75cbce6d34.png)

Installed games still show the correct indicator:
![image](https://user-images.githubusercontent.com/188464/179631919-34fe7627-fcbf-4063-a157-8d83b85ef4a4.png)
![image](https://user-images.githubusercontent.com/188464/179631939-ba25d83f-7468-42d9-9d57-201501fe0f76.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
