### PR TITLE
[MacOS/Linux] Fix up runWineCommand

### DIFF
--- a/src/backend/api/helpers.ts
+++ b/src/backend/api/helpers.ts
@@ -43,15 +43,14 @@ export const getInstallInfo = async (
   runner: Runner,
   installPlatform?: InstallPlatform | string
 ) => ipcRenderer.invoke('getInstallInfo', appName, runner, installPlatform)
-interface runWineCommand {
-  appName: string
-  runner: string
-  command: string
-}
+
 export const runWineCommand = async (args: WineCommandArgs) =>
   ipcRenderer.invoke('runWineCommand', args)
-export const runWineCommandForGame = async (command: runWineCommand) =>
-  ipcRenderer.invoke('runWineCommandForGame', command)
+export const runWineCommandForGame = async (args: {
+  appName: string
+  runner: Runner
+  commandParts: string[]
+}) => ipcRenderer.invoke('runWineCommandForGame', args)
 export const requestSettings = async (appName: string) =>
   ipcRenderer.invoke('requestSettings', appName)
 

--- a/src/backend/games.ts
+++ b/src/backend/games.ts
@@ -5,7 +5,8 @@ import {
   ExtraInfo,
   GameInfo,
   GameSettings,
-  InstallArgs
+  InstallArgs,
+  ProtonVerb
 } from 'common/types'
 
 import { BrowserWindow } from 'electron'
@@ -43,7 +44,11 @@ abstract class Game {
   abstract uninstall(): Promise<ExecResult>
   abstract update(): Promise<{ status: 'done' | 'error' | 'abort' }>
   abstract isNative(): boolean
-  abstract runWineCommand(command: string, wait?: boolean): Promise<ExecResult>
+  abstract runWineCommand(
+    commandParts: string[],
+    wait?: boolean,
+    protonVerb?: ProtonVerb
+  ): Promise<ExecResult>
 }
 
 export { Game }

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -21,7 +21,8 @@ import {
   GameSettings,
   ExecResult,
   InstallArgs,
-  InstalledInfo
+  InstalledInfo,
+  ProtonVerb
 } from 'common/types'
 import { appendFileSync, existsSync, rmSync } from 'graceful-fs'
 import {
@@ -816,9 +817,9 @@ class GOGGame extends Game {
   }
 
   public async runWineCommand(
-    command: string,
+    commandParts: string[],
     wait = false,
-    forceRunInPrefixVerb = false
+    protonVerb?: ProtonVerb
   ): Promise<ExecResult> {
     if (this.isNative()) {
       logError('runWineCommand called on native game!', {
@@ -832,9 +833,9 @@ class GOGGame extends Game {
     return runWineCommand({
       gameSettings,
       installFolderName: folder_name,
-      command,
+      commandParts,
       wait,
-      forceRunInPrefixVerb
+      protonVerb
     })
   }
 

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -466,8 +466,12 @@ export async function verifyWinePrefix(
   const haveToWait = !existsSync(systemRegPath)
 
   const command = game
-    ? game.runWineCommand('wineboot', haveToWait)
-    : runWineCommand({ command: 'wineboot', wait: haveToWait, gameSettings })
+    ? game.runWineCommand(['wineboot', '--init'], haveToWait)
+    : runWineCommand({
+        commandParts: ['wineboot', '--init'],
+        wait: haveToWait,
+        gameSettings
+      })
 
   return command
     .then((result) => {
@@ -494,9 +498,9 @@ function launchCleanup(rpcClient?: RpcClient) {
 }
 async function runWineCommand({
   gameSettings,
-  command,
+  commandParts,
   wait,
-  forceRunInPrefixVerb,
+  protonVerb = 'run',
   installFolderName,
   options,
   startFolder
@@ -520,46 +524,18 @@ async function runWineCommand({
     ...setupWineEnvVars(settings, installFolderName)
   }
 
-  let additional_command = ''
-  let protonCommand = ''
-  if (wineVersion.type === 'proton') {
-    if (forceRunInPrefixVerb) {
-      protonCommand = 'runinprefix'
-    } else if (wait) {
-      protonCommand = 'waitforexitandrun'
-    } else {
-      protonCommand = 'run'
-    }
-    // TODO: Use Steamruntime here in the future
-  } else {
-    // Can't wait if we don't have a Wineserver
-    if (wait) {
-      if (wineVersion.wineserver) {
-        additional_command = `"${wineVersion.wineserver}" --wait`
-      } else {
-        logWarning('Unable to wait on Wine command, no Wineserver!', {
-          prefix: LogPrefix.Backend
-        })
-      }
-    }
+  const isProton = wineVersion.type === 'proton'
+  if (isProton) {
+    commandParts.unshift(protonVerb)
   }
 
   const wineBin = wineVersion.bin.replaceAll("'", '')
-  let finalCommand = `${command}`
-  if (additional_command) {
-    finalCommand += ` && ${additional_command}`
-  }
 
-  logDebug(['Running Wine command:', finalCommand], {
+  logDebug(['Running Wine command:', commandParts.join(' ')], {
     prefix: LogPrefix.Backend
   })
 
-  return new Promise((res) => {
-    additional_command = additional_command ? `&& ${additional_command}` : ''
-    const commandParts = [protonCommand, command, additional_command].filter(
-      Boolean
-    )
-
+  return new Promise<{ stderr: string; stdout: string }>((res) => {
     const wrappers = options?.wrappers || []
     let bin = ''
     if (wrappers.length) {
@@ -573,7 +549,8 @@ async function runWineCommand({
       env: env_vars,
       cwd: startFolder
     })
-    const response = { stderr: '', stdout: '' }
+    child.stdout.setEncoding('utf-8')
+    child.stderr.setEncoding('utf-8')
 
     if (options?.logFile) {
       logDebug(`Logging to file "${options?.logFile}"`, {
@@ -592,35 +569,47 @@ async function runWineCommand({
     const stdout: string[] = []
     const stderr: string[] = []
 
-    child.stdout.on('data', (data: Buffer) => {
+    child.stdout.on('data', (data: string) => {
       if (options?.logFile) {
-        appendFileSync(options.logFile, data.toString())
+        appendFileSync(options.logFile, data)
       }
 
       if (options?.onOutput) {
-        options.onOutput(data.toString())
+        options.onOutput(data, child)
       }
 
-      stdout.push(data.toString().trim())
+      stdout.push(data.trim())
     })
 
-    child.stderr.on('data', (data: Buffer) => {
+    child.stderr.on('data', (data: string) => {
       if (options?.logFile) {
-        appendFileSync(options.logFile, data.toString())
+        appendFileSync(options.logFile, data)
       }
 
       if (options?.onOutput) {
-        options.onOutput(data.toString())
+        options.onOutput(data, child)
       }
 
-      stderr.push(data.toString().trim())
+      stderr.push(data.trim())
     })
 
-    child.on('close', () => {
-      response.stdout = stdout.join('')
-      response.stderr = stderr.join('')
+    child.on('close', async () => {
+      const response = { stderr: stderr.join(''), stdout: stdout.join('') }
+
+      if (wait && wineVersion.wineserver) {
+        await new Promise<void>((res_wait) => {
+          const wait_child = spawn(wineVersion.wineserver!, ['--wait'], {
+            env: env_vars,
+            cwd: startFolder
+          })
+
+          wait_child.on('close', () => {
+            res_wait()
+          })
+        })
+      }
+
       res(response)
-      return response
     })
 
     child.on('error', (error) => {
@@ -699,7 +688,7 @@ async function callRunner(
       }
 
       if (options?.onOutput) {
-        options.onOutput(data)
+        options.onOutput(data, child)
       }
 
       stdout.push(data.trim())
@@ -712,7 +701,7 @@ async function callRunner(
       }
 
       if (options?.onOutput) {
-        options.onOutput(data)
+        options.onOutput(data, child)
       }
 
       stderr.push(data.trim())

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -11,7 +11,8 @@ import {
   ExtraInfo,
   GameInfo,
   InstallArgs,
-  InstallPlatform
+  InstallPlatform,
+  ProtonVerb
 } from 'common/types'
 import { Game } from '../games'
 import { GameConfig } from '../game_config'
@@ -779,9 +780,9 @@ class LegendaryGame extends Game {
   }
 
   public async runWineCommand(
-    command: string,
+    commandParts: string[],
     wait = false,
-    forceRunInPrefixVerb = false
+    protonVerb?: ProtonVerb
   ): Promise<ExecResult> {
     if (this.isNative()) {
       logError('runWineCommand called on native game!', {
@@ -796,9 +797,9 @@ class LegendaryGame extends Game {
     return runWineCommand({
       gameSettings,
       installFolderName: folder_name,
-      command,
+      commandParts,
       wait,
-      forceRunInPrefixVerb
+      protonVerb
     })
   }
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -684,14 +684,18 @@ ipcMain.handle(
         break
       case 'winecfg':
         isSideloaded
-          ? runWineCommand({ gameSettings, command: 'winecfg', wait: false })
-          : game.runWineCommand('winecfg')
+          ? runWineCommand({
+              gameSettings,
+              commandParts: ['winecfg'],
+              wait: false
+            })
+          : game.runWineCommand(['winecfg'])
         break
       case 'runExe':
         if (exe) {
           isSideloaded
-            ? runWineCommand({ gameSettings, command: exe, wait: false })
-            : game.runWineCommand(exe)
+            ? runWineCommand({ gameSettings, commandParts: [exe], wait: false })
+            : game.runWineCommand([exe])
         }
         break
     }
@@ -1558,7 +1562,14 @@ ipcMain.handle('getFonts', async (event, reload = false) => {
 
 ipcMain.handle(
   'runWineCommandForGame',
-  async (event, { appName, command, runner }) => {
+  async (
+    event,
+    {
+      appName,
+      commandParts,
+      runner
+    }: { appName: string; runner: Runner; commandParts: string[] }
+  ) => {
     const game = getGame(appName, runner)
     const isSideloaded = runner === 'sideload'
     const gameSettings = isSideloaded
@@ -1566,7 +1577,7 @@ ipcMain.handle(
       : await game.getSettings()
 
     if (isWindows) {
-      return execAsync(command)
+      return execAsync(commandParts.join(' '))
     }
     const { updated } = await verifyWinePrefix(gameSettings)
 
@@ -1574,7 +1585,7 @@ ipcMain.handle(
       await setup(game.appName)
     }
 
-    return game.runWineCommand(command, false, true)
+    return game.runWineCommand(commandParts, false, 'runinprefix')
   }
 )
 

--- a/src/backend/sideload/games.ts
+++ b/src/backend/sideload/games.ts
@@ -187,10 +187,9 @@ export async function launchApp(appName: string): Promise<boolean> {
     })
 
     await runWineCommand({
-      command: executable,
+      commandParts: [executable],
       gameSettings,
       wait: false,
-      forceRunInPrefixVerb: false,
       startFolder: folder_name,
       options: {
         wrappers,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -2,6 +2,7 @@ import { GOGCloudSavesLocation, GogInstallPlatform } from './types/gog'
 import { LegendaryInstallPlatform } from './types/legendary'
 import { VersionInfo } from 'heroic-wine-downloader'
 import { IpcRendererEvent } from 'electron'
+import { ChildProcess } from 'child_process'
 
 export type Runner = 'legendary' | 'gog' | 'sideload'
 
@@ -371,7 +372,7 @@ export interface CallRunnerOptions {
   logFile?: string
   env?: Record<string, string> | NodeJS.ProcessEnv
   wrappers?: string[]
-  onOutput?: (output: string) => void
+  onOutput?: (output: string, child: ChildProcess) => void
 }
 
 export interface EnviromentVariable {
@@ -518,9 +519,9 @@ export interface DMQueueElement {
 }
 
 export type WineCommandArgs = {
-  command: string
+  commandParts: string[]
   wait: boolean
-  forceRunInPrefixVerb?: boolean
+  protonVerb?: ProtonVerb
   gameSettings?: GameSettings
   installFolderName?: string
   options?: CallRunnerOptions
@@ -541,3 +542,11 @@ export interface SideloadGame {
   folder_name?: string
   canRunOffline: boolean
 }
+
+export type ProtonVerb =
+  | 'run'
+  | 'waitforexitandrun'
+  | 'runinprefix'
+  | 'destroyprefix'
+  | 'getcompatpath'
+  | 'getnativepath'

--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -142,8 +142,13 @@ async function fixGogSaveFolder(
         const documentsResult = await window.api.runWineCommandForGame({
           appName,
           runner: 'gog',
-          command:
-            'reg query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders" /v Personal'
+          commandParts: [
+            'reg',
+            'query',
+            'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders',
+            '/v',
+            'Personal'
+          ]
         })
         const documentsFolder = documentsResult.stdout
           ?.trim()
@@ -243,8 +248,13 @@ async function fixLegendarySaveFolder(
     const documentsResult = await window.api.runWineCommandForGame({
       appName,
       runner: 'legendary',
-      command:
-        'reg query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders" /v Personal'
+      commandParts: [
+        'reg',
+        'query',
+        'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders',
+        '/v',
+        'Personal'
+      ]
     })
     const documentsFolder = documentsResult.stdout
       ?.trim()

--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -189,9 +189,9 @@ export default function SideloadDialog({
           { ...gameSettings, winePrefix, wineVersion }
         ])
         await window.api.runWineCommand({
-          command: exeToRun,
+          commandParts: [exeToRun],
           wait: true,
-          forceRunInPrefixVerb: true,
+          protonVerb: 'runinprefix',
           gameSettings: {
             ...gameSettings,
             winePrefix,

--- a/src/frontend/screens/Settings/components/SyncSaves/gog.tsx
+++ b/src/frontend/screens/Settings/components/SyncSaves/gog.tsx
@@ -91,7 +91,7 @@ export default function GOGSyncSaves({
             .runWineCommandForGame({
               appName,
               runner: 'gog',
-              command: `cmd /c winepath "${saveLocation}"`
+              commandParts: ['cmd', '/c', 'winepath', saveLocation]
             })
             .catch((error) => {
               window.api.logError(

--- a/src/frontend/screens/Settings/components/SyncSaves/legendary.tsx
+++ b/src/frontend/screens/Settings/components/SyncSaves/legendary.tsx
@@ -80,7 +80,7 @@ export default function LegendarySyncSaves({
           .runWineCommandForGame({
             appName,
             runner: 'legendary',
-            command: `cmd /c winepath "${folder}"`
+            commandParts: ['cmd', '/c', 'winepath', folder]
           })
           .catch((error) => {
             console.error('There was an error getting the path', error)


### PR DESCRIPTION
This brings runWineCommand closer to how callRunner works for example. The same `commandParts` idiom is used to make it possible to exactly specify what the arguments are that should be passed to `wine`  
In practice, this now means that commands like `winepath` or `reg` can be ran successfully again

In the process, I've also made the `wait` variable actually work again (with spawn, we're no longer using a shell, so we have to put in a little more work than adding `&& <extra_command>` to run another command after the first one finishes)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
