### PR TITLE
[Linux] Fixup: Show Wine Prefix in Game Settings again

### DIFF
--- a/src/frontend/screens/Settings/components/WineSettings/WinePrefix.tsx
+++ b/src/frontend/screens/Settings/components/WineSettings/WinePrefix.tsx
@@ -26,10 +26,6 @@ const WinePrefix = () => {
     `${home}/.wine`
   )
 
-  if (!isLinux || !isDefault) {
-    return <></>
-  }
-
   return (
     <>
       {isLinux && isDefault && (


### PR DESCRIPTION
After the settings refactor (#1726), I noticed that the "Wine Prefix" setting was missing from the game settings. Took a quick look at the code, this bit at the start of the WinePrefix component seems to be the issue

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
