### PR TITLE
[Steam Deck] Restart xdg-desktop-portal when Heroic is launched

### DIFF
--- a/flatpak/local.heroic.yml
+++ b/flatpak/local.heroic.yml
@@ -21,6 +21,7 @@ finish-args:
   - --allow=devel
   - --device=all
   - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.Flatpak
   - --persist=.wine
   - --filesystem=host
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib32


### PR DESCRIPTION
In SteamOS, the `xdg-desktop-portal` service is misconfigured, preventing URLs from opening unless it's restarted.  
Some Epic games need external account access (which'll open up a web page for the user to grant it) and will fail silently if it's not granted

This PR restarts the service every time Heroic is launched, which I admit is a pretty crude solution, but it *is* a solution
As with #1736, to use `flatpak-spawn --host`, it's necessary to add `--talk-name=org.freedesktop.Flatpak` when building the app

Note that I can't test this myself, since I don't own a deck  

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
