### PR TITLE
[General] Show quit button if controller is activated

### DIFF
--- a/src/components/UI/ControllerHints/index.tsx
+++ b/src/components/UI/ControllerHints/index.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
+import ContextProvider from 'src/state/ContextProvider'
 
 import './index.css'
 
 export default function ControllerHints() {
-  const [controller, setController] = useState('')
+  const { activeController } = useContext(ContextProvider)
   const [layout, setLayout] = useState('steam-deck') // default to steam deck icons
   const [mainActionHint, setMainActionHint] = useState('') // A / Cross
   const [altActionHint, setAltActionHint] = useState('') // X / Square
@@ -18,7 +19,6 @@ export default function ControllerHints() {
 
   // set hints for an element
   const setHintsFor = (target: HTMLElement) => {
-    console.log({ target })
     const classes = target.classList
 
     let main = t('controller.hints.activate', 'Activate')
@@ -90,11 +90,6 @@ export default function ControllerHints() {
   // listen to `controller-changed` custom events to set the controller brand
   // listen to `focus` events to detect the current focused element
   useEffect(() => {
-    const onControllerChanged = (e: CustomEvent<{ controllerId: string }>) => {
-      setController(e.detail.controllerId)
-    }
-    window.addEventListener('controller-changed', onControllerChanged)
-
     const onFocusChanged = (e: FocusEvent) => {
       const tgt = !e.target ? null : (e.target as HTMLElement)
       setHints(tgt)
@@ -103,7 +98,6 @@ export default function ControllerHints() {
     window.addEventListener('focus', onFocusChanged, true)
 
     return () => {
-      window.removeEventListener('controller-changed', onControllerChanged)
       window.removeEventListener('focus', onFocusChanged)
     }
   }, [])
@@ -122,19 +116,19 @@ export default function ControllerHints() {
 
   useEffect(() => {
     // set the brand for the images to use
-    if (controller.match(/sony|0ce6|PS3|PLAYSTATION|0268|'2563.*0523/i)) {
+    if (activeController.match(/sony|0ce6|PS3|PLAYSTATION|0268|'2563.*0523/i)) {
       setLayout('ps')
-    } else if (controller.match(/28de.*11ff/)) {
+    } else if (activeController.match(/28de.*11ff/)) {
       setLayout('steam-deck')
-    } else if (controller.match(/microsoft|xbox/i)) {
+    } else if (activeController.match(/microsoft|xbox/i)) {
       setLayout('xbox')
     } else {
       setLayout('steam-deck')
     }
-  }, [controller])
+  }, [activeController])
 
   // empty if no controller activated
-  if (!controller) {
+  if (!activeController) {
     return <></>
   }
 

--- a/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -52,7 +52,7 @@ export default function SidebarLinks() {
   const location = useLocation() as { pathname: string }
   const [, , runner, appName, type] = location.pathname.split('/') as PathSplit
 
-  const { epic, gog, platform } = useContext(ContextProvider)
+  const { epic, gog, platform, activeController } = useContext(ContextProvider)
 
   //console.log({ isAppSettings, runner, gameInfo })
   const isStore = location.pathname.includes('store')
@@ -393,7 +393,7 @@ export default function SidebarLinks() {
         </div>
         <span>Ko-fi</span>
       </button>
-      {isFullscreen && <QuitButton />}
+      {(isFullscreen || activeController) && <QuitButton />}
     </div>
   )
 }

--- a/src/state/ContextProvider.tsx
+++ b/src/state/ContextProvider.tsx
@@ -66,7 +66,8 @@ const initialContext: ContextType = {
   allTilesInColor: false,
   setAllTilesInColor: () => null,
   sidebarCollapsed: false,
-  setSideBarCollapsed: () => null
+  setSideBarCollapsed: () => null,
+  activeController: ''
 }
 
 export default React.createContext(initialContext)

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -79,6 +79,7 @@ interface StateProps {
   actionsFontFamily: string
   allTilesInColor: boolean
   sidebarCollapsed: boolean
+  activeController: string
 }
 
 export class GlobalState extends PureComponent<Props> {
@@ -145,7 +146,8 @@ export class GlobalState extends PureComponent<Props> {
       (configStore.get('contentFontFamily') as string) || "'Cabin', sans-serif",
     actionsFontFamily:
       (configStore.get('actionsFontFamily') as string) || "'Rubik', sans-serif",
-    allTilesInColor: (configStore.get('allTilesInColor') as boolean) || false
+    allTilesInColor: (configStore.get('allTilesInColor') as boolean) || false,
+    activeController: ''
   }
 
   setLanguage = (newLanguage: string) => {
@@ -590,6 +592,13 @@ export class GlobalState extends PureComponent<Props> {
         runInBackground: Boolean(epic.library.length)
       })
     }
+
+    window.addEventListener(
+      'controller-changed',
+      (e: CustomEvent<{ controllerId: string }>) => {
+        this.setState({ activeController: e.detail.controllerId })
+      }
+    )
 
     ipcRenderer.send('frontendReady')
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,7 @@ export interface ContextType {
   setAllTilesInColor: (value: boolean) => void
   setSideBarCollapsed: (value: boolean) => void
   sidebarCollapsed: boolean
+  activeController: string
 }
 
 export type LibraryTopSectionOptions =


### PR DESCRIPTION
This PR makes the sidebar show the Quit button when a controller is activated. The button is hidden again if the controller is disconnected.

I added a new `activeController` property in the global state so we only need to listen to the window event in one place.

This fixes #1666 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
