### PR TITLE
[Fix] Verify that a valid Wine/Proton prefix exists before running any Wine command

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -437,10 +437,6 @@ export async function verifyWinePrefix(
     return { res: { stdout: '', stderr: '' }, updated: false }
   }
 
-  if (!(await validWine(wineVersion))) {
-    return { res: { stdout: '', stderr: '' }, updated: false }
-  }
-
   if (wineVersion.type === 'crossover') {
     return { res: { stdout: '', stderr: '' }, updated: false }
   }

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -185,10 +185,7 @@ async function prepareWineLaunch(game: LegendaryGame | GOGGame): Promise<{
     }
   }
 
-  const { updated: winePrefixUpdated } = await verifyWinePrefix(
-    gameSettings,
-    game
-  )
+  const { updated: winePrefixUpdated } = await verifyWinePrefix(gameSettings)
   if (winePrefixUpdated) {
     logInfo(['Created/Updated Wineprefix at', gameSettings.winePrefix], {
       prefix: LogPrefix.Backend
@@ -428,15 +425,13 @@ export async function validWine(
 
 /**
  * Verifies that a Wineprefix exists by running 'wineboot --init'
- * @param game The game to verify the Wineprefix of
+ * @param gameSettings The settings of the game to verify the Wineprefix of
  * @returns stderr & stdout of 'wineboot --init'
  */
 export async function verifyWinePrefix(
-  settings: GameSettings,
-  game?: LegendaryGame | GOGGame
+  settings: GameSettings
 ): Promise<{ res: ExecResult; updated: boolean }> {
-  const gameSettings = game ? await game.getSettings() : settings
-  const { winePrefix, wineVersion } = gameSettings
+  const { winePrefix, wineVersion } = settings
 
   if (!(await validWine(wineVersion))) {
     return { res: { stdout: '', stderr: '' }, updated: false }
@@ -465,13 +460,11 @@ export async function verifyWinePrefix(
       : join(winePrefix, 'system.reg')
   const haveToWait = !existsSync(systemRegPath)
 
-  const command = game
-    ? game.runWineCommand(['wineboot', '--init'], haveToWait)
-    : runWineCommand({
-        commandParts: ['wineboot', '--init'],
-        wait: haveToWait,
-        gameSettings
-      })
+  const command = runWineCommand({
+    commandParts: ['wineboot', '--init'],
+    wait: haveToWait,
+    gameSettings: settings
+  })
 
   return command
     .then((result) => {

--- a/src/backend/legendary/eos_overlay/eos_overlay.ts
+++ b/src/backend/legendary/eos_overlay/eos_overlay.ts
@@ -167,8 +167,8 @@ async function enable(
   if (isLinux) {
     const game = getGame(appName, 'legendary')
     const gameSettings = await game.getSettings()
-    await verifyWinePrefix(gameSettings, game)
-    const { winePrefix, wineVersion } = await game.getSettings()
+    await verifyWinePrefix(gameSettings)
+    const { winePrefix, wineVersion } = gameSettings
     prefix =
       wineVersion.type === 'proton' ? join(winePrefix, 'pfx') : winePrefix
   }

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -677,10 +677,10 @@ ipcMain.handle(
       ? await getAppSettings(appName)
       : await game.getSettings()
     const { wineVersion, winePrefix } = gameSettings
-    await verifyWinePrefix(gameSettings)
 
     switch (tool) {
       case 'winetricks':
+        await verifyWinePrefix(gameSettings)
         await Winetricks.run(wineVersion, winePrefix, event)
         break
       case 'winecfg':

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -529,6 +529,7 @@ export type WineCommandArgs = {
   installFolderName?: string
   options?: CallRunnerOptions
   startFolder?: string
+  skipPrefixCheckIKnowWhatImDoing?: boolean
 }
 
 export interface SideloadGame {


### PR DESCRIPTION
This will prevent Heroic from running any Wine commands unless all files required in a Wine/Proton prefix are actually present, which will in turn prevent us from creating invalid Proton prefixes (note that this will not fix already broken Proton prefixes)

This is achieved by checking for known-required prefix files in `runWineCommand`. If any are missing, `verifyWinePrefix` is used to create / hopefully fix the prefix.  
Because of that, Proton will no longer get skipped in `verifyWinePrefix` (even though `wineboot` itself doesn't actually get ran, which is fine since Proton creates the prefix itself)

If you really have to disable this check when running commands (`verifyWinePrefix` uses `runWineCommand` to create the prefix for example), pass `skipPrefixCheckIKnowWhatImDoing` to `runWineCommand`

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
