### PR TITLE
[Fix] TypeError: Unexpected end of json

### DIFF
--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -264,9 +264,12 @@ export class LegendaryLibrary {
 
     // Once we ran `legendary list`, `assets.json` will be updated with the newest
     // game versions, and `installed.json` has our currently installed ones
-    const installedJson: Record<string, InstalledJsonMetadata> = JSON.parse(
-      readFileSync(join(legendaryConfigPath, 'installed.json')).toString()
-    )
+    const installedJsonFile = join(legendaryConfigPath, 'installed.json')
+    let installedJson: Record<string, InstalledJsonMetadata> = {}
+    if (existsSync(installedJsonFile)) {
+      installedJson = JSON.parse(readFileSync(installedJsonFile).toString())
+    }
+
     // First go through all our installed games and store their versions...
     const installedGames: Map<string, { version: string; platform: string }> =
       new Map()
@@ -278,9 +281,12 @@ export class LegendaryLibrary {
     }
     // ...and now go through all games in `assets.json` to get the newest version
     // HACK: Same as above,                         ↓ this isn't always `string`, but it works for now
-    const assetsJson: Record<string, Record<string, string>[]> = JSON.parse(
-      readFileSync(join(legendaryConfigPath, 'assets.json')).toString()
-    )
+    const assetsJsonFile = join(legendaryConfigPath, 'assets.json')
+    let assetsJson: Record<string, Record<string, string>[]> = {}
+    if (existsSync(assetsJsonFile)) {
+      assetsJson = JSON.parse(readFileSync(assetsJsonFile).toString())
+    }
+
     const updateableGames: string[] = []
     for (const [platform, assets] of Object.entries(assetsJson)) {
       installedGames.forEach(

--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -266,8 +266,13 @@ export class LegendaryLibrary {
     // game versions, and `installed.json` has our currently installed ones
     const installedJsonFile = join(legendaryConfigPath, 'installed.json')
     let installedJson: Record<string, InstalledJsonMetadata> = {}
-    if (existsSync(installedJsonFile)) {
+    try {
       installedJson = JSON.parse(readFileSync(installedJsonFile).toString())
+    } catch (error) {
+      logWarning(
+        `Failed to read games from ${installedJsonFile} with:\n${error}`,
+        LogPrefix.Legendary
+      )
     }
 
     // First go through all our installed games and store their versions...
@@ -283,8 +288,13 @@ export class LegendaryLibrary {
     // HACK: Same as above,                         ↓ this isn't always `string`, but it works for now
     const assetsJsonFile = join(legendaryConfigPath, 'assets.json')
     let assetsJson: Record<string, Record<string, string>[]> = {}
-    if (existsSync(assetsJsonFile)) {
+    try {
       assetsJson = JSON.parse(readFileSync(assetsJsonFile).toString())
+    } catch (error) {
+      logWarning(
+        `Failed to read games from ${assetsJsonFile} with:\n${error}`,
+        LogPrefix.Legendary
+      )
     }
 
     const updateableGames: string[] = []

--- a/src/backend/legendary/user.ts
+++ b/src/backend/legendary/user.ts
@@ -57,8 +57,8 @@ export class LegendaryUser {
       configStore.delete('userInfo')
       return {}
     }
-    const userInfoContent = readFileSync(userInfo).toString()
     try {
+      const userInfoContent = readFileSync(userInfo).toString()
       const userInfoObject = JSON.parse(userInfoContent)
       const info: UserInfo = {
         account_id: userInfoObject.account_id,

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -770,7 +770,10 @@ ipcMain.handle(
       const info = await getGame(game, runner).getInstallInfo(installPlatform)
       return info
     } catch (error) {
-      logError(`${error}`, LogPrefix.Backend)
+      logError(
+        `${error}`,
+        runner === 'legendary' ? LogPrefix.Legendary : LogPrefix.Gog
+      )
       return null
     }
   }

--- a/src/frontend/screens/Settings/components/Tools/index.tsx
+++ b/src/frontend/screens/Settings/components/Tools/index.tsx
@@ -1,6 +1,6 @@
 import './index.css'
 
-import React, { useEffect, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'


### PR DESCRIPTION
We never checked if `installed.json` and `assets.json` exist. Passing an empty string to `JSON.parse()` will throw `Unexpected end of JSON`.

- Added try/catch around reading of `installed.json` and `assets.json`.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
