### PR TITLE
[General/Protocol] Fix protocol not launching gog games

### DIFF
--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -1,9 +1,8 @@
 import { BrowserWindow, dialog } from 'electron'
 import { logError, logInfo, LogPrefix } from './logger/logger'
 import i18next from 'i18next'
-import { getGame } from './utils'
+import { getInfo } from './utils'
 import { Runner } from 'common/types'
-import { getAppInfo } from './sideload/games'
 
 export async function handleProtocol(window: BrowserWindow, args: string[]) {
   // Figure out which argv element is our protocol
@@ -36,15 +35,11 @@ export async function handleProtocol(window: BrowserWindow, args: string[]) {
     const runners: Runner[] = ['legendary', 'gog', 'sideload']
 
     const game = runners
-      .map((runner) =>
-        runner === 'sideload'
-          ? getAppInfo(arg)
-          : getGame(arg, runner).getGameInfo()
-      )
+      .map((runner) => getInfo(arg, runner))
       .filter(({ app_name }) => app_name)
       .shift()
 
-    if (!game?.app_name) {
+    if (!game) {
       return logError(`Could not receive game data for ${arg}!`, {
         prefix: LogPrefix.ProtocolHandler
       })

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -31,11 +31,14 @@ export async function handleProtocol(window: BrowserWindow, args: string[]) {
   }
 
   if (command === 'launch') {
-    const game =
-      getGame(arg, 'legendary').getGameInfo() ||
-      getGame(arg, 'gog').getGameInfo()
+    let game = getGame(arg, 'legendary').getGameInfo()
 
-    if (!game) {
+    // getGameInfo returns {} so we need to check for underlying value
+    if (!game?.app_name) {
+      game = getGame(arg, 'gog').getGameInfo()
+    }
+
+    if (!game?.app_name) {
       return logError(`Could not receive game data for ${arg}!`, {
         prefix: LogPrefix.ProtocolHandler
       })


### PR DESCRIPTION
This fixes the issue we discovered on latest 2.5.0.beta.1 release that prevents gog games from launching using protocol.  
Fixed it by checking for underlying value of a object returned by getGameInfo methods, since empty object `{}` is always true in boolean expressions

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
