### PR TITLE
Log Legendary's launch info/config when launching games

### DIFF
--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -645,24 +645,21 @@ class LegendaryGame extends Game {
     }
 
     // Log any launch information configured in Legendary's config.ini
-    await runLegendaryCommand(['launch', this.appName, '--json'], {
-      onOutput: (output) => {
-        if (output.match(/game_parameters/)) {
-          appendFileSync(
-            this.logFileLocation,
-            "Legendary's base config from config.ini:\n"
-          )
-          const json = JSON.parse(output)
-          // remove egl auth info
-          delete json['egl_parameters']
+    const { stdout } = await runLegendaryCommand([
+      'launch',
+      this.appName,
+      '--json',
+      '--offline'
+    ])
+    appendFileSync(
+      this.logFileLocation,
+      "Legendary's config from config.ini (before Heroic's settings):\n"
+    )
+    const json = JSON.parse(stdout)
+    // remove egl auth info
+    delete json['egl_parameters']
 
-          appendFileSync(
-            this.logFileLocation,
-            JSON.stringify(json, null, 2) + '\n\n'
-          )
-        }
-      }
-    })
+    appendFileSync(this.logFileLocation, JSON.stringify(json, null, 2) + '\n\n')
 
     const commandParts = [
       'launch',

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -643,6 +643,27 @@ class LegendaryGame extends Game {
           : ['--wine', wineBin])
       )
     }
+
+    // Log any launch information configured in Legendary's config.ini
+    await runLegendaryCommand(['launch', this.appName, '--json'], {
+      onOutput: (output) => {
+        if (output.match(/game_parameters/)) {
+          appendFileSync(
+            this.logFileLocation,
+            "Legendary's base config from config.ini:\n"
+          )
+          const json = JSON.parse(output)
+          // remove egl auth info
+          delete json['egl_parameters']
+
+          appendFileSync(
+            this.logFileLocation,
+            JSON.stringify(json, null, 2) + '\n\n'
+          )
+        }
+      }
+    })
+
     const commandParts = [
       'launch',
       this.appName,


### PR DESCRIPTION
This PR adds the configuration Legendary has to launch a game before Heroic's modification (i.e: what's configured in its config.ini).

This should help debug problems that had happen some times in the past, people following some tutorial or instructions that tells them to modify legendary's config.ini and they forget and we have no visibility of this information in the logs.

Now the logs will include this information after the game's settings:

```
...
}

Game launched at: Mon Oct 17 2022 01:00:50 GMT-0300 (hora estándar de Argentina)

Legendary's base config from config.ini:
{
  "game_parameters": [],
  "game_executable": "absolutedrift.exe",
  "game_directory": "/home/ariel/Games/Heroic/AbsoluteDrift",
  "launch_command": [
    "wine"
  ],
  "working_directory": "/home/ariel/Games/Heroic/AbsoluteDrift",
  "user_parameters": [],
  "environment": {
    "LC_ALL": "es_ES"
  },
  "pre_launch_command": "",
  "pre_launch_wait": false
}

Launch Command: LD_PRELOAD= WINEPREFIX=/home/....
```

In this case, the `LC_ALL = "es_ES"` en variable is configured in legendary's `config.ini` as a default env variable for all games for example.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
