### PR TITLE
[Fix] Pass `runner` in `callTool` IPC call

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -591,25 +591,29 @@ interface Tools {
   exe: string
   tool: string
   appName: string
+  runner: Runner
 }
 
-ipcMain.handle('callTool', async (event, { tool, exe, appName }: Tools) => {
-  const game = Game.get(appName)
-  const { wineVersion, winePrefix } = await game.getSettings()
-  await verifyWinePrefix(game)
+ipcMain.handle(
+  'callTool',
+  async (event, { tool, exe, appName, runner }: Tools) => {
+    const game = Game.get(appName, runner)
+    const { wineVersion, winePrefix } = await game.getSettings()
+    await verifyWinePrefix(game)
 
-  switch (tool) {
-    case 'winetricks':
-      Winetricks.run(wineVersion, winePrefix)
-      break
-    case 'winecfg':
-      game.runWineCommand('winecfg')
-      break
-    case 'runExe':
-      game.runWineCommand(exe)
-      break
+    switch (tool) {
+      case 'winetricks':
+        Winetricks.run(wineVersion, winePrefix)
+        break
+      case 'winecfg':
+        game.runWineCommand('winecfg')
+        break
+      case 'runExe':
+        game.runWineCommand(exe)
+        break
+    }
   }
-})
+)
 
 /// IPC handlers begin here.
 

--- a/src/screens/Settings/components/Tools/index.tsx
+++ b/src/screens/Settings/components/Tools/index.tsx
@@ -7,12 +7,14 @@ import classNames from 'classnames'
 import { getGameInfo, quoteIfNecessary } from 'src/helpers'
 
 import { ipcRenderer } from 'src/helpers'
+import { Runner } from 'src/types'
 
 interface Props {
   appName: string
+  runner: Runner
 }
 
-export default function Tools({ appName }: Props) {
+export default function Tools({ appName, runner }: Props) {
   const { t } = useTranslation()
   const [winecfgRunning, setWinecfgRunning] = useState(false)
   const [winetricksRunning, setWinetricksRunning] = useState(false)
@@ -29,7 +31,8 @@ export default function Tools({ appName }: Props) {
     await ipcRenderer.invoke('callTool', {
       tool,
       exe,
-      appName
+      appName,
+      runner
     })
     setWinetricksRunning(false)
     setWinecfgRunning(false)

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -538,7 +538,9 @@ function Settings() {
               togglePreferSystemLibs={togglePreferSystemLibs}
             />
           )}
-          {isWineSettings && !isDefault && <Tools appName={appName} />}
+          {isWineSettings && !isDefault && (
+            <Tools appName={appName} runner={runner} />
+          )}
           {isWineExtensions && (
             <WineExtensions
               winePrefix={winePrefix}


### PR DESCRIPTION
This fixes not being able to run Winetricks/winecfg/any executable via Wine for GOG games

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
