### PR TITLE
[UI] Fix dialog content width

### DIFF
--- a/src/frontend/components/UI/DialogHandler/components/MessageBoxModal/index.css
+++ b/src/frontend/components/UI/DialogHandler/components/MessageBoxModal/index.css
@@ -17,13 +17,8 @@
   padding-block: 4px;
   padding-inline: 6px;
   height: 25em;
-  width: calc(90vw - var(--sidebar-width));
   overflow: auto;
   user-select: text;
-}
-
-.errorDialog.error-box.collapsed {
-  width: calc(90vw - var(--sidebar-width));
 }
 
 .errorDialog.contentHeader {

--- a/src/frontend/components/UI/ProgressDialog/index.css
+++ b/src/frontend/components/UI/ProgressDialog/index.css
@@ -13,13 +13,8 @@
   padding-block: 4px;
   padding-inline: 6px;
   height: 25em;
-  width: calc(90vw - var(--sidebar-width));
   overflow: auto;
   user-select: text;
-}
-
-.progressDialog.log-box.collapsed {
-  width: calc(90vw - var(--sidebar-width));
 }
 
 .progressDialog.log-error,


### PR DESCRIPTION
This PR fixes this visual issue I just found when showing an error dialog:

Before:

https://user-images.githubusercontent.com/188464/200153300-f53a8754-74dd-4642-8150-9edf70747fb1.mp4

After:

https://user-images.githubusercontent.com/188464/200153335-6cedbb6e-1aaf-4f19-8eca-9cbb164eee1c.mp4


A similar issue happens for the winetricks dialog:

![image](https://user-images.githubusercontent.com/188464/200153495-c9718429-2bad-4387-9513-fcfbed3f4ecb.png)

And the same fix applies.

I also removed the style for the `.....collapsed` variants, since it was the same calc as without `collapsed` and I couldn't really find anywhere in the code that sets that class on those element.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
