### PR TITLE
[Fix] context menu selection/hovering

### DIFF
--- a/src/frontend/screens/Library/components/ContextMenu/index.tsx
+++ b/src/frontend/screens/Library/components/ContextMenu/index.tsx
@@ -25,7 +25,7 @@ export default function ContextMenu({ children, items }: Props) {
     setContextMenu(
       contextMenu === null
         ? {
-            mouseX: event.clientX - 2,
+            mouseX: event.clientX,
             mouseY: event.clientY - 2
           }
         : null

--- a/src/frontend/screens/Library/components/ContextMenu/index.tsx
+++ b/src/frontend/screens/Library/components/ContextMenu/index.tsx
@@ -26,7 +26,7 @@ export default function ContextMenu({ children, items }: Props) {
       contextMenu === null
         ? {
             mouseX: event.clientX - 2,
-            mouseY: event.clientY - 4
+            mouseY: event.clientY - 2
           }
         : null
     )


### PR DESCRIPTION
This is an **incomplete** fix to issue #1908 
It fixes the issue most of the times. It does not always work for games near/at the bottom of the window/screen, where the context menu is rendered on top of the clicked item (GameCard or install button) triggering the hover effect (darker color).

Another idea is to disable the hover effect entirely when using the keyboard/gamepad navigation, not sure how to go about that though.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
