### PR TITLE
[UI] Hide Clear button for Library's Search Bar

### DIFF
--- a/src/frontend/components/UI/SearchBar/index.tsx
+++ b/src/frontend/components/UI/SearchBar/index.tsx
@@ -83,21 +83,24 @@ export default function SearchBar() {
         className="searchBarInput"
       />
       {filterText.length > 0 && (
-        <ul className="autoComplete">
-          {list.length > 0 &&
-            list.map((title, i) => (
-              <li
-                onClick={(e) => handleClick(e.currentTarget.innerText)}
-                key={i}
-              >
-                {title}
-              </li>
-            ))}
-        </ul>
+        <>
+          <ul className="autoComplete">
+            {list.length > 0 &&
+              list.map((title, i) => (
+                <li
+                  onClick={(e) => handleClick(e.currentTarget.innerText)}
+                  key={i}
+                >
+                  {title}
+                </li>
+              ))}
+          </ul>
+
+          <button className="clearSearchButton" onClick={onClear} tabIndex={-1}>
+            <FontAwesomeIcon icon={faXmark} />
+          </button>
+        </>
       )}
-      <button className="clearSearchButton" onClick={onClear} tabIndex={-1}>
-        <FontAwesomeIcon icon={faXmark} />
-      </button>
     </div>
   )
 }


### PR DESCRIPTION
By default, the clear button (X) is always visible even if there's no input or text. 

Instead, display the clear button whenever the user starts typing into the search bar and disable it when cleared.


https://user-images.githubusercontent.com/74495920/200341520-b262f7ba-ad62-4bee-bc14-884880180ae4.mp4

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
