### PR TITLE
[UI] Add css variable for controller hints background

### DIFF
--- a/src/frontend/components/UI/ControllerHints/index.css
+++ b/src/frontend/components/UI/ControllerHints/index.css
@@ -1,5 +1,5 @@
 .controller-hints {
-  background: transparent;
+  background: var(--controller-hints-background);
   display: flex;
   box-shadow: 0 0 36px 10px rgb(0 0 0 / 70%);
   z-index: 1;

--- a/src/frontend/styles/_colors.scss
+++ b/src/frontend/styles/_colors.scss
@@ -44,6 +44,7 @@
   --osk-background: var(--body-background);
   --osk-button-background: var(--input-background);
   --osk-button-border: var(--navbar-background);
+  --controller-hints-background: transparent;
 
   --anticheat-denied: var(--danger);
   --anticheat-broken: #e8590c;


### PR DESCRIPTION
Adds a new css variable to allow the controller hint bar to be styled independently in themes.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
