### PR TITLE
[UI] Show Cloud Save unsupported status

### DIFF
--- a/public/locales/bg/gamepage.json
+++ b/public/locales/bg/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Деинсталиране",
         "update": "Обновяване"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Изключено",
     "dlc": {
         "installDlcs": "Инсталиране на всички сваляеми съдържания"

--- a/public/locales/ca/gamepage.json
+++ b/public/locales/ca/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Desinstal·la",
         "update": "Actualitza"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Desactivat",
     "dlc": {
         "installDlcs": "Instal·la tots els DLCs"

--- a/public/locales/cs/gamepage.json
+++ b/public/locales/cs/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Odinstalovat",
         "update": "Update"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Zakázáno",
     "dlc": {
         "installDlcs": "Instalovat všechna DLC"

--- a/public/locales/de/gamepage.json
+++ b/public/locales/de/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Deinstallieren",
         "update": "Update"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Deaktiviert",
     "dlc": {
         "installDlcs": "Alle DLCs installieren"

--- a/public/locales/el/gamepage.json
+++ b/public/locales/el/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Απεγκατάσταση",
         "update": "Ενημέρωση"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Απενεργοποιημένο",
     "dlc": {
         "installDlcs": "Εγκατάσταση όλων των DLCs"

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Uninstall",
         "update": "Update"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Disabled",
     "dlc": {
         "installDlcs": "Install all DLCs"

--- a/public/locales/es/gamepage.json
+++ b/public/locales/es/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Desinstalar",
         "update": "Actualizar"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Deshabilitado",
     "dlc": {
         "installDlcs": "Instalar todos los DLCs"

--- a/public/locales/et/gamepage.json
+++ b/public/locales/et/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Eemalda",
         "update": "Uuenda"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Keelatud",
     "dlc": {
         "installDlcs": "Paigalda kõik DLC'd"

--- a/public/locales/fa/gamepage.json
+++ b/public/locales/fa/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "حذف",
         "update": "بهروزرسانی"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "غیر فعال",
     "dlc": {
         "installDlcs": "نصب همه DLCها"

--- a/public/locales/fi/gamepage.json
+++ b/public/locales/fi/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Poista",
         "update": "Päivitä"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Pois käytöstä",
     "dlc": {
         "installDlcs": "Asenna kaikki ladattava sisältö"

--- a/public/locales/fr/gamepage.json
+++ b/public/locales/fr/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Désinstaller",
         "update": "Mise à jour"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Désactivé",
     "dlc": {
         "installDlcs": "Installer tout le contenu téléchargeable (DLC)"

--- a/public/locales/gl/gamepage.json
+++ b/public/locales/gl/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Desinstalar",
         "update": "Actualizar"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Deshabilitar",
     "dlc": {
         "installDlcs": "Instalar todos os DLCs"

--- a/public/locales/hr/gamepage.json
+++ b/public/locales/hr/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Deinstaliraj",
         "update": "Ažuriraj"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Onemogućeno",
     "dlc": {
         "installDlcs": "Instaliraj sve DLC-eve"

--- a/public/locales/hu/gamepage.json
+++ b/public/locales/hu/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Eltávolítás",
         "update": "Frissítés"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Letiltva",
     "dlc": {
         "installDlcs": "Összes DLC telepítése"

--- a/public/locales/id/gamepage.json
+++ b/public/locales/id/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Copot",
         "update": "Perbarui"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Dinonaktifkan",
     "dlc": {
         "installDlcs": "Pasang semua DLC"

--- a/public/locales/it/gamepage.json
+++ b/public/locales/it/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Disinstalla",
         "update": "Update"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Disattivato",
     "dlc": {
         "installDlcs": "Installa tutti i DLC"

--- a/public/locales/ja/gamepage.json
+++ b/public/locales/ja/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "アンインストール",
         "update": "アップデート"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "無効になっています",
     "dlc": {
         "installDlcs": "すべてのDLCをインストールします"

--- a/public/locales/ko/gamepage.json
+++ b/public/locales/ko/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "설치 제거",
         "update": "업데이트"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "비활성화",
     "dlc": {
         "installDlcs": "모든 DLC를 설치합니다"

--- a/public/locales/ml/gamepage.json
+++ b/public/locales/ml/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "എടുത്തുനീക്കൂ",
         "update": "പുതുക്കൂ"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "പ്രവര്ത്തനരഹിതം",
     "dlc": {
         "installDlcs": "എല്ലാ കൂട്ടുരേഖകളും നടൂ"

--- a/public/locales/nl/gamepage.json
+++ b/public/locales/nl/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Verwijderen",
         "update": "Update"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Uitgeschakeld",
     "dlc": {
         "installDlcs": "Installeer alle DLC's"

--- a/public/locales/pl/gamepage.json
+++ b/public/locales/pl/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Odinstaluj",
         "update": "Aktualizuj"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Wyłączone",
     "dlc": {
         "installDlcs": "Zainstaluj wszystkie DLC"

--- a/public/locales/pt/gamepage.json
+++ b/public/locales/pt/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Desinstalar",
         "update": "Update"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Desabilitado",
     "dlc": {
         "installDlcs": "Instalar todas as DLCs"

--- a/public/locales/pt_BR/gamepage.json
+++ b/public/locales/pt_BR/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Desinstalar",
         "update": "Update"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Desabilitado",
     "dlc": {
         "installDlcs": "Instalar DLCs"

--- a/public/locales/ru/gamepage.json
+++ b/public/locales/ru/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Удалить",
         "update": "Обновить"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Выключено",
     "dlc": {
         "installDlcs": "Установить все DLC"

--- a/public/locales/sv/gamepage.json
+++ b/public/locales/sv/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Avinstallera",
         "update": "Uppdatera"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Inaktiverad",
     "dlc": {
         "installDlcs": "Installera alla DLC"

--- a/public/locales/ta/gamepage.json
+++ b/public/locales/ta/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "நிறுவல் நீக்கு",
         "update": "Update"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "முடக்கப்பட்டது",
     "dlc": {
         "installDlcs": "Install all DLCs"

--- a/public/locales/tr/gamepage.json
+++ b/public/locales/tr/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Kaldır",
         "update": "Güncelle"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Devre dışı",
     "dlc": {
         "installDlcs": "Tüm DLC'leri kur"

--- a/public/locales/uk/gamepage.json
+++ b/public/locales/uk/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Видалити",
         "update": "Оновити"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Вимкнено",
     "dlc": {
         "installDlcs": "Встановити всі DLC"

--- a/public/locales/vi/gamepage.json
+++ b/public/locales/vi/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "Gỡ cài đặt",
         "update": "Cập nhật"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "Tắt",
     "dlc": {
         "installDlcs": "Cài đặt tất cả bản mở rộng (DLC)"

--- a/public/locales/zh_Hans/gamepage.json
+++ b/public/locales/zh_Hans/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "卸载",
         "update": "更新"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "已禁用",
     "dlc": {
         "installDlcs": "安装所有 DLC"

--- a/public/locales/zh_Hant/gamepage.json
+++ b/public/locales/zh_Hant/gamepage.json
@@ -48,6 +48,7 @@
         "uninstall": "解除安裝",
         "update": "更新"
     },
+    "cloud_save_unsupported": "Unsupported",
     "disabled": "已禁用",
     "dlc": {
         "installDlcs": "安裝所有DLC"

--- a/src/screens/Game/GamePage/index.tsx
+++ b/src/screens/Game/GamePage/index.tsx
@@ -282,6 +282,16 @@ export default function GamePage(): JSX.Element | null {
                           {autoSyncSaves ? t('enabled') : t('disabled')}
                         </div>
                       )}
+                      {is_installed && !showCloudSaveInfo && (
+                        <div
+                          style={{
+                            color: '#F45460'
+                          }}
+                        >
+                          {t('info.syncsaves')}:{' '}
+                          {t('cloud_save_unsupported', 'Unsupported')}
+                        </div>
+                      )}
                       {!is_installed && (
                         <>
                           <div>


### PR DESCRIPTION
- Display unsupported status for games that don't support cloud save syncing (eg. Linux Native GOG games, Rocket League, etc.)
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
