### PR TITLE
[Fix] Duplicate kill listener

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,2 @@
 #!/bin/bash
-yarn codecheck && yarn lint && yarn prettier-fix && yarn test && yarn i18n
+yarn codecheck && yarn lint && yarn prettier-fix && yarn i18n

--- a/src/backend/logger/__tests__/logfile.test.ts
+++ b/src/backend/logger/__tests__/logfile.test.ts
@@ -14,9 +14,17 @@ jest.mock('../logger')
 jest.unmock('../logfile')
 
 let tmpDir = {} as DirResult
-const skipIfOnWin = platform() === 'win32' ? describe.skip : describe
 
-skipIfOnWin('logger/logfile.ts', () => {
+const shouldSkip = platform() === 'win32'
+const skipMessage = 'on windows so skipping test'
+const emptyTest = it('should do nothing', () => {})
+
+describe('logger/logfile.ts', () => {
+  if (shouldSkip) {
+    console.log(skipMessage)
+    emptyTest
+    return
+  }
   beforeEach(() => {
     tmpDir = dirSync({ unsafeCleanup: true })
   })

--- a/src/backend/logger/__tests__/logfile.test.ts
+++ b/src/backend/logger/__tests__/logfile.test.ts
@@ -5,6 +5,7 @@ import { app } from 'electron'
 import { configStore } from '../../constants'
 import * as logfile from '../logfile'
 import { logError } from '../logger'
+import { platform } from 'os'
 
 jest.mock('electron')
 jest.mock('electron-store')
@@ -13,8 +14,9 @@ jest.mock('../logger')
 jest.unmock('../logfile')
 
 let tmpDir = {} as DirResult
+const skipIfOnWin = platform() === 'win32' ? describe.skip : describe
 
-describe('logger/logfile.ts', () => {
+skipIfOnWin('logger/logfile.ts', () => {
   beforeEach(() => {
     tmpDir = dirSync({ unsafeCleanup: true })
   })

--- a/src/backend/logger/__tests__/logger.test.ts
+++ b/src/backend/logger/__tests__/logger.test.ts
@@ -39,9 +39,17 @@ function getStringPassedToLogFile(type: logLevel, skipMessagePrefix = false) {
     '} Error: FAILED'
   ].join('\n')
 }
-const skipIfOnWin = platform() === 'win32' ? describe.skip : describe
 
-skipIfOnWin('logger/logger.ts', () => {
+const shouldSkip = platform() === 'win32'
+const skipMessage = 'on windows so skipping test'
+const emptyTest = it('should do nothing', () => {})
+
+describe('logger/logger.ts', () => {
+  if (shouldSkip) {
+    console.log(skipMessage)
+    emptyTest
+    return
+  }
   afterEach(jest.restoreAllMocks)
 
   test('log invokes console', () => {

--- a/src/backend/logger/__tests__/logger.test.ts
+++ b/src/backend/logger/__tests__/logger.test.ts
@@ -1,6 +1,7 @@
 import * as logger from '../logger'
 import { appendMessageToLogFile } from '../logfile'
 import { showDialogBoxModalAuto } from '../../dialog/dialog'
+import { platform } from 'os'
 
 jest.mock('../logfile')
 jest.mock('../../dialog/dialog')
@@ -38,8 +39,9 @@ function getStringPassedToLogFile(type: logLevel, skipMessagePrefix = false) {
     '} Error: FAILED'
   ].join('\n')
 }
+const skipIfOnWin = platform() === 'win32' ? describe.skip : describe
 
-describe('logger/logger.ts', () => {
+skipIfOnWin('logger/logger.ts', () => {
   afterEach(jest.restoreAllMocks)
 
   test('log invokes console', () => {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -135,7 +135,8 @@ import {
   getAppSettings,
   isNativeApp,
   launchApp,
-  removeApp
+  removeApp,
+  stop
 } from './sideload/games'
 import { callAbortController } from './utils/aborthandler/aborthandler'
 
@@ -1322,7 +1323,7 @@ ipcMain.handle(
 
 ipcMain.handle('kill', async (event, appName, runner) => {
   callAbortController(appName)
-  return getGame(appName, runner).stop()
+  return runner === 'sideload' ? stop(appName) : getGame(appName, runner).stop()
 })
 
 ipcMain.handle('updateGame', async (event, appName, runner) => {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -559,10 +559,6 @@ ipcMain.on('unlock', () => {
   }
 })
 
-ipcMain.handle('kill', async (event, appName, runner) => {
-  return getGame(appName, runner).stop()
-})
-
 ipcMain.handle('checkDiskSpace', async (event, folder: string) => {
   const parent = getFirstExistingParentPath(folder)
   return new Promise((res) => {

--- a/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
+++ b/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
@@ -11,6 +11,7 @@ import {
 // @ts-ignore: Don't know why ts complains about it.
 import { test_data } from './test_data/github-api-heroic-test-data.json'
 import { dirSync } from 'tmp'
+import { platform } from 'os'
 
 const testUrl =
   'https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v2.3.9/Heroic-2.3.9.AppImage'
@@ -21,8 +22,9 @@ const testTarFileWithSubfolder = join(
 )
 
 afterEach(jest.restoreAllMocks)
+const skipIfNotOnLinux = platform() === 'linux' ? describe : describe.skip
 
-describe('getAssetDataFromDownload', () => {
+skipIfNotOnLinux('getAssetDataFromDownload', () => {
   it('Success', async () => {
     // https://stackoverflow.com/a/43047378
     jest.spyOn(axios, 'get').mockResolvedValue(test_data)
@@ -75,7 +77,7 @@ describe('getAssetDataFromDownload', () => {
   })
 })
 
-describe('downloadFile', () => {
+skipIfNotOnLinux('downloadFile', () => {
   it('Success', async () => {
     const expectedData = readFileSync(testTarFilePath)
 
@@ -150,7 +152,7 @@ describe('downloadFile', () => {
   })
 })
 
-describe('extractTarFile', () => {
+skipIfNotOnLinux('extractTarFile', () => {
   it('Success without strip', async () => {
     const tmpDir = dirSync({ unsafeCleanup: true })
     jest.spyOn(child_process, 'spawn')

--- a/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
+++ b/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
@@ -22,9 +22,17 @@ const testTarFileWithSubfolder = join(
 )
 
 afterEach(jest.restoreAllMocks)
-const skipIfNotOnLinux = platform() === 'linux' ? describe : describe.skip
 
-skipIfNotOnLinux('getAssetDataFromDownload', () => {
+const shouldSkip = platform() !== 'linux'
+const skipMessage = 'not on linux so skipping test'
+const emptyTest = it('should do nothing', () => {})
+
+describe('getAssetDataFromDownload', () => {
+  if (shouldSkip) {
+    console.log(skipMessage)
+    emptyTest
+    return
+  }
   it('Success', async () => {
     // https://stackoverflow.com/a/43047378
     jest.spyOn(axios, 'get').mockResolvedValue(test_data)
@@ -77,7 +85,12 @@ skipIfNotOnLinux('getAssetDataFromDownload', () => {
   })
 })
 
-skipIfNotOnLinux('downloadFile', () => {
+describe('downloadFile', () => {
+  if (shouldSkip) {
+    console.log(skipMessage)
+    emptyTest
+    return
+  }
   it('Success', async () => {
     const expectedData = readFileSync(testTarFilePath)
 
@@ -152,7 +165,12 @@ skipIfNotOnLinux('downloadFile', () => {
   })
 })
 
-skipIfNotOnLinux('extractTarFile', () => {
+describe('extractTarFile', () => {
+  if (shouldSkip) {
+    console.log(skipMessage)
+    emptyTest
+    return
+  }
   it('Success without strip', async () => {
     const tmpDir = dirSync({ unsafeCleanup: true })
     jest.spyOn(child_process, 'spawn')


### PR DESCRIPTION
Removes the duplicate 'kill' handler added in from download manager PR which causes issues with other ipcMain handlers.

Also removed the pre-push test command and added os checks to certain tests that are only written for linux.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
