### PR TITLE
Remove `draggable` from `Run EXE on Prefix` button

### DIFF
--- a/src/frontend/screens/Settings/components/Tools/index.tsx
+++ b/src/frontend/screens/Settings/components/Tools/index.tsx
@@ -61,9 +61,8 @@ export default function Tools() {
     })
     if (path) {
       exe = path
-      return callTools('runExe', exe)
+      callTools('runExe', exe)
     }
-    return
   }
 
   function dropHandler(ev: React.DragEvent<HTMLSpanElement>) {
@@ -119,12 +118,10 @@ export default function Tools() {
             <span className="toolTitle">Winetricks</span>
           </button>
           <a
-            data-testid="toolsDrag"
-            draggable
             onDrop={(ev) => dropHandler(ev)}
             onDragOver={(ev) => dragOverHandler(ev)}
             className="tools drag"
-            onClick={async () => handleRunExe()}
+            onClick={handleRunExe}
           >
             {t('setting.runexe.title')}
             <br />


### PR DESCRIPTION
This PR removes the `draggable` attribute of the button. The button supports dragging and dropping a file ON the button, but the button itself does not need to be draggable.

I think this is causing issues when clicking that button on the Steam Deck (it might be trying to trigger the `drag` instead of clicking it). I'm not sure how to test this directly on the device though but it's the only difference I can see comparing this button with the other buttons that open a file picker dialog.

Click and dropping files on the button still work fine after this change.

The `return`s were not needed

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
