### PR TITLE
[Fix] WinePrefix FAQ link

### DIFF
--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -83,6 +83,7 @@ const wikiLink =
 const weblateUrl = 'https://hosted.weblate.org/projects/heroic-games-launcher'
 const kofiPage = 'https://ko-fi.com/heroicgames'
 const patreonPage = 'https://www.patreon.com/heroicgameslauncher'
+const wineprefixFAQ = 'https://wiki.winehq.org/FAQ#Wineprefixes'
 
 /**
  * Get shell for different os
@@ -223,5 +224,6 @@ export {
   runtimePath,
   isCLIFullscreen,
   isCLINoGui,
-  GITHUB_API
+  GITHUB_API,
+  wineprefixFAQ
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -98,7 +98,8 @@ import {
   isSteamDeckGameMode,
   isCLIFullscreen,
   isCLINoGui,
-  isFlatpak
+  isFlatpak,
+  wineprefixFAQ
 } from './constants'
 import { handleProtocol } from './protocol'
 import {
@@ -584,6 +585,7 @@ ipcMain.on('openLoginPage', async () => openUrlOrFile(epicLoginUrl))
 ipcMain.on('openDiscordLink', async () => openUrlOrFile(discordLink))
 ipcMain.on('openPatreonPage', async () => openUrlOrFile(patreonPage))
 ipcMain.on('openKofiPage', async () => openUrlOrFile(kofiPage))
+ipcMain.on('openWinePrefixFAQ', async () => openUrlOrFile(wineprefixFAQ))
 ipcMain.on('openWebviewPage', async (event, url) => openUrlOrFile(url))
 ipcMain.on('openWikiLink', async () => openUrlOrFile(wikiLink))
 ipcMain.on('openSidInfoPage', async () => openUrlOrFile(sidInfoUrl))

--- a/src/screens/Settings/components/WineSettings/index.css
+++ b/src/screens/Settings/components/WineSettings/index.css
@@ -8,3 +8,7 @@
   padding-left: 5px;
   color: var(--accent);
 }
+
+.winefaq {
+  color: var(--accent);
+}

--- a/src/screens/Settings/components/WineSettings/index.tsx
+++ b/src/screens/Settings/components/WineSettings/index.tsx
@@ -203,8 +203,14 @@ export default function WineSettings({
                   'Wine uses what is called a WINEPREFIX to encapsulate Windows applications. This prefix contains the Wine configuration files and a reproduction of the file hierarchy of C: (the main disk on a Windows OS). In this reproduction of the C: drive, your game save files and dependencies installed via winetricks are stored.'
                 )}
               </p>
-              <a href={'https://wiki.winehq.org/FAQ#Wineprefixes'}>
-                Wineprefix FAQ
+
+              <a>
+                <span
+                  className="winefaq"
+                  onClick={() => ipcRenderer.send('openWinePrefixFAQ')}
+                >
+                  WinePrefix FAQ
+                </span>
               </a>
             </InfoBox>
           }

--- a/src/screens/Settings/components/WineSettings/index.tsx
+++ b/src/screens/Settings/components/WineSettings/index.tsx
@@ -197,13 +197,13 @@ export default function WineSettings({
           }
           afterInput={
             <InfoBox text={t('infobox.wine-prefix.title', 'Wine Prefix')}>
-              <p>
-                {t(
-                  'infobox.wine-repfix.message',
-                  'Wine uses what is called a WINEPREFIX to encapsulate Windows applications. This prefix contains the Wine configuration files and a reproduction of the file hierarchy of C: (the main disk on a Windows OS). In this reproduction of the C: drive, your game save files and dependencies installed via winetricks are stored.'
-                )}
-              </p>
+              {t(
+                'infobox.wine-repfix.message',
+                'Wine uses what is called a WINEPREFIX to encapsulate Windows applications. This prefix contains the Wine configuration files and a reproduction of the file hierarchy of C: (the main disk on a Windows OS). In this reproduction of the C: drive, your game save files and dependencies installed via winetricks are stored.'
+              )}
 
+              <br />
+              <br />
               <a>
                 <span
                   className="winefaq"


### PR DESCRIPTION
- Create coloured hyperlink
- Open link in browser

This PR fixes two things -
1. The WinePrefix FAQ under (_Settings->Wine->Wine Prefix InfoBox_) is displayed like a simple text. Thus, users don't know that it is actually a link. 
2. Moreover, the link opens up the web page in the Heroic window itself and there's no way to go back to Heroic.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
