### PR TITLE
Log frontend errors in log files

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -468,6 +468,10 @@ ipcMain.on('frontendReady', () => {
   handleProtocol(mainWindow, [openUrlArgument, ...process.argv])
 })
 
+ipcMain.on('frontendError', async (event, error: string) => {
+  logError(error, LogPrefix.Frontend)
+})
+
 // Maybe this can help with white screens
 process.on('uncaughtException', async (err) => {
   logError(`${err.name}: ${err.message}`, LogPrefix.Backend)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,11 @@ import GlobalState from 'src/state/GlobalState'
 import { UpdateComponentBase } from 'src/components/UI/UpdateComponent'
 import { initShortcuts } from './helpers/shortcuts'
 import { configStore } from './helpers/electronStores'
+import { ipcRenderer } from './helpers'
+
+window.addEventListener('error', (ev: ErrorEvent) => {
+  ipcRenderer.send('frontendError', ev.error.stack)
+})
 
 const Backend = new HttpApi(null, {
   addPath: 'build/locales/{{lng}}/{{ns}}',


### PR DESCRIPTION
This PR adds an `error` event listener in the frontend so we can send the error message to the backend to log frontend error messages in the log files.

This should make it easier to debug problems and we won't have to ask users to open the dev tools > go to console steps to find frontend errors.

At least with my tests, things like the images cache miss don't show up so that's a good thing (those are expected for example) but I'm not sure if there are other errors that might not show up that are important, but I tested breaking the app on purpose and the error is handled by the backend.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
