### PR TITLE
Use new `--accept-path` flag in save sync

### DIFF
--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -1,6 +1,6 @@
 import { Runner } from 'common/types'
 import { GOGCloudSavesLocation, SaveFolderVariable } from 'common/types/gog'
-import { getWinePath, setupWineEnvVars } from './launcher'
+import { getWinePath, setupWineEnvVars, verifyWinePrefix } from './launcher'
 import { runLegendaryCommand, LegendaryLibrary } from './legendary/library'
 import { GOGLibrary } from './gog/library'
 import {
@@ -14,7 +14,6 @@ import { getGame, getShellPath } from './utils'
 import { existsSync, realpathSync } from 'graceful-fs'
 import { app } from 'electron'
 import {
-  callAbortController,
   createAbortController,
   deleteAbortController
 } from './utils/aborthandler/aborthandler'
@@ -43,59 +42,40 @@ async function getDefaultLegendarySavePath(appName: string): Promise<string> {
     })
     return save_path
   }
+
+  await verifyWinePrefix(await game.getSettings())
+
   // If Legendary doesn't have a save folder set yet, run it & accept its generated path
-  // TODO: This whole interaction is a little weird, maybe ask Rodney if he's willing to
-  //       make this a little smoother to automate
   logInfo(['Computing default save path for', appName], {
     prefix: LogPrefix.Legendary
   })
-  // NOTE: The easiest way I've found to just compute the path is by running the sync
-  //       and disabling both save up- and download
-  let gotSavePath = false
   const abortControllerName = appName + '-savePath'
   await runLegendaryCommand(
-    ['sync-saves', appName, '--skip-upload', '--skip-download'],
+    [
+      'sync-saves',
+      appName,
+      '--skip-upload',
+      '--skip-download',
+      '--accept-path'
+    ],
     createAbortController(abortControllerName),
     {
       logMessagePrefix: 'Getting default save path',
-      env: setupWineEnvVars(await game.getSettings()),
-      onOutput: (output, child) => {
-        if (output.includes('Is this correct?')) {
-          gotSavePath = true
-          child.stdin?.cork()
-          child.stdin?.write('y\n')
-          child.stdin?.uncork()
-        } else if (
-          output.includes(
-            'Path contains unprocessed variables, please enter the correct path manually'
-          )
-        ) {
-          callAbortController(abortControllerName)
-          logError(
-            [
-              'Legendary was unable to compute the default save path of',
-              appName
-            ],
-            { prefix: LogPrefix.Legendary }
-          )
-        }
-      }
+      env: setupWineEnvVars(await game.getSettings())
     }
   )
   deleteAbortController(abortControllerName)
-  if (!gotSavePath) {
+
+  // If the save path was computed successfully, Legendary will have saved
+  // this path in `installed.json` (so the GameInfo)
+  const { save_path: new_save_path, save_folder } =
+    LegendaryLibrary.get().getGameInfo(appName, true)!
+  if (!new_save_path) {
     logError(['Unable to compute default save path for', appName], {
       prefix: LogPrefix.Legendary
     })
-    return ''
+    return save_folder
   }
-  // If the save path was computed successfully, Legendary will have saved
-  // this path in `installed.json` (so the GameInfo)
-  // `= ''` here just in case Legendary failed to write the file
-  const { save_path: new_save_path = '' } = LegendaryLibrary.get().getGameInfo(
-    appName,
-    true
-  )!
   logInfo(['Computed save path:', new_save_path], {
     prefix: LogPrefix.Legendary
   })


### PR DESCRIPTION
With Legendary 0.20.31, a new hidden `--accept-path` flag got added to the sync-saves command. With it, we can just accept the path Legendary computed for us, instead of fiddling around with parsing its output.
This makes our job a lot easier

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
