### PR TITLE
[Tech] Fix Windows artifacts naming and builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ build_script:
 test: off
 
 artifacts:
-  - path: dist\Heroic*.exe
+  - path: dist\*Setup.exe
     name: Heroic_setup
 
 deploy:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       }
     ],
     "win": {
-      "artifactName": "Heroic_Setup_${version}.${ext}",
+      "artifactName": "${productName}-${version}-Setup.${ext}",
       "icon": "build/win_icon.ico",
       "asarUnpack": [
         "build/bin/win32/legendary.exe",
@@ -51,6 +51,9 @@
       "files": [
         "build/bin/win32/*"
       ]
+    },
+    "portable": {
+      "artifactName": "${productName}-${version}-Portable.${ext}"
     },
     "mac": {
       "target": "dmg",


### PR DESCRIPTION
I noticed that the portable and setup artifacts had the same name so the portable was being overwritten by the Setup and not being uploaded to the releases page.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
