### PR TITLE
[GOG setup] Fix invalid executable paths

### DIFF
--- a/electron/gog/setup.ts
+++ b/electron/gog/setup.ts
@@ -159,12 +159,18 @@ async function setup(
           }" /nodesktopshorctut /nodesktopshortcut`
 
           const workingDir = handlePathVars(
-            actionArguments.workingDir,
+            actionArguments.workingDir.replace(
+              '{app}',
+              gameInfo.install.install_path
+            ),
             pathsValues
           )
 
           const executablePath = path.join(
-            handlePathVars(executableName, pathsValues)
+            handlePathVars(
+              executableName.replace('{app}', gameInfo.install.install_path),
+              pathsValues
+            )
           )
 
           let command = `${commandPrefix} "${executablePath}" ${exeArguments}`


### PR DESCRIPTION
This will fix some issues with older games. Especially when executable name contains `{app}` variable.
By replacing it earlier we avoid using `Z:/path/to/game` on Linux, which caused issues

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
