### PR TITLE
[Fix] Esync/Fsync toggle buttons for Proton

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -298,11 +298,17 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
     ret.WINE_FULLSCREEN_FSR = '1'
     ret.WINE_FULLSCREEN_FSR_STRENGTH = gameSettings.maxSharpness.toString()
   }
-  if (gameSettings.enableEsync) {
+  if (gameSettings.enableEsync && wineVersion.type !== 'proton') {
     ret.WINEESYNC = '1'
   }
-  if (gameSettings.enableFsync) {
+  if (!gameSettings.enableEsync && wineVersion.type === 'proton') {
+    ret.PROTON_NO_ESYNC = '1'
+  }
+  if (gameSettings.enableFsync && wineVersion.type !== 'proton') {
     ret.WINEFSYNC = '1'
+  }
+  if (!gameSettings.enableFsync && wineVersion.type === 'proton') {
+    ret.PROTON_NO_FSYNC = '1'
   }
   if (gameSettings.enableResizableBar) {
     ret.VKD3D_CONFIG = 'upload_hvv'


### PR DESCRIPTION
Proton enables Esync/Fsync by default. Instead of enabling it with `WINEESYNC`/`WINEFSYNC`, you use `PROTON_NO_ESYNC`/`PROTON_NO_FSYNC` to disable it.
We weren't setting these variables correctly (we just always used `WINEESYNC`/`WINEFSYNC`). That's now fixed

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
