### PR TITLE
[Fix] Discrepancy in game count

### DIFF
--- a/src/frontend/screens/Library/components/LibraryHeader/index.tsx
+++ b/src/frontend/screens/Library/components/LibraryHeader/index.tsx
@@ -31,10 +31,8 @@ export default function LibraryHeader({
     if (!list) {
       return null
     }
-    const dlcCount =
-      category === 'legendary'
-        ? list.filter((lib) => lib.install.is_dlc).length
-        : 0
+    // is_dlc is only applicable when the game is from legendary, but checking anyway doesn't cause errors and enable accurate counting in the 'ALL' game tab
+    const dlcCount = list.filter((lib) => lib.install.is_dlc).length
 
     const total = list.length - dlcCount
     return total > 0 ? `(${total})` : null


### PR DESCRIPTION
This PR fix the discrepancy in game count between the game count in the All Games section of the library and the sum of the ones on the Epic Games and the Gog sections. Now it is also coherent with the number of game shown.

Fix #1877 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
