### PR TITLE
[Fix] Show gamesettings only for installed games.

### DIFF
--- a/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -87,7 +87,6 @@ export default function SidebarLinks() {
       tmpAppName = ''
     }
     
-
     if (tmpAppName) {
       setSettingsPath(`/settings/${tmpAppName}/wine`)
       setIsDefaultSetting(false)

--- a/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -74,6 +74,19 @@ export default function SidebarLinks() {
       tmpAppName = appName !== 'default' ? appName : ''
     }
 
+    if (
+      !(
+        gog.library.some(
+          (game) => game.app_name === tmpAppName && game.is_installed
+        ) ||
+        epic.library.some(
+          (game) => game.app_name === tmpAppName && game.is_installed
+        )
+      )
+    ) {
+      tmpAppName = ''
+    }
+
     if (tmpAppName) {
       setSettingsPath(`/settings/${tmpAppName}/wine`)
       setIsDefaultSetting(false)

--- a/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -86,6 +86,7 @@ export default function SidebarLinks() {
     ) {
       tmpAppName = ''
     }
+    
 
     if (tmpAppName) {
       setSettingsPath(`/settings/${tmpAppName}/wine`)

--- a/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -86,7 +86,7 @@ export default function SidebarLinks() {
     ) {
       tmpAppName = ''
     }
-    
+
     if (tmpAppName) {
       setSettingsPath(`/settings/${tmpAppName}/wine`)
       setIsDefaultSetting(false)


### PR DESCRIPTION
Clicking on a not installed game card, GameSettings are not shown anymore in the Sidebar.

**Note:** I don't like that solution, maybe someone has a better idea?

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
