### PR TITLE
[Fix] Skip fetch/check of tools if game is not installed

### DIFF
--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -268,7 +268,7 @@
             },
             "remove": {
                 "steam": {
-                    "corrupt": "Gra {{game}} nie mogła zostać usunięta dla wszystkich użytkowników Steam. Sprawdź logi po więcej informacji. Restart Steam'a jest wymagany, by zastosować\u00a0zmiany.",
+                    "corrupt": "Gra {{game}} nie mogła zostać usunięta dla wszystkich użytkowników Steam. Sprawdź logi po więcej informacji. Restart Steam'a jest wymagany, by zastosować zmiany.",
                     "success": "Gra {{game}} została usunięta ze Steam. Restart Steam'a jest wymagany, by zastosować zmiany.",
                     "title": "Usunięto ze Steam"
                 }

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -268,7 +268,7 @@
             },
             "remove": {
                 "steam": {
-                    "corrupt": "Gra {{game}} nie mogła zostać usunięta dla wszystkich użytkowników Steam. Sprawdź logi po więcej informacji. Restart Steam'a jest wymagany, by zastosować zmiany.",
+                    "corrupt": "Gra {{game}} nie mogła zostać usunięta dla wszystkich użytkowników Steam. Sprawdź logi po więcej informacji. Restart Steam'a jest wymagany, by zastosować\u00a0zmiany.",
                     "success": "Gra {{game}} została usunięta ze Steam. Restart Steam'a jest wymagany, by zastosować zmiany.",
                     "title": "Usunięto ze Steam"
                 }

--- a/src/screens/Game/GameSubMenu/index.tsx
+++ b/src/screens/Game/GameSubMenu/index.tsx
@@ -248,10 +248,7 @@ export default function GamesSubmenu({
   }
 
   useEffect(() => {
-    if (isInstalled) {
-      if (isWin) {
-        return
-      }
+    if (isInstalled && !isWin) {
       const getWineInfo = async () => {
         try {
           const { wineVersion, winePrefix }: AppSettings =

--- a/src/screens/Game/GameSubMenu/index.tsx
+++ b/src/screens/Game/GameSubMenu/index.tsx
@@ -248,56 +248,58 @@ export default function GamesSubmenu({
   }
 
   useEffect(() => {
-    if (isInstalled) {
-      if (!isWin) {
-        // get information about wine (Prefix)
-        const getWineInfo = async () => {
-          try {
-            const { wineVersion, winePrefix }: AppSettings =
-              await ipcRenderer.invoke('requestSettings', appName)
-            let wine = wineVersion.name
-              .replace('Wine - ', '')
-              .replace('Proton - ', '')
-            if (wine.includes('Default')) {
-              wine = wine.split('-')[0]
-            }
-            setInfo({ prefix: winePrefix, wine })
-          } catch (error) {
-            ipcRenderer.send('logError', error)
+    if (!isInstalled) {
+      return
+    }
+
+    // Check for game shortcuts on desktop and start menu
+    ipcRenderer.invoke('shortcutsExists', appName, runner).then((added) => {
+      setHasShortcuts(added)
+    })
+
+    // Check for game shortcuts on Steam
+    ipcRenderer.invoke('isAddedToSteam', appName, runner).then((added) => {
+      setAddedToSteam(added)
+    })
+
+    // only unix specific
+    if (!isWin) {
+      // get information about wine (Prefix)
+      const getWineInfo = async () => {
+        try {
+          const { wineVersion, winePrefix }: AppSettings =
+            await ipcRenderer.invoke('requestSettings', appName)
+          let wine = wineVersion.name
+            .replace('Wine - ', '')
+            .replace('Proton - ', '')
+          if (wine.includes('Default')) {
+            wine = wine.split('-')[0]
           }
+          setInfo({ prefix: winePrefix, wine })
+        } catch (error) {
+          ipcRenderer.send('logError', error)
         }
-        getWineInfo()
-
-        // get information if game is a linux native game
-        const getGameDetails = async () => {
-          const gameInfo = await getGameInfo(appName, runner)
-          const isLinuxNative =
-            gameInfo.install?.platform === 'linux' && isLinux
-          setIsNative(isLinuxNative)
-        }
-        getGameDetails()
-
-        // check if eos overlay is enabled
-        const { status } =
-          libraryStatus.filter(
-            (game: GameStatus) => game.appName === eosOverlayAppName
-          )[0] || {}
-        setEosOverlayRefresh(status === 'installing')
-
-        ipcRenderer
-          .invoke('isEosOverlayEnabled', appName, runner)
-          .then((enabled) => setEosOverlayEnabled(enabled))
       }
+      getWineInfo()
 
-      // Check for game shortcuts on desktop and start menu
-      ipcRenderer.invoke('shortcutsExists', appName, runner).then((added) => {
-        setHasShortcuts(added)
-      })
+      // get information if game is a linux native game
+      const getGameDetails = async () => {
+        const gameInfo = await getGameInfo(appName, runner)
+        const isLinuxNative = gameInfo.install?.platform === 'linux' && isLinux
+        setIsNative(isLinuxNative)
+      }
+      getGameDetails()
 
-      // Check for game shortcuts on Steam
-      ipcRenderer.invoke('isAddedToSteam', appName, runner).then((added) => {
-        setAddedToSteam(added)
-      })
+      // check if eos overlay is enabled
+      const { status } =
+        libraryStatus.filter(
+          (game: GameStatus) => game.appName === eosOverlayAppName
+        )[0] || {}
+      setEosOverlayRefresh(status === 'installing')
+
+      ipcRenderer
+        .invoke('isEosOverlayEnabled', appName, runner)
+        .then((enabled) => setEosOverlayEnabled(enabled))
     }
   }, [])
 


### PR DESCRIPTION
Fixed also a bug where we skipped checking of added to steam and shortcuts on windows. This two functions are available on any os.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
