### PR TITLE
Fix some issues when uninstalling games

### DIFF
--- a/public/locales/az/gamepage.json
+++ b/public/locales/az/gamepage.json
@@ -170,6 +170,7 @@
         "queued": "Queued",
         "reparing": "Oyun Təmir edilir, zəhmət olmasa gözləyin",
         "totalDownloaded": "Toplam Endirilib",
+        "uninstalling": "Uninstalling",
         "updating": "Oyun Yenilənir"
     },
     "submenu": {

--- a/public/locales/be/gamepage.json
+++ b/public/locales/be/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Ідзе рамонт гульні, пачакайце",
         "totalDownloaded": "Усяго спампавана",
+        "uninstalling": "Uninstalling",
         "updating": "Абнаўленне гульні"
     },
     "submenu": {

--- a/public/locales/bg/gamepage.json
+++ b/public/locales/bg/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Поправяне на играта; моля, изчакайте",
         "totalDownloaded": "Общо свалено",
+        "uninstalling": "Uninstalling",
         "updating": "Обновяване на играта"
     },
     "submenu": {

--- a/public/locales/bs/gamepage.json
+++ b/public/locales/bs/gamepage.json
@@ -170,6 +170,7 @@
         "queued": "Queued",
         "reparing": "Popravljanje video igre, molimo čekajte",
         "totalDownloaded": "Ukupno preuzeto",
+        "uninstalling": "Uninstalling",
         "updating": "Ažuriranje video igre"
     },
     "submenu": {

--- a/public/locales/ca/gamepage.json
+++ b/public/locales/ca/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "S'està reparant el joc. Espereu.",
         "totalDownloaded": "Total baixat",
+        "uninstalling": "Uninstalling",
         "updating": "S'està actualitzant el joc"
     },
     "submenu": {

--- a/public/locales/cs/gamepage.json
+++ b/public/locales/cs/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Opravuji hru, čekejte prosím",
         "totalDownloaded": "Celkově staženo",
+        "uninstalling": "Uninstalling",
         "updating": "Aktualizuji hru"
     },
     "submenu": {

--- a/public/locales/de/gamepage.json
+++ b/public/locales/de/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Spiel wird repariert, bitte warten",
         "totalDownloaded": "Insgesamt heruntergeladen",
+        "uninstalling": "Uninstalling",
         "updating": "Spiel wird aktualisiert"
     },
     "submenu": {

--- a/public/locales/el/gamepage.json
+++ b/public/locales/el/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Επιδιόρθωση παιχνιδιού, παρακαλώ περιμένετε",
         "totalDownloaded": "Σύνολο ληφθέντων",
+        "uninstalling": "Uninstalling",
         "updating": "Ενημέρωση παιχνιδιού"
     },
     "submenu": {

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Repairing Game, please wait",
         "totalDownloaded": "Total Downloaded",
+        "uninstalling": "Uninstalling",
         "updating": "Updating Game"
     },
     "submenu": {

--- a/public/locales/es/gamepage.json
+++ b/public/locales/es/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Reparando el juego, por favor espere",
         "totalDownloaded": "Total descargado",
+        "uninstalling": "Uninstalling",
         "updating": "Actualización de juego"
     },
     "submenu": {

--- a/public/locales/et/gamepage.json
+++ b/public/locales/et/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Mängu parandamine, palun oodake",
         "totalDownloaded": "Allalaaditud kokku",
+        "uninstalling": "Uninstalling",
         "updating": "Mängu uuendamine"
     },
     "submenu": {

--- a/public/locales/eu/gamepage.json
+++ b/public/locales/eu/gamepage.json
@@ -170,6 +170,7 @@
         "queued": "Queued",
         "reparing": "Jokoaren konponketa, mesedez",
         "totalDownloaded": "Deskargatutakoa, guztira",
+        "uninstalling": "Uninstalling",
         "updating": "Jokoa eguneratzea"
     },
     "submenu": {

--- a/public/locales/fa/gamepage.json
+++ b/public/locales/fa/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "در حال تعمیر بازی، لطفا صبر کنید",
         "totalDownloaded": "حجم کل دانلود شده",
+        "uninstalling": "Uninstalling",
         "updating": "در حال به روزرسانی بازی"
     },
     "submenu": {

--- a/public/locales/fi/gamepage.json
+++ b/public/locales/fi/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Korjataan peliä, odota",
         "totalDownloaded": "Ladattu yhteensä",
+        "uninstalling": "Uninstalling",
         "updating": "Päivitetään peliä"
     },
     "submenu": {

--- a/public/locales/fr/gamepage.json
+++ b/public/locales/fr/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Réparation du jeu en cours, veuillez patienter",
         "totalDownloaded": "Total Téléchargé",
+        "uninstalling": "Uninstalling",
         "updating": "Mise à jour du jeu en cours"
     },
     "submenu": {

--- a/public/locales/gl/gamepage.json
+++ b/public/locales/gl/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Reparando xogo, agarda",
         "totalDownloaded": "Total descargado",
+        "uninstalling": "Uninstalling",
         "updating": "Actualización do xogo"
     },
     "submenu": {

--- a/public/locales/hr/gamepage.json
+++ b/public/locales/hr/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Popravljanje igrice, molimo pričekajte",
         "totalDownloaded": "Sveukupno preuzeto",
+        "uninstalling": "Uninstalling",
         "updating": "Ažuriranje igrice"
     },
     "submenu": {

--- a/public/locales/hu/gamepage.json
+++ b/public/locales/hu/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Játék javítása, kérlek várj",
         "totalDownloaded": "Teljesen letöltve",
+        "uninstalling": "Uninstalling",
         "updating": "Játék frissítése"
     },
     "submenu": {

--- a/public/locales/id/gamepage.json
+++ b/public/locales/id/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Memperbaiki Gim, harap tunggu",
         "totalDownloaded": "Jumlah yang Diunduh",
+        "uninstalling": "Uninstalling",
         "updating": "Memperbarui Gim"
     },
     "submenu": {

--- a/public/locales/it/gamepage.json
+++ b/public/locales/it/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Riparazione del gioco in corso, per favore attendi",
         "totalDownloaded": "Totale scaricato",
+        "uninstalling": "Uninstalling",
         "updating": "Aggiornamento in corso"
     },
     "submenu": {

--- a/public/locales/ja/gamepage.json
+++ b/public/locales/ja/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "ゲームを修復しています、お待ちください",
         "totalDownloaded": "ダウンロードの総数",
+        "uninstalling": "Uninstalling",
         "updating": "ゲームを更新しています"
     },
     "submenu": {

--- a/public/locales/ko/gamepage.json
+++ b/public/locales/ko/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "게임을 복구 중입니다, 잠시만 기다려 주세요",
         "totalDownloaded": "총 다운로드",
+        "uninstalling": "Uninstalling",
         "updating": "게임 업데이트 중"
     },
     "submenu": {

--- a/public/locales/ml/gamepage.json
+++ b/public/locales/ml/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "കളി നന്നാക്കുന്നു, ഒന്നു കാക്കൂ",
         "totalDownloaded": "ആകെ ഇറക്കിയെടുത്തത്",
+        "uninstalling": "Uninstalling",
         "updating": "കളി പുതുക്കുന്നു"
     },
     "submenu": {

--- a/public/locales/nb_NO/gamepage.json
+++ b/public/locales/nb_NO/gamepage.json
@@ -170,6 +170,7 @@
         "queued": "Queued",
         "reparing": "Reparerer spillet, vennligst vent",
         "totalDownloaded": "Totalt nedlastede",
+        "uninstalling": "Uninstalling",
         "updating": "Oppdaterer spillet"
     },
     "submenu": {

--- a/public/locales/nl/gamepage.json
+++ b/public/locales/nl/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Spel aan het repareren, even geduld",
         "totalDownloaded": "Totaal gedownload",
+        "uninstalling": "Uninstalling",
         "updating": "Spel aan het updaten"
     },
     "submenu": {

--- a/public/locales/pl/gamepage.json
+++ b/public/locales/pl/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Naprawianie gry, proszę czekać",
         "totalDownloaded": "Łącznie pobrane",
+        "uninstalling": "Uninstalling",
         "updating": "Aktualizowanie gry"
     },
     "submenu": {

--- a/public/locales/pt/gamepage.json
+++ b/public/locales/pt/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Reparando jogo, por favor espere",
         "totalDownloaded": "Total Baixado",
+        "uninstalling": "Uninstalling",
         "updating": "Atualizando jogo"
     },
     "submenu": {

--- a/public/locales/pt_BR/gamepage.json
+++ b/public/locales/pt_BR/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Reparando Jogo, Por favor Aguarde",
         "totalDownloaded": "Total Baixado",
+        "uninstalling": "Uninstalling",
         "updating": "Atualizando Jogo"
     },
     "submenu": {

--- a/public/locales/ro/gamepage.json
+++ b/public/locales/ro/gamepage.json
@@ -170,6 +170,7 @@
         "queued": "Queued",
         "reparing": "Reparare joc, vă rugăm așteptați",
         "totalDownloaded": "Descărcat total",
+        "uninstalling": "Uninstalling",
         "updating": "Joc in curs de actualizare"
     },
     "submenu": {

--- a/public/locales/ru/gamepage.json
+++ b/public/locales/ru/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Восстановление игры. Пожалуйста, подождите",
         "totalDownloaded": "Всего загружено",
+        "uninstalling": "Uninstalling",
         "updating": "Обновление игры"
     },
     "submenu": {

--- a/public/locales/sk/gamepage.json
+++ b/public/locales/sk/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Oprava hry, čakajte prosím",
         "totalDownloaded": "Celkom stiahnutých",
+        "uninstalling": "Uninstalling",
         "updating": "Aktualizácia hry"
     },
     "submenu": {

--- a/public/locales/sv/gamepage.json
+++ b/public/locales/sv/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Reparerar spelet, vänligen vänta",
         "totalDownloaded": "Nedladdning",
+        "uninstalling": "Uninstalling",
         "updating": "Updaterar spelet"
     },
     "submenu": {

--- a/public/locales/ta/gamepage.json
+++ b/public/locales/ta/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "விளையாட்டு பழுதுபார்க்கப்படுகிறது, தயவுசெய்து காத்திருக்கவும்",
         "totalDownloaded": "மொத்த பதிவிறக்கம்",
+        "uninstalling": "Uninstalling",
         "updating": "விளையாட்டு புதுப்பிக்கப்படுகிறது"
     },
     "submenu": {

--- a/public/locales/tr/gamepage.json
+++ b/public/locales/tr/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Oyun onarılıyor, lütfen bekleyin",
         "totalDownloaded": "Toplam İndirilen",
+        "uninstalling": "Uninstalling",
         "updating": "Oyun Güncelleniyor"
     },
     "submenu": {

--- a/public/locales/uk/gamepage.json
+++ b/public/locales/uk/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Відновлюю гру, будь ласка зачекайте",
         "totalDownloaded": "Всього завантажено",
+        "uninstalling": "Uninstalling",
         "updating": "Оновлюю гру"
     },
     "submenu": {

--- a/public/locales/vi/gamepage.json
+++ b/public/locales/vi/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "Đang sửa game, vui lòng đợi",
         "totalDownloaded": "Tổng số đã tải",
+        "uninstalling": "Uninstalling",
         "updating": "Đang cập nhật Game"
     },
     "submenu": {

--- a/public/locales/zh_Hans/gamepage.json
+++ b/public/locales/zh_Hans/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "正在修复游戏，请稍等",
         "totalDownloaded": "下载总计",
+        "uninstalling": "Uninstalling",
         "updating": "游戏更新中"
     },
     "submenu": {

--- a/public/locales/zh_Hant/gamepage.json
+++ b/public/locales/zh_Hant/gamepage.json
@@ -169,6 +169,7 @@
         "queued": "Queued",
         "reparing": "遊戲修復中，請稍等",
         "totalDownloaded": "總共已下載",
+        "uninstalling": "Uninstalling",
         "updating": "遊戲更新中"
     },
     "submenu": {

--- a/src/backend/api/library.ts
+++ b/src/backend/api/library.ts
@@ -15,8 +15,9 @@ export const uninstall = async (
   const [appName, shouldRemovePrefix, runner] = args
   if (runner === 'sideload') {
     return ipcRenderer.invoke('removeApp', { appName, shouldRemovePrefix })
+  } else {
+    return ipcRenderer.invoke('uninstall', args)
   }
-  ipcRenderer.invoke('uninstall', args)
 }
 export const repair = async (appName: string, runner: Runner) =>
   ipcRenderer.invoke('repair', appName, runner)

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -99,6 +99,7 @@ export default function GamePage(): JSX.Element | null {
   const isQueued = status === 'queued'
   const isReparing = status === 'repairing'
   const isMoving = status === 'moving'
+  const isUninstalling = status === 'uninstalling'
 
   const backRoute = location.state?.fromDM ? '/download-manager' : '/'
 
@@ -390,6 +391,16 @@ export default function GamePage(): JSX.Element | null {
               </div>
               <TimeContainer game={appName} />
               <div className="gameStatus">
+                {isUninstalling && (
+                  <p
+                    style={{
+                      color: 'var(--danger)',
+                      fontStyle: 'italic'
+                    }}
+                  >
+                    {t('status.uninstalling', 'Uninstalling')}
+                  </p>
+                )}
                 {isInstalling ||
                   (isUpdating && (
                     <progress
@@ -427,15 +438,15 @@ export default function GamePage(): JSX.Element | null {
               <Anticheat gameInfo={gameInfo} />
               <div className="buttonsWrapper">
                 {is_installed && (
-                  <>
-                    <button
-                      disabled={isReparing || isMoving || isUpdating}
-                      onClick={handlePlay()}
-                      className={`button ${getPlayBtnClass()}`}
-                    >
-                      {getPlayLabel()}
-                    </button>
-                  </>
+                  <button
+                    disabled={
+                      isReparing || isMoving || isUpdating || isUninstalling
+                    }
+                    onClick={handlePlay()}
+                    className={`button ${getPlayBtnClass()}`}
+                  >
+                    {getPlayLabel()}
+                  </button>
                 )}
                 {is_installed ? (
                   <Link
@@ -454,7 +465,13 @@ export default function GamePage(): JSX.Element | null {
                 ) : (
                   <button
                     onClick={async () => handleInstall(is_installed)}
-                    disabled={isPlaying || isUpdating || isReparing || isMoving}
+                    disabled={
+                      isPlaying ||
+                      isUpdating ||
+                      isReparing ||
+                      isMoving ||
+                      isUninstalling
+                    }
                     className={`button ${getButtonClass(is_installed)}`}
                   >
                     {`${getButtonLabel(is_installed)}`}

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -96,8 +96,14 @@ const GameCard = ({
   const isMoving = status === 'moving'
   const isPlaying = status === 'playing'
   const isQueued = status === 'queued'
+  const isUninstalling = status === 'uninstalling'
   const haveStatus =
-    isMoving || isReparing || isInstalling || isUpdating || isQueued
+    isMoving ||
+    isReparing ||
+    isInstalling ||
+    isUpdating ||
+    isQueued ||
+    isUninstalling
 
   const { percent = '' } = progress
   const installingGrayscale = isInstalling
@@ -127,6 +133,9 @@ const GameCard = ({
   }
 
   function getStatus() {
+    if (isUninstalling) {
+      return t('status.uninstalling', 'Uninstalling')
+    }
     if (isUpdating) {
       return t('status.updating') + ` ${percent}%`
     }
@@ -155,6 +164,13 @@ const GameCard = ({
   }
 
   const renderIcon = () => {
+    if (isUninstalling) {
+      return (
+        <button className="svg-button iconDisabled">
+          <svg />
+        </button>
+      )
+    }
     if (isQueued) {
       return (
         <SvgButton
@@ -366,7 +382,7 @@ const GameCard = ({
                     <FontAwesomeIcon size={'2x'} icon={faRepeat} />
                   </SvgButton>
                 )}
-                {isInstalled && (
+                {isInstalled && !isUninstalling && (
                   <>
                     <SvgButton
                       title={`${t('submenu.settings')} (${title})`}


### PR DESCRIPTION
This PR fixes (and partially fixes) some issues I've noticed:

- after uninstalling a game (but not a sideloaded app), the library status was not updated properly (it was a new but, no the one that was fixed haha)
- in slow systems, since you confirm uninstalling a game until it actually gets uninstalled and the UI is updated you can still click the play button which will try to start the game and make everything act weird

This PR disabled the play buttons when uninstalling and shows more visual feedback with an `uninstalling` status label, both in the game card and in the game page.

There are still issues (you can click uninstall multiple times, and you can click any of the game tools/menu options while it's getting uninstalled, but I'll add a separated issue for that since I think it requires more discussions)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
