### PR TITLE
Fix automatic shortcuts creation

### DIFF
--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -274,6 +274,7 @@ class GOGGame extends Game {
       })
       await setup(this.appName, installedData)
     }
+    this.addShortcuts()
     return { status: 'done' }
   }
 

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -459,6 +459,7 @@ class LegendaryGame extends Game {
       }
       return { status: 'error' }
     }
+    this.addShortcuts()
     return { status: 'done' }
   }
 


### PR DESCRIPTION
I noticed the feature to automatically add games to the desktop/menu was not working, and seems like I broke it a year ago https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/740/files :see_no_evil:

This PR re-adds the method call to `addShortcuts` that takes care of adding the shortcuts after a game is installed if needed.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
