### PR TITLE
Fix setting not updating after another setting changes

### DIFF
--- a/src/frontend/hooks/useSetting.ts
+++ b/src/frontend/hooks/useSetting.ts
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import SettingsContext from 'frontend/screens/Settings/SettingsContext'
 
 const useSetting = <T>(key: string, fallback: T): [T, (newVal: T) => void] => {

--- a/src/frontend/hooks/useSetting.ts
+++ b/src/frontend/hooks/useSetting.ts
@@ -1,28 +1,19 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext } from 'react'
 import SettingsContext from 'frontend/screens/Settings/SettingsContext'
 
-const useSetting = <T>(
-  key: string,
-  fallback: T
-): [T, React.Dispatch<React.SetStateAction<T>>] => {
+const useSetting = <T>(key: string, fallback: T): [T, (newVal: T) => void] => {
   const { getSetting, setSetting } = useContext(SettingsContext)
 
-  let initialValue = getSetting(key) as T
-  if (initialValue === undefined) {
-    initialValue = fallback
+  let currentValue = getSetting(key) as T
+  if (currentValue === undefined) {
+    currentValue = fallback
   }
-  const [value, setValue] = useState<T>(initialValue)
-  const [dirty, setDirty] = useState(false)
 
-  useEffect(() => {
-    if (dirty) {
-      setSetting(key, value)
-    } else if (value !== initialValue) {
-      setDirty(true)
-    }
-  }, [value, dirty])
+  const setSettingF = (newValue: T) => {
+    setSetting(key, newValue)
+  }
 
-  return [value, setValue]
+  return [currentValue, setSettingF]
 }
 
 export default useSetting


### PR DESCRIPTION
This PR fixes an issue after the settings refactor that the useSetting was not triggering a re-render other components after setting the new value.

It was using some useEffects/useStates but they were actually not needed.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
