### PR TITLE
Fix virtual keyboard keypress

### DIFF
--- a/src/components/UI/SearchBar/index.tsx
+++ b/src/components/UI/SearchBar/index.tsx
@@ -63,7 +63,10 @@ export default function SearchBar() {
           ref={input}
           data-testid="searchInput"
           placeholder={t('search')}
-          id="search" // this id is used for the virtualkeyboard, don't change it
+          // this id is used for the virtualkeyboard, don't change it,
+          // if this must be changed, reflect the change in src/helpers/virtualKeyboard.ts#searchInput
+          // and in src/helpers/gamepad.ts#isSearchInput
+          id="search"
           className="FormControl__input"
         />
         {filterText.length > 0 && (

--- a/src/helpers/gamepad.ts
+++ b/src/helpers/gamepad.ts
@@ -178,6 +178,8 @@ export const initGamepad = () => {
     const el = currentElement()
     if (!el) return false
 
+    // only change this if you change the id of the input element
+    // in src/components/UI/SearchBar/index.tsx
     return el.id === 'search'
   }
 

--- a/src/helpers/virtualKeyboard.ts
+++ b/src/helpers/virtualKeyboard.ts
@@ -8,6 +8,8 @@ function currentElement() {
 }
 
 function searchInput() {
+  // only change this if you change the id of the input element
+  // in src/components/UI/SearchBar/index.tsx
   return document.querySelector('#search') as HTMLInputElement
 }
 

--- a/src/helpers/virtualKeyboard.ts
+++ b/src/helpers/virtualKeyboard.ts
@@ -8,7 +8,7 @@ function currentElement() {
 }
 
 function searchInput() {
-  return document.querySelector('.searchInput') as HTMLInputElement
+  return document.querySelector('#search') as HTMLInputElement
 }
 
 function focusKeyboard() {


### PR DESCRIPTION
This PR fixes the virtual keyboard ketpress handler that had the wrong selector to write in the search box.

This fixes #1607 and should also fix #1510 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
