### PR TITLE
[Fix] Run winetricks with spawn

### DIFF
--- a/electron/logger/logger.ts
+++ b/electron/logger/logger.ts
@@ -28,7 +28,8 @@ export enum LogPrefix {
   Frontend = 'Frontend',
   Backend = 'Backend',
   Runtime = 'Runtime',
-  Shortcuts = 'Shortcuts'
+  Shortcuts = 'Shortcuts',
+  WineTricks = 'Winetricks'
 }
 
 let longestPrefix = 0

--- a/electron/tools.ts
+++ b/electron/tools.ts
@@ -1,7 +1,7 @@
 import { WineInstallation } from './types'
 import * as axios from 'axios'
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { exec } from 'child_process'
+import { exec, spawn } from 'child_process'
 import { existsSync, readFileSync } from 'graceful-fs'
 
 import {
@@ -216,21 +216,29 @@ export const Winetricks = {
 
     const winepath = dirname(wineBin)
 
-    // use wine instead of wine64 since it breaks on flatpak
-    const command = `WINEPREFIX='${winePrefix}' PATH='${winepath}':$PATH ${winetricks} -q`
-
-    logInfo(['trying to run', command], LogPrefix.Backend)
-    try {
-      const { stderr, stdout } = await execAsync(command, execOptions)
-      logInfo(`Output: ${stderr} \n ${stdout}`)
-    } catch (error) {
-      logError(
-        [
-          `Something went wrong! Check if WineTricks is available and ${wineBin} exists`,
-          `${error}`
-        ],
-        LogPrefix.Backend
-      )
+    const envs = {
+      ...process.env,
+      WINEPREFIX: winePrefix,
+      PATH: `${winepath}:${process.env.PATH}`
     }
+
+    logInfo(
+      `Running WINEPREFIX='${winePrefix}' PATH='${winepath}':$PATH ${winetricks} -q`,
+      LogPrefix.WineTricks
+    )
+
+    const child = spawn(winetricks, ['-q'], { env: envs })
+
+    child.stdout.on('data', (data: Buffer) => {
+      logInfo(data.toString(), LogPrefix.WineTricks)
+    })
+
+    child.stderr.on('data', (data: Buffer) => {
+      logError(data.toString(), LogPrefix.WineTricks)
+    })
+
+    child.on('error', (error) => {
+      logError(`Winetricks throwed Error: ${error}`, LogPrefix.WineTricks)
+    })
   }
 }


### PR DESCRIPTION
- live logging of winetricks
- somehow the catch block catched a error and stopped winetricks, which was on my system not a error to stop winetricks.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
