### PR TITLE
[Tech] System info cache

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1002,6 +1002,7 @@ ipcMain.handle(
       game.logFileLocation,
       'System Info:\n' +
         `${systemInfo}\n` +
+        '\n' +
         `Game Settings: ${gameSettingsString}\n` +
         '\n' +
         `Game launched at: ${startPlayingDate}\n` +

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -344,7 +344,9 @@ if (!gotTheLock) {
   app.whenReady().then(async () => {
     initOnlineMonitor()
 
-    const systemInfo = await getSystemInfo()
+    getSystemInfo().then((systemInfo) =>
+      logInfo(`\n\n${systemInfo}\n`, { prefix: LogPrefix.Backend })
+    )
 
     initImagesCache()
 
@@ -355,7 +357,6 @@ if (!gotTheLock) {
     logInfo(['GOGDL location:', join(...Object.values(getGOGdlBin()))], {
       prefix: LogPrefix.Gog
     })
-    logInfo(`\n\n${systemInfo}\n`, { prefix: LogPrefix.Backend })
     // We can't use .config since apparently its not loaded fast enough.
     const { language, darkTrayIcon } = await GlobalConfig.get().getSettings()
 
@@ -1001,7 +1002,6 @@ ipcMain.handle(
       game.logFileLocation,
       'System Info:\n' +
         `${systemInfo}\n` +
-        '\n' +
         `Game Settings: ${gameSettingsString}\n` +
         '\n' +
         `Game launched at: ${startPlayingDate}\n` +

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -247,7 +247,13 @@ async function handleExit(window: BrowserWindow) {
   app.exit()
 }
 
+// This won't change while the app is running
+// Caching significantly increases performance when launching games
+let systemInfoCache = ''
 export const getSystemInfo = async () => {
+  if (systemInfoCache !== '') {
+    return systemInfoCache
+  }
   const heroicVersion = getHeroicVersion()
   const legendaryVersion = await getLegendaryVersion()
 
@@ -276,7 +282,7 @@ export const getSystemInfo = async () => {
     ? (await execAsync('echo $XDG_SESSION_TYPE')).stdout.replaceAll('\n', '')
     : ''
 
-  return `Heroic Version: ${heroicVersion}
+  systemInfoCache = `Heroic Version: ${heroicVersion}
 Legendary Version: ${legendaryVersion}
 OS: ${distro} KERNEL: ${kernel} ARCH: ${arch}
 CPU: ${manufacturer} ${brand} @${speed} ${
@@ -285,6 +291,7 @@ CPU: ${manufacturer} ${brand} @${speed} ${
 RAM: Total: ${getFileSize(total)} Available: ${getFileSize(available)}
 GRAPHICS: ${graphicsCards}
 ${isLinux ? `PROTOCOL: ${xEnv}` : ''}`
+  return systemInfoCache
 }
 
 type ErrorHandlerMessage = {


### PR DESCRIPTION
This improves game launch speed by caching system info that won't change while the app is running.

Time to launch was reduced from 20 seconds to 9 seconds with League of Legends on Windows. 

It also speeds up Heroic launch time by ~5 seconds. Before, we were unnecessarily awaiting getSystemInfo before launching the main window. Now it runs asynchronously.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
