### PR TITLE
Try to use image cache for images with full url

### DIFF
--- a/src/components/UI/CachedImage/index.tsx
+++ b/src/components/UI/CachedImage/index.tsx
@@ -8,7 +8,7 @@ interface CachedImageProps {
 type Props = React.ImgHTMLAttributes<HTMLImageElement> & CachedImageProps
 
 const CachedImage = (props: Props) => {
-  const [useCache, setUseCache] = useState(true)
+  const [useCache, setUseCache] = useState(props.src.startsWith('http'))
   const [useFallback, setUseFallback] = useState(false)
 
   const onError = () => {
@@ -19,7 +19,7 @@ const CachedImage = (props: Props) => {
       // if not cached and can't access real, try with the fallback
       if (props.fallback) {
         setUseFallback(true)
-        setUseCache(true)
+        setUseCache(props.fallback.startsWith('http'))
       }
     }
   }


### PR DESCRIPTION
This PR changes the CachedImage component to not try to use the cache when the src of the img is relative.

Relative paths are local files so we don't really need to cache them and the cache handler fails to download that file since it's not a valid complete url. This avoid some errors in the backend for games with no image that has to use the fallback and makes the component easier to re-use without worring about the url passed as src.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
