### PR TITLE
Gamepad navigation tweaks

### DIFF
--- a/public/locales/az/translation.json
+++ b/public/locales/az/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Aktivləşdirin",
             "back": "Geri",
             "backspace": "Backspace",
-            "close_context_menu": "Kontekst menyusunu bağlayın",
             "close_dialog": "Dialoqu bağlayın",
             "close_keyboard": "Klaviaturanı bağlayın",
-            "context_menu": "Kontekst menyusu",
+            "close_options": "Close Options",
             "game_details": "Oyun təfərrüatları",
             "game_settings": "Oyun parametrləri",
             "install_game": "Oyun quraşdırın",
             "move_cursor": "Kursoru köçürün",
-            "none": "Heç biri",
             "open_virtual_keyboard": "Virtual klaviaturanı açın",
+            "options": "Options",
             "play_game": "Oyun oynamaq",
             "scroll": "Sürüşdürün",
+            "select": "Select",
             "space": "Kosmos",
             "update_game": "Oyunu yeniləyin"
         }

--- a/public/locales/be/translation.json
+++ b/public/locales/be/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/bs/translation.json
+++ b/public/locales/bs/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Aktiviraj",
             "back": "Nazad",
             "backspace": "Backspace",
-            "close_context_menu": "Zatvorite kontekstni meni",
             "close_dialog": "Zatvori dijalog",
             "close_keyboard": "Zatvorite tastaturu",
-            "context_menu": "Kontekstni meni",
+            "close_options": "Close Options",
             "game_details": "Detalji igre",
             "game_settings": "Postavke igre",
             "install_game": "Instaliraj igru",
             "move_cursor": "Pomeri kursor",
-            "none": "Nema",
             "open_virtual_keyboard": "Otvorite virtuelnu tastaturu",
+            "options": "Options",
             "play_game": "Igrati igru",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Prostor",
             "update_game": "Ažurirajte igru"
         }

--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activa",
             "back": "Enrere",
             "backspace": "Backspace",
-            "close_context_menu": "Tanca el menú contextual",
             "close_dialog": "Tanca el diàleg",
             "close_keyboard": "Tanca el teclat virtual",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Detalls del joc",
             "game_settings": "Configuració del joc",
             "install_game": "Instal·la el joc",
             "move_cursor": "Mou el cursor",
-            "none": "None",
             "open_virtual_keyboard": "Obre el teclat virtual",
+            "options": "Options",
             "play_game": "Juga al joc",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Espai",
             "update_game": "Actualitza el joc"
         }

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Aktivovat",
             "back": "Zpět",
             "backspace": "Backspace",
-            "close_context_menu": "Zavřít kontextovou nabídku",
             "close_dialog": "Zavřít dialogové okno",
             "close_keyboard": "Zavřít klávesnici",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Podrobnosti o hře",
             "game_settings": "Nastavení hry",
             "install_game": "Instalovat hru",
             "move_cursor": "Přesunout kurzor",
-            "none": "None",
             "open_virtual_keyboard": "Otevřít virtuální klávesnici",
+            "options": "Options",
             "play_game": "Hrát hru",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Místo",
             "update_game": "Aktualizovat hru"
         }

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Aktivieren",
             "back": "Zurück",
             "backspace": "Backspace",
-            "close_context_menu": "Kontextmenü schließen",
             "close_dialog": "Dialog schließen",
             "close_keyboard": "Tastatur schließen",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Spieldetails",
             "game_settings": "Spiel-Einstellungen",
             "install_game": "Spiel installieren",
             "move_cursor": "Cursor bewegen",
-            "none": "Nichts",
             "open_virtual_keyboard": "Virtuelle Tastatur öffnen",
+            "options": "Options",
             "play_game": "Spiel starten",
             "scroll": "Scrollen",
+            "select": "Select",
             "space": "Leertaste",
             "update_game": "Spiel aktualisieren"
         }

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Ενεργοποίηση",
             "back": "Πίσω",
             "backspace": "Backspace",
-            "close_context_menu": "Κλείστε το σχετικό μενού",
             "close_dialog": "Κλείσιμο παραθύρου διαλόγου",
             "close_keyboard": "Κλείσιμο πληκτρολογίου",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Πληροφορίες παιχνιδιού",
             "game_settings": "Ρυθμίσεις παιχνιδιού",
             "install_game": "Εγκατάσταση παιχνιδιού",
             "move_cursor": "Μετακίνηση του δείκτη ποντικιού",
-            "none": "None",
             "open_virtual_keyboard": "Άνοιγκα ψηφιακού πληκτρολογίου",
+            "options": "Options",
             "play_game": "Παίξτε",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Ενημέρωση παιχνιδιού"
         }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activar",
             "back": "Volver",
             "backspace": "Borrar",
-            "close_context_menu": "Cerrar menú contextual",
             "close_dialog": "Cerrar diálogo",
             "close_keyboard": "Ocultar teclado",
-            "context_menu": "Menú contextual",
+            "close_options": "Close Options",
             "game_details": "Detalles del juego",
             "game_settings": "Configuración del juego",
             "install_game": "Instalar juego",
             "move_cursor": "Mover puntero",
-            "none": "Nada",
             "open_virtual_keyboard": "Abrir teclado virtual",
+            "options": "Options",
             "play_game": "Ejecutar juego",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Espacio",
             "update_game": "Actualizar juego"
         }

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Aktiveeri",
             "back": "Tagasi",
             "backspace": "Backspace",
-            "close_context_menu": "Sulge kontekstimenüü",
             "close_dialog": "Sulge dialoog",
             "close_keyboard": "Sulge klaviatuur",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Mängu üksikasjad",
             "game_settings": "Mängu seaded",
             "install_game": "Paigalda mäng",
             "move_cursor": "Liiguta kursorit",
-            "none": "None",
             "open_virtual_keyboard": "Ava virtuaalne klaviatuur",
+            "options": "Options",
             "play_game": "Mängi mängu",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Tühik",
             "update_game": "Uuenda mängu"
         }

--- a/public/locales/eu/translation.json
+++ b/public/locales/eu/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Aktibatu",
             "back": "Itzuli",
             "backspace": "Atzera atzera",
-            "close_context_menu": "Itxi laster-menua",
             "close_dialog": "Itxi elkarrizketa-koadroa",
             "close_keyboard": "Itxi teklatua",
-            "context_menu": "Testuinguruko menua",
+            "close_options": "Close Options",
             "game_details": "Jokoaren xehetasunak",
             "game_settings": "Jokoaren ezarpenak",
             "install_game": "Instalatu jokoa",
             "move_cursor": "Mugitu kurtsorea",
-            "none": "Bat ere ez",
             "open_virtual_keyboard": "Ireki teklatu birtuala",
+            "options": "Options",
             "play_game": "Jolastu",
             "scroll": "Korritu",
+            "select": "Select",
             "space": "Espazioa",
             "update_game": "Eguneratu jokoa"
         }

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "فعال سازی",
             "back": "بازگشت",
             "backspace": "Backspace",
-            "close_context_menu": "بستن منو محتوا",
             "close_dialog": "بستن دیالوگ",
             "close_keyboard": "بستن صفحه کلید",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "مشخصات بازی",
             "game_settings": "تنظیمات بازی",
             "install_game": "نصب بازی",
             "move_cursor": "انتقال اشاره گر",
-            "none": "None",
             "open_virtual_keyboard": "باز کردن صفحه کلید مجازی",
+            "options": "Options",
             "play_game": "اجرای بازی",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "فضا",
             "update_game": "به روزرسانی بازی"
         }

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activer",
             "back": "Retour",
             "backspace": "Backspace",
-            "close_context_menu": "Fermer le menu contextuel",
             "close_dialog": "Fermer la fenêtre",
             "close_keyboard": "Faire disparaître le clavier",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Caractéristiques du jeu",
             "game_settings": "Paramètres du jeu",
             "install_game": "Installer le jeu",
             "move_cursor": "Déplacer le curseur",
-            "none": "None",
             "open_virtual_keyboard": "Afficher le clavier virtuel",
+            "options": "Options",
             "play_game": "Lancer le jeu",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Espace",
             "update_game": "Mettre à jour le jeu"
         }

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Indietro",
             "backspace": "Backspace",
-            "close_context_menu": "Chiudi il menu contestuale",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Dettagli del gioco",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "활성화",
             "back": "뒤로",
             "backspace": "Backspace",
-            "close_context_menu": "우클릭 메뉴 닫기",
             "close_dialog": "대화상자 닫기",
             "close_keyboard": "키보드 닫기",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "게임 세부 정보",
             "game_settings": "게임 설정",
             "install_game": "게임 설치",
             "move_cursor": "커서 이동",
-            "none": "None",
             "open_virtual_keyboard": "가상 키보드 열기",
+            "options": "Options",
             "play_game": "게임 플레이",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "스페이스바",
             "update_game": "게임 업데이트"
         }

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/nb_NO/translation.json
+++ b/public/locales/nb_NO/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Aktiver",
             "back": "Tilbake",
             "backspace": "Tilbake",
-            "close_context_menu": "Lukk kontekstmenyen",
             "close_dialog": "Lukk dialog",
             "close_keyboard": "Lukk tastaturet",
-            "context_menu": "Kontekstmenyen",
+            "close_options": "Close Options",
             "game_details": "Spilldetaljer",
             "game_settings": "Spillinnstillinger",
             "install_game": "Installer spillet",
             "move_cursor": "Flytt markøren",
-            "none": "Ingen",
             "open_virtual_keyboard": "Åpne virtuelt tastatur",
+            "options": "Options",
             "play_game": "Spill",
             "scroll": "Rull",
+            "select": "Select",
             "space": "Rom",
             "update_game": "Oppdater spillet"
         }

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Aktywuj",
             "back": "Cofnij",
             "backspace": "Backspace",
-            "close_context_menu": "Zamknij menu kontekstowe",
             "close_dialog": "Zamknij okno",
             "close_keyboard": "Zamknij klawiaturę",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Szczegóły gry",
             "game_settings": "Ustawienia gry",
             "install_game": "Zainstaluj grę",
             "move_cursor": "Przesuń kursor",
-            "none": "None",
             "open_virtual_keyboard": "Otwórz wirtualną klawiaturę",
+            "options": "Options",
             "play_game": "Uruchom grę",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "spacja",
             "update_game": "Zaktualizuj grę"
         }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activar",
             "back": "Atrás",
             "backspace": "Backspace",
-            "close_context_menu": "Fechar Contexto menu",
             "close_dialog": "Fechar diálogo",
             "close_keyboard": "Fechar teclado",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Detalhes do Jogo",
             "game_settings": "Configurações do jogo",
             "install_game": "Instalar Jogo",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Abrir teclado virtual",
+            "options": "Options",
             "play_game": "Jogar jogo",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Actualizar Jogo"
         }

--- a/public/locales/pt_BR/translation.json
+++ b/public/locales/pt_BR/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Ativar",
             "back": "Voltar",
             "backspace": "Backspace",
-            "close_context_menu": "Fechar menu de contexto",
             "close_dialog": "Fechar caixa de diálogo",
             "close_keyboard": "Fechar teclado",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Detalhes do jogo",
             "game_settings": "Configurações do jogo",
             "install_game": "Instalar jogo",
             "move_cursor": "Mover cursor",
-            "none": "None",
             "open_virtual_keyboard": "Abrir teclado virtual",
+            "options": "Options",
             "play_game": "Jogar um jogo",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Espaço",
             "update_game": "Atualizar jogo"
         }

--- a/public/locales/ro/translation.json
+++ b/public/locales/ro/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activati",
             "back": "Negru",
             "backspace": "Backspace",
-            "close_context_menu": "Închideți meniul contextual",
             "close_dialog": "Închide caseta de dialog",
             "close_keyboard": "Închideți tastatura",
-            "context_menu": "Meniul contextual",
+            "close_options": "Close Options",
             "game_details": "Detalii joc",
             "game_settings": "Setările jocului",
             "install_game": "Instalează jocul",
             "move_cursor": "Mutați cursorul",
-            "none": "Nici unul",
             "open_virtual_keyboard": "Deschideți tastatura virtuală",
+            "options": "Options",
             "play_game": "Joaca jocul",
             "scroll": "Sul",
+            "select": "Select",
             "space": "Spaţiu",
             "update_game": "Actualizați jocul"
         }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Активировать",
             "back": "Назад",
             "backspace": "Backspace",
-            "close_context_menu": "Закрыть контекстное меню",
             "close_dialog": "Закрыть диалог",
             "close_keyboard": "Закрыть клавиатуру",
-            "context_menu": "Контекстное меню",
+            "close_options": "Close Options",
             "game_details": "Детали игры",
             "game_settings": "Настройки игры",
             "install_game": "Установить игру",
             "move_cursor": "Перемещение курсора",
-            "none": "None",
             "open_virtual_keyboard": "Открыть виртуальную клавиатуру",
+            "options": "Options",
             "play_game": "Играть",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Пробел",
             "update_game": "Обновить игру"
         }

--- a/public/locales/sk/translation.json
+++ b/public/locales/sk/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/public/locales/zh_Hans/translation.json
+++ b/public/locales/zh_Hans/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "激活",
             "back": "返回",
             "backspace": "Backspace",
-            "close_context_menu": "关闭右键菜单",
             "close_dialog": "关闭对话框",
             "close_keyboard": "关闭键盘",
-            "context_menu": "右键菜单",
+            "close_options": "Close Options",
             "game_details": "游戏详情",
             "game_settings": "游戏设置",
             "install_game": "安装游戏",
             "move_cursor": "移动光标",
-            "none": "无",
             "open_virtual_keyboard": "打开虚拟键盘",
+            "options": "Options",
             "play_game": "玩游戏",
             "scroll": "滚动",
+            "select": "Select",
             "space": "空格",
             "update_game": "更新游戏"
         }

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -152,21 +152,20 @@
     },
     "controller": {
         "hints": {
-            "activate": "Activate",
             "back": "Back",
             "backspace": "Backspace",
-            "close_context_menu": "Close context menu",
             "close_dialog": "Close dialog",
             "close_keyboard": "Close keyboard",
-            "context_menu": "Context menu",
+            "close_options": "Close Options",
             "game_details": "Game details",
             "game_settings": "Game settings",
             "install_game": "Install game",
             "move_cursor": "Move cursor",
-            "none": "None",
             "open_virtual_keyboard": "Open virtual keyboard",
+            "options": "Options",
             "play_game": "Play game",
             "scroll": "Scroll",
+            "select": "Select",
             "space": "Space",
             "update_game": "Update game"
         }

--- a/src/frontend/components/UI/ControllerHints/index.tsx
+++ b/src/frontend/components/UI/ControllerHints/index.tsx
@@ -41,8 +41,15 @@ export default function ControllerHints() {
         main = t('controller.hints.play_game', 'Play game')
       } else if (classes.contains('downIcon')) {
         main = t('controller.hints.install_game', 'Install game')
+      } else if (
+        card?.classList.contains('installed') ||
+        list?.classList.contains('installed')
+      ) {
+        main = t('controller.hints.game_details', 'Game details')
+        alt2 = t('controller.hints.play_game', 'Play game')
       } else {
         main = t('controller.hints.game_details', 'Game details')
+        alt2 = t('controller.hints.install_game', 'Install game')
       }
     } else if (target.id === 'search') {
       // focusing the search bar

--- a/src/frontend/components/UI/ControllerHints/index.tsx
+++ b/src/frontend/components/UI/ControllerHints/index.tsx
@@ -27,10 +27,11 @@ export default function ControllerHints() {
     let back = ''
 
     const card = target.closest('.gameCard')
+    const list = target.closest('.gameListItem')
     const installDialog = target.closest('.InstallModal__dialog')
 
-    if (card) {
-      // focusing a card or an icon inside card
+    if (card || list) {
+      // focusing a card/list item or an icon inside a card/list item
       alt = t('controller.hints.options', 'Options')
       if (classes.contains('updateIcon')) {
         main = t('controller.hints.update_game', 'Update game')
@@ -50,10 +51,10 @@ export default function ControllerHints() {
         'Open virtual keyboard'
       )
     } else if (target.closest('.MuiMenu-list')) {
-      // focusing a context menu on a card
+      // focusing a context menu on a card or list item
       main = t('controller.hints.select', 'Select')
       back = t('controller.hints.back', 'Back')
-      alt = t('controller.hints.close_options', 'Close Options')
+      alt = t('controller.hints.close_options', 'Close options')
     } else if (classes.contains('hg-button')) {
       // focusing a virtual keyboard element
       main = t('controller.hints.select', 'Select')

--- a/src/frontend/components/UI/ControllerHints/index.tsx
+++ b/src/frontend/components/UI/ControllerHints/index.tsx
@@ -21,7 +21,7 @@ export default function ControllerHints() {
   const setHintsFor = (target: HTMLElement) => {
     const classes = target.classList
 
-    let main = t('controller.hints.activate', 'Activate')
+    let main = t('controller.hints.select', 'Select')
     let alt = ''
     let alt2 = ''
     let back = ''
@@ -31,7 +31,7 @@ export default function ControllerHints() {
 
     if (card) {
       // focusing a card or an icon inside card
-      alt = t('controller.hints.context_menu', 'Context menu')
+      alt = t('controller.hints.options', 'Options')
       if (classes.contains('updateIcon')) {
         main = t('controller.hints.update_game', 'Update game')
       } else if (classes.contains('settingsIcon')) {
@@ -51,11 +51,11 @@ export default function ControllerHints() {
       )
     } else if (target.closest('.MuiMenu-list')) {
       // focusing a context menu on a card
-      main = t('controller.hints.activate', 'Activate')
-      alt = t('controller.hints.close_context_menu', 'Close context menu')
+      main = t('controller.hints.select', 'Select')
+      alt = t('controller.hints.close_options', 'Close Options')
     } else if (classes.contains('hg-button')) {
       // focusing a virtual keyboard element
-      main = t('controller.hints.activate', 'Activate')
+      main = t('controller.hints.select', 'Select')
       back = t('controller.hints.close_keyboard', 'Close keyboard')
       alt = t('controller.hints.backspace', 'Backspace')
       alt2 = t('controller.hints.space', 'Space')
@@ -132,21 +132,19 @@ export default function ControllerHints() {
     <div className={`controller-hints ${layout}`}>
       <div className="hint">
         <i className="buttonImage main-action" />
-        {mainActionHint || t('controller.hints.none', 'None')}
+        {mainActionHint || '–'}
       </div>
       <div className="hint">
         <i className="buttonImage back" />
-        {backActionHint ||
-          backActionFallback ||
-          t('controller.hints.none', 'None')}
+        {backActionHint || backActionFallback || '–'}
       </div>
       <div className="hint">
         <i className="buttonImage alt-action" />
-        {altActionHint || t('controller.hints.none', 'None')}
+        {altActionHint || '–'}
       </div>
       <div className="hint">
         <i className="buttonImage alt-action2" />
-        {altActionHint2 || t('controller.hints.none', 'None')}
+        {altActionHint2 || '–'}
       </div>
       <div className="hint">
         <i className="buttonImage d-pad" />

--- a/src/frontend/components/UI/ControllerHints/index.tsx
+++ b/src/frontend/components/UI/ControllerHints/index.tsx
@@ -52,6 +52,7 @@ export default function ControllerHints() {
     } else if (target.closest('.MuiMenu-list')) {
       // focusing a context menu on a card
       main = t('controller.hints.select', 'Select')
+      back = t('controller.hints.back', 'Back')
       alt = t('controller.hints.close_options', 'Close Options')
     } else if (classes.contains('hg-button')) {
       // focusing a virtual keyboard element

--- a/src/frontend/components/UI/ControllerHints/index.tsx
+++ b/src/frontend/components/UI/ControllerHints/index.tsx
@@ -40,12 +40,8 @@ export default function ControllerHints() {
         main = t('controller.hints.play_game', 'Play game')
       } else if (classes.contains('downIcon')) {
         main = t('controller.hints.install_game', 'Install game')
-      } else if (card.classList.contains('installed')) {
-        alt2 = t('controller.hints.game_details', 'Game details')
-        main = t('controller.hints.play_game', 'Play game')
       } else {
-        alt2 = t('controller.hints.game_details', 'Game details')
-        main = t('controller.hints.install_game', 'Install game')
+        main = t('controller.hints.game_details', 'Game details')
       }
     } else if (target.id === 'search') {
       // focusing the search bar

--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -114,13 +114,8 @@ export const initGamepad = () => {
             // some tags require a simulated click, some require a javascript click() call
             // if the current element requires a simulated click, change the action to `leftClick`
             action = 'leftClick'
-          } else if (playable()) {
-            // if the current element is a card of a game and it's installed, play it
-            playGame()
-            return
           } else if (isGameCard()) {
-            installGame()
-            return
+            action === 'mainAction'
           } else if (VirtualKeyboardController.isButtonFocused()) {
             // simulate a left click on a virtual keyboard button
             action = 'leftClick'
@@ -146,10 +141,7 @@ export const initGamepad = () => {
           }
           break
         case 'altAction':
-          if (isGameCard()) {
-            // when pressing Y on a game card, open the game details
-            action = 'mainAction'
-          } else if (VirtualKeyboardController.isActive()) {
+          if (VirtualKeyboardController.isActive()) {
             VirtualKeyboardController.space()
             return
           }
@@ -203,46 +195,6 @@ export const initGamepad = () => {
     if (!parent) return false
 
     return parent.classList.contains('gameCard')
-  }
-
-  function playable() {
-    const el = currentElement()
-    if (!el) return false
-
-    const parent = el.parentElement
-    if (!parent) return false
-
-    const classes = parent.classList
-    const isGameCard =
-      classes.contains('gameCard') || classes.contains('gameListItem')
-    const isInstalled = classes.contains('installed')
-    return isGameCard && isInstalled
-  }
-
-  function playGame() {
-    const el = currentElement()
-    if (!el) return false
-
-    const parent = el.parentElement
-    if (!parent) return false
-
-    const playButton = parent.querySelector('.playIcon') as HTMLButtonElement
-    if (playButton) playButton.click()
-
-    return true
-  }
-
-  function installGame() {
-    const el = currentElement()
-    if (!el) return false
-
-    const parent = el.parentElement
-    if (!parent) return false
-
-    const installButton = parent.querySelector('.downIcon') as HTMLButtonElement
-    if (installButton) installButton.click()
-
-    return true
   }
 
   function insideInstallDialog() {

--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -143,7 +143,11 @@ export const initGamepad = () => {
           }
           break
         case 'altAction':
-          if (VirtualKeyboardController.isActive()) {
+          if (isGameCard()) {
+            // launch game on pressing Y
+            if (playable()) playGame()
+            else installGame()
+          } else if (VirtualKeyboardController.isActive()) {
             VirtualKeyboardController.space()
             return
           }
@@ -207,6 +211,46 @@ export const initGamepad = () => {
     if (!parent) return false
 
     return parent.classList.contains('MuiMenu-list')
+  }
+
+  function playable() {
+    const el = currentElement()
+    if (!el) return false
+
+    const parent = el.parentElement
+    if (!parent) return false
+
+    const classes = parent.classList
+    const isGameCard =
+      classes.contains('gameCard') || classes.contains('gameListItem')
+    const isInstalled = classes.contains('installed')
+    return isGameCard && isInstalled
+  }
+
+  function playGame() {
+    const el = currentElement()
+    if (!el) return false
+
+    const parent = el.parentElement
+    if (!parent) return false
+
+    const playButton = parent.querySelector('.playIcon') as HTMLButtonElement
+    if (playButton) playButton.click()
+
+    return true
+  }
+
+  function installGame() {
+    const el = currentElement()
+    if (!el) return false
+
+    const parent = el.parentElement
+    if (!parent) return false
+
+    const installButton = parent.querySelector('.downIcon') as HTMLButtonElement
+    if (installButton) installButton.click()
+
+    return true
   }
 
   function insideInstallDialog() {

--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -138,6 +138,8 @@ export const initGamepad = () => {
             return
           } else if (insideInstallDialog()) {
             closeInstallDialog()
+          } else if (isContextMenu()) {
+            action = 'rightClick'
           }
           break
         case 'altAction':
@@ -195,6 +197,16 @@ export const initGamepad = () => {
     if (!parent) return false
 
     return parent.classList.contains('gameCard')
+  }
+
+  function isContextMenu() {
+    const el = currentElement()
+    if (!el) return false
+
+    const parent = el.parentElement
+    if (!parent) return false
+
+    return parent.classList.contains('MuiMenu-list')
   }
 
   function insideInstallDialog() {

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -440,6 +440,7 @@ export default function GamePage(): JSX.Element | null {
                     disabled={
                       isReparing || isMoving || isUpdating || isUninstalling
                     }
+                    autoFocus={true}
                     onClick={handlePlay()}
                     className={`button ${getPlayBtnClass()}`}
                   >
@@ -470,6 +471,7 @@ export default function GamePage(): JSX.Element | null {
                       isMoving ||
                       isUninstalling
                     }
+                    autoFocus={true}
                     className={`button ${getButtonClass(is_installed)}`}
                   >
                     {`${getButtonLabel(is_installed)}`}

--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -114,6 +114,10 @@
   padding: var(--space-xs-fixed);
 }
 
+.gameCard > .icons.gamepad {
+  display: none;
+}
+
 .gameCard > .icons > .svg-button {
   justify-self: center;
 }

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -249,31 +249,49 @@ const GameCard = ({
 
   const items: Item[] = [
     {
+      // remove from install queue
+      label: t('button.queue.remove'),
+      onclick: () => handleRemoveFromQueue(),
+      show: isQueued && !isInstalling
+    },
+    {
+      // stop if running
+      label: t('label.playing.stop'),
+      onclick: async () => handlePlay(runner),
+      show: isPlaying
+    },
+    {
+      // launch game
+      label: t('label.playing.start'),
+      onclick: async () => handlePlay(runner),
+      show: isInstalled && !isPlaying && !isUpdating
+    },
+    {
+      // update
       label: t('button.update', 'Update'),
       onclick: async () => handleUpdate(),
-      show: hasUpdate
+      show: hasUpdate && !isUpdating
     },
     {
-      label: t('button.uninstall'),
-      onclick: onUninstallClick,
-      show: isInstalled
-    },
-    {
+      // install
       label: t('button.install'),
       onclick: () => (!isInstalled ? buttonClick() : () => null),
       show: !isInstalled
     },
     {
+      // cancel installation/update
       label: t('button.cancel'),
       onclick: async () => handlePlay(runner),
-      show: isInstalling && isQueued
+      show: isInstalling || isUpdating
     },
     {
+      // hide
       label: t('button.hide_game', 'Hide Game'),
       onclick: () => hiddenGames.add(appName, title),
       show: !isHiddenGame
     },
     {
+      // unhide
       label: t('button.unhide_game', 'Unhide Game'),
       onclick: () => hiddenGames.remove(appName),
       show: isHiddenGame
@@ -292,6 +310,27 @@ const GameCard = ({
       label: t('button.remove_from_recent', 'Remove From Recent'),
       onclick: async () => window.api.removeRecentGame(appName),
       show: isRecent
+    },
+    {
+      // settings
+      label: t('submenu.settings'),
+      onclick: () =>
+        navigate(pathname, {
+          state: {
+            fromGameCard: true,
+            runner,
+            hasCloudSave,
+            isLinuxNative,
+            isMacNative
+          }
+        }),
+      show: isInstalled && !isUninstalling
+    },
+    {
+      // uninstall
+      label: t('button.uninstall'),
+      onclick: onUninstallClick,
+      show: isInstalled && !isUpdating
     }
   ]
 

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -211,8 +211,7 @@ const GameCard = ({
           <PlayIcon />
         </SvgButton>
       )
-    }
-    if (!isInstalled) {
+    } else {
       return (
         <SvgButton
           className="downIcon"
@@ -405,43 +404,45 @@ const GameCard = ({
               {getStoreName(runner, t2('Other'))}
             </span>
           </Link>
-          {!activeController && (
-            <>
-              <span className="icons">
-                {hasUpdate && !isUpdating && (
+          <>
+            <span
+              className={classNames('icons', {
+                gamepad: activeController
+              })}
+            >
+              {hasUpdate && !isUpdating && (
+                <SvgButton
+                  className="updateIcon"
+                  title={`${t('button.update')} (${title})`}
+                  onClick={async () => handleUpdate()}
+                >
+                  <FontAwesomeIcon size={'2x'} icon={faRepeat} />
+                </SvgButton>
+              )}
+              {isInstalled && !isUninstalling && (
+                <>
                   <SvgButton
-                    className="updateIcon"
-                    title={`${t('button.update')} (${title})`}
-                    onClick={async () => handleUpdate()}
+                    title={`${t('submenu.settings')} (${title})`}
+                    className="settingsIcon"
+                    onClick={() =>
+                      navigate(pathname, {
+                        state: {
+                          fromGameCard: true,
+                          runner,
+                          hasCloudSave,
+                          isLinuxNative,
+                          isMacNative
+                        }
+                      })
+                    }
                   >
-                    <FontAwesomeIcon size={'2x'} icon={faRepeat} />
+                    <SettingsIcon />
                   </SvgButton>
-                )}
-                {isInstalled && !isUninstalling && (
-                  <>
-                    <SvgButton
-                      title={`${t('submenu.settings')} (${title})`}
-                      className="settingsIcon"
-                      onClick={() =>
-                        navigate(pathname, {
-                          state: {
-                            fromGameCard: true,
-                            runner,
-                            hasCloudSave,
-                            isLinuxNative,
-                            isMacNative
-                          }
-                        })
-                      }
-                    >
-                      <SettingsIcon />
-                    </SvgButton>
-                  </>
-                )}
-                {renderIcon()}
-              </span>
-            </>
-          )}
+                </>
+              )}
+              {renderIcon()}
+            </span>
+          </>
         </div>
       </ContextMenu>
     </div>

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -308,6 +308,8 @@ const GameCard = ({
     grid ? 'gameCard' : 'gameListItem'
   }  ${instClass} ${hiddenClass}`
 
+  const { activeController } = useContext(ContextProvider)
+
   return (
     <div>
       {showUninstallModal && (
@@ -364,7 +366,7 @@ const GameCard = ({
               {getStoreName(runner, t2('Other'))}
             </span>
           </Link>
-          {
+          {!activeController && (
             <>
               <span className="icons">
                 {hasUpdate && !isUpdating && (
@@ -400,7 +402,7 @@ const GameCard = ({
                 {renderIcon()}
               </span>
             </>
-          }
+          )}
         </div>
       </ContextMenu>
     </div>


### PR DESCRIPTION
Several tweaks regarding gamepad controls. The goal is app-wide consistency and better integration with steam deck controls.

- "A"-button on game cards and list items _always_ opens the game info page (list/grid/installed or not), launching/installing directly from library still works with "Y"-button
- Relabeled Controller hints
  - **–** instead of **None**
  - **Select** instead of **Activate**
  - **Options** instead of **Context menu**
- Back button closes the context menu if open
- Added controller hints to library list view
- Autofocus play/install button on game page
- Icons in library grid view (install, play, settings, update) are hidden when gamepad input is active
- More options in game card context menu (play, stop, settings, remove from queue, cancel installation)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
