### PR TITLE
Do not check the EOS overlay for GOG games

### DIFF
--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -240,7 +240,7 @@ export default function GamesSubmenu({
     })
 
     // only unix specific
-    if (!isWin) {
+    if (!isWin && runner === 'legendary') {
       // check if eos overlay is enabled
       const { status } =
         libraryStatus.filter(


### PR DESCRIPTION
When opening the game page for a GOG game, we are currently checking if the EOS overlay is installed, which will always be false for GOG games.

This PR skips that check.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
