### PR TITLE
[UI] Hide wine-related settings for games when Wine is not used

### DIFF
--- a/src/frontend/screens/Settings/SettingsContext.tsx
+++ b/src/frontend/screens/Settings/SettingsContext.tsx
@@ -9,7 +9,9 @@ const initialContext: SettingsContextType = {
   isDefault: true,
   appName: 'default',
   runner: 'legendary',
-  gameInfo: null
+  gameInfo: null,
+  isMacNative: false,
+  isLinuxNative: false
 }
 
 export default React.createContext(initialContext)

--- a/src/frontend/screens/Settings/SettingsContext.tsx
+++ b/src/frontend/screens/Settings/SettingsContext.tsx
@@ -8,7 +8,8 @@ const initialContext: SettingsContextType = {
   config: null,
   isDefault: true,
   appName: 'default',
-  runner: 'legendary'
+  runner: 'legendary',
+  gameInfo: null
 }
 
 export default React.createContext(initialContext)

--- a/src/frontend/screens/Settings/components/EnableEsync.tsx
+++ b/src/frontend/screens/Settings/components/EnableEsync.tsx
@@ -5,14 +5,16 @@ import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import SettingsContext from '../SettingsContext'
 
 const EnableEsync = () => {
   const { t } = useTranslation()
   const { platform } = useContext(ContextProvider)
+  const { isLinuxNative } = useContext(SettingsContext)
   const isLinux = platform === 'linux'
   const [enableEsync, setEnableEsync] = useSetting('enableEsync', false)
 
-  if (!isLinux) {
+  if (!isLinux || isLinuxNative) {
     return <></>
   }
 

--- a/src/frontend/screens/Settings/components/EnableFSR.tsx
+++ b/src/frontend/screens/Settings/components/EnableFSR.tsx
@@ -5,15 +5,17 @@ import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import SettingsContext from '../SettingsContext'
 
 const EnableFSR = () => {
   const { t } = useTranslation()
   const { platform } = useContext(ContextProvider)
+  const { isLinuxNative } = useContext(SettingsContext)
   const isLinux = platform === 'linux'
   const [enableFSR, setEnableFSR] = useSetting('enableFSR', false)
   const [maxSharpness, setFsrSharpness] = useSetting('maxSharpness', 5)
 
-  if (!isLinux) {
+  if (!isLinux || isLinuxNative) {
     return <></>
   }
 

--- a/src/frontend/screens/Settings/components/EnableFsync.tsx
+++ b/src/frontend/screens/Settings/components/EnableFsync.tsx
@@ -5,14 +5,16 @@ import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import SettingsContext from '../SettingsContext'
 
 const EnableFsync = () => {
   const { t } = useTranslation()
   const { platform } = useContext(ContextProvider)
+  const { isLinuxNative } = useContext(SettingsContext)
   const isLinux = platform === 'linux'
   const [enableFsync, setEnableFsync] = useSetting('enableFsync', false)
 
-  if (!isLinux) {
+  if (!isLinux || isLinuxNative) {
     return <></>
   }
 

--- a/src/frontend/screens/Settings/components/ShowFPS.tsx
+++ b/src/frontend/screens/Settings/components/ShowFPS.tsx
@@ -1,19 +1,16 @@
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation } from 'react-router-dom'
 import { ToggleSwitch } from 'frontend/components/UI'
 import ContextProvider from 'frontend/state/ContextProvider'
 import useSetting from 'frontend/hooks/useSetting'
-import { LocationState } from 'frontend/types'
+import SettingsContext from '../SettingsContext'
 
 const ShowFPS = () => {
   const { t } = useTranslation()
   const [showFps, setShowFps] = useSetting('showFps', false)
   const { platform } = useContext(ContextProvider)
+  const { isMacNative, isLinuxNative } = useContext(SettingsContext)
   const isWin = platform === 'win32'
-  const {
-    state: { isLinuxNative, isMacNative }
-  } = useLocation() as { state: LocationState }
   const shouldRenderFpsOption = !isMacNative && !isWin && !isLinuxNative
 
   if (!shouldRenderFpsOption) {

--- a/src/frontend/screens/Settings/components/SteamRuntime.tsx
+++ b/src/frontend/screens/Settings/components/SteamRuntime.tsx
@@ -1,19 +1,16 @@
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation } from 'react-router-dom'
 import { ToggleSwitch } from 'frontend/components/UI'
 import ContextProvider from 'frontend/state/ContextProvider'
 import useSetting from 'frontend/hooks/useSetting'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import { defaultWineVersion } from '..'
-import { LocationState } from 'frontend/types'
+import SettingsContext from '../SettingsContext'
 
 const SteamRuntime = () => {
   const { t } = useTranslation()
-  const {
-    state: { isLinuxNative }
-  } = useLocation() as { state: LocationState }
+  const { isLinuxNative } = useContext(SettingsContext)
   const { platform } = useContext(ContextProvider)
   const isLinux = platform === 'linux'
   const isWin = platform === 'win32'

--- a/src/frontend/screens/Settings/index.tsx
+++ b/src/frontend/screens/Settings/index.tsx
@@ -1,6 +1,6 @@
 import './index.css'
 
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 
 import { NavLink, useLocation, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
@@ -25,6 +25,7 @@ import {
 import { getGameInfo, writeConfig } from 'frontend/helpers'
 import { UpdateComponent } from 'frontend/components/UI'
 import { LocationState, SettingsContextType } from 'frontend/types'
+import ContextProvider from 'frontend/state/ContextProvider'
 
 export const defaultWineVersion: WineInstallation = {
   bin: '/usr/bin/wine',
@@ -34,6 +35,7 @@ export const defaultWineVersion: WineInstallation = {
 
 function Settings() {
   const { t, i18n } = useTranslation()
+  const { platform } = useContext(ContextProvider)
   const {
     state: { fromGameCard, runner }
   } = useLocation() as { state: LocationState }
@@ -52,6 +54,10 @@ function Settings() {
   const isGamesSettings = type === 'games_settings'
   const isLogSettings = type === 'log'
   const isAdvancedSetting = type === 'advanced' && isDefault
+  const isLinux = platform === 'linux'
+  const isMac = platform === 'darwin'
+  const isMacNative = isMac && (gameInfo?.is_mac_native || false)
+  const isLinuxNative = isLinux && (gameInfo?.is_linux_native || false)
 
   // Load Heroic's or game's config, only if not loaded already
   useEffect(() => {
@@ -110,7 +116,9 @@ function Settings() {
     isDefault,
     appName,
     runner,
-    gameInfo
+    gameInfo,
+    isLinuxNative,
+    isMacNative
   }
 
   return (

--- a/src/frontend/screens/Settings/index.tsx
+++ b/src/frontend/screens/Settings/index.tsx
@@ -16,7 +16,12 @@ import {
   SyncSaves,
   AdvancedSettings
 } from './sections'
-import { AppSettings, GameSettings, WineInstallation } from 'common/types'
+import {
+  AppSettings,
+  GameInfo,
+  GameSettings,
+  WineInstallation
+} from 'common/types'
 import { getGameInfo, writeConfig } from 'frontend/helpers'
 import { UpdateComponent } from 'frontend/components/UI'
 import { LocationState, SettingsContextType } from 'frontend/types'
@@ -38,6 +43,8 @@ function Settings() {
     AppSettings | GameSettings | null
   >(null)
 
+  const [gameInfo, setGameInfo] = useState<GameInfo | null>(null)
+
   const { appName = '', type = '' } = useParams()
   const isDefault = appName === 'default'
   const isGeneralSettings = type === 'general'
@@ -56,6 +63,7 @@ function Settings() {
 
       if (!isDefault) {
         const info = await getGameInfo(appName, runner)
+        setGameInfo(info)
         setTitle(info?.title ?? appName)
       } else {
         setTitle(t('globalSettings', 'Global Settings'))
@@ -101,7 +109,8 @@ function Settings() {
     config: currentConfig,
     isDefault,
     appName,
-    runner
+    runner,
+    gameInfo
   }
 
   return (

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -40,11 +40,9 @@ export default function GamesSettings() {
   const { isDefault, gameInfo } = useContext(SettingsContext)
   const isLinux = platform === 'linux'
 
-  let shouldRenderWineSettings = false
+  let usesWine = isLinux
   if (gameInfo) {
-    shouldRenderWineSettings = isLinux && !gameInfo.is_linux_native
-  } else {
-    shouldRenderWineSettings = isLinux
+    usesWine = isLinux && !gameInfo.is_linux_native
   }
 
   return (
@@ -59,7 +57,7 @@ export default function GamesSettings() {
         </p>
       )}
 
-      {shouldRenderWineSettings && (
+      {usesWine && (
         <>
           <section>
             <h3 className="settingSubheader">
@@ -96,15 +94,15 @@ export default function GamesSettings() {
 
         <AlternativeExe />
 
-        <ShowFPS />
+        {usesWine && <ShowFPS />}
 
-        <PreferSystemLibs />
+        {usesWine && <PreferSystemLibs />}
 
-        <EnableFSR />
+        {usesWine && <EnableFSR />}
 
-        <EnableEsync />
+        {usesWine && <EnableEsync />}
 
-        <EnableFsync />
+        {usesWine && <EnableFsync />}
 
         <GameMode />
 

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -37,9 +37,15 @@ import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 export default function GamesSettings() {
   const { t } = useTranslation()
   const { platform } = useContext(ContextProvider)
-  const { isDefault } = useContext(SettingsContext)
+  const { isDefault, gameInfo } = useContext(SettingsContext)
   const isLinux = platform === 'linux'
-  const isWin = platform === 'win32'
+
+  let shouldRenderWineSettings = false
+  if (gameInfo) {
+    shouldRenderWineSettings = isLinux && !gameInfo.is_linux_native
+  } else {
+    shouldRenderWineSettings = isLinux
+  }
 
   return (
     <>
@@ -53,7 +59,7 @@ export default function GamesSettings() {
         </p>
       )}
 
-      {!isWin && (
+      {shouldRenderWineSettings && (
         <>
           <section>
             <h3 className="settingSubheader">

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -37,12 +37,17 @@ import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 export default function GamesSettings() {
   const { t } = useTranslation()
   const { platform } = useContext(ContextProvider)
-  const { isDefault, gameInfo } = useContext(SettingsContext)
+  const { isDefault, gameInfo, isMacNative, isLinuxNative } =
+    useContext(SettingsContext)
   const isLinux = platform === 'linux'
+  const isMac = platform === 'darwin'
+  const isWin = platform === 'win32'
 
-  let usesWine = isLinux
+  let showWine = !isWin
+
   if (gameInfo) {
-    usesWine = isLinux && !gameInfo.is_linux_native
+    // show wine/crossover for non-native linux/mac games
+    showWine = (isLinux && !isLinuxNative) || (isMac && !isMacNative)
   }
 
   return (
@@ -57,7 +62,7 @@ export default function GamesSettings() {
         </p>
       )}
 
-      {usesWine && (
+      {showWine && (
         <>
           <section>
             <h3 className="settingSubheader">
@@ -94,15 +99,15 @@ export default function GamesSettings() {
 
         <AlternativeExe />
 
-        {usesWine && <ShowFPS />}
+        <ShowFPS />
 
-        {usesWine && <PreferSystemLibs />}
+        <PreferSystemLibs />
 
-        {usesWine && <EnableFSR />}
+        <EnableFSR />
 
-        {usesWine && <EnableEsync />}
+        <EnableEsync />
 
-        {usesWine && <EnableFsync />}
+        <EnableFsync />
 
         <GameMode />
 

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -196,6 +196,7 @@ export interface SettingsContextType {
   isDefault: boolean
   appName: string
   runner: Runner
+  gameInfo: GameInfo | null
 }
 
 export interface LocationState {

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -197,6 +197,8 @@ export interface SettingsContextType {
   appName: string
   runner: Runner
   gameInfo: GameInfo | null
+  isMacNative: boolean
+  isLinuxNative: boolean
 }
 
 export interface LocationState {


### PR DESCRIPTION
This PR fixes a regresion after refactoring the settings that some wine settings where showing up for native games (native linux, window or mac).

With this PR, all the wine-related settings (wine, prefix, extensions, fps, fsr, fsync, esync, system libraries) are only shown in linux for non-native games.

Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1998

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
