### PR TITLE
Images offline cache

### DIFF
--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -55,6 +55,7 @@ const userInfo = join(legendaryConfigPath, 'user.json')
 const heroicInstallPath = join(homedir(), 'Games', 'Heroic')
 const heroicDefaultWinePrefix = join(homedir(), 'Games', 'Heroic', 'Prefixes')
 const heroicAnticheatDataPath = join(heroicFolder, 'areweanticheatyet.json')
+const imagesCachePath = join(heroicFolder, 'images-cache')
 
 const { currentLogFile: currentLogFile, lastLogFile: lastLogFile } =
   createNewLogFileAndClearOldOnces()
@@ -194,6 +195,7 @@ export {
   heroicToolsPath,
   heroicDefaultWinePrefix,
   heroicAnticheatDataPath,
+  imagesCachePath,
   userHome,
   flatPakHome,
   kofiPage,

--- a/electron/images_cache.ts
+++ b/electron/images_cache.ts
@@ -1,0 +1,34 @@
+import { existsSync, createWriteStream, mkdirSync } from 'graceful-fs'
+import { createHash } from 'crypto'
+import { imagesCachePath } from './constants'
+import { join } from 'path'
+import axios from 'axios'
+import { protocol } from 'electron'
+
+export const initImagesCache = () => {
+  // make sure we have a folder to store the cache
+  if (!existsSync(imagesCachePath)) {
+    mkdirSync(imagesCachePath)
+  }
+
+  // use a fake protocol for images we want to cache
+  protocol.registerFileProtocol('imagecache', (request, callback) => {
+    callback({ path: getImageFromCache(request.url) })
+  })
+}
+
+const getImageFromCache = (url: string) => {
+  const realUrl = url.replace('imagecache://', '')
+  // digest of the image url for the file name
+  const digest = createHash('sha256').update(realUrl).digest('hex')
+  const cachePath = join(imagesCachePath, digest)
+
+  if (!existsSync(cachePath)) {
+    // if not found, download in the background
+    axios
+      .get(realUrl, { responseType: 'stream' })
+      .then((response) => response.data.pipe(createWriteStream(cachePath)))
+  }
+
+  return join(cachePath)
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,3 +1,4 @@
+import { initImagesCache } from './images_cache'
 import { downloadAntiCheatData } from './anticheat/utils'
 import {
   InstallParams,
@@ -327,6 +328,8 @@ if (!gotTheLock) {
   })
   app.whenReady().then(async () => {
     const systemInfo = await getSystemInfo()
+
+    initImagesCache()
 
     logInfo(
       ['Legendary location:', join(...Object.values(getLegendaryBin()))],

--- a/src/components/CachedImage/index.tsx
+++ b/src/components/CachedImage/index.tsx
@@ -1,0 +1,17 @@
+import React, { useState } from 'react'
+
+interface CachedImageProps {
+  src: string
+}
+
+type Props = React.ImgHTMLAttributes<HTMLImageElement> & CachedImageProps
+
+const CachedImage = (props: Props) => {
+  const [useCache, setUseCache] = useState(true)
+
+  const src = props.src && useCache ? `imagecache://${props.src}` : props.src
+
+  return <img {...props} src={src} onError={() => setUseCache(false)} />
+}
+
+export default CachedImage

--- a/src/screens/Game/GamePicture/index.tsx
+++ b/src/screens/Game/GamePicture/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import './index.css'
 import fallbackImage from 'src/assets/fallback-image.jpg'
+import CachedImage from 'src/components/CachedImage'
+
 type Props = {
   art_square: string
   store: string
@@ -18,7 +20,11 @@ function GamePicture({ art_square, store }: Props) {
 
   return (
     <div className="gamePicture">
-      <img alt="cover-art" src={getImageFormatting()} className="gameImg" />
+      <CachedImage
+        alt="cover-art"
+        src={getImageFormatting()}
+        className="gameImg"
+      />
     </div>
   )
 }

--- a/src/screens/Library/components/GameCard/index.tsx
+++ b/src/screens/Library/components/GameCard/index.tsx
@@ -24,6 +24,7 @@ import { hasProgress } from 'src/hooks/hasProgress'
 import { ReactComponent as EpicLogo } from 'src/assets/epic-logo.svg'
 import { ReactComponent as GOGLogo } from 'src/assets/gog-logo.svg'
 import classNames from 'classnames'
+import CachedImage from 'src/components/CachedImage'
 
 interface Card {
   appName: string
@@ -337,9 +338,9 @@ const GameCard = ({
             }
           >
             {showStoreLogos()}
-            <img src={imageSrc} className={imgClasses} alt="cover" />
+            <CachedImage src={imageSrc} className={imgClasses} alt="cover" />
             {logo && (
-              <img
+              <CachedImage
                 alt="logo"
                 src={`${logo}?h=400&resize=1&w=300`}
                 className={logoClasses}


### PR DESCRIPTION
This PR adds a mechanism to cache game images in the file system to be overcome the issue with the chrome's cache having a limit in size.

How it works:
- added a custom protocol `imagecache://` intercepted by electron to respond with a local file
- added a CachedImage component that first tries to use the cache, and, if the request fails, it fallback to the original url
- added an images_cache module with a function that will convert a `imagecache://` url into a local file response and, if the file is not already cached, cache it in the background

this was suprisingly way easier than I expected xD

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
