### PR TITLE
[Feat] Proper Handler of Adding and Removal of Desktop/Menu Shortcuts

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,2 @@
 #!/bin/bash
-yarn lint && yarn prettier-fix
+yarn lint && yarn prettier-fix && yarn i18n

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -681,7 +681,6 @@ ipcMain.handle('getGameInfo', async (event, appName, runner) => {
       return null
     }
     info.extra = await game.getExtraInfo()
-    // eslint-disable-next-line @typescript-eslint/return-await
     return info
   } catch (error) {
     logError(`${error}`, LogPrefix.Backend)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -681,6 +681,7 @@ ipcMain.handle('getGameInfo', async (event, appName, runner) => {
       return null
     }
     info.extra = await game.getExtraInfo()
+    // eslint-disable-next-line @typescript-eslint/return-await
     return info
   } catch (error) {
     logError(`${error}`, LogPrefix.Backend)

--- a/electron/shortcuts/shortcuts/shortcuts.ts
+++ b/electron/shortcuts/shortcuts/shortcuts.ts
@@ -131,4 +131,4 @@ function shortcutFiles(gameTitle: string) {
   return [desktopFile, menuFile]
 }
 
-export { removeShortcuts, addShortcuts }
+export { removeShortcuts, addShortcuts, shortcutFiles }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "url": "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher"
   },
   "author": {
-    "name": "Heroic",
-    "email": "flavioislima@gmail.com"
+    "name": "Heroic Games Launcher",
+    "email": "heroicgameslauncher@protonmail.com"
   },
   "build": {
     "appId": "com.electron.heroic",
@@ -20,8 +20,8 @@
     "files": [
       "build/**/*",
       "node_modules/**/*",
-      "build/bin/legendary.LICENSE",
-      "!build/bin/*"
+      "!build/bin/*",
+      "build/bin/legendary.LICENSE"
     ],
     "asarUnpack": [
       "build/icon.png",
@@ -215,7 +215,7 @@
     "@types/tmp": "^0.2.3",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
-    "electron": "^19.0.8",
+    "electron": "^19.0.9",
     "electron-builder": "^23.1.0",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.13.0",

--- a/public/locales/bg/gamepage.json
+++ b/public/locales/bg/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Преместване на играта",
         "protondb": "Проверка на съвместимостта",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Настройки",
         "store": "Страница в магазина",
         "verify": "Проверка и поправяне"

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Бяха създадени преки пътища на работния плот и в менюто с приложения",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Преки пътища"
         },
         "sync": {

--- a/public/locales/ca/gamepage.json
+++ b/public/locales/ca/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Mou el joc",
         "protondb": "Comprova la compatibilitat",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Configuració",
         "store": "Botiga",
         "verify": "Verifica i repara"

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "S'han creat dreceres a l'escriptori i al menú d'inici",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Dreceres"
         },
         "sync": {

--- a/public/locales/cs/gamepage.json
+++ b/public/locales/cs/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Přesunout hru",
         "protondb": "Zkontrolovat kompatibilitu",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Nastavení",
         "store": "Stránka obchodu",
         "verify": "Zkontrolovat a opravit"

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Zástupci byli vytvořeni na ploše a v nabídce Start",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Zástupci"
         },
         "sync": {

--- a/public/locales/de/gamepage.json
+++ b/public/locales/de/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Spiel verschieben",
         "protondb": "Kompatibilität überprüfen",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Einstellungen",
         "store": "Store-Seite",
         "verify": "Prüfen und reparieren"

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Verknüpfungen wurden auf dem Desktop und im Startmenü erstellt",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Verknüpfungen"
         },
         "sync": {

--- a/public/locales/el/gamepage.json
+++ b/public/locales/el/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Μετακίνηση παιχνιδιού",
         "protondb": "Έλεγχος συμβατότητας",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Ρυθμίσεις",
         "store": "Κατάστημα",
         "verify": "Επαλήθευση και Επιδιόρθωση"

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Συντομεύσεις δημιουργήθηκαν στην Επιφάνεια Εργασίας και στο Μενού Έναρξης",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Συντομεύσεις"
         },
         "sync": {

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Move Game",
         "protondb": "Check Compatibility",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Settings",
         "store": "Store Page",
         "verify": "Verify and Repair"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Shortcuts were created on Desktop and Start Menu",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Shortcuts"
         },
         "sync": {

--- a/public/locales/es/gamepage.json
+++ b/public/locales/es/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Mover juego",
         "protondb": "Verificar compatibilidad",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Ajustes",
         "store": "Página de la tienda",
         "verify": "Verificar y reparar"

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Se han creado accesos directos en el Escritorio y en el Menú Inicio",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Accesos directos"
         },
         "sync": {

--- a/public/locales/et/gamepage.json
+++ b/public/locales/et/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Liiguta mängu",
         "protondb": "Kontrolli ühilduvust",
         "removeFromSteam": "Eemalda Steamist",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Seaded",
         "store": "Poe lehekülg",
         "verify": "Kontrolli ja paranda"

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Töölauale ja Start Menüüsse on loodud otseteed",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Otseteed"
         },
         "sync": {

--- a/public/locales/fa/gamepage.json
+++ b/public/locales/fa/gamepage.json
@@ -132,6 +132,7 @@
         "move": "انتقال بازی",
         "protondb": "بررسی سازگاری",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "تنظیمات",
         "store": "صفحه فروشگاه",
         "verify": "بررسی و تعمیر"

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "میانبرها در دسکتاپ و منوی استارت ایجاد شدند",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "میانبرها"
         },
         "sync": {

--- a/public/locales/fi/gamepage.json
+++ b/public/locales/fi/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Siirrä peli",
         "protondb": "Tarkista yhteensopivuus",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Asetukset",
         "store": "Kauppasivu",
         "verify": "Vahvista ja korjaa"

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Pikakuvakkeet luotiin työpöydälle ja Käynnistä-valikkoon",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Pikanäppäimet"
         },
         "sync": {

--- a/public/locales/fr/gamepage.json
+++ b/public/locales/fr/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Déplacer le jeu",
         "protondb": "Vérifier la compatibilité",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Options",
         "store": "Page du magasin",
         "verify": "Vérifier et réparer"

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Les raccourcis ont été créés sur le Bureau et dans le menu Démarrer",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Raccourcis"
         },
         "sync": {

--- a/public/locales/gl/gamepage.json
+++ b/public/locales/gl/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Mover xogo",
         "protondb": "Verificar compatibilidade",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Axustes",
         "store": "Páxina da tenda",
         "verify": "Verificar e reparar"

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Creáronse atallos no escritorio e no menú principal",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Atallos"
         },
         "sync": {

--- a/public/locales/hr/gamepage.json
+++ b/public/locales/hr/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Premjesti igricu",
         "protondb": "Provjeri Kompatibilnost",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Postavke",
         "store": "Stranica Trgovine",
         "verify": "Provjeri i popravi"

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Shortcuts were created on Desktop and Start Menu",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Shortcuts"
         },
         "sync": {

--- a/public/locales/hu/gamepage.json
+++ b/public/locales/hu/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Játék áthelyezése",
         "protondb": "Kompatibilitás ellenőrzése",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Beállítások",
         "store": "Áruházi oldal",
         "verify": "Ellenőrzés és javítás"

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Parancsikonok létre lettek hozva az asztalon és a Start menüben",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Parancsikonok"
         },
         "sync": {

--- a/public/locales/id/gamepage.json
+++ b/public/locales/id/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Pindahkan gim",
         "protondb": "Periksa Kompatibilitas",
         "removeFromSteam": "Hapus dari Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Pengaturan",
         "store": "Halaman Toko",
         "verify": "Verifikasi dan Perbaiki"

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Pintasan dibuat di Desktop dan Start Menu",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Pintasan"
         },
         "sync": {

--- a/public/locales/it/gamepage.json
+++ b/public/locales/it/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Muovi gioco",
         "protondb": "Controlla compatibilità",
         "removeFromSteam": "Rimuovi da Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Impostazioni",
         "store": "Pagina dello store",
         "verify": "Verifica e ripara"

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Sono stati creati i collegamenti sul Desktop e nel menu Start",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Collegamenti"
         },
         "sync": {

--- a/public/locales/ja/gamepage.json
+++ b/public/locales/ja/gamepage.json
@@ -132,6 +132,7 @@
         "move": "ゲームを移動する",
         "protondb": "互換性を確認する",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "設定",
         "store": "ストアページ",
         "verify": "確認と修復"

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Shortcuts were created on Desktop and Start Menu",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Shortcuts"
         },
         "sync": {

--- a/public/locales/ko/gamepage.json
+++ b/public/locales/ko/gamepage.json
@@ -132,6 +132,7 @@
         "move": "게임 이동",
         "protondb": "호환성 체크",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "설정",
         "store": "스토어 페이지",
         "verify": "확인 및 복구"

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "바탕 화면 및 시작 메뉴에 바로 가기가 생성되었습니다",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "바로가기"
         },
         "sync": {

--- a/public/locales/ml/gamepage.json
+++ b/public/locales/ml/gamepage.json
@@ -132,6 +132,7 @@
         "move": "കളി മാറ്റൂ",
         "protondb": "പറ്റുമോന്നു നോക്കൂ",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "ക്രമീകരണങ്ങള്",
         "store": "കടത്താള്",
         "verify": "കണ്ടെത്തി നന്നാക്കൂ"

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "കുറുക്കുവഴികള് പണിമേശയിലേക്കും തുടക്കപ്പട്ടികയിലേക്കും ചേര്ത്തിട്ടുണ്ട്",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "കുറുക്കുവഴികള്"
         },
         "sync": {

--- a/public/locales/nl/gamepage.json
+++ b/public/locales/nl/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Spel verplaatsen",
         "protondb": "Compatibiliteit controleren",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Instellingen",
         "store": "Winkel",
         "verify": "Verifiëren en repareren"

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Shortcuts were created on Desktop and Start Menu",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Shortcuts"
         },
         "sync": {

--- a/public/locales/pl/gamepage.json
+++ b/public/locales/pl/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Przenieś grę",
         "protondb": "Sprawdź kompatybilność",
         "removeFromSteam": "Usuń ze Steam'a",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Ustawienia",
         "store": "Strona sklepu",
         "verify": "Sprawdź i napraw"

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Skróty zostały stworzone na Pulpicie i w Menu Start",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Skróty"
         },
         "sync": {

--- a/public/locales/pt/gamepage.json
+++ b/public/locales/pt/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Mover Jogo",
         "protondb": "Compatibilidade",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Configurações",
         "store": "Página da Loja",
         "verify": "Verificar e Reparar"

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Shortcuts were created on Desktop and Start Menu",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Shortcuts"
         },
         "sync": {

--- a/public/locales/pt_BR/gamepage.json
+++ b/public/locales/pt_BR/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Mover o Jogo",
         "protondb": "Verificar Compatibilidade",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Configurações",
         "store": "Loja Epic",
         "verify": "Verificar e Reparar"

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Os atalhos foram criados na área de trabalho e no menu Iniciar",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Atalhos"
         },
         "sync": {

--- a/public/locales/ru/gamepage.json
+++ b/public/locales/ru/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Переместить игру",
         "protondb": "Проверить совместимость",
         "removeFromSteam": "Удалить из Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Настройки",
         "store": "Страница в магазине",
         "verify": "Проверить и восстановить"

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Ярлыки созданы на Рабочем столе и в Меню приложений",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Ярлыки"
         },
         "sync": {

--- a/public/locales/sv/gamepage.json
+++ b/public/locales/sv/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Flytta spelet",
         "protondb": "Kontrollera kompatibilitet",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Inställningar",
         "store": "Butikssida",
         "verify": "Verifiera och reparera"

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Genvägar skapades på Skrivbordet och Startmenyn",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Genvägar"
         },
         "sync": {

--- a/public/locales/ta/gamepage.json
+++ b/public/locales/ta/gamepage.json
@@ -132,6 +132,7 @@
         "move": "விளையாட்டை நகர்த்து",
         "protondb": "பொருந்தக்கூடிய தன்மையை சரிபார்",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "அமைப்புகள்",
         "store": "விற்பனைக்கூடம்",
         "verify": "சரிபார்த்து சரிசெய்"

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Shortcuts were created on Desktop and Start Menu",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Shortcuts"
         },
         "sync": {

--- a/public/locales/tr/gamepage.json
+++ b/public/locales/tr/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Oyunu Taşı",
         "protondb": "Uyumluluğu Denetle",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Ayarlar",
         "store": "Mağaza Sayfası",
         "verify": "Doğrula ve Onar"

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Kısayol Masaüstüne ve Başlat Menüsüne eklendi",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Kısayol"
         },
         "sync": {

--- a/public/locales/uk/gamepage.json
+++ b/public/locales/uk/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Перенести гру",
         "protondb": "Перевірити сумісність",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Налаштування",
         "store": "Сторінка в крамниці",
         "verify": "Перевірити і відновити"

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "На робочому столі та в головному меню створені ярлики",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Ярлики"
         },
         "sync": {

--- a/public/locales/vi/gamepage.json
+++ b/public/locales/vi/gamepage.json
@@ -132,6 +132,7 @@
         "move": "Di chuyển game",
         "protondb": "Kiểm tra độ tương thích",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "Cài đặt",
         "store": "Cửa hàng",
         "verify": "Kiểm tra và sửa chữa"

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "Shortcut đã được tạo ở màn hình chính và menu Start",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "Shortcut"
         },
         "sync": {

--- a/public/locales/zh_Hans/gamepage.json
+++ b/public/locales/zh_Hans/gamepage.json
@@ -132,6 +132,7 @@
         "move": "移动游戏",
         "protondb": "检查兼容性",
         "removeFromSteam": "从 Steam 删除",
+        "removeShortcut": "Remove shortcuts",
         "settings": "设置",
         "store": "商店页面",
         "verify": "验证并修复"

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "桌面与开始菜单快捷方式已创建",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "快捷方式"
         },
         "sync": {

--- a/public/locales/zh_Hant/gamepage.json
+++ b/public/locales/zh_Hant/gamepage.json
@@ -132,6 +132,7 @@
         "move": "移動遊戲",
         "protondb": "檢查相容性",
         "removeFromSteam": "Remove from Steam",
+        "removeShortcut": "Remove shortcuts",
         "settings": "設定",
         "store": "商店頁面",
         "verify": "驗證並修復遊戲文件"

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -115,6 +115,7 @@
         },
         "shortcuts": {
             "message": "已建立捷徑在桌面和開始功能表內",
+            "message-remove": "Shortcuts were removed from Desktop and Start Menu",
             "title": "捷徑"
         },
         "sync": {

--- a/src/screens/Library/index.css
+++ b/src/screens/Library/index.css
@@ -1,8 +1,8 @@
 .gameList {
   color: var(--text-secondary);
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-  grid-gap: 1.2rem;
+  grid-template-columns: repeat(auto-fill, minmax(156px, 1fr));
+  grid-gap: 1.5rem;
   padding: 1rem 1rem 7rem;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4911,10 +4911,10 @@ electron-updater@^5.0.1:
     semver "^7.3.5"
     typed-emitter "^2.1.0"
 
-electron@^19.0.8:
-  version "19.0.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.8.tgz#c4d4ba915de554f2926261eb37d3527d2b092d4c"
-  integrity sha512-OWK3P/NbDFfBUv+wbYv1/OV4jehY5DQPT7n1maQJfN9hsnrWTMktXS/bmS05eSUAjNAzHmKPKfiKH2c1Yr7nGw==
+electron@^19.0.9:
+  version "19.0.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.9.tgz#e95bc18e14aac0af1290fcc7045001ef5ad96a64"
+  integrity sha512-ooEwrv8Y7NSzdhKcl6kPCYecnzcg5nFWuS5ryG+VFH3MMBR8zXh9nW2wLsZrBz6OGUxXrcc5BKBC7dA8C6RhGQ==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
This PR improves a few things related to shortcuts:
- [x] Add IPC handler to check if the menu or desktop shortcuts exists
- [x] Change the text Add Shortcut to Remove Shortcut if there is any
- [x] Fix Message box not showing up when adding shortcuts
- [x] Add new Message box with info on removed shortcuts

![image](https://user-images.githubusercontent.com/26871415/180773627-a5159d7d-c292-4cfa-b79a-0988b3777ea9.png)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
