### PR TITLE
[i18n] Add translation for 'add game' button text

### DIFF
--- a/public/locales/az/translation.json
+++ b/public/locales/az/translation.json
@@ -7,6 +7,7 @@
         "title": "Əlçatanlıq",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Hamısı",
     "anticheat": {
         "anticheats": "Antifırıldaqçılar",

--- a/public/locales/be/translation.json
+++ b/public/locales/be/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Усе",
     "anticheat": {
         "anticheats": "Anticheats",
@@ -598,9 +599,9 @@
     "userselector": {
         "discord": "Discord",
         "logout": "Logout",
+        "logout_confirmation": "Вы ўпэўнены, што хочаце выйсці?",
         "manageaccounts": "Manage Accounts",
-        "quit": "Quit",
-        "logout_confirmation": "Вы ўпэўнены, што хочаце выйсці?"
+        "quit": "Quit"
     },
     "webview": {
         "controls": {

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -7,6 +7,7 @@
         "title": "Достъпност",
         "zoom": "Увеличаване"
     },
+    "add_game": "Add Game",
     "All": "Всички",
     "anticheat": {
         "anticheats": "Софтуер против мамене",

--- a/public/locales/bs/translation.json
+++ b/public/locales/bs/translation.json
@@ -7,6 +7,7 @@
         "title": "Pristupačnost",
         "zoom": "Povećanje"
     },
+    "add_game": "Add Game",
     "All": "Sve",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibilitat",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Tot",
     "anticheat": {
         "anticheats": "Antitrampes",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -7,6 +7,7 @@
         "title": "Přístupnost",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Vše",
     "anticheat": {
         "anticheats": "Anticheaty",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -7,6 +7,7 @@
         "title": "Barrierefreiheit",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Alle",
     "anticheat": {
         "anticheats": "Anticheat-Systeme",

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -7,6 +7,7 @@
         "title": "Προσβασιμότητα",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Όλα",
     "anticheat": {
         "anticheats": "Προστασία από cheats",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "All",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -7,6 +7,7 @@
         "title": "Accesibilidad",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Todos",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -7,6 +7,7 @@
         "title": "Kättesaadavus",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Kõik",
     "anticheat": {
         "anticheats": "Sohitegemisvastased tarkvarad",

--- a/public/locales/eu/translation.json
+++ b/public/locales/eu/translation.json
@@ -7,6 +7,7 @@
         "title": "Erabilerraztasuna",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Dena",
     "anticheat": {
         "anticheats": "Antitranpak",

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -7,6 +7,7 @@
         "title": "دسترسی ها",
         "zoom": "زوم"
     },
+    "add_game": "Add Game",
     "All": "همه",
     "anticheat": {
         "anticheats": "آنتی چیت ها",

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Kaikki",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibilité",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Tout",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Todos",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -7,6 +7,7 @@
         "title": "Prilagođeni pristup",
         "zoom": "Uvečaj"
     },
+    "add_game": "Add Game",
     "All": "Sve",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -7,6 +7,7 @@
         "title": "Hozzáférhetőség",
         "zoom": "Nagyítás"
     },
+    "add_game": "Add Game",
     "All": "Összes",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -7,6 +7,7 @@
         "title": "Aksesibilitas",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Semua",
     "anticheat": {
         "anticheats": "Anticheat",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibilità",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Tutto",
     "anticheat": {
         "anticheats": "Anticheat",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "全て",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -7,6 +7,7 @@
         "title": "접근성",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "모두",
     "anticheat": {
         "anticheats": "안티 치트",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "എല്ലാം",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/nb_NO/translation.json
+++ b/public/locales/nb_NO/translation.json
@@ -7,6 +7,7 @@
         "title": "tilgjengelighet",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Alle",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Allemaal",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -7,6 +7,7 @@
         "title": "Ułatwienia dostępu",
         "zoom": "Przybliż"
     },
+    "add_game": "Add Game",
     "All": "Wszystkie",
     "anticheat": {
         "anticheats": "Anticheaty",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Tudo",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibilidade",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Todos",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/ro/translation.json
+++ b/public/locales/ro/translation.json
@@ -7,6 +7,7 @@
         "title": "Accesibilitate",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Toate",
     "anticheat": {
         "anticheats": "Antitrucuri",

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -7,6 +7,7 @@
         "title": "Доступность",
         "zoom": "Масштаб"
     },
+    "add_game": "Add Game",
     "All": "Все",
     "anticheat": {
         "anticheats": "Античиты",

--- a/public/locales/sk/translation.json
+++ b/public/locales/sk/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Všetky",
     "anticheat": {
         "anticheats": "Anticheats",
@@ -598,9 +599,9 @@
     "userselector": {
         "discord": "Discord",
         "logout": "Logout",
+        "logout_confirmation": "Naozaj sa chcete odhlásiť?",
         "manageaccounts": "Manage Accounts",
-        "quit": "Quit",
-        "logout_confirmation": "Naozaj sa chcete odhlásiť?"
+        "quit": "Quit"
     },
     "webview": {
         "controls": {

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Alla",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "அனைத்தும்",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -7,6 +7,7 @@
         "title": "Erişilebilirlik",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Tümü",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -7,6 +7,7 @@
         "title": "Спец. можливості",
         "zoom": "Маштабування"
     },
+    "add_game": "Add Game",
     "All": "Всі",
     "anticheat": {
         "anticheats": "Античіти",

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -7,6 +7,7 @@
         "title": "Accessibility",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "Tất cả",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -7,6 +7,7 @@
         "title": "辅助功能",
         "zoom": "缩放"
     },
+    "add_game": "Add Game",
     "All": "全部",
     "anticheat": {
         "anticheats": "反作弊",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -7,6 +7,7 @@
         "title": "無障礙設定",
         "zoom": "Zoom"
     },
+    "add_game": "Add Game",
     "All": "全部",
     "anticheat": {
         "anticheats": "反作弊",

--- a/src/frontend/screens/Library/components/LibraryHeader/index.tsx
+++ b/src/frontend/screens/Library/components/LibraryHeader/index.tsx
@@ -80,7 +80,7 @@ export default function LibraryHeader({
             className="sideloadGameButton"
             onClick={handleAddGameButtonClick}
           >
-            Add Game
+            {t('add_game', 'Add Game')}
           </button>
         </span>
         <ActionIcons


### PR DESCRIPTION
Added string translation for the new _Add Game_ button in the library view.
Ran a `yarn i18next` afterwards.

---

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
