### PR TITLE
[Fix] Runtime toggle logic fix + GameMode message for Flatpak

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -92,7 +92,8 @@ import {
   isMac,
   isSteamDeckGameMode,
   isCLIFullscreen,
-  isCLINoGui
+  isCLINoGui,
+  isFlatpak
 } from './constants'
 import { handleProtocol } from './protocol'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
@@ -637,6 +638,7 @@ ipcMain.handle('getHeroicVersion', () => app.getVersion())
 ipcMain.handle('getLegendaryVersion', async () => getLegendaryVersion())
 ipcMain.handle('getGogdlVersion', async () => getGogdlVersion())
 ipcMain.handle('isFullscreen', () => isSteamDeckGameMode || isCLIFullscreen)
+ipcMain.handle('isFlatpak', () => isFlatpak)
 
 ipcMain.handle('getPlatform', () => process.platform)
 

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Изберете изпълнимия файл на Wine или Proton",
         "default-install-path": "Изберете пътя по подразбиране за инсталиране",
         "default-steam-path": "Път до Steam.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Избиране",
             "error": "Неправилен път",
             "title": "Изберете папка за запазване на файлове"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Версия на Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Изчистване на кеша на Heroic",
         "copiedToClipboard": "Копирано в буфера за обмен!",
         "copyToClipboard": "Копиране на всички настройки в буфера за обмен",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Журналът е отрязан. Показани са последните 1000 реда!"
         },
@@ -430,7 +458,8 @@
             "general": "Общи",
             "log": "Журнал",
             "other": "Други",
-            "sync": "Синхронизиране на запазените файлове"
+            "sync": "Синхронизиране на запазените файлове",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Отваряне на конфигурационния файл",
         "reset-heroic": "Зачистване на Heroic",

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Selecciona el binary del Wine o del Proton",
         "default-install-path": "Tria la ruta d'instal·lació predefinida",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Tria",
             "error": "Ruta no vàlida",
             "title": "Tria el directori de partides desades"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Versió del Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Esborra la memòria cau de l'Heroic",
         "copiedToClipboard": "S'ha copiat al porta-retalls.",
         "copyToClipboard": "Copia tota la configuració al porta-retalls",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "S'ha truncat el registre. Es mostren les últimes 1.000 línies."
         },
@@ -430,7 +458,8 @@
             "general": "General",
             "log": "Registre",
             "other": "Altres",
-            "sync": "Desa-sincronitza"
+            "sync": "Desa-sincronitza",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Obre el fitxer de configuració",
         "reset-heroic": "Restableix l'Heroic",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Vyberte spustitelný soubor Wine nebo Proton",
         "default-install-path": "Vyberte výchozí cestu pro instalaci",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Vybrat",
             "error": "Neplatná cesta",
             "title": "Vyberte cestu s uloženými soubory"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Verze Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Vymazat mezipaměť Heroic",
         "copiedToClipboard": "Zkopírováno do schránky!",
         "copyToClipboard": "Kopírovat všechna nastavení do schránky",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Záznam je zkrácen, zobrazeno je posledních 1000 řádků!"
         },
@@ -430,7 +458,8 @@
             "general": "Obecné",
             "log": "Log",
             "other": "Ostatní",
-            "sync": "Synchronizace uložených souborů"
+            "sync": "Synchronizace uložených souborů",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Otevřít soubor konfigurace",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Benutzerdefinierte Wine/Proton Pfade",
         "default-install-path": "Wähle den Standard Installations-Pfad",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Auswählen",
             "error": "Ungültiger Pfad",
             "title": "Wähle das Spielstand-Verzeichnis"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine-Version"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Heroic Cache leeren",
         "copiedToClipboard": "In die Zwischenablage kopiert!",
         "copyToClipboard": "Alle Einstellungen in die Zwischenablage kopieren",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log abgeschnitten, die letzten 1000 Zeilen werden angezeigt!"
         },
@@ -430,7 +458,8 @@
             "general": "Allgemein",
             "log": "Log",
             "other": "Andere",
-            "sync": "Spielstände-Synchronisation"
+            "sync": "Spielstände-Synchronisation",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Konfigurationsdatei öffnen",
         "reset-heroic": "Heroic zurücksetzen",

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Επιλέξτε το δυαδικό αρχείο Wine ή Proton",
         "default-install-path": "Επιλέξτε Κύρια Διαδρομή Εγκατάστασης",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Επιλέξτε",
             "error": "Μη έγκυρη διαδρομή",
             "title": "Επιλέξτε την διαδρομή αποθήκευσης"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Έκδοση Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Εκκαθάριση κρυφής μνήμης Heroic",
         "copiedToClipboard": "Αντιγράφηκε στι Πρόχειρο!",
         "copyToClipboard": "Αντιγραφή όλών των ρυθμίσεων στο Πρόχειρο",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Το αρχείο καταγραφής ελαττώθηκε, εμφάνιση τελευταίων 1000 γραμμών!"
         },
@@ -430,7 +458,8 @@
             "general": "Γενικά",
             "log": "Log",
             "other": "Άλλα",
-            "sync": "Αποθήκευση-Συγχρονισμός"
+            "sync": "Αποθήκευση-Συγχρονισμός",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Select the Wine or Proton binary",
         "default-install-path": "Choose Default Install Path",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Choose",
             "error": "Invalid Path",
             "title": "Choose the saves directory"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine Version"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Clear Heroic Cache",
         "copiedToClipboard": "Copied to Clipboard!",
         "copyToClipboard": "Copy All Settings to Clipboard",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log truncated, last 1000 lines are shown!"
         },
@@ -430,7 +458,8 @@
             "general": "General",
             "log": "Log",
             "other": "Other",
-            "sync": "Save-Sync"
+            "sync": "Save-Sync",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Seleccione binario de Wine o Proton",
         "default-install-path": "Elija la ruta de instalación predeterminada",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Elegir",
             "error": "Ruta no válida",
             "title": "Elija el directorio de guardado"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Versión de Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Borrar la caché de Heroic",
         "copiedToClipboard": "¡Copiado en el portapapeles!",
         "copyToClipboard": "Copiar todas las configuraciones al portapapeles",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Registro truncado. ¡Se mostrarán las últimas 1000 líneas!"
         },
@@ -430,7 +458,8 @@
             "general": "General",
             "log": "Registro",
             "other": "Otro",
-            "sync": "Guardar-Sincronización"
+            "sync": "Guardar-Sincronización",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Restablecer Heroic",

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Valige Wine või Proton-i binaar",
         "default-install-path": "Valige Vaikimisi paigalduskoht",
         "default-steam-path": "Steami tee.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Valige",
             "error": "Vale koht",
             "title": "Valige salvestuste kaust"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine'i versioon"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Tühjenda Heroic'u vahemälu",
         "copiedToClipboard": "Kopeeritud lõikelauale!",
         "copyToClipboard": "Kopeeri kõik seaded lõikelauale",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Logi on kärbitud, näidatakse viimased 1000 rida!"
         },
@@ -430,7 +458,8 @@
             "general": "Üldine",
             "log": "Logi",
             "other": "Muu",
-            "sync": "Salvesta-sünkrooni"
+            "sync": "Salvesta-sünkrooni",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Ava konfiguratsioonifail",
         "reset-heroic": "Lähtesta Heroic",

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -29,6 +29,7 @@
         "customWine": "انتخاب فایل باینری Wine یا Proton",
         "default-install-path": "انتخاب محل پیشفرض نصب",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "انتخاب",
             "error": "مسیر نامعتبر",
             "title": "انتخاب محل ذخیره"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "نسخه Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "پاک کردن کش Heroic",
         "copiedToClipboard": "در کليپ بورد کپی شد!",
         "copyToClipboard": "کپی کردن همه تنظیمات در کليپ بورد",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "لاگ کوتاه شد، ١٠٠٠ خط آخر نمایش داده شدهاند!"
         },
@@ -430,7 +458,8 @@
             "general": "عمومی",
             "log": "Log",
             "other": "بقیه",
-            "sync": "همگامسازی ذخیرهها"
+            "sync": "همگامسازی ذخیرهها",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "باز کردن فایل پیکربندی",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Valitse Wine tai Proton-binääritiedosto",
         "default-install-path": "Valitse Oletus Asennussijainti",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Valitse",
             "error": "Virheellinen Polku",
             "title": "Valitse kansio tallennuksille"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Winen versio"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Tyhjennä Heroicin välimuisti",
         "copiedToClipboard": "Kopioitu leikepöydälle!",
         "copyToClipboard": "Jäljennä kaikki asetukset leikepöydälle",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Loki typistetty, viimeiset 1000 riviä näytetään!"
         },
@@ -430,7 +458,8 @@
             "general": "Yleiset",
             "log": "Log",
             "other": "Muut",
-            "sync": "Tallenna ja synkronoi"
+            "sync": "Tallenna ja synkronoi",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Sélectionner le binaire Wine ou Proton",
         "default-install-path": "Choisir le chemin par défaut",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Sélectionner",
             "error": "Chemin invalide",
             "title": "Choisir le dossier de sauvegardes"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Version de Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Effacer le cache Heroic",
         "copiedToClipboard": "Copied to Clipboard!",
         "copyToClipboard": "Copier tous les paramètres dans le presse-papier",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log truncated, last 1000 lines are shown!"
         },
@@ -430,7 +458,8 @@
             "general": "Général",
             "log": "Log",
             "other": "Autre",
-            "sync": "Synchronisation des sauvegardes"
+            "sync": "Synchronisation des sauvegardes",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Selecciona o binario de Wine ou Proton",
         "default-install-path": "Seleccionar a ruta de instalación predeterminada",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Seleccionar",
             "error": "Ruta non válida",
             "title": "Seleccionar o cartafol de partidas gardadas"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Versión de Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Limpar caché de Heroic",
         "copiedToClipboard": "Copied to Clipboard!",
         "copyToClipboard": "Copiar todas as configuracións al portapapeis",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log truncated, last 1000 lines are shown!"
         },
@@ -430,7 +458,8 @@
             "general": "Xeral",
             "log": "Log",
             "other": "Outro",
-            "sync": "Gardar-Sincronizar"
+            "sync": "Gardar-Sincronizar",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Restabelecer Heroic",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Select the Wine or Proton Binary",
         "default-install-path": "Odaberite Zadanu Lokaciju Instalacije",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Odaberi",
             "error": "Pogrešni put",
             "title": "Odaberi mapu za podatke"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine Verzija"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Clear Heroic Cache",
         "copiedToClipboard": "Copied to Clipboard!",
         "copyToClipboard": "Copy All Settings to Clipboard",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log truncated, last 1000 lines are shown!"
         },
@@ -430,7 +458,8 @@
             "general": "Općenito",
             "log": "Log",
             "other": "Ostalo",
-            "sync": "Spremi-Podatke"
+            "sync": "Spremi-Podatke",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Válaszd ki a Wine vagy Proton binárist",
         "default-install-path": "Válassz alapértelmezett telepítési útvonalat",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Kiválasztás",
             "error": "Érvénytelen útvonal",
             "title": "Válaszd ki a mentések könyvtárát"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine verzió"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Heroic gyorsítótár törlése",
         "copiedToClipboard": "Vágólapra másolva!",
         "copyToClipboard": "Összes beállítás másolása a vágólapra",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "A napló rövidítve van, az utolsó 1000 sor van megjelenítve!"
         },
@@ -430,7 +458,8 @@
             "general": "Általános",
             "log": "Napló",
             "other": "Egyéb",
-            "sync": "Mentés szinkronizálás"
+            "sync": "Mentés szinkronizálás",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Heroic visszaállítása",

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Pilih Wine atau Proton Binary",
         "default-install-path": "Pilih Lokasi Pemasangan Bawaan",
         "default-steam-path": "Lokasi Steam.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Pilih",
             "error": "Lokasi Tidak Valid",
             "title": "Pilih direktori penyimpanan"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Versi Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Hapus Tembolok Heroic",
         "copiedToClipboard": "Disalin ke Papan Klip!",
         "copyToClipboard": "Salin Semua Pengaturan ke Papan Klip",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log terpotong, 1000 baris terakhir akan ditampilkan!"
         },
@@ -430,7 +458,8 @@
             "general": "Umum",
             "log": "Log",
             "other": "Lainnya",
-            "sync": "Sinkronisasi Penyimpanan"
+            "sync": "Sinkronisasi Penyimpanan",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Buka Berkas Pengaturan",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Scegli fra il binario Wine o Proton",
         "default-install-path": "Seleziona il percorso d'installazione predefinito",
         "default-steam-path": "Percorso Steam.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Scegli",
             "error": "Percorso non valido",
             "title": "Seleziona la cartella dei salvataggi"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Versione di Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Pulisci cache Heroic",
         "copiedToClipboard": "Copiato negli appunti!",
         "copyToClipboard": "Copia tutte le impostazioni negli appunti",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log truncated, last 1000 lines are shown!"
         },
@@ -430,7 +458,8 @@
             "general": "Generale",
             "log": "Log",
             "other": "Altro",
-            "sync": "Sincronizzazione salvataggi"
+            "sync": "Sincronizzazione salvataggi",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -29,6 +29,7 @@
         "customWine": "WineまたはProtonバイナリを選択します",
         "default-install-path": "デフォルトのインストールパスを選択します",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "選ぶ",
             "error": "無効なパス",
             "title": "保存ディレクトリを選択します"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wineバージョン"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Clear Heroic Cache",
         "copiedToClipboard": "Copied to Clipboard!",
         "copyToClipboard": "Copy All Setting to Clipboard",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log truncated, last 1000 lines are shown!"
         },
@@ -430,7 +458,8 @@
             "general": "一般",
             "log": "Log",
             "other": "他",
-            "sync": "同期を保存"
+            "sync": "同期を保存",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Wine 혹은 Proton 바이너리 파일 선택",
         "default-install-path": "기본 설치 경로 선택",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "선택",
             "error": "유효하지 않은 경로",
             "title": "저장 디렉토리 선택"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine 버전"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Heroic 캐시 삭제",
         "copiedToClipboard": "클립보드에 복사되었습니다!",
         "copyToClipboard": "모든 설정을 클립보드에 복사",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "로그 잘림, 마지막 1000줄이 표시됩니다!"
         },
@@ -430,7 +458,8 @@
             "general": "일반",
             "log": "Log",
             "other": "기타",
-            "sync": "세이브-동기화"
+            "sync": "세이브-동기화",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -29,6 +29,7 @@
         "customWine": "വൈനിന്റെയോ പ്രോട്ടോണിന്റെയോ ഈരക്കരേഖ(Binary file) നല്കൂ",
         "default-install-path": "പൊതു ഇന്സ്റ്റാളിടം തിരഞ്ഞെടുക്കൂ",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "തിരഞ്ഞെടുക്കൂ",
             "error": "വഴി ശരിയല്ലല്ലോ",
             "title": "സൂക്ഷിക്കാനുള്ള അറ തിരഞ്ഞെടുക്കൂ"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "വൈനിന്റെ പതിപ്പ്"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Clear Heroic Cache",
         "copiedToClipboard": "Copied to Clipboard!",
         "copyToClipboard": "Copy All Setting to Clipboard",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log truncated, last 1000 lines are shown!"
         },
@@ -430,7 +458,8 @@
             "general": "പൊതുവായവ",
             "log": "Log",
             "other": "മറ്റുള്ളവ",
-            "sync": "ഒന്നിപ്പിക്കല് സൂക്ഷിക്കൂ"
+            "sync": "ഒന്നിപ്പിക്കല് സൂക്ഷിക്കൂ",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Selecteer de Wine of Proton Binary",
         "default-install-path": "Selecteer een standaard map",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Selecteer",
             "error": "Ongeldig Pad",
             "title": "Selecteer de saves directory"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine versie"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Clear Heroic Cache",
         "copiedToClipboard": "Copied to Clipboard!",
         "copyToClipboard": "Copy All Setting to Clipboard",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log truncated, last 1000 lines are shown!"
         },
@@ -430,7 +458,8 @@
             "general": "Algemeen",
             "log": "Log",
             "other": "Overig",
-            "sync": "Save-synchronisatie"
+            "sync": "Save-synchronisatie",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Wybierz plik binarny Wine lub Proton",
         "default-install-path": "Wybierz domyślną ścieżkę instalacji",
         "default-steam-path": "Ścieżka Steam.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Wybierz",
             "error": "Nieprawidłowa ścieżka",
             "title": "Wybierz folder zapisów gry"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -255,7 +265,7 @@
             },
             "remove": {
                 "steam": {
-                    "corrupt": "Gra {{game}} nie mogła zostać usunięta dla wszystkich użytkowników Steam. Sprawdź logi po więcej informacji. Restart Steam'a jest wymagany, by zastosować zmiany.",
+                    "corrupt": "Gra {{game}} nie mogła zostać usunięta dla wszystkich użytkowników Steam. Sprawdź logi po więcej informacji. Restart Steam'a jest wymagany, by zastosować\u00a0zmiany.",
                     "success": "Gra {{game}} została usunięta ze Steam. Restart Steam'a jest wymagany, by zastosować zmiany.",
                     "title": "Usunięto ze Steam"
                 }
@@ -419,9 +429,27 @@
         "wineversion": "Wersja Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Wyczyść pamięć cache Heroic",
         "copiedToClipboard": "Skopiowano do schowka!",
         "copyToClipboard": "Kopiuj wszystkie ustawienia do schowka",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log skrócony, wyświetlane jest ostatnie 1000 linijek!"
         },
@@ -430,7 +458,8 @@
             "general": "Główne",
             "log": "Log",
             "other": "Inne",
-            "sync": "Synchronizuj zapisy"
+            "sync": "Synchronizuj zapisy",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Otwórz plik konfiguracyjny",
         "reset-heroic": "Zresetuj Heroic",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Selecione o binário do Wine ou Proton",
         "default-install-path": "Selecione o Local de instalação padrão",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Selecionar",
             "error": "Caminho Inválido",
             "title": "Selecione o diretório com os Saves"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Versão do Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Clear Heroic Cache",
         "copiedToClipboard": "Copied to Clipboard!",
         "copyToClipboard": "Copiar todas as configurações para a área de transferência",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log truncated, last 1000 lines are shown!"
         },
@@ -430,7 +458,8 @@
             "general": "Geral",
             "log": "Log",
             "other": "Outros",
-            "sync": "Sincronização"
+            "sync": "Sincronização",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Selecione o binário do Wine ou Proton",
         "default-install-path": "Selecione o local de instalação padrão",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Selecionar",
             "error": "Caminho Inválido",
             "title": "Selecione a pasta de saves"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Versão do WINE"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Limpar cache do Heroic",
         "copiedToClipboard": "Copiado para a área de Transferência!",
         "copyToClipboard": "Copiar todas as configurações para a área de transferência",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log truncado, últimas 1000 linhas serão mostradas!"
         },
@@ -430,7 +458,8 @@
             "general": "Config. Gerais",
             "log": "Log",
             "other": "Outros",
-            "sync": "Sincronização"
+            "sync": "Sincronização",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Abrir arquivo de configuração",
         "reset-heroic": "Redefinir Heroic",

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Выбрать исполняемый файл Wine или Proton",
         "default-install-path": "Выбрать стандартный путь установки",
         "default-steam-path": "Путь к Steam.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Выбрать",
             "error": "Неправильный путь",
             "title": "Выбрать путь для сохранений"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Версия Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Очистить кэш Heroic",
         "copiedToClipboard": "Скопировано в буфер обмена!",
         "copyToClipboard": "Скопировать все настройки в буфер обмена",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Журнал урезан, показаны последние 1000 строк!"
         },
@@ -430,7 +458,8 @@
             "general": "Основные",
             "log": "Журнал",
             "other": "Другие",
-            "sync": "Сохранение-Синхронизация"
+            "sync": "Сохранение-Синхронизация",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Открыть файл конфигурации",
         "reset-heroic": "Сброс Heroic",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Ange Wine/Proton version",
         "default-install-path": "Ange standard installationssökväg",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Ok",
             "error": "Ogilltig sökväg",
             "title": "Väl mapp för sparfiler"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine version"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Rensa Heroic cache",
         "copiedToClipboard": "Kopierat till urklipp/klippbord!",
         "copyToClipboard": "Kopiera all inställningar till urklipp/klippbord",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Loggen avkortad , enbart senaste 1000 rader visas!"
         },
@@ -430,7 +458,8 @@
             "general": "Allmänt",
             "log": "Logg",
             "other": "Övrigt",
-            "sync": "Synkronisera sparfiler"
+            "sync": "Synkronisera sparfiler",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Grundinställ Heroic",

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Wine அல்லது Proton binary யைத் தேர்வு செய்",
         "default-install-path": "இயல்புநிலை நிறுவல் பாதையை தேர்வு செய்",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "தேர்வு செய்",
             "error": "தவறான பாதை",
             "title": "சேமிக்கும் கோப்பகத்தை தேர்வுசெய்"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine பதிப்பு"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Clear Heroic Cache",
         "copiedToClipboard": "Copied to Clipboard!",
         "copyToClipboard": "அனைத்து செட்டிங்ஸையும் கிளிப் போர்டில் நகல் எடு",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log truncated, last 1000 lines are shown!"
         },
@@ -430,7 +458,8 @@
             "general": "பொதுவானவை",
             "log": "Log",
             "other": "மற்றவை",
-            "sync": "சேமிப்பு-ஒத்திசைவு"
+            "sync": "சேமிப்பு-ஒத்திசைவு",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Wine veya Proton çalıştırılabilir dosyasını seç",
         "default-install-path": "Öntanımlı Kurulum Yerini Seçin",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Seç",
             "error": "Geçersiz Yol",
             "title": "Kayıtların olduğu klasörü seçin"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine Sürümü"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Heroic Önbelleğini Temizle",
         "copiedToClipboard": "Panoya kopyalandı!",
         "copyToClipboard": "Tüm Ayarları Panoya Kopyala",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Günlük kısaltıldı, son 1000 satır gösteriliyor!"
         },
@@ -430,7 +458,8 @@
             "general": "Genel",
             "log": "Log",
             "other": "Diğer",
-            "sync": "Kaydet-Eşzamanla"
+            "sync": "Kaydet-Eşzamanla",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Yapılandırma Dosyasını Aç",
         "reset-heroic": "Heroic'i Sıfırla",

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Оберіть двійковий файл Wine або Proton",
         "default-install-path": "Вкажіть стандартний шлях встановлення",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Обрати",
             "error": "Неіснуючий шлях",
             "title": "Оберіть теку збережень"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Версія Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Очистити кеш Heroic",
         "copiedToClipboard": "Копійовано в сховище обміну!",
         "copyToClipboard": "Копіювати всі налаштування в сховище обміну",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Лог усічений, показані останні 1000 рядків!"
         },
@@ -430,7 +458,8 @@
             "general": "Загальні",
             "log": "Лог",
             "other": "Інше",
-            "sync": "Синхронізація збережень"
+            "sync": "Синхронізація збережень",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Відкрити файл конфігурації",
         "reset-heroic": "Скинути Heroic",

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -29,6 +29,7 @@
         "customWine": "Chọn Wine/Proton binary",
         "default-install-path": "Chọn đường dẫn cài mặc định",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "Chọn",
             "error": "Đường dẫn không hợp lệ",
             "title": "Chọn thư mục lưu"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Phiên bản Wine"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "Xóa bộ nhớ đệm của Heroic",
         "copiedToClipboard": "Đã sao chép vào bộ nhớ tạm!",
         "copyToClipboard": "Sao chép toàn bộ cài đặt vào bộ nhớ tạm",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "Log bị cắt ngắn, hiển thị 1000 dòng cuối!"
         },
@@ -430,7 +458,8 @@
             "general": "Tổng quan",
             "log": "Log",
             "other": "Khác",
-            "sync": "Lưu - Đồng bộ"
+            "sync": "Lưu - Đồng bộ",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "Mở tệp cấu hình",
         "reset-heroic": "Đặt lại Heroic",

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -29,6 +29,7 @@
         "customWine": "选择 Wine 或 Proton 二进制文件",
         "default-install-path": "选择默认安装路径",
         "default-steam-path": "Steam 路径.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "选择",
             "error": "无效路径",
             "title": "选择存档的目录"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine 版本"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "清理 Heroic 缓存",
         "copiedToClipboard": "已复制到剪贴板！",
         "copyToClipboard": "复制所有设置到剪贴板",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "日志被截断，显示最后 1000 行！"
         },
@@ -430,7 +458,8 @@
             "general": "常规",
             "log": "日志",
             "other": "其它",
-            "sync": "存档-同步"
+            "sync": "存档-同步",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "打开配置文件",
         "reset-heroic": "重置 Heroic",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -29,6 +29,7 @@
         "customWine": "選擇已編譯的Wine或Proton",
         "default-install-path": "選擇預設安裝路徑",
         "default-steam-path": "Steam path.",
+        "downloadNow": "Download now",
         "error": {
             "add": {
                 "steam": {
@@ -120,6 +121,15 @@
             "button": "選擇",
             "error": "無效路徑",
             "title": "選擇存檔的目錄"
+        },
+        "vcruntime": {
+            "install": {
+                "message": "The download links for the Visual C++ Runtimes have been opened. Please install both the x86 and x64 versions."
+            },
+            "notfound": {
+                "message": "The Microsoft Visual C++ Runtimes are not installed, which are required by some games",
+                "title": "VCRuntime not installed"
+            }
         },
         "warning": {
             "epic": {
@@ -419,9 +429,27 @@
         "wineversion": "Wine 版本"
     },
     "settings": {
+        "battlEyeRuntime": {
+            "installing": "Installing BattlEye Runtime...",
+            "name": "BattlEye AntiCheat Runtime"
+        },
         "clear-cache": "清除 Heroic 快取",
         "copiedToClipboard": "已複製到剪貼簿！",
         "copyToClipboard": "複製所有設定至剪貼簿",
+        "eacRuntime": {
+            "gameModeRequired": {
+                "message": "GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?",
+                "title": "GameMode required"
+            },
+            "installing": "Installing EAC Runtime...",
+            "name": "EasyAntiCheat Runtime"
+        },
+        "gameMode": {
+            "eacRuntimeEnabled": {
+                "message": "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?",
+                "title": "EAC runtime enabled"
+            }
+        },
         "log": {
             "long-log-hint": "日誌被截斷，顯示最後一千行！"
         },
@@ -430,7 +458,8 @@
             "general": "一般",
             "log": "Log",
             "other": "其它",
-            "sync": "存檔-同步"
+            "sync": "存檔-同步",
+            "wineExt": "Wine Extensions"
         },
         "open-config-file": "開啟配置檔案",
         "reset-heroic": "Reset Heroic",

--- a/src/screens/Settings/components/OtherSettings/index.tsx
+++ b/src/screens/Settings/components/OtherSettings/index.tsx
@@ -53,11 +53,13 @@ interface Props {
   toggleOffline: () => void
   togglePrimeRun: () => void
   toggleUseGameMode: () => void
+  toggleEacRuntime: () => void
   toggleAddDesktopShortcuts: () => void
   toggleAddGamesToStartMenu: () => void
   toggleDiscordRPC: () => void
   targetExe: string
   useGameMode: boolean
+  eacRuntime: boolean
   useSteamRuntime: boolean
   toggleUseSteamRuntime: () => void
   isProton: boolean
@@ -104,7 +106,9 @@ export default function OtherSettings({
   isProton,
   appName,
   setDefaultSteamPath,
-  defaultSteamPath
+  defaultSteamPath,
+  toggleEacRuntime,
+  eacRuntime
 }: Props) {
   const handleEnviromentVariables = (values: ColumnProps[]) => {
     const envs: EnviromentVariable[] = []
@@ -205,6 +209,30 @@ export default function OtherSettings({
     setTargetExe('')
   }, [targetExe])
 
+  async function handleGameMode() {
+    if (useGameMode && eacRuntime) {
+      const isFlatpak = await ipcRenderer.invoke('isFlatpak')
+      if (isFlatpak) {
+        const { response } = await ipcRenderer.invoke('openMessageBox', {
+          message: t(
+            'settings.gameMode.eacRuntimeEnabled.message',
+            "The EAC runtime is enabled, which won't function correctly without GameMode. Do you want to disable the EAC Runtime and GameMode?"
+          ),
+          title: t(
+            'settings.gameMode.eacRuntimeEnabled.title',
+            'EAC runtime enabled'
+          ),
+          buttons: [t('box.yes'), t('box.no')]
+        })
+        if (response === 1) {
+          return
+        }
+        toggleEacRuntime()
+      }
+    }
+    toggleUseGameMode()
+  }
+
   return (
     <>
       <h3 className="settingSubheader">{t('settings.navbar.other')}</h3>
@@ -243,7 +271,7 @@ export default function OtherSettings({
             <ToggleSwitch
               htmlId="gamemode"
               value={useGameMode}
-              handleChange={toggleUseGameMode}
+              handleChange={handleGameMode}
               title={t('setting.gamemode')}
             />
 

--- a/src/screens/Settings/components/WineExtensions/index.tsx
+++ b/src/screens/Settings/components/WineExtensions/index.tsx
@@ -37,7 +37,6 @@ export default function WineExtensions({
   const { t } = useTranslation()
 
   const handleEacRuntime = async () => {
-    toggleEacRuntime()
     if (!eacRuntime) {
       const isInstalled = await ipcRenderer.invoke(
         'isRuntimeInstalled',
@@ -49,14 +48,13 @@ export default function WineExtensions({
           'downloadRuntime',
           'eac_runtime'
         )
-        if (!success) {
-          // We already know we're toggling the runtime on here, so toggling it again will make it stay off
-          // Error handling/communication is handled in downloadRuntime by the backend
-          toggleEacRuntime()
-        }
         setEacInstalling(false)
+        if (!success) {
+          return
+        }
       }
     }
+    toggleEacRuntime()
   }
 
   const handleBattlEyeRuntime = async () => {

--- a/src/screens/Settings/components/WineExtensions/index.tsx
+++ b/src/screens/Settings/components/WineExtensions/index.tsx
@@ -69,10 +69,10 @@ export default function WineExtensions({
           'downloadRuntime',
           'battleye_runtime'
         )
-        if (!success) {
-          toggleBattlEyeRuntime()
-        }
         setBattlEyeInstalling(false)
+        if (!success) {
+          return
+        }
       }
     }
     toggleBattlEyeRuntime()

--- a/src/screens/Settings/components/WineExtensions/index.tsx
+++ b/src/screens/Settings/components/WineExtensions/index.tsx
@@ -11,6 +11,8 @@ interface Props {
   winePrefix: string
   eacRuntime: boolean
   toggleEacRuntime: () => void
+  gameMode: boolean
+  toggleGameMode: () => void
   battlEyeRuntime: boolean
   toggleBattlEyeRuntime: () => void
   autoInstallDxvk: boolean
@@ -23,10 +25,12 @@ export default function WineExtensions({
   wineVersion,
   winePrefix,
   eacRuntime,
+  gameMode,
   battlEyeRuntime,
   autoInstallDxvk,
   autoInstallVkd3d,
   toggleEacRuntime,
+  toggleGameMode,
   toggleBattlEyeRuntime,
   toggleAutoInstallDxvk,
   toggleAutoInstallVkd3d
@@ -38,6 +42,26 @@ export default function WineExtensions({
 
   const handleEacRuntime = async () => {
     if (!eacRuntime) {
+      if (!gameMode) {
+        const isFlatpak = await ipcRenderer.invoke('isFlatpak')
+        if (isFlatpak) {
+          const { response } = await ipcRenderer.invoke('openMessageBox', {
+            message: t(
+              'settings.eacRuntime.gameModeRequired.message',
+              'GameMode is required for the EAC runtime to work on Flatpak. Do you want to enable it now?'
+            ),
+            title: t(
+              'settings.eacRuntime.gameModeRequired.title',
+              'GameMode required'
+            ),
+            buttons: [t('box.yes'), t('box.no')]
+          })
+          if (response === 1) {
+            return
+          }
+          toggleGameMode()
+        }
+      }
       const isInstalled = await ipcRenderer.invoke(
         'isRuntimeInstalled',
         'eac_runtime'

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -545,6 +545,8 @@ function Settings() {
               wineVersion={wineVersion}
               eacRuntime={eacRuntime}
               toggleEacRuntime={toggleEacRuntime}
+              gameMode={useGameMode}
+              toggleGameMode={toggleUseGameMode}
               battlEyeRuntime={battlEyeRuntime}
               toggleBattlEyeRuntime={toggleBattlEyeRuntime}
               autoInstallDxvk={autoInstallDxvk}
@@ -565,6 +567,8 @@ function Settings() {
               setLanguageCode={setLanguageCode}
               useGameMode={useGameMode}
               toggleUseGameMode={toggleUseGameMode}
+              eacRuntime={eacRuntime}
+              toggleEacRuntime={toggleEacRuntime}
               primeRun={nvidiaPrime}
               togglePrimeRun={toggleNvidiaPrime}
               showFps={showFps}


### PR DESCRIPTION
This PR addresses two issues:
- It was possible to exit the Wine Extensions page in a way that enabled a runtime that wasn't installed
  Note: Even if this was rather unlikely, the changes also avoid unnecessary settings updates and thus disk writes
- This is more of a feature, but I'd say it's a feature that fixes an issue:
  On Flatpak, GameMode is still required for the EAC runtime to not crash. Messages about this are now displayed when either enabling the runtime while GameMode is disabled, or disabling GameMode while the runtime is enabled

Since this adds new translation keys, I've as always waited on running `yarn i18next` until final approval of the provided defaults

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
