### PR TITLE
[Fix] Disable notifications if they are not supported. (E.g. Steamdeck Gamemode)

### DIFF
--- a/electron/__tests__/shortcuts/nonesteamgame.test.ts
+++ b/electron/__tests__/shortcuts/nonesteamgame.test.ts
@@ -7,7 +7,6 @@ import {
   removeNonSteamGame
 } from '../../shortcuts/nonesteamgame/nonesteamgame'
 import { dialog } from 'electron'
-
 import { createNewLogFileAndClearOldOnces } from '../../logger/logger'
 
 jest.mock('../../logger/logger', () => {
@@ -15,6 +14,14 @@ jest.mock('../../logger/logger', () => {
   return {
     ...original,
     createNewLogFileAndClearOldOnces: jest.fn().mockReturnValue('')
+  }
+})
+
+jest.mock('../../utils', () => {
+  const original = jest.requireActual('../../utils')
+  return {
+    ...original,
+    notify: jest.fn()
   }
 })
 

--- a/electron/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/electron/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -10,6 +10,7 @@ import { join } from 'path'
 import { GameInfo } from '../../types'
 import { ShortcutsResult } from '../types'
 import { getIcon } from '../utils'
+import { notify } from '../../utils'
 import {
   prepareImagesForSteam,
   generateShortcutId,
@@ -17,7 +18,7 @@ import {
   generateShortAppId,
   removeImagesFromSteam
 } from './steamhelper'
-import { app, dialog, Notification } from 'electron'
+import { app, dialog } from 'electron'
 import { isFlatpak, isWindows, tsStore } from '../../constants'
 import { logError, logInfo, LogPrefix, logWarning } from '../../logger/logger'
 import i18next from 'i18next'
@@ -66,10 +67,10 @@ function notifyFrontend(props: { message: string; adding: boolean }) {
     ? i18next.t('notify.finished.add.steam.title', 'Added to Steam')
     : i18next.t('notify.finished.remove.steam.title', 'Removed from Steam')
 
-  new Notification({
+  notify({
     body: props.message,
     title
-  }).show()
+  })
 }
 
 /**

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -15,7 +15,6 @@ import {
   heroicConfigPath,
   heroicGamesConfigPath,
   icon,
-  isSteamDeckGameMode,
   isWindows
 } from './constants'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
@@ -749,7 +748,7 @@ type NotifyType = {
 }
 
 export function notify({ body, title }: NotifyType) {
-  if (!isSteamDeckGameMode) {
+  if (Notification.isSupported()) {
     const mainWindow = BrowserWindow.getAllWindows()[0]
     const notify = new Notification({
       body,

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -15,6 +15,7 @@ import {
   heroicConfigPath,
   heroicGamesConfigPath,
   icon,
+  isSteamDeckGameMode,
   isWindows
 } from './constants'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
@@ -748,14 +749,16 @@ type NotifyType = {
 }
 
 export function notify({ body, title }: NotifyType) {
-  const mainWindow = BrowserWindow.getAllWindows()[0]
-  const notify = new Notification({
-    body,
-    title
-  })
+  if (!isSteamDeckGameMode) {
+    const mainWindow = BrowserWindow.getAllWindows()[0]
+    const notify = new Notification({
+      body,
+      title
+    })
 
-  notify.on('click', () => mainWindow.show())
-  notify.show()
+    notify.on('click', () => mainWindow.show())
+    notify.show()
+  }
 }
 
 export {

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -755,7 +755,6 @@ export function notify({ body, title }: NotifyType) {
       body,
       title
     })
-
     notify.on('click', () => mainWindow.show())
     notify.show()
   }

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -15,6 +15,7 @@ import {
   heroicConfigPath,
   heroicGamesConfigPath,
   icon,
+  isSteamDeckGameMode,
   isWindows
 } from './constants'
 import { logError, logInfo, LogPrefix, logWarning } from './logger/logger'
@@ -748,7 +749,7 @@ type NotifyType = {
 }
 
 export function notify({ body, title }: NotifyType) {
-  if (Notification.isSupported()) {
+  if (Notification.isSupported() && !isSteamDeckGameMode) {
     const mainWindow = BrowserWindow.getAllWindows()[0]
     const notify = new Notification({
       body,

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -755,6 +755,7 @@ export function notify({ body, title }: NotifyType) {
       body,
       title
     })
+
     notify.on('click', () => mainWindow.show())
     notify.show()
   }


### PR DESCRIPTION
Current heroic flatpak freezes in gamemode, because electron can't show a notification.
- Disable notifications on gamemode
- Disable notifications if they are not supported by the system. (https://www.electronjs.org/de/docs/latest/api/notification#notificationissupported)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
