### PR TITLE
Fix error when clicking "Settings" when the current screen is a login webview

### DIFF
--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -64,7 +64,7 @@ export default function SidebarLinks() {
   const loggedIn = epic.username || gog.username
 
   useEffect(() => {
-    if (!runner || runner === 'app') {
+    if (!runner || runner === 'app' || !appName) {
       setIsDefaultSetting(true)
       setGameInfo({ ...gameInfo, cloud_save_enabled: false })
       setSettingsPath('/settings/app/default/general')


### PR DESCRIPTION
This PR fixes an issue I just noticed while working on another PR.

Steps to reproduce the issue before this fix:
- go to Manage Accounts
- click Login for any store
- click Settings
- react app crashes with an error in the console, blank screen

The issue is that the url for the logins is `/loginweb/legendary` or `/loginweb/gog` and the sidebar component does a `split` on that url and was considering `legendary` and `gog` as runners like it happens for game page urls `/gamepage/legendary/someGame` but the was no appName in the url.

This PR fixes that by only linking to a game setting if we have an app name

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
