### PR TITLE
Some dialog fixes

### DIFF
--- a/src/frontend/components/UI/Dialog/components/Dialog.tsx
+++ b/src/frontend/components/UI/Dialog/components/Dialog.tsx
@@ -40,7 +40,16 @@ export const Dialog: React.FC<DialogProps> = ({
   const onDialogClick = useCallback(
     (e: SyntheticEvent) => {
       if (e.target === dialogRef.current) {
-        onClose()
+        const ev = e.nativeEvent as MouseEvent
+        const tg = e.target as HTMLElement
+        if (
+          ev.offsetX < 0 ||
+          ev.offsetX > tg.offsetWidth ||
+          ev.offsetY < 0 ||
+          ev.offsetY > tg.offsetHeight
+        ) {
+          onClose()
+        }
       }
     },
     [onClose]

--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -78,10 +78,9 @@
 }
 
 .Dialog__footer {
-  display: grid;
-  grid-gap: 16px;
-  grid-auto-flow: column;
-  margin: 0 0 0 auto;
+  display: flex;
+  gap: 16px;
+  justify-content: end;
   padding: 0 var(--dialog-margin-horizontal) var(--dialog-margin-vertical)
     var(--dialog-margin-horizontal);
 }

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -326,7 +326,7 @@ const GameCard = ({
   }
 
   return (
-    <>
+    <div>
       {showUninstallModal && (
         <UninstallModal
           appName={appName}
@@ -416,7 +416,7 @@ const GameCard = ({
           }
         </div>
       </ContextMenu>
-    </>
+    </div>
   )
 
   async function handlePlay(runner: Runner) {


### PR DESCRIPTION
This PR fixes 3 issues with dialogs:
- Uninstall dialog was adding an empty space in grid view in library Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1930
- Clicking at the left empty are of the buttons was closing the dialog https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1931
- Selecting text in some cases was closing the dialog (no issue for this I just noticed it while testing the other fixes)

A comment on the last fix, the bug is present only when selecting text from different HTML elements, for example selecting text from the title and the content. That triggered a `click` event with the parent dialog as the target (since it can trigger an event with the 2 targets). To reproduce this issue before this fix, select text like this for example:
![image](https://user-images.githubusercontent.com/188464/197345237-3ea50a2e-c255-4bbb-b0ce-ba696d31fc9b.png)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
