### PR TITLE
[FIX] Don't show Recent Games if the list is empty

### DIFF
--- a/src/screens/Library/components/RecentlyPlayed/index.tsx
+++ b/src/screens/Library/components/RecentlyPlayed/index.tsx
@@ -40,6 +40,10 @@ export default function RecentlyPlayed({ handleModal, onlyInstalled }: Props) {
     }
   })
 
+  if (!recentGames.length) {
+    return null
+  }
+
   return (
     <>
       <h3 className="libraryHeader">{t('Recent', 'Played Recently')}</h3>


### PR DESCRIPTION
This fixes the issue of showing the recent played games lane with a empty list.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
