### PR TITLE
Fix incorrect variable passed to setupWineEnvVars

### DIFF
--- a/electron/launcher.ts
+++ b/electron/launcher.ts
@@ -229,8 +229,7 @@ async function prepareWineLaunch(game: LegendaryGame | GOGGame): Promise<{
     }
   }
 
-  const { folder_name: installFolderName } = game.getGameInfo()
-  const envVars = setupWineEnvVars(gameSettings, installFolderName)
+  const envVars = setupWineEnvVars(gameSettings, game.appName)
 
   return { success: true, envVars: envVars }
 }
@@ -321,7 +320,7 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
   }
   if (wineVersion.type === 'proton') {
     // If we don't set this, GE-Proton tries to guess the AppID from the prefix path, which doesn't work in our case
-    ret.STEAM_COMPAT_APP_ID = '0'
+    ret.STEAM_COMPAT_APP_ID = `heroic-${gameId}`
     ret.SteamAppId = ret.STEAM_COMPAT_APP_ID
     // This sets the name of the log file given when setting PROTON_LOG=1
     ret.SteamGameId = `heroic-${gameId}`
@@ -440,14 +439,13 @@ async function runWineCommand(
   forceRunInPrefixVerb = false
 ) {
   const gameSettings = await game.getSettings()
-  const { folder_name: installFolderName } = game.getGameInfo()
 
   const { wineVersion } = gameSettings
 
   const env_vars = {
     ...process.env,
     ...setupEnvVars(gameSettings),
-    ...setupWineEnvVars(gameSettings, installFolderName)
+    ...setupWineEnvVars(gameSettings, game.appName)
   }
 
   let additional_command = ''


### PR DESCRIPTION
This fixes protonfixes in ProtonGE for the GOG integration and allows to create workarounds for games https://github.com/GloriousEggroll/protonfixes

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
