### PR TITLE
[Fix] Show Tools EOS Overlay button for Epic games only

### DIFF
--- a/src/screens/Game/GameSubMenu/index.tsx
+++ b/src/screens/Game/GameSubMenu/index.tsx
@@ -355,7 +355,8 @@ export default function GamesSubmenu({
                   : t('submenu.addToSteam', 'Add to Steam')}
               </button>
             )}
-            {isLinux && runner === 'legendary' &&
+            {isLinux &&
+              runner === 'legendary' &&
               (eosOverlayRefresh ? (
                 refreshCircle()
               ) : (

--- a/src/screens/Game/GameSubMenu/index.tsx
+++ b/src/screens/Game/GameSubMenu/index.tsx
@@ -355,7 +355,7 @@ export default function GamesSubmenu({
                   : t('submenu.addToSteam', 'Add to Steam')}
               </button>
             )}
-            {isLinux &&
+            {isLinux && runner === 'legendary' &&
               (eosOverlayRefresh ? (
                 refreshCircle()
               ) : (


### PR DESCRIPTION
The Enable/Disable EOS Overlay in the Tools screen should be displayed for Epic games only. Doesn't make sense to display for GOG games.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
