### PR TITLE
Update Protocol & clean up `Game.launch` some more

### DIFF
--- a/electron/games.ts
+++ b/electron/games.ts
@@ -33,7 +33,10 @@ abstract class Game {
   abstract import(path: string): Promise<ExecResult>
   abstract install(args: InstallArgs): Promise<{ status: string }>
   abstract addShortcuts(): Promise<void>
-  abstract launch(launchArguments?: string): Promise<boolean>
+  abstract launch(
+    launchArguments: string,
+    mainWindow?: BrowserWindow
+  ): Promise<boolean>
   abstract moveInstall(newInstallPath: string): Promise<string>
   abstract repair(): Promise<ExecResult>
   abstract stop(): Promise<void>

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -361,12 +361,12 @@ export interface SteamRuntime {
 
 export interface LaunchPreperationResult {
   success: boolean
+  startPlayingDate: Date
   failureReason?: string
   rpcClient?: RpcClient
   mangoHudCommand?: string[]
   gameModeBin?: string
   steamRuntime?: string[]
-  startPlayingDate?: Date
 }
 
 export interface RpcClient {

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -363,9 +363,10 @@ export interface LaunchPreperationResult {
   success: boolean
   failureReason?: string
   rpcClient?: RpcClient
-  mangoHudCommand?: string
+  mangoHudCommand?: string[]
   gameModeBin?: string
-  steamRuntime?: string
+  steamRuntime?: string[]
+  startPlayingDate?: Date
 }
 
 export interface RpcClient {
@@ -456,3 +457,8 @@ export interface Runtime {
 }
 
 export type RuntimeName = 'eac_runtime' | 'battleye_runtime'
+
+export type RecentGame = {
+  appName: string
+  title: string
+}

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -354,9 +354,9 @@ export interface GamepadInputEventMouse {
 }
 
 export interface SteamRuntime {
-  type: 'unpackaged' | 'flatpak'
   path: string
-  version: 'soldier' | 'scout'
+  type: 'soldier' | 'scout'
+  args: string[]
 }
 
 export interface LaunchPreperationResult {

--- a/src/screens/Settings/components/WineExtensions/index.tsx
+++ b/src/screens/Settings/components/WineExtensions/index.tsx
@@ -93,7 +93,7 @@ export default function WineExtensions({
               htmlId="autodxvk"
               value={autoInstallDxvk}
               handleChange={() => {
-                const action = autoInstallDxvk ? 'restore' : 'backup'
+                const action = autoInstallDxvk ? 'remove' : 'install'
                 ipcRenderer.send('toggleDXVK', [
                   { winePrefix, winePath: wineVersion.bin },
                   action
@@ -120,7 +120,7 @@ export default function WineExtensions({
               htmlId="autovkd3d"
               value={autoInstallVkd3d}
               handleChange={() => {
-                const action = autoInstallVkd3d ? 'restore' : 'backup'
+                const action = autoInstallDxvk ? 'remove' : 'install'
                 ipcRenderer.send('toggleVKD3D', [
                   { winePrefix, winePath: wineVersion.bin },
                   action

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -590,7 +590,7 @@ function Settings() {
               toggleUseSteamRuntime={toggleUseSteamRuntime}
               isMacNative={isMacNative}
               isLinuxNative={isLinuxNative}
-              isProton={wineVersion.type === 'proton'}
+              isProton={!isWin && wineVersion.type === 'proton'}
               appName={appName}
               defaultSteamPath={defaultSteamPath}
               setDefaultSteamPath={setDefaultSteamPath}


### PR DESCRIPTION
I've updated the protocol parser to make it possible to pass variables to it, e. g. `heroic://launch?appName=Quail&runner=legendary`. As an added bonus, the frontend is no longer called when launching games through the protocol.
To make that possible, I've moved all the logic of `ipcMain.handle('launch', ...)` into `prepareLaunch` and `launchCleanup`

@Nocccer If you could update the "Add to Steam" function so it generates this new protocol link instead, that would be great

Other, smaller changes:
- DXVK/VKD3D installer was cleaned up a bit ('install' and 'remove' actions are much clearer than 'backup' and 'restore' IMO)
- When launching fails, error messages are now displayed directly (they were only written to the log before
- GOG's somewhat wonky game folder existence check was integrated into `prepareLaunch` (before, we'd just continue to launch the game even if that check failed)

I've tested this on my main Linux setup and a clean install of EndeavourOS in a VM, with no issues found there. I'm also in the process of testing this on Windows.
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
