### PR TITLE
[Fix] Pass `--offline` correctly again

### DIFF
--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -594,7 +594,7 @@ class LegendaryGame extends Game {
       return false
     }
 
-    const offlineFlag = offlineMode ? '--offline' : ''
+    const offlineFlag = offlineMode ? ['--offline'] : []
     const exeOverrideFlag = gameSettings.targetExe
       ? ['--override-exe', gameSettings.targetExe]
       : []


### PR DESCRIPTION
*Someone* (me) mistakenly applied the spread operator (...) to `offlineFlag` when passing it to Legendary. I'd say that instead of removing it there again, let's put the variable in line with all the other flags being `string[]` (even if it's just one string)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
