### PR TITLE
[UI] Tweak backToTopBtn color theme

### DIFF
--- a/src/frontend/screens/Library/index.css
+++ b/src/frontend/screens/Library/index.css
@@ -73,7 +73,7 @@
 }
 
 #backToTopBtn:hover {
-  opacity: 1.0;
+  opacity: 1;
 }
 
 .listing {

--- a/src/frontend/screens/Library/index.css
+++ b/src/frontend/screens/Library/index.css
@@ -58,9 +58,9 @@
   bottom: 3%;
   right: 0;
   margin: var(--space-md) var(--space-xl);
-  border: 1px var(--download-button) solid;
+  border: 1px var(--accent) solid;
   background-color: var(--background);
-  color: var(--download-button);
+  color: var(--accent);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -69,11 +69,11 @@
   visibility: hidden;
   transition: all 0.3s ease-in;
   cursor: pointer;
+  opacity: 0.7;
 }
 
 #backToTopBtn:hover {
-  background-color: var(--download-button);
-  color: var(--text-default);
+  opacity: 1.0;
 }
 
 .listing {


### PR DESCRIPTION
- Match the border and color with theme color
- Reduce opacity when not hovered


https://user-images.githubusercontent.com/74495920/194710202-62b09dca-4f06-428c-9c7d-7d205ba2d340.mp4



---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
