### PR TITLE
[Fix] Show uncaught exception in frontend and exit heroic.

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -471,8 +471,22 @@ ipcMain.on('frontendReady', () => {
 })
 
 // Maybe this can help with white screens
-process.on('uncaughtException', (err) => {
+process.on('uncaughtException', async (err) => {
   logError(`${err.name}: ${err.message}`, LogPrefix.Backend)
+  await showErrorBoxModal(
+    mainWindow,
+    i18next.t(
+      'box.error.uncaught-exception.title',
+      'Uncaught Exception occured!'
+    ),
+    i18next.t('box.error.uncaught-exception.message', {
+      defaultValue:
+        'A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.',
+      newLine: '\n',
+      error: err
+    })
+  )
+  app.exit(1)
 })
 
 let powerId: number | null

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -486,6 +486,7 @@ process.on('uncaughtException', async (err) => {
       error: err
     })
   )
+
   app.exit(1)
 })
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -486,7 +486,6 @@ process.on('uncaughtException', async (err) => {
       error: err
     })
   )
-
   app.exit(1)
 })
 

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -40,19 +40,19 @@ const statAsync = promisify(stat)
 
 const { showErrorBox, showMessageBox } = dialog
 
-export function showErrorBoxModal(
+export async function showErrorBoxModal(
   window: BrowserWindow | undefined | null,
   title: string,
   message: string
 ) {
   if (window) {
-    showMessageBox(window, {
+    await showMessageBox(window, {
       type: 'error',
       title,
       message
     })
   } else {
-    showErrorBox(title, message)
+    await showErrorBox(title, message)
   }
 }
 
@@ -304,7 +304,7 @@ async function errorHandler(
 
   if (logPath) {
     execAsync(`tail "${logPath}" | grep 'disk space'`)
-      .then(({ stdout }) => {
+      .then(async ({ stdout }) => {
         if (stdout.includes(noSpaceMsg)) {
           logError(noSpaceMsg, LogPrefix.Backend)
           return showErrorBoxModal(
@@ -339,7 +339,7 @@ async function errorHandler(
       }
     }
 
-    otherErrorMessages.forEach((message) => {
+    otherErrorMessages.forEach(async (message) => {
       if (error.includes(message)) {
         return showErrorBoxModal(
           window,

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Грешка",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Нещо се обърка при обновяването. Проверете журналите или опитайте отново по-късно!",
                 "title": "Грешка при обновяването"

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Error",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "L'actualització ha fallat. Si us plau, comproveu els registres o proveu-ho de nou més tard.",
                 "title": "Update Error"

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Error",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Při aktualizaci se něco pokazilo, zkontrolujte záznamy nebo to zkuste znovu později!",
                 "title": "Update Error"

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Error",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Bei der Aktualisierung ist etwas schiefgelaufen, bitte überprüfe die Logs oder versuche es später noch einmal!",
                 "title": "Update Error"

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Σφάλμα",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Κάτι πήγε στραβά με την ενημέρωση, ελέγξτε τα αρχεία καταγραφής ή δοκιμάστε ξανά αργότερα!",
                 "title": "Σφάλμα ενημέρωσης"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Error",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Error",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Ocurrió un problema con la actualización. Por favor, revise los registros e intente nuevamente!",
                 "title": "Error al actualizar"

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Viga",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Midagi läks uuendusega valesti, palun kontrollige logisid või proovige hiljem uuesti!",
                 "title": "Viga uuendamisel"

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "خطا",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "مشکلی در به روز رسانی پیش آمد، لطفا لاگ ها را بررسی کرده و مجددا امتحان کنید!",
                 "title": "Update Error"

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Virhe",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Erreur",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Erro",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Greška",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Hiba",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Galat",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Terjadi kesalahan saat melakukan pembaruan, silakan cek log atau coba lagi nanti!",
                 "title": "Update Error"

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Errore",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Qualcosa è andato storto con l'aggiornamento, controlla i log o riprova più tardi!",
                 "title": "Update Error"

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "エラー",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "오류",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "업데이트에 문제가 발생했습니다. 로그를 확인하거나 나중에 다시 시도하세요!",
                 "title": "Update Error"

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "കുഴപ്പം",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Error",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Error",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Aktualizacja nie powiodła się, sprawdź logi lub spróbuj ponownie!",
                 "title": "Błąd aktualizacji"

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Error",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Erro",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Algo deu errado ao atualizar, cheque os logs ou tente novamente mais tarde!",
                 "title": "Update Error"

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Ошибка",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Что-то пошло не так с обновлением, проверьте журналы или повторите попытку позже!",
                 "title": "Ошибка обновления"

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Problem",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Uppdateringen misslyckades, kontrollera loggfilen eller försök igen senare.",
                 "title": "Problem vid uppdatering"

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "பிழை",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Hata",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Güncellemeyle ilgili bir sorun oluştu, lütfen günlük kayıtlarına göz atın veya daha sonra tekrar deneyin!",
                 "title": "Update Error"

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Помилка",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "З оновленням щось пішло не так. Будь ласка, перевірте журнали або повторіть спробу пізніше!",
                 "title": "Помилка оновлення"

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "Lỗi",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "Đã xảy ra lỗi với bản cập nhật, vui lòng kiểm tra lại log hoặc thử lại sau!",
                 "title": "Update Error"

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "错误",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "更新有问题，请检查日志或稍后再试！",
                 "title": "更新错误"

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -70,6 +70,10 @@
                 }
             },
             "title": "錯誤",
+            "uncaught-exception": {
+                "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}}Heroic will be closed! Report the exception on our Github repository.",
+                "title": "Uncaught Exception occured!"
+            },
             "update": {
                 "message": "更新出現問題，請檢查日誌或稍後再試！",
                 "title": "Update Error"


### PR DESCRIPTION
- According to #1118 this can fill the logs.
- Also uncaught exception should not be ignored and instead shown as message box in the frontend.
- Close the app to avoid unexpected behavior. We should catch all errors we know can be thrown.

Can be tested by throwing a error somewhere in the backend.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
