### PR TITLE
Show an error if the select wine doesn't exist

### DIFF
--- a/public/locales/az/translation.json
+++ b/public/locales/az/translation.json
@@ -69,6 +69,7 @@
                 "title": "Yeniləmə xətası"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Şərab Versiyası Seçilməyib. Oyun Parametrlərini yoxlayın!",
                 "title": "Şərab tapılmadı"
             },

--- a/public/locales/be/translation.json
+++ b/public/locales/be/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No Wine Version Selected. Check Game Settings!",
                 "title": "Wine Not Found"
             },

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -69,6 +69,7 @@
                 "title": "Грешка при обновяването"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Няма избрана версия на Wine. Проверете настройките на играта!",
                 "title": "Wine не е намерен"
             },

--- a/public/locales/bs/translation.json
+++ b/public/locales/bs/translation.json
@@ -69,6 +69,7 @@
                 "title": "Greška ažuriranja"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Nije odabrana Wine verzija. Provjerite postavke video igre!",
                 "title": "Wine nije pronađen"
             },

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No s'ha seleccionat cap versió del Wine. Comprova la configuració del joc.",
                 "title": "No s'ha trobat el Wine"
             },

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Není vybrána žádná verze Wine. Zkontrolujte nastavení hry!",
                 "title": "Wine nenalezen"
             },

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Keine Wine-Version ausgewählt. Überprüfe die Spieleinstellungen!",
                 "title": "Wine nicht gefunden"
             },

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -69,6 +69,7 @@
                 "title": "Σφάλμα ενημέρωσης"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Δεν επιλέχθηκε έκδοση Wine. Ελέγξτε τις ρυθμίσεις παιχνιδιού!",
                 "title": "Το Wine δεν βρέθηκε"
             },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No Wine Version Selected. Check Game Settings!",
                 "title": "Wine Not Found"
             },

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -69,6 +69,7 @@
                 "title": "Error al actualizar"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No se ha seleccionado la versión de Wine. ¡Comprueba la configuración del juego!",
                 "title": "No se ha encontrado Wine"
             },

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -69,6 +69,7 @@
                 "title": "Viga uuendamisel"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Wine'i versiooni pole valitud. Kontrolli mängu seadeid!",
                 "title": "Wine'i ei leitud"
             },

--- a/public/locales/eu/translation.json
+++ b/public/locales/eu/translation.json
@@ -69,6 +69,7 @@
                 "title": "Eguneraketa errorea"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Ez da Wine bertsioa hautatu. Egiaztatu jokoaren konfigurazioa!",
                 "title": "Wine ez da aurkitu"
             },

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "نسخه ای از Wine انتخاب نشده است. تنظیمات بازی را چک کنید!",
                 "title": "Wine یافت نشد"
             },

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Winen versiota ei ole valittu. Tarkista peliasetukset!",
                 "title": "Wineä ei löytynyt"
             },

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No Wine Version Selected. Check Game Settings!",
                 "title": "Wine non trouvé"
             },

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No se seleccionou a versión de Wine. ¡Comprueba a configuración do xogo!",
                 "title": "No se atopou Wine"
             },

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No Wine Version Selected. Check Game Settings!",
                 "title": "Wine Not Found"
             },

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Nincs kiválasztott Wine verzió. Ellenőrizd a játék beállításait!",
                 "title": "Wine nem található"
             },

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Tidak Ada Versi Wine yang Dipilih. Periksa Pengaturan Gim!",
                 "title": "Wine Tidak Ditemukan"
             },

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Nessuna versione di Wine selezionata. Controlla le impostazioni del gioco!",
                 "title": "Wine non trovato"
             },

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No Wine Version Selected. Check Game Settings!",
                 "title": "Wine Not Found"
             },

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Wine 버전이 선택되지 않았습니다. 게임 설정을 확인하세요!",
                 "title": "Wine을 찾을 수 없음"
             },

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No Wine Version Selected. Check Game Settings!",
                 "title": "Wine Not Found"
             },

--- a/public/locales/nb_NO/translation.json
+++ b/public/locales/nb_NO/translation.json
@@ -69,6 +69,7 @@
                 "title": "Oppdateringsfeil"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Ingen Wine-versjon valgt. Sjekk spill-innstillingene.",
                 "title": "Fant ikke Wine"
             },

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No Wine Version Selected. Check Game Settings!",
                 "title": "Wine Not Found"
             },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -69,6 +69,7 @@
                 "title": "Błąd aktualizacji"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Nie wybrano wersji Wine. Sprawdź ustawienia gry!",
                 "title": "Nie znaleziono Wine"
             },

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No Wine Version Selected. Check Game Settings!",
                 "title": "Wine Not Found"
             },

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Nenhuma Versão do wine selecionada. Cheque as configurações do jogo!",
                 "title": "Wine Não Encontrado"
             },

--- a/public/locales/ro/translation.json
+++ b/public/locales/ro/translation.json
@@ -69,6 +69,7 @@
                 "title": "Eroare de actualizare"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Nicio versiune Wine selectată. Verificați setările jocului!",
                 "title": "Wine nu a fost găsit"
             },

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -69,6 +69,7 @@
                 "title": "Ошибка обновления"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Не выбрана версия Wine. Проверьте настройки игры!",
                 "title": "Wine не найден"
             },

--- a/public/locales/sk/translation.json
+++ b/public/locales/sk/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No Wine Version Selected. Check Game Settings!",
                 "title": "Wine Not Found"
             },

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -69,6 +69,7 @@
                 "title": "Problem vid uppdatering"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Ingen Wine version vald. Kontrollera spelinställningar!",
                 "title": "Wine hittades ej"
             },

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "No Wine Version Selected. Check Game Settings!",
                 "title": "Wine Not Found"
             },

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Wine Sürümü Seçilmedi. Oyun Ayarlarını Denetleyin!",
                 "title": "Wine Bulunamadı"
             },

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -69,6 +69,7 @@
                 "title": "Помилка оновлення"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Не обрана версія Wine. Перевірте налаштування гри!",
                 "title": "Wine не знайдено"
             },

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "Chưa chọn phiên bản Wine. Kiểm tra phần cài đặt!",
                 "title": "Không tìm thấy Wine"
             },

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -69,6 +69,7 @@
                 "title": "更新错误"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "未选择 Wine 版本。检查游戏设置！",
                 "title": "未找到 Wine"
             },

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -69,6 +69,7 @@
                 "title": "Update Error"
             },
             "wine-not-found": {
+                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
                 "message": "沒有選擇之 Wine 版本。檢查遊戲設定！",
                 "title": "未找到Wine"
             },

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -363,10 +363,12 @@ class GOGGame extends Game {
           this.logFileLocation,
           `Launch aborted: ${wineLaunchPrepFailReason}`
         )
-        showErrorBoxModalAuto({
-          title: t('box.error.launchAborted', 'Launch aborted'),
-          error: wineLaunchPrepFailReason!
-        })
+        if (wineLaunchPrepFailReason) {
+          showErrorBoxModalAuto({
+            title: t('box.error.launchAborted', 'Launch aborted'),
+            error: wineLaunchPrepFailReason
+          })
+        }
         return false
       }
 

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -498,15 +498,12 @@ async function runWineCommand(
   forceRunInPrefixVerb = false
 ) {
   const gameSettings = await game.getSettings()
+  const { folder_name: installFolderName } = game.getGameInfo()
   const { wineVersion } = gameSettings
 
   if (!(await validWine(wineVersion))) {
     return { stdout: '', stderr: '' }
   }
-
-  const wineBin = wineVersion.bin.replaceAll("'", '')
-
-  const { folder_name: installFolderName } = game.getGameInfo()
 
   const env_vars = {
     ...process.env,
@@ -537,6 +534,7 @@ async function runWineCommand(
     }
   }
 
+  const wineBin = wineVersion.bin.replaceAll("'", '')
   let finalCommand = `"${wineBin}" ${command}`
   if (additional_command) {
     finalCommand += ` && ${additional_command}`

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -388,7 +388,7 @@ function setupWrappers(
 
 /**
  * Checks if the game's selected Wine version exists
- * @param game The game to check the Wine version of
+ * @param wineVersion an object of type WineInstallation with binary path and name to check
  * @returns true if the wine version exists, false if it doesn't
  */
 export async function validWine(

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -151,14 +151,7 @@ async function prepareWineLaunch(game: LegendaryGame | GOGGame): Promise<{
 
   // Verify that a Wine binary is set
   // This happens when there aren't any Wine versions installed
-  if (!gameSettings.wineVersion.bin) {
-    showErrorBoxModalAuto({
-      title: i18next.t('box.error.wine-not-found.title', 'Wine Not Found'),
-      error: i18next.t(
-        'box.error.wine-not-found.message',
-        'No Wine Version Selected. Check Game Settings!'
-      )
-    })
+  if (!(await validWine(gameSettings.wineVersion))) {
     return { success: false }
   }
 

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -42,7 +42,8 @@ import {
   ExecResult,
   GameSettings,
   LaunchPreperationResult,
-  RpcClient
+  RpcClient,
+  WineInstallation
 } from 'common/types'
 import { spawn } from 'child_process'
 import shlex from 'shlex'
@@ -395,6 +396,45 @@ function setupWrappers(
 }
 
 /**
+ * Checks if the game's selected Wine version exists
+ * @param game The game to check the Wine version of
+ * @returns true if the wine version exists, false if it doesn't
+ */
+export async function validWine(
+  wineVersion: WineInstallation
+): Promise<boolean> {
+  const wineBin = wineVersion.bin
+
+  if (!wineBin) {
+    showErrorBoxModalAuto({
+      title: i18next.t('box.error.wine-not-found.title', 'Wine Not Found'),
+      error: i18next.t(
+        'box.error.wine-not-found.message',
+        'No Wine Version Selected. Check Game Settings!'
+      )
+    })
+    return false
+  }
+
+  if (!existsSync(wineBin)) {
+    showErrorBoxModalAuto({
+      title: i18next.t('box.error.wine-not-found.title', 'Wine Not Found'),
+      error: i18next.t('box.error.wine-not-found.invalid', {
+        defaultValue:
+          "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
+        version: wineVersion.name,
+        path: wineBin,
+        newline: '\n',
+        interpolation: { escapeValue: false }
+      })
+    })
+    return false
+  }
+
+  return true
+}
+
+/**
  * Verifies that a Wineprefix exists by running 'wineboot --init'
  * @param game The game to verify the Wineprefix of
  * @returns stderr & stdout of 'wineboot --init'
@@ -403,6 +443,10 @@ export async function verifyWinePrefix(
   game: LegendaryGame | GOGGame
 ): Promise<{ res: ExecResult; updated: boolean }> {
   const { winePrefix, wineVersion } = await game.getSettings()
+
+  if (!(await validWine(wineVersion))) {
+    return { res: { stdout: '', stderr: '' }, updated: false }
+  }
 
   if (wineVersion.type === 'crossover') {
     return { res: { stdout: '', stderr: '' }, updated: false }
@@ -454,9 +498,15 @@ async function runWineCommand(
   forceRunInPrefixVerb = false
 ) {
   const gameSettings = await game.getSettings()
-  const { folder_name: installFolderName } = game.getGameInfo()
-
   const { wineVersion } = gameSettings
+
+  if (!(await validWine(wineVersion))) {
+    return { stdout: '', stderr: '' }
+  }
+
+  const wineBin = wineVersion.bin.replaceAll("'", '')
+
+  const { folder_name: installFolderName } = game.getGameInfo()
 
   const env_vars = {
     ...process.env,
@@ -487,7 +537,6 @@ async function runWineCommand(
     }
   }
 
-  const wineBin = wineVersion.bin.replaceAll("'", '')
   let finalCommand = `"${wineBin}" ${command}`
   if (additional_command) {
     finalCommand += ` && ${additional_command}`

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -149,8 +149,6 @@ async function prepareWineLaunch(game: LegendaryGame | GOGGame): Promise<{
     GameConfig.get(game.appName).config ||
     (await GameConfig.get(game.appName).getSettings())
 
-  // Verify that a Wine binary is set
-  // This happens when there aren't any Wine versions installed
   if (!(await validWine(gameSettings.wineVersion))) {
     return { success: false }
   }

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -614,10 +614,12 @@ class LegendaryGame extends Game {
           this.logFileLocation,
           `Launch aborted: ${wineLaunchPrepFailReason}`
         )
-        showErrorBoxModalAuto({
-          title: t('box.error.launchAborted', 'Launch aborted'),
-          error: wineLaunchPrepFailReason!
-        })
+        if (wineLaunchPrepFailReason) {
+          showErrorBoxModalAuto({
+            title: t('box.error.launchAborted', 'Launch aborted'),
+            error: wineLaunchPrepFailReason
+          })
+        }
         return false
       }
 

--- a/src/backend/tools.ts
+++ b/src/backend/tools.ts
@@ -10,6 +10,7 @@ import i18next from 'i18next'
 import { dirname } from 'path'
 import { isOnline } from './online_monitor'
 import { showErrorBoxModalAuto } from './dialog/dialog'
+import { validWine } from './launcher'
 
 export const DXVK = {
   getLatest: async () => {
@@ -216,6 +217,10 @@ export const Winetricks = {
     baseWinePrefix: string,
     event: Electron.IpcMainInvokeEvent
   ) => {
+    if (!(await validWine(wineVersion))) {
+      return
+    }
+
     return new Promise<void>((resolve) => {
       const winetricks = `${heroicToolsPath}/winetricks`
 


### PR DESCRIPTION
This PR adds an error dialog when a user tries to do an action that requires Wine but the binary doesn't exist.

This is really common when deleting wine versions without updating the wine version of the game for example, and trying to run the game/winetricks/winecfg/exe on prefix were failing silently in the frontend or confusingly (winetricks dialog stuck doing nothing).

This would address https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1906 and also show more info for the user to quickly address the problem without having to check the logs.

![image](https://user-images.githubusercontent.com/188464/196011273-5ad5f1ac-23bc-4806-94a1-46804d1eb1df.png)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
