### PR TITLE
Add shortcuts to Steam automatically

### DIFF
--- a/public/locales/az/translation.json
+++ b/public/locales/az/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "İş masası qısayollarını avtomatik əlavə edin",
         "addgamestostartmenu": "Menyuya avtomatik başlamaq üçün oyunlar əlavə edin",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "İstifadə etmək üçün Alternativ GOGDL Binary seçin",
         "alt-legendary-bin": "Alternativ Əfsanəvi Binary seçin",
         "audiofix": "Audio Düzəltmə (Pulse Audio Latency)",

--- a/public/locales/be/translation.json
+++ b/public/locales/be/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Add desktop shortcuts automatically",
         "addgamestostartmenu": "Add games to start menu automatically",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Choose an Alternative GOGDL Binary to use (needs restart)",
         "alt-legendary-bin": "Choose an Alternative Legendary Binary  (needs restart)to use",
         "audiofix": "",

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Автоматично добавяне на преки пътища на работния плот",
         "addgamestostartmenu": "Автоматично добавяне на игрите в менюто с приложения",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Избиране на алтернативен изпълним файл на GOGDL",
         "alt-legendary-bin": "Избиране на алтернативен изпълним файл на Legendary",
         "audiofix": "Поправка за звука (забавяне на Pulse Audio)",

--- a/public/locales/bs/translation.json
+++ b/public/locales/bs/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Automatski dodajte prečice na radnoj površini",
         "addgamestostartmenu": "Automatski dodajte igre u početni meni",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Odaberite alternativnu GOGDL binarnu datoteku koju želite koristiti",
         "alt-legendary-bin": "Odaberite alternativnu Legendary binarnu datoteku",
         "audiofix": "Popravak zvuka (kašnjenje pulsnog zvuka)",

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Afegeix les dreceres a l'escriptori automàticament",
         "addgamestostartmenu": "Afegeix els jocs al menú d'inici automàticament",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Tria un fitxer binari alternatiu del GOGDL",
         "alt-legendary-bin": "Tria un binari alternatiu del Legendary",
         "audiofix": "Corregeix l'àudio (latència del Pulse Audio)",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Automaticky přidávat zástupce na plochu",
         "addgamestostartmenu": "Přidat hry do nabídky Start automaticky",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Vyberte alternativní spustitelný soubor GOGDL, který chcete použít",
         "alt-legendary-bin": "Vyberte alternativní spustitelný soubor Legendary",
         "audiofix": "Oprava zvuku (Pulse Audio latence)",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Desktop-Verknüpfungen automatisch hinzufügen",
         "addgamestostartmenu": "Spiele automatisch zum Startmenü hinzufügen",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Alternative GOGDL Binary zur Verwendung auswählen",
         "alt-legendary-bin": "Alternative Legendary Binärdatei auswählen",
         "audiofix": "Audio-Fix (Pulse Audio Latenz)",

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Αυτόματη προσθήκη συντομεύσεων επιφάνειας εργασίας",
         "addgamestostartmenu": "Αυτόματη προσθήκη παιχνιδιών στο Μενού εκκίνησης",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Επιλογή Εναλλακτικού δυαδικού GOGDL για χρήση",
         "alt-legendary-bin": "Επιλέξτε ένα εναλλακτικό δυαδικό αρχείο Legendary",
         "audiofix": "Επισκευή ήχου (Καθυστέρηση Pulse Audio)",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Add desktop shortcuts automatically",
         "addgamestostartmenu": "Add games to start menu automatically",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Choose an Alternative GOGDL Binary to use",
         "alt-legendary-bin": "Choose an Alternative Legendary Binary",
         "audiofix": "Audio Fix (Pulse Audio Latency)",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Añadir accesos directos al escritorio automáticamente",
         "addgamestostartmenu": "Añadir juegos al menú de inicio automáticamente",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Elige un binario de GOGDL alternativo para usar",
         "alt-legendary-bin": "Elige un binario de Legendary alternativo",
         "audiofix": "Corrección de audio (latencia de Pulseaudio)",

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Lisa töölaua otseteed automaatselt",
         "addgamestostartmenu": "Mängude automaatne lisamine stardimenüüsse",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Valige alternatiivne GOGDL binaarfail",
         "alt-legendary-bin": "Valige alternatiivne Legendary binaarfail",
         "audiofix": "Heliparandus (Pulse Audio Latency)",

--- a/public/locales/eu/translation.json
+++ b/public/locales/eu/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Gehitu mahaigaineko lasterbideak automatikoki",
         "addgamestostartmenu": "Gehitu jokoak menua automatikoki hasteko",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Aukeratu GOGDL Binario alternatibo bat erabiltzeko",
         "alt-legendary-bin": "Aukeratu kondairazko bitar alternatibo bat",
         "audiofix": "Audio konponketa (Pultso Audio latentzia)",

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "افزودن خودکار میانبرهای دسکتاپ",
         "addgamestostartmenu": "افزودن خودکار میانبرهای منوی استارت",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "انتخاب باینری GOGDL جایگزین برای استفاده",
         "alt-legendary-bin": "انتخاب باینری Legendary جایگزین",
         "audiofix": "تنظیم صدا (تاخیر Pulse Audio)",

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Lisää työpöydän pikakuvakkeet automaattisesti",
         "addgamestostartmenu": "Lisää pelit aloitusvalikkoon automaattisesti",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Valitse vaihtoehtoinen GOGDL-binääri käytettäväksi (vaatii uudelleenkäynnistyksen)",
         "alt-legendary-bin": "Valitse vaihtoehtoinen Legendary-binääritiedosto (uudelleenkäynnistys vaaditaan)",
         "audiofix": "Äänikorjaus (Pulse Audion viive)",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Ajouter automatiquement des raccourcis sur le Bureau",
         "addgamestostartmenu": "Ajouter automatiquement les jeux au menu Démarrer",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Choisir un binaire GOGDL alternatif à utiliser",
         "alt-legendary-bin": "Choisir un autre exécutable Legendary (redémarrage Heroic nécessaire)",
         "audiofix": "Corriger l'audio (Latence Pulse Audio)",

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Engadir atallos de escritorio automaticamente",
         "addgamestostartmenu": "Engadir xogos ao menú de inicio automaticamente",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Selecciona un binario de GOGDL alternativo a usar",
         "alt-legendary-bin": "Seleccione o binario de Legendary alternativo",
         "audiofix": "Correción de audio (latencia de Pulseaudio)",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Add desktop shortcuts automatically",
         "addgamestostartmenu": "Add games to start menu automatically",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Odaberi drugu verziju GOGDL programa za koristiti",
         "alt-legendary-bin": "Odaberi drugu verziju Legendary programa",
         "audiofix": "Popravak zvuka (Pulse audio latencija)",

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Parancsikonok automatikus hozzáadása az asztalhoz",
         "addgamestostartmenu": "Parancsikonok automatikus hozzáadása a Start Menühöz",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Alternatív GOGDL bináris kiválasztása",
         "alt-legendary-bin": "Alternatív Legendary bináris kiválasztása",
         "audiofix": "Hangzásjavítás (Pulse Audio késleltetés)",

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Tambahkan pintasan desktop secara otomatis",
         "addgamestostartmenu": "Tambahkan gim untuk memulai menu secara otomatis",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Pilih GOGDL Binary alternatif untuk digunakan",
         "alt-legendary-bin": "Pilih Legendary Binary Alternatif",
         "audiofix": "Perbaikan Audio (Latensi Pulsa Audio )",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Aggiungere automaticamente i collegamenti desktop",
         "addgamestostartmenu": "Aggiungere automaticamente giochi al menu start",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Scegli un binario GOGDL alternativo da utilizzare",
         "alt-legendary-bin": "Scegli un binario Legendary alternativo",
         "audiofix": "Audio Fix (Latenza Pulse Audio)",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "デスクトップショートカットを自動的に追加する",
         "addgamestostartmenu": "ゲームをスタートメニューに自動的に追加する",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Choose an Alternative GOGDL Binary to use (needs restart)",
         "alt-legendary-bin": "Choose an Alternative Legendary Binary  (needs restart)",
         "audiofix": "オーディオ修正（Pulseaudioレイテンシー）",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "데스크톱 바로 가기 자동 추가",
         "addgamestostartmenu": "시작 메뉴에 게임 자동 추가",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "대신 사용할 GOGDL 바이너리 파일 선택",
         "alt-legendary-bin": "대신 사용할 Legendary 바이너리 파일 선택",
         "audiofix": "오디오 픽스 (Pulse Audio 지연)",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "കുറുക്കുവഴികള് മേശപ്പുറത്ത് താനേ ചേര്ക്കൂ",
         "addgamestostartmenu": "കളികള് തുടക്കപ്പട്ടികയില് താനേ ചേര്ക്കൂ",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Choose an Alternative GOGDL Binary to use (needs restart)",
         "alt-legendary-bin": "Choose an Alternative Legendary Binary  (needs restart)",
         "audiofix": "ശബ്ദം ശരിയാക്കൂ (പള്സ് ഓഡിയോ ലാറ്റന്സി)",

--- a/public/locales/nb_NO/translation.json
+++ b/public/locales/nb_NO/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Legg til skrivebordssnarveier automatisk",
         "addgamestostartmenu": "Legg til spill på startmenyen automatisk",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Velg en alternativ GOGDL-binær du vil bruke",
         "alt-legendary-bin": "Velg en alternativ legendarisk binær",
         "audiofix": "Lydfiks (pulslydforsinkelse)",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Desktop shortcuts automatish toevoegen",
         "addgamestostartmenu": "Spellen automatish toevoegen aan start menu",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Choose an Alternative GOGDL Binary to use (needs restart)",
         "alt-legendary-bin": "Kies een andere Legendary Binary om te gebruiken",
         "audiofix": "Geluid fix (Pulse Audio Latency)",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Dodawaj automatycznie skróty na pulpicie",
         "addgamestostartmenu": "Dodawaj automatycznie gry do menu start",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Wybierz alternatywny plik binarny GOGDL",
         "alt-legendary-bin": "Wybierz alternatywny plik binarny Legendary",
         "audiofix": "Łatka audio (Opóźnienie Pulse Audio)",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Adicionar atalhos à area de trabalho automaticamente",
         "addgamestostartmenu": "Adicionar atalhos ao menu automaticamente",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Choose an Alternative GOGDL Binary to use (needs restart)",
         "alt-legendary-bin": "Choose an Alternative Legendary Binary  (needs restart)",
         "audiofix": "Consertar Audio do Jogo",

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Adicionar atalhos na área de trabalho automaticamente",
         "addgamestostartmenu": "Adicionar atalhos dos jogos no menu iniciar automaticamente",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Escolha um binário do GOGDL alternativo para usar",
         "alt-legendary-bin": "Escolha um binário alternativo do Legendary",
         "audiofix": "Consertar áudio do jogo (latência do PulseAudio)",

--- a/public/locales/ro/translation.json
+++ b/public/locales/ro/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Adăugați automat comenzi rapide pe desktop",
         "addgamestostartmenu": "Adăugați jocuri în meniul Start automat",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Alegeți un binar GOGDL alternativ pe care să îl utilizați",
         "alt-legendary-bin": "Alegeți un Legendary Binary alternativ pe care să îl utilizați",
         "audiofix": "Fixare Audio (Latență în PulseAudio)",

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Создать ярлыки на рабочем столе автоматически",
         "addgamestostartmenu": "Добавить игры в меню приложений автоматически",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Выбрать другой исполняемый файл GOGDL",
         "alt-legendary-bin": "Выбрать другой исполняемый файл Legendary",
         "audiofix": "Фикс аудио (Задержка Pulse Audio)",

--- a/public/locales/sk/translation.json
+++ b/public/locales/sk/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Add desktop shortcuts automatically",
         "addgamestostartmenu": "Add games to start menu automatically",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Choose an Alternative GOGDL Binary to use (needs restart)",
         "alt-legendary-bin": "Choose an Alternative Legendary Binary  (needs restart)to use",
         "audiofix": "",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Skapa skrivbordsgenvägar automatiskt",
         "addgamestostartmenu": "Lägg till spel i startmenyn automatiskt",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Ange alternativ GOGDL version (omstart krävs)",
         "alt-legendary-bin": "Ange alternativ Legendary version",
         "audiofix": "Ljudfix (Pulse Audio latens)",

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "திரைமுகப்பு குறுக்குவழிகளை தானாக சேர்",
         "addgamestostartmenu": "துவகுப்பட்டியில் விளையாட்டுகளை தானாக சேர்",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "மாற்று GOGDL Binary ஐத் தேர்வு செய்",
         "alt-legendary-bin": "மாற்று Legendary Binary ஐத் தேர்வு செய்",
         "audiofix": "கேட்பொலி பிழைத்திருத்தம் (Pulse Audio Latency)",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Masaüstü kısayollarını otomatik ekle",
         "addgamestostartmenu": "Oyunları başlangıç menüsüne otomatik ekle",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Bir muadil GOGDL çalıştırılabilir dosyasını seçin",
         "alt-legendary-bin": "Bir muadil Legendary dosyası seçin",
         "audiofix": "Ses Çözümü (Pulse Audio Gecikmesi)",

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Створювати ярлики на робочому столі автоматично",
         "addgamestostartmenu": "Додавати ігри до головного меню автоматично",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Обрати інший двійковий файл GOGDL",
         "alt-legendary-bin": "Обрати інший двійковий файл Legendary",
         "audiofix": "Лагодження звуку (затримка Pulse Audio)",

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "Tự động thêm shortcut trên màn hình chính",
         "addgamestostartmenu": "Tự động thêm game vào menu Start",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Chọn GOGDL binary thay thế để sử dụng",
         "alt-legendary-bin": "Chọn Legendary binary thay thế để sử dụng",
         "audiofix": "Sửa âm thanh (Pulse Audio Latency)",

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "自动添加桌面快捷方式",
         "addgamestostartmenu": "自动添加到启动菜单快捷方式",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "选择要使用的备选 GOGDL 二进制文件",
         "alt-legendary-bin": "选择备选的 Legendary 二进制文件",
         "audiofix": "音频修复（Pulse Audio延迟）",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -387,6 +387,7 @@
     "setting": {
         "adddesktopshortcuts": "自動添加桌面捷徑",
         "addgamestostartmenu": "自動添加捷徑到開始功能表",
+        "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "選擇要使用的備選 GOGDL 二進制文件",
         "alt-legendary-bin": "選擇備選的 Legendary 二進制文件",
         "audiofix": "音頻修覆（Pulse Audio延遲）",

--- a/src/backend/api/menu.ts
+++ b/src/backend/api/menu.ts
@@ -22,13 +22,8 @@ export const installEosOverlay = async () =>
   ipcRenderer.invoke('installEosOverlay')
 export const removeFromSteam = async (appName: string, runner: Runner) =>
   ipcRenderer.invoke('removeFromSteam', appName, runner)
-export const addToSteam = async (
-  appName: string,
-  runner: Runner,
-  bkgDataURL: string,
-  bigPicDataURL: string
-) =>
-  ipcRenderer.invoke('addToSteam', appName, runner, bkgDataURL, bigPicDataURL)
+export const addToSteam = async (appName: string, runner: Runner) =>
+  ipcRenderer.invoke('addToSteam', appName, runner)
 export const shortcutsExists = async (appName: string, runner: Runner) =>
   ipcRenderer.invoke('shortcutsExists', appName, runner)
 export const isAddedToSteam = async (appName: string, runner: Runner) =>

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -475,6 +475,7 @@ class GlobalConfigV0 extends GlobalConfig {
       enableUpdates: false,
       addDesktopShortcuts: false,
       addStartMenuShortcuts: false,
+      addSteamShortcuts: false,
       autoInstallDxvk: false,
       autoInstallVkd3d: false,
       preferSystemLibs: false,

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -630,12 +630,7 @@ class GOGGame extends Game {
     await removeShortcuts(this.appName, 'gog')
     syncStore.delete(this.appName)
     const gameInfo = await this.getGameInfo()
-    const { defaultSteamPath } = await GlobalConfig.get().getSettings()
-    const steamUserdataDir = join(
-      defaultSteamPath.replaceAll("'", ''),
-      'userdata'
-    )
-    await removeNonSteamGame({ steamUserdataDir, gameInfo })
+    await removeNonSteamGame({ gameInfo })
     return res
   }
 

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -274,6 +274,7 @@ class GOGGame extends Game {
       })
       await setup(this.appName, installedData)
     }
+    this.addShortcuts()
     return { status: 'done' }
   }
 

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -478,12 +478,7 @@ class LegendaryGame extends Game {
       LegendaryLibrary.get().installState(this.appName, false)
       await removeShortcuts(this.appName, 'legendary')
       const gameInfo = this.getGameInfo()
-      const { defaultSteamPath } = await GlobalConfig.get().getSettings()
-      const steamUserdataDir = join(
-        defaultSteamPath.replaceAll("'", ''),
-        'userdata'
-      )
-      await removeNonSteamGame({ steamUserdataDir, gameInfo })
+      await removeNonSteamGame({ gameInfo })
     }
     return res
   }

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -459,6 +459,7 @@ class LegendaryGame extends Game {
       }
       return { status: 'error' }
     }
+    this.addShortcuts()
     return { status: 'done' }
   }
 

--- a/src/backend/shortcuts/ipc_handler.ts
+++ b/src/backend/shortcuts/ipc_handler.ts
@@ -1,8 +1,6 @@
 import { existsSync } from 'graceful-fs'
-import { GlobalConfig } from '../config'
 import { ipcMain, dialog } from 'electron'
 import i18next from 'i18next'
-import { join } from 'path'
 import { Runner } from 'common/types'
 import {
   addNonSteamGame,
@@ -11,11 +9,6 @@ import {
 } from './nonesteamgame/nonesteamgame'
 import { getGame } from '../utils'
 import { shortcutFiles } from './shortcuts/shortcuts'
-
-const getSteamUserdataDir = async () => {
-  const { defaultSteamPath } = await GlobalConfig.get().getSettings()
-  return join(defaultSteamPath.replaceAll("'", ''), 'userdata')
-}
 
 ipcMain.on(
   'addShortcut',
@@ -54,36 +47,20 @@ ipcMain.on('removeShortcut', async (event, appName: string, runner: Runner) => {
   })
 })
 
-ipcMain.handle(
-  'addToSteam',
-  async (
-    event,
-    appName: string,
-    runner: Runner,
-    bkgDataUrl: string,
-    bigPicDataUrl: string
-  ) => {
-    const game = getGame(appName, runner)
-    const gameInfo = await game.getGameInfo()
-    const steamUserdataDir = await getSteamUserdataDir()
+ipcMain.handle('addToSteam', async (event, appName: string, runner: Runner) => {
+  const game = getGame(appName, runner)
+  const gameInfo = await game.getGameInfo()
 
-    return addNonSteamGame({
-      steamUserdataDir,
-      gameInfo,
-      bkgDataUrl,
-      bigPicDataUrl
-    })
-  }
-)
+  return addNonSteamGame({ gameInfo })
+})
 
 ipcMain.handle(
   'removeFromSteam',
   async (event, appName: string, runner: Runner) => {
     const game = getGame(appName, runner)
     const gameInfo = await game.getGameInfo()
-    const steamUserdataDir = await getSteamUserdataDir()
 
-    await removeNonSteamGame({ steamUserdataDir, gameInfo })
+    await removeNonSteamGame({ gameInfo })
   }
 )
 
@@ -92,8 +69,7 @@ ipcMain.handle(
   async (event, appName: string, runner: Runner) => {
     const game = getGame(appName, runner)
     const gameInfo = await game.getGameInfo()
-    const steamUserdataDir = await getSteamUserdataDir()
 
-    return isAddedToSteam({ steamUserdataDir, gameInfo })
+    return isAddedToSteam({ gameInfo })
   }
 )

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -30,6 +30,22 @@ const getSteamUserdataDir = async () => {
   return join(defaultSteamPath.replaceAll("'", ''), 'userdata')
 }
 
+const generateImage = async (
+  src: string,
+  width: number,
+  height: number
+): Promise<string> => {
+  const window = BrowserWindow.getAllWindows()[0]
+
+  if (!window) {
+    return Promise.resolve('')
+  }
+
+  return window.webContents.executeJavaScript(
+    `window.imageData("${src}", ${width}, ${height})`
+  )
+}
+
 /**
  * Opens a error dialog in frontend with the error message
  * @param props
@@ -198,14 +214,8 @@ async function addNonSteamGame(props: {
   let bigPicDataUrl = props.bigPicDataUrl
 
   if (bkgDataUrl === undefined || bigPicDataUrl === undefined) {
-    const window = BrowserWindow.getAllWindows()[0]
-
-    bkgDataUrl = await window.webContents.executeJavaScript(
-      `window.imageData("${props.gameInfo.art_cover}", 1920, 620)`
-    )
-    bigPicDataUrl = await window.webContents.executeJavaScript(
-      `window.imageData("${props.gameInfo.art_cover}", 920, 430)`
-    )
+    bkgDataUrl = await generateImage(props.gameInfo.art_cover, 1920, 620)
+    bigPicDataUrl = await generateImage(props.gameInfo.art_cover, 920, 430)
   }
 
   const { folders, error } = checkSteamUserDataDir(steamUserdataDir)
@@ -284,8 +294,8 @@ async function addNonSteamGame(props: {
         otherGridAppID: generateShortAppId(newEntry.Exe, newEntry.AppName)
       },
       gameInfo: props.gameInfo,
-      bkgDataUrl: bkgDataUrl!,
-      bigPicDataUrl: bigPicDataUrl!
+      bkgDataUrl: bkgDataUrl,
+      bigPicDataUrl: bigPicDataUrl
     })
 
     const args = []

--- a/src/backend/shortcuts/shortcuts/shortcuts.ts
+++ b/src/backend/shortcuts/shortcuts/shortcuts.ts
@@ -7,6 +7,7 @@ import { Runner, GameInfo } from 'common/types'
 import { userHome } from '../../constants'
 import { GOGLibrary } from '../../gog/library'
 import { getIcon } from '../utils'
+import { addNonSteamGame } from '../nonesteamgame/nonesteamgame'
 
 /**
  * Adds a desktop shortcut to $HOME/Desktop and to /usr/share/applications
@@ -25,8 +26,12 @@ async function addShortcuts(gameInfo: GameInfo, fromMenu?: boolean) {
   if (!desktopFile || !menuFile) {
     return
   }
-  const { addDesktopShortcuts, addStartMenuShortcuts } =
+  const { addDesktopShortcuts, addStartMenuShortcuts, addSteamShortcuts } =
     await GlobalConfig.get().getSettings()
+
+  if (addSteamShortcuts) {
+    addNonSteamGame({ gameInfo })
+  }
 
   switch (process.platform) {
     case 'linux': {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -51,6 +51,7 @@ export interface AppSettings {
   enableUpdates: boolean
   addDesktopShortcuts: boolean
   addStartMenuShortcuts: boolean
+  addSteamShortcuts: boolean
   altLegendaryBin: string
   altGogdlBin: string
   audioFix: boolean

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -111,3 +111,59 @@ ReactDOM.render(
   </React.StrictMode>,
   document.getElementById('root')
 )
+
+// helper function to generate images for steam
+// image is centered, sides are padded with blurred image
+// returns dataURL of the generated image
+
+// This is added globally to be able to call it directly from the backend
+window.imageData = async (
+  src: string,
+  cw: number,
+  ch: number
+): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const canvas = document.createElement('CANVAS') as HTMLCanvasElement
+    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D
+    const img = document.createElement('IMG') as HTMLImageElement
+    img.crossOrigin = 'anonymous' // prevents cors errors when exporting
+
+    img.addEventListener(
+      'load',
+      function () {
+        // measure canvas and image
+        canvas.width = cw
+        canvas.height = ch
+        const imgWidth = img.width
+        const imgHeight = img.height
+
+        // calculate drawing of the background
+        const bkgW = cw
+        const bkgH = (imgHeight * cw) / imgWidth
+        const bkgX = 0
+        const bkgY = ch / 2 - bkgH / 2
+        ctx.filter = 'blur(10px)' // add blur and draw
+        ctx.drawImage(img, bkgX, bkgY, bkgW, bkgH)
+
+        // calculate drawing of the foreground
+        const drawH = ch
+        const drawW = (imgWidth * ch) / imgHeight
+        const drawY = 0
+        const drawX = cw / 2 - drawW / 2
+        ctx.filter = 'blur(0)' // remove blur and draw
+        ctx.drawImage(img, drawX, drawY, drawW, drawH)
+
+        // resolve with dataURL
+        resolve(canvas.toDataURL('image/jpeg', 0.9))
+      },
+      false
+    )
+
+    img.addEventListener('error', (error) => {
+      reject(error)
+    })
+
+    // set src to trigger the callback
+    img.src = src
+  })
+}

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -269,7 +269,6 @@ export default function GamePage(): JSX.Element | null {
                 runner={gameInfo.runner}
                 handleUpdate={handleUpdate}
                 disableUpdate={updateRequested || isUpdating}
-                steamImageUrl={gameInfo.art_cover}
                 onShowRequirements={
                   hasRequirements ? () => setShowRequirements(true) : undefined
                 }

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -20,62 +20,7 @@ interface Props {
   runner: Runner
   handleUpdate: () => void
   disableUpdate: boolean
-  steamImageUrl: string
   onShowRequirements?: () => void
-}
-
-// helper function to generate images for steam
-// image is centered, sides are padded with blurred image
-// returns dataURL of the generated image
-const imageData = async (
-  src: string,
-  cw: number,
-  ch: number
-): Promise<string> => {
-  return new Promise((resolve, reject) => {
-    const canvas = document.createElement('CANVAS') as HTMLCanvasElement
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D
-    const img = document.createElement('IMG') as HTMLImageElement
-    img.crossOrigin = 'anonymous' // prevents cors errors when exporting
-
-    img.addEventListener(
-      'load',
-      function () {
-        // measure canvas and image
-        canvas.width = cw
-        canvas.height = ch
-        const imgWidth = img.width
-        const imgHeight = img.height
-
-        // calculate drawing of the background
-        const bkgW = cw
-        const bkgH = (imgHeight * cw) / imgWidth
-        const bkgX = 0
-        const bkgY = ch / 2 - bkgH / 2
-        ctx.filter = 'blur(10px)' // add blur and draw
-        ctx.drawImage(img, bkgX, bkgY, bkgW, bkgH)
-
-        // calculate drawing of the foreground
-        const drawH = ch
-        const drawW = (imgWidth * ch) / imgHeight
-        const drawY = 0
-        const drawX = cw / 2 - drawW / 2
-        ctx.filter = 'blur(0)' // remove blur and draw
-        ctx.drawImage(img, drawX, drawY, drawW, drawH)
-
-        // resolve with dataURL
-        resolve(canvas.toDataURL('image/jpeg', 0.9))
-      },
-      false
-    )
-
-    img.addEventListener('error', (error) => {
-      reject(error)
-    })
-
-    // set src to trigger the callback
-    img.src = src
-  })
 }
 
 export default function GamesSubmenu({
@@ -86,7 +31,6 @@ export default function GamesSubmenu({
   runner,
   handleUpdate,
   disableUpdate,
-  steamImageUrl,
   onShowRequirements
 }: Props) {
   const { handleGameStatus, refresh, platform, libraryStatus } =
@@ -214,11 +158,8 @@ export default function GamesSubmenu({
         .removeFromSteam(appName, runner)
         .then(() => setAddedToSteam(false))
     } else {
-      const bkgDataURL = await imageData(steamImageUrl, 1920, 620)
-      const bigPicDataURL = await imageData(steamImageUrl, 920, 430)
-
       await window.api
-        .addToSteam(appName, runner, bkgDataURL, bigPicDataURL)
+        .addToSteam(appName, runner)
         .then((added) => setAddedToSteam(added))
     }
     setSteamRefresh(false)

--- a/src/frontend/screens/Settings/components/OtherSettings/Shortcuts.tsx
+++ b/src/frontend/screens/Settings/components/OtherSettings/Shortcuts.tsx
@@ -21,6 +21,10 @@ const Shortcuts = () => {
     'addStartMenuShortcuts',
     false
   )
+  const [addSteamShortcuts, setAddSteamShortcuts] = useSetting<boolean>(
+    'addSteamShortcuts',
+    false
+  )
 
   if (!isDefault || !supportsShortcuts) {
     return <></>
@@ -45,6 +49,12 @@ const Shortcuts = () => {
           'setting.addgamestostartmenu',
           'Add games to start menu automatically'
         )}
+      />
+      <ToggleSwitch
+        htmlId="shortcutsToSteam"
+        value={addSteamShortcuts}
+        handleChange={() => setAddSteamShortcuts(!addSteamShortcuts)}
+        title={t('setting.addgamestosteam', 'Add games to Steam automatically')}
       />
     </>
   )

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -193,6 +193,13 @@ interface AntiCheatReference {
 }
 
 declare global {
+  interface Window {
+    imageData: (
+      src: string,
+      canvas_width: number,
+      canvas_height: number
+    ) => Promise<string>
+  }
   interface WindowEventMap {
     'controller-changed': CustomEvent<{ controllerId: string }>
   }


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1868 adding the setting to automatically add games to Steam after installation.

I'll add some notes in the diff to clarify some of the changes.

This branch is branched from https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/1903, if 1903 gets merged first we may need to change the `base` of this PR before merging!

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
