### PR TITLE
Move game menu next to the title

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.scss
+++ b/src/frontend/screens/Game/GamePage/index.scss
@@ -6,12 +6,78 @@
   justify-content: stretch;
   position: relative;
 
-  .title {
-    font-weight: var(--medium);
-    font-size: var(--text-xl);
-    line-height: 30px;
-    color: var(--text-default);
-    text-align: left;
+  .titleWrapper {
+    display: flex;
+    .title {
+      font-weight: var(--medium);
+      font-size: var(--text-xl);
+      line-height: 30px;
+      color: var(--text-default);
+      text-align: left;
+      flex-basis: 100%;
+      align-self: center;
+    }
+
+    .game-actions {
+      float: right;
+      position: relative;
+      display: flex;
+      flex-direction: column;
+
+      .toggle {
+        align-self: flex-end;
+        background-color: transparent;
+        border: none;
+        color: var(--accent);
+        font-size: var(--text-2xl);
+        padding: var(--space-xs-fixed);
+        cursor: pointer;
+        position: relative;
+        transition: background-color 0.2s;
+        display: flex;
+      }
+
+      &:focus-within .toggle,
+      &:hover .toggle,
+      .toggle:hover {
+        color: var(--text-title);
+      }
+
+      .gameTools {
+        position: absolute;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s, max-height 0.2s;
+        background: var(--navbar-background);
+        border-radius: 5px;
+        z-index: 2;
+        padding: 1rem;
+        max-height: 0px;
+        overflow: hidden;
+        right: 0;
+        top: 100%;
+      }
+
+      .gameTools .link {
+        width: 100%;
+        padding: 0 0 0.5rem;
+        text-align: left;
+        white-space: nowrap;
+        font-size: 1rem;
+
+        &:last-child {
+          padding-bottom: 0;
+        }
+      }
+
+      &:focus-within .gameTools,
+      &:hover .gameTools {
+        opacity: 1;
+        pointer-events: all;
+        max-height: 100vh;
+        box-shadow: 4px 5px 5px -2px rgba(0, 0, 0, 0.2);
+      }
+    }
   }
 
   .store-icon {
@@ -248,66 +314,5 @@
 @keyframes animate-stripes {
   100% {
     background-position: -100px 0px;
-  }
-}
-
-.game-actions {
-  position: absolute;
-  right: 1rem;
-  top: var(--space-xs-fixed);
-  display: flex;
-  flex-direction: column;
-
-  .toggle {
-    align-self: flex-end;
-    background-color: transparent;
-    border: none;
-    color: var(--accent);
-    font-size: var(--text-2xl);
-    padding: var(--space-xs-fixed);
-    cursor: pointer;
-    position: relative;
-    transition: background-color 0.2s;
-  }
-
-  &:focus-within .toggle,
-  &:hover .toggle,
-  .toggle:hover {
-    color: var(--text-title);
-  }
-
-  .gameTools {
-    position: absolute;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s, max-height 0.2s;
-    background: var(--navbar-background);
-    border-radius: 5px;
-    z-index: 2;
-    padding: 1rem;
-    max-height: 0px;
-    overflow: hidden;
-    right: 0;
-    top: 100%;
-  }
-
-  .gameTools .link {
-    width: 100%;
-    padding: 0 0 0.5rem;
-    text-align: left;
-    white-space: nowrap;
-    font-size: 1rem;
-
-    &:last-child {
-      padding-bottom: 0;
-    }
-  }
-
-  &:focus-within .gameTools,
-  &:hover .gameTools {
-    opacity: 1;
-    pointer-events: all;
-    max-height: 100vh;
-    box-shadow: 4px 5px 5px -2px rgba(0, 0, 0, 0.2);
   }
 }

--- a/src/frontend/screens/Game/GamePage/index.scss
+++ b/src/frontend/screens/Game/GamePage/index.scss
@@ -19,7 +19,6 @@
     }
 
     .game-actions {
-      float: right;
       position: relative;
       display: flex;
       flex-direction: column;

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -256,27 +256,31 @@ export default function GamePage(): JSX.Element | null {
             <div className="store-icon">
               {runner === 'legendary' ? <EpicLogo /> : <GOGLogo />}
             </div>
-            <div className="game-actions">
-              <button className="toggle">
-                <FontAwesomeIcon icon={faEllipsisV} />
-              </button>
-
-              <GameSubMenu
-                appName={appName}
-                isInstalled={is_installed}
-                title={title}
-                storeUrl={gameInfo.store_url}
-                runner={gameInfo.runner}
-                handleUpdate={handleUpdate}
-                disableUpdate={updateRequested || isUpdating}
-                steamImageUrl={gameInfo.art_cover}
-                onShowRequirements={
-                  hasRequirements ? () => setShowRequirements(true) : undefined
-                }
-              />
-            </div>
             <div className="gameInfo">
-              <h1 className="title">{title}</h1>
+              <div className="titleWrapper">
+                <h1 className="title">{title}</h1>
+                <div className="game-actions">
+                  <button className="toggle">
+                    <FontAwesomeIcon icon={faEllipsisV} />
+                  </button>
+
+                  <GameSubMenu
+                    appName={appName}
+                    isInstalled={is_installed}
+                    title={title}
+                    storeUrl={gameInfo.store_url}
+                    runner={gameInfo.runner}
+                    handleUpdate={handleUpdate}
+                    disableUpdate={updateRequested || isUpdating}
+                    steamImageUrl={gameInfo.art_cover}
+                    onShowRequirements={
+                      hasRequirements
+                        ? () => setShowRequirements(true)
+                        : undefined
+                    }
+                  />
+                </div>
+              </div>
               <div className="infoWrapper">
                 <div className="developer">{developer}</div>
                 <div className="summary">


### PR DESCRIPTION
This PR is a quick fix moving the game menu next to the game's title instead of the top-right corner as described https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/1841#issuecomment-1272344083

Tested with different title lengths too:
![image](https://user-images.githubusercontent.com/188464/195461167-2a7ebf91-1d08-4e21-b7a5-cf1e9f07bd5c.png)
![image](https://user-images.githubusercontent.com/188464/195461211-e5f9ada0-6c6b-46a4-9edc-4a4fcb9b295e.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
