### PR TITLE
[Fix] Unicode chars in non-steam-game error dialog

### DIFF
--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -33,7 +33,8 @@ function showErrorInFrontend(props: { gameTitle: string; error: string }) {
     defaultValue: 'Adding {{game}} to Steam failed with:{{newLine}} {{error}}',
     game: props.gameTitle,
     newLine: '\n',
-    error: props.error
+    error: props.error,
+    interpolation: { escapeValue: false }
   })
 
   const title = i18next.t(


### PR DESCRIPTION
The unicode appears in the dialog box because i18next escapes the value to avoid XSS injection attacks by default. 
Solved by turning off the escaping flag.

Related Issue:
#1867 
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
