### PR TITLE
[Fix] Hide Install when downloading a game

### DIFF
--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -261,7 +261,7 @@ const GameCard = ({
     {
       label: t('button.install'),
       onclick: () => (!hasDownloads ? buttonClick() : () => null),
-      show: !isInstalled && !isInstalling
+      show: !isInstalled && !isInstalling && !hasDownloads
     },
     {
       label: t('button.cancel'),


### PR DESCRIPTION
Hide the unnecessary Install option in the gamecard (_right-click menu_) of an uninstalled game while another game is being downloaded.

**Screenshot:**
 
![fix-gamecard-install-option](https://user-images.githubusercontent.com/74495920/183679456-d402feaf-59b5-4cb2-b0df-8db152200af7.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
