### PR TITLE
[Fix] App breaking after GOG login

### DIFF
--- a/electron/gog/library.ts
+++ b/electron/gog/library.ts
@@ -628,6 +628,9 @@ export class GOGLibrary {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public readInfoFile(appName: string, installPath?: string): any {
     const gameInfo = this.getGameInfo(appName)
+    if (!gameInfo) {
+      return
+    }
     const infoFileName = `goggame-${appName}.info`
     let infoFilePath = join(
       installPath ? installPath : gameInfo.install.install_path,

--- a/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -189,7 +189,7 @@ export default function SidebarLinks() {
           state={{
             fromGameCard: false,
             runner: runner,
-            hasCloudSave: gameInfo.cloud_save_enabled
+            hasCloudSave: gameInfo?.cloud_save_enabled
           }}
         >
           <>


### PR DESCRIPTION
This small fix was introduced on #1646. It breaks heroic on redirect from the login to library.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
