### PR TITLE
[UI] Fixes game page scroll when content doesn't fit the screen

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.scss
+++ b/src/frontend/screens/Game/GamePage/index.scss
@@ -8,6 +8,11 @@
 
   .titleWrapper {
     display: flex;
+    position: sticky;
+    top: 0px;
+    padding-top: 2rem;
+    margin-top: 2rem;
+    background: var(--background-darker);
     .title {
       font-weight: var(--medium);
       font-size: var(--text-xl);
@@ -140,9 +145,11 @@
   color: var(--text-default);
   display: flex;
   flex-direction: column;
-  max-width: 650px;
+  flex: 100%;
+  max-height: 100vh;
+  overflow-y: auto;
   user-select: text;
-  padding: 8vh 2.2em 1.2em 1.2em;
+  padding: 0 2.2em 4rem 1.2em;
 
   .title {
     font-weight: var(--bold);


### PR DESCRIPTION
This PR addresses an issue reported on Discord:
![image](https://user-images.githubusercontent.com/188464/200140600-1e1eb37f-e314-43bb-9794-415048e27f96.png)

were scrolling moved all the content instead of only scrolling the info section.

I applied 3 changes mainly:
- only the info section scrolls now
- the title of the game and the menu button are now sticky to the top so they are always visible when scrolling
- added some bottom padding so the bottom of the content doesn't end up that close to the bottom

With this changes:

https://user-images.githubusercontent.com/188464/200140652-d08ceea2-129b-46f8-a73a-7451814e95c8.mp4

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
