### PR TITLE
[Fix] crash on install from context menu

### DIFF
--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -274,7 +274,13 @@ const GameCard = ({
     {
       // install
       label: t('button.install'),
-      onclick: () => (!isInstalled ? buttonClick() : () => null),
+      onclick: () => {
+        // close context menu first
+        // TODO this should be done more elegant
+        setTimeout(() => {
+          buttonClick()
+        }, 1)
+      },
       show: !isInstalled
     },
     {


### PR DESCRIPTION
Fixes the bug of heroic crashing upon selecting install from context menu of a GameCard.
More a dirty workaround than a solution to the problem, I will have another look into it later this week. But this works for now.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
