### PR TITLE
[Linux] Set some more Wine-related env vars when launching with built-in libraries

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -330,20 +330,37 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
     }
   }
   if (!gameSettings.preferSystemLibs && wineVersion.type === 'wine') {
-    if (wineVersion.lib32 && wineVersion.lib) {
+    // https://github.com/ValveSoftware/Proton/blob/4221d9ef07cc38209ff93dbbbca9473581a38255/proton#L1091-L1093
+    if (!process.env.ORIG_LD_LIBRARY_PATH) {
+      ret.ORIG_LD_LIBRARY_PATH = process.env.LD_LIBRARY_PATH ?? ''
+    }
+
+    const { lib32, lib } = wineVersion
+    if (lib32 && lib) {
       // append wine libs at the beginning
-      ret.LD_LIBRARY_PATH = [
-        wineVersion.lib32,
-        wineVersion.lib,
-        process.env.LD_LIBRARY_PATH
-      ]
+      ret.LD_LIBRARY_PATH = [lib, lib32, process.env.LD_LIBRARY_PATH]
         .filter(Boolean)
         .join(':')
+
+      // https://github.com/ValveSoftware/Proton/blob/4221d9ef07cc38209ff93dbbbca9473581a38255/proton#L1099
+      // NOTE: Proton does not make sure that these folders exist first, I believe we should :^)
+      const gstp_path_lib64 = join(lib, 'gstreamer-1.0')
+      const gstp_path_lib32 = join(lib32, 'gstreamer-1.0')
+      if (existsSync(gstp_path_lib64) && existsSync(gstp_path_lib32)) {
+        ret.GST_PLUGIN_SYSTEM_PATH_1_0 = gstp_path_lib64 + ':' + gstp_path_lib32
+      }
+
+      // https://github.com/ValveSoftware/Proton/blob/4221d9ef07cc38209ff93dbbbca9473581a38255/proton#L1097
+      const winedll_path_lib64 = join(lib, 'wine')
+      const winedll_path_lib32 = join(lib32, 'wine')
+      if (existsSync(winedll_path_lib64) && existsSync(winedll_path_lib32)) {
+        ret.WINEDLLPATH = winedll_path_lib64 + ':' + winedll_path_lib32
+      }
     } else {
       logError(
         [
           `Couldn't find all library folders of ${wineVersion.name}!`,
-          `Missing ${wineVersion.lib32} or ${wineVersion.lib}!`,
+          `Missing ${lib32} and/or ${lib}!`,
           `Falling back to system libraries!`
         ].join('\n')
       )


### PR DESCRIPTION
These are largely copied over from Proton's source code, and should make some more games work OOTB (as an example, Drone Racing League Simulator, which is free on the EGS right now)

Looking at the launch command now, I believe a new way we print that out is in order soon:tm:

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
