### PR TITLE
[Windows - Fix] Replace wmic with powershell command, because it is deprecated.

### DIFF
--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -637,12 +637,16 @@ function detectVCRedist(mainWindow: BrowserWindow) {
   let stderr = ''
 
   // get applications
-  const child = spawn('powershell', [
+  const child = spawn('powershell.exe', [
     'Get-ItemProperty',
     'HKLM:\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*,',
     'HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*',
-    '-Name',
-    'DisplayName'
+    '|',
+    'Select-Object',
+    'DisplayName',
+    '|',
+    'Format-Table',
+    '–AutoSize'
   ])
 
   child.stdout.setEncoding('utf-8')

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -630,34 +630,48 @@ function detectVCRedist(mainWindow: BrowserWindow) {
     return
   }
 
+  // According to this article avoid using wmic and Win32_Product
+  // https://xkln.net/blog/please-stop-using-win32product-to-find-installed-software-alternatives-inside/
+  // wmic is also deprecated
   const detectedVCRInstallations: string[] = []
   let stderr = ''
-  const child = spawn('wmic', [
-    'path',
-    'Win32_Product',
-    'WHERE',
-    'Name LIKE "Microsoft Visual C++ 2022%"',
-    'GET',
-    'Name'
+
+  // get applications
+  const child = spawn('powershell', [
+    'Get-ItemProperty',
+    'HKLM:\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*,',
+    'HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*',
+    '-Name',
+    'DisplayName'
   ])
-  child.stdout.on('data', (data: Buffer) => {
-    // WMIC might push more than one line at a time
-    const splitData = data.toString().split('\n')
+
+  child.stdout.setEncoding('utf-8')
+  child.stdout.on('data', (data: string) => {
+    const splitData = data.split('\n')
     for (const installation of splitData) {
-      if (installation) {
+      if (installation && installation.includes('Microsoft Visual C++ 2022')) {
         detectedVCRInstallations.push(installation)
       }
     }
   })
-  child.stderr.on('data', (data: Buffer) => {
-    stderr += data.toString()
+
+  child.stderr.setEncoding('utf-8')
+  child.stderr.on('data', (data: string) => {
+    stderr += data
   })
-  child.on('close', async (code) => {
+
+  child.on('error', (error: Error) => {
+    logError(`Check of VCRuntime crashed with:\n${error}`, LogPrefix.Backend)
+    return
+  })
+
+  child.on('close', async (code: number) => {
     if (code) {
       logError(
         `Failed to check for VCRuntime installations\n${stderr}`,
         LogPrefix.Backend
       )
+      return
     }
     // VCR installers install both the "Minimal" and "Additional" runtime, and we have 2 installers (x86 and x64) -> 4 installations in total
     if (detectedVCRInstallations.length < 4) {

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -646,7 +646,7 @@ function detectVCRedist(mainWindow: BrowserWindow) {
     'DisplayName',
     '|',
     'Format-Table',
-    '–AutoSize'
+    '-AutoSize'
   ])
 
   child.stdout.setEncoding('utf-8')


### PR DESCRIPTION
- wmic is deprecated in win11 and since win10 21H1. See https://www.bleepingcomputer.com/news/microsoft/microsoft-starts-killing-off-wmic-in-windows-will-thwart-attacks/#:~:text=%22The%20WMIC%20tool%20is%20deprecated,the%20command%2Dline%20management%20tool.
- According to this article it is not good to use wmic and Win32_product:
  https://devblogs.microsoft.com/scripting/use-powershell-to-find-installed-software/

- Replaced wmic with the solution suggest in the article above.
- Added `child.on('error')`, else heroic will close all the time, because of uncaught exception.
- Didn't tested this, because i don't have a windows machine. Will test with people reported the problem.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
