### PR TITLE
Remove extra game status change when killing a game

### DIFF
--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -427,7 +427,6 @@ const GameCard = ({
       })
     }
     if (status === 'playing' || status === 'updating') {
-      await handleGameStatus({ appName, runner, status: 'done' })
       return sendKill(appName, runner)
     }
     if (isInstalled) {


### PR DESCRIPTION
This PR fixes #1698 . The problem is better explained in the linked issue but basically, when killing a game using the `(x)` button in the library, the libraryStatus global state got corrupted because of the line I'm now removing.

This line is not used when killing a game in the Game Page component so I understand it's safe to remove and it fixes the problem.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
