### PR TITLE
Refresh recent games when game is launched + no longer sort them on a per-store basis

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -854,11 +854,6 @@ ipcMain.handle(
   'launch',
   async (event, { appName, launchArguments, runner }: LaunchParams) => {
     const window = BrowserWindow.getAllWindows()[0]
-    window.webContents.send('setGameStatus', {
-      appName,
-      runner,
-      status: 'playing'
-    })
     const recentGames =
       (configStore.get('games.recent') as Array<RecentGame>) || []
     const game = Game.get(appName, runner)
@@ -893,6 +888,12 @@ ipcMain.handle(
     } else {
       configStore.set('games.recent', [{ appName: game.appName, title }])
     }
+
+    window.webContents.send('setGameStatus', {
+      appName,
+      runner,
+      status: 'playing'
+    })
 
     if (minimizeOnLaunch) {
       mainWindow.hide()

--- a/src/helpers/library.ts
+++ b/src/helpers/library.ts
@@ -299,12 +299,17 @@ type RecentGame = {
   title: string
 }
 
-function getRecentGames(library: GameInfo[]) {
+function getRecentGames(libraries: GameInfo[]) {
   const recentGames =
     (configStore.get('games.recent', []) as Array<RecentGame>) || []
-  const recentGamesList = recentGames.map((a) => a.appName) as string[]
-
-  return library.filter((game) => recentGamesList.includes(game.app_name))
+  return (
+    recentGames
+      .map((game) => {
+        return libraries.find((info) => info.app_name === game.appName)
+      })
+      // With this `.filter`, no empty entries can be returned. TS doesn't understand this, so we have to add the `as GameInfo[]`
+      .filter(Boolean) as GameInfo[]
+  )
 }
 
 export const epicCategories = ['all', 'legendary', 'epic', 'unreal']

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -460,6 +460,20 @@ export class GlobalState extends PureComponent<Props> {
       (game) => game.appName === appName
     )[0]
 
+    // Update recently played games if the game was just launched
+    // HACK: Ideally we'd use `configStore.onDidChange('games.recent')` here, but it's for some reason not working
+    if (status === 'playing') {
+      const { epic, gog } = this.state
+      const recentGames: GameInfo[] = getRecentGames([
+        ...epic.library,
+        ...gog.library
+      ])
+
+      this.setState({
+        recentGames
+      })
+    }
+
     // add app to libraryStatus if it was not present
     if (!currentApp) {
       return this.setState({

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -584,14 +584,10 @@ export class GlobalState extends PureComponent<Props> {
       this.setState({ gameUpdates: storedGameUpdates })
     }
 
-    let recentGames: GameInfo[] = []
-
-    if (epic.library.length > 0) {
-      recentGames = [...getRecentGames(epic.library)]
-    }
-    if (gog.library.length > 0) {
-      recentGames = [...recentGames, ...getRecentGames(gog.library)]
-    }
+    const recentGames: GameInfo[] = getRecentGames([
+      ...epic.library,
+      ...gog.library
+    ])
 
     this.setState({
       platform,


### PR DESCRIPTION
This fixes two things:
- Recent games were fetched in the order "Epic -> GOG", which resulted in Epic games always appearing first
- When a game was launched, the recent game list was not updated
  Note: This is done in a somewhat hacky way that relies on the backend first setting the recent games and then sending the `playing` game status update. I would've liked to use `configStore.onDidChange('games.recent', callback)` here, but the callback is for some reason never called

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
