### PR TITLE
[Logs] Catch invalid JSON outputs from legendary when launching games

### DIFF
--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -713,15 +713,25 @@ class LegendaryGame extends Game {
       ['launch', this.appName, '--json', '--offline'],
       createAbortController(this.appName)
     )
+
     appendFileSync(
       this.logFileLocation,
       "Legendary's config from config.ini (before Heroic's settings):\n"
     )
-    const json = JSON.parse(stdout)
-    // remove egl auth info
-    delete json['egl_parameters']
 
-    appendFileSync(this.logFileLocation, JSON.stringify(json, null, 2) + '\n\n')
+    try {
+      const json = JSON.parse(stdout)
+      // remove egl auth info
+      delete json['egl_parameters']
+
+      appendFileSync(
+        this.logFileLocation,
+        JSON.stringify(json, null, 2) + '\n\n'
+      )
+    } catch (error) {
+      // in case legendary's command fails and the output is not json
+      appendFileSync(this.logFileLocation, error + '\n' + stdout + '\n\n')
+    }
 
     const commandParts = [
       'launch',


### PR DESCRIPTION
When we launch an Epic game, we request a json object with launch information. If legendary fails to return this information for any reason, the output is invalid JSON, causing an exception and the game is not executed.

This PR adds a try/catch there so if there's any issue that prevents legendary to respond with valid JSON then we just ignore this info in the logs and print the actual output from legendary to help debugging.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
