### PR TITLE
[Fix] Not permanently saving downloadNoHttps config option

### DIFF
--- a/src/frontend/screens/Settings/index.tsx
+++ b/src/frontend/screens/Settings/index.tsx
@@ -337,6 +337,7 @@ function Settings() {
       defaultWinePrefix,
       disableController,
       discordRPC,
+      downloadNoHttps,
       egsLinkedPath,
       enableEsync,
       enableFsync,


### PR DESCRIPTION
My last pull request #1538 (for issue #1032) did not save the new option within the config file. So after closing heroic the option got lost.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
