### PR TITLE
[Linux - UI/UX] Show Checkbox to use default Wine Settings on new Installs

### DIFF
--- a/public/locales/az/gamepage.json
+++ b/public/locales/az/gamepage.json
@@ -141,6 +141,9 @@
     "sdl": {
         "title": "Quraşdırılacaq komponentləri seçin"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/be/gamepage.json
+++ b/public/locales/be/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Выберыце кампаненты для ўстаноўкі"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/bg/gamepage.json
+++ b/public/locales/bg/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Изберете компоненти за инсталиране"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/bs/gamepage.json
+++ b/public/locales/bs/gamepage.json
@@ -141,6 +141,9 @@
     "sdl": {
         "title": "Odaberite komponente za instalaciju"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/ca/gamepage.json
+++ b/public/locales/ca/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Selecciona els components a instal·lar"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Títol"

--- a/public/locales/cs/gamepage.json
+++ b/public/locales/cs/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Vyberte součásti k instalaci"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Název"

--- a/public/locales/de/gamepage.json
+++ b/public/locales/de/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Zu installierende Komponenten auswählen"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Titel"

--- a/public/locales/el/gamepage.json
+++ b/public/locales/el/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Διαλέξτε στοιχεία για εγκατάσταση"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Select components to Install"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/es/gamepage.json
+++ b/public/locales/es/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Elija componentes a instalar"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Título"

--- a/public/locales/et/gamepage.json
+++ b/public/locales/et/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Valige komponendid, mida installida"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/eu/gamepage.json
+++ b/public/locales/eu/gamepage.json
@@ -141,6 +141,9 @@
     "sdl": {
         "title": "Instalatzeko osagaiak hautatzea"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/fa/gamepage.json
+++ b/public/locales/fa/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "انتخاب محتواها برای نصب"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/fa/translation.json
+++ b/public/locales/fa/translation.json
@@ -539,7 +539,7 @@
         },
         "gameMode": {
             "eacRuntimeEnabled": {
-                "message": "ران تایم EAC که بدون GameMode به درستی کار نمی کند،\u200c فعال شده است. آیا می خواهید ران تایم EAC و GameMode را غیرفعال کنید؟",
+                "message": "ران تایم EAC که بدون GameMode به درستی کار نمی کند، فعال شده است. آیا می خواهید ران تایم EAC و GameMode را غیرفعال کنید؟",
                 "title": "ران تایم EAC فعال شد"
             }
         },

--- a/public/locales/fi/gamepage.json
+++ b/public/locales/fi/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Valitse asennettavat komponentit"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/fr/gamepage.json
+++ b/public/locales/fr/gamepage.json
@@ -33,7 +33,7 @@
         },
         "uninstall": {
             "checkbox": "Supprimer le préfixe : {{prefix}}{{newLine}}Note : cela ne peut pas être annulé et supprimera également les fichiers de sauvegarde non sauvegardés.",
-            "message": "Voulez-vous désinstaller ce jeu ?",
+            "message": "Voulez-vous désinstaller ce jeu?",
             "title": "Désinstaller"
         },
         "update": {
@@ -139,6 +139,9 @@
     "report_problem": "Signaler un problème de fonctionnement du jeu",
     "sdl": {
         "title": "Sélectionnez les composants à installer"
+    },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
     },
     "sideload": {
         "field": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -2,7 +2,7 @@
     "accessibility": {
         "actions_font_family_no_default": "Police d'écriture pour les actions (Par défaut : ",
         "all_tiles_in_color": "Afficher les vignettes de tous les jeux en couleur",
-        "content_font_family_no_default": "Police d'écriture pour les contenus (Par défaut : ",
+        "content_font_family_no_default": "Police d'écriture pour les contenus (Par défaut: ",
         "fonts": "Polices d'écriture",
         "title": "Accessibilité",
         "zoom": "Zoom"
@@ -70,7 +70,7 @@
                 "title": "Erreur de mise-à-jour"
             },
             "wine-not-found": {
-                "invalid": "La version de Wine sélectionnée n'a pas été trouvée. Installez-le ou sélectionnez une version différente dans les paramètres du jeu{{newline}}Version : {{version}}{{newline}}Chemin : {{path}}",
+                "invalid": "La version de Wine sélectionnée n'a pas été trouvée. Installez-le ou sélectionnez une version différente dans les paramètres du jeu{{newline}}Version: {{version}}{{newline}}Chemin: {{path}}",
                 "message": "Aucune version de Wine n'est sélectionnée. Vérifiez les paramètres de jeu !",
                 "title": "Wine non trouvé"
             },
@@ -246,12 +246,12 @@
         "sync": {
             "part1": "Heroic essaie de trouver le bon dossier de sauvergarde, cela fonctionne dans la plus part des cas. Dans le cas où le dossier n'est pas le bon, utiisez la boîte écraser pour le changer.",
             "part2": "Dans le cas où vous changez le dossier de prefix de Wine ou Proton, vous aurez besoin de revérifier ce chemin car Proton utilise un prefix différent (/pfx) et un username (steamuser). Vous pouvez simplement effacer le chemin actuel quitter la page des options pour que Heroic essaie de deviner une fois de plus le dossier avec le bon prefix.",
-            "part3": "Synchronisation manuelle : Choisissez « Télécharger » pour télécharger les sauvegardes des jeux enregistrées dans le Cloud et « Téléverser » pour transférer les fichiers locaux vers le Cloud. « Forcer le téléchargement » et « Forcer le téléversement » ignoreront la version locale ou celle du Cloud.",
+            "part3": "Synchronisation manuelle: Choisissez « Télécharger » pour télécharger les sauvegardes des jeux enregistrées dans le Cloud et « Téléverser » pour transférer les fichiers locaux vers le Cloud. « Forcer le téléchargement » et « Forcer le téléversement » ignoreront la version locale ou celle du Cloud.",
             "part4": "Les sauvegardes automatiques synchroniseront vos sauvegardes à chaque fois que vous lancerez un jeu et que vous l'arrêtez."
         },
         "vkd3d": "VKD3D est une interface de compatibilité basée sur Vulkan pour les jeux nécessitant DirectX 12. L'activer pourrait grandement améliorer la compatibilité. N'a aucun effet sur les jeux utilisant des versions de DirectX plus anciennes.",
         "wine": {
-            "part1": "Heroic recherche des versions de Wine, Proton et CrossOver dans ces dossiers :",
+            "part1": "Heroic recherche des versions de Wine, Proton et CrossOver dans ces dossiers:",
             "part2": "Pour d'autres emplacements, utilisez un lien symbolique vers un de ces dossiers"
         }
     },

--- a/public/locales/gl/gamepage.json
+++ b/public/locales/gl/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Seleccione os compoñentes a instalar"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/hr/gamepage.json
+++ b/public/locales/hr/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Odaberite komponente za instalaciju"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/hu/gamepage.json
+++ b/public/locales/hu/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Válaszd ki a telepíteni kívánt elemeket"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/id/gamepage.json
+++ b/public/locales/id/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Pilih komponen untuk dipasang"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/it/gamepage.json
+++ b/public/locales/it/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Seleziona i componenti da installare"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Titolo"

--- a/public/locales/ja/gamepage.json
+++ b/public/locales/ja/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "インストールするコンポーネントを選択します"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/ko/gamepage.json
+++ b/public/locales/ko/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "설치할 구성 요소를 선택합니다"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/ml/gamepage.json
+++ b/public/locales/ml/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "നടുവാനുള്ള ഘടകങ്ങള് തിരഞ്ഞെടുക്കൂ"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/nb_NO/gamepage.json
+++ b/public/locales/nb_NO/gamepage.json
@@ -141,6 +141,9 @@
     "sdl": {
         "title": "Velg komponenter som skal installeres"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/nl/gamepage.json
+++ b/public/locales/nl/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Selecteer componenten om te installeren"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/pl/gamepage.json
+++ b/public/locales/pl/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Wybierz komponenty do instalacji"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/pt/gamepage.json
+++ b/public/locales/pt/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Selecione os componentes para instalar"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/pt_BR/gamepage.json
+++ b/public/locales/pt_BR/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Selecione os componentes para instalar"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Título"

--- a/public/locales/ro/gamepage.json
+++ b/public/locales/ro/gamepage.json
@@ -141,6 +141,9 @@
     "sdl": {
         "title": "Selectați componentele de instalat"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/ru/gamepage.json
+++ b/public/locales/ru/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Выбрать компоненты для установки"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Название"

--- a/public/locales/sk/gamepage.json
+++ b/public/locales/sk/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Vyberte komponenty na inštaláciu"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/sv/gamepage.json
+++ b/public/locales/sv/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Ange komponenter att installera"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Titel"

--- a/public/locales/ta/gamepage.json
+++ b/public/locales/ta/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Select components to Install"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/tr/gamepage.json
+++ b/public/locales/tr/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Kurulacak bileşenleri seç"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/uk/gamepage.json
+++ b/public/locales/uk/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Оберіть компоненти для встановлення"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/vi/gamepage.json
+++ b/public/locales/vi/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "Chọn các thành phần cần cài"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/public/locales/zh_Hans/gamepage.json
+++ b/public/locales/zh_Hans/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "选择要安装的组件"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "标题"

--- a/public/locales/zh_Hant/gamepage.json
+++ b/public/locales/zh_Hant/gamepage.json
@@ -140,6 +140,9 @@
     "sdl": {
         "title": "選擇要安裝的元件"
     },
+    "setting": {
+        "use-default-wine-settings": "Use Default Wine Settings"
+    },
     "sideload": {
         "field": {
             "title": "Title"

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -490,6 +490,7 @@ class GlobalConfigV0 extends GlobalConfig {
       checkForUpdatesOnStartup: !isFlatpak,
       customWinePaths: isWindows ? null : [],
       defaultInstallPath: heroicInstallPath,
+      libraryTopSection: 'disabled',
       defaultSteamPath: getSteamCompatFolder(),
       defaultWinePrefix: heroicDefaultWinePrefix,
       language: 'en',

--- a/src/frontend/components/UI/ToggleSwitch/index.tsx
+++ b/src/frontend/components/UI/ToggleSwitch/index.tsx
@@ -5,15 +5,24 @@ import './index.css'
 
 interface Props {
   htmlId: string
-  disabled?: boolean
   handleChange: ChangeEventHandler<HTMLInputElement>
   value: boolean
   title: string
+  disabled?: boolean
   extraClass?: string
+  description?: string
 }
 
 export default function ToggleSwitch(props: Props) {
-  const { handleChange, value, disabled, title, htmlId, extraClass } = props
+  const {
+    handleChange,
+    value,
+    disabled,
+    title,
+    htmlId,
+    extraClass,
+    description = ''
+  } = props
   const { isRTL } = useContext(ContextProvider)
 
   return (
@@ -32,6 +41,7 @@ export default function ToggleSwitch(props: Props) {
           isRTL
         })}
         htmlFor={htmlId}
+        title={description}
       >
         {title}
       </label>

--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -109,7 +109,7 @@ function getProgress(progress: InstallProgress): number {
 }
 
 function removeSpecialcharacters(text: string): string {
-  const regexp = new RegExp('[:|/|*|?|<|>|\\|&|{|}|%|$|@|`|!|™|+]', 'gi')
+  const regexp = new RegExp(/[:|/|*|?|<|>|\\|&|{|}|%|$|@|`|!|™|+|'|"|®]/, 'gi')
   return text.replaceAll(regexp, '')
 }
 

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -9,6 +9,7 @@ import React from 'react'
 import { AppSettings, WineInstallation } from 'common/types'
 import { useTranslation } from 'react-i18next'
 import { configStore } from 'frontend/helpers/electronStores'
+import { removeSpecialcharacters } from 'frontend/helpers'
 
 type Props = {
   setWineVersion: React.Dispatch<
@@ -48,7 +49,9 @@ export default function WineSelector({
       setWinePrefix(defaultPrefix)
       setWineVersion(wineVersion)
     } else {
-      const sugestedWinePrefix = `${prefixFolder}/${title}`
+      const sugestedWinePrefix = `${prefixFolder}/${removeSpecialcharacters(
+        title
+      )}`
       setWinePrefix(sugestedWinePrefix)
       setWineVersion(wineVersion || undefined)
     }

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -32,7 +32,7 @@ export default function WineSelector({
 }: Props) {
   const { t } = useTranslation('gamepage')
 
-  const [useDefaultSettings, setUseDefaultSettings] = React.useState(true)
+  const [useDefaultSettings, setUseDefaultSettings] = React.useState(false)
   const [description, setDescription] = React.useState('')
 
   React.useEffect(() => {

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -1,10 +1,14 @@
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { TextInputWithIconField, SelectField } from 'frontend/components/UI'
+import {
+  TextInputWithIconField,
+  SelectField,
+  ToggleSwitch
+} from 'frontend/components/UI'
 import React from 'react'
-import { Runner, WineInstallation } from 'common/types'
+import { AppSettings, WineInstallation } from 'common/types'
 import { useTranslation } from 'react-i18next'
-import { getGameInfo } from 'frontend/helpers'
+import { configStore } from 'frontend/helpers/electronStores'
 
 type Props = {
   setWineVersion: React.Dispatch<
@@ -14,8 +18,7 @@ type Props = {
   winePrefix: string
   wineVersionList: WineInstallation[]
   wineVersion: WineInstallation | undefined
-  appName: string
-  runner: Runner
+  title?: string
 }
 
 export default function WineSelector({
@@ -24,64 +27,86 @@ export default function WineSelector({
   winePrefix,
   wineVersionList,
   wineVersion,
-  appName,
-  runner
+  title = 'sideload'
 }: Props) {
   const { t } = useTranslation('gamepage')
 
+  const [useDefaultSettings, setUseDefaultSettings] = React.useState(true)
+  const [description, setDescription] = React.useState('')
+
   React.useEffect(() => {
-    const getInfo = async () => {
-      const gameData =
-        runner === 'sideload'
-          ? { folder_name: 'sideload' }
-          : await getGameInfo(appName, runner)
-      const bottleName = gameData?.folder_name
-      const { defaultWinePrefix, wineVersion } =
-        await window.api.requestAppSettings()
-      const sugestedWinePrefix = `${defaultWinePrefix}/${bottleName}`
+    const {
+      defaultWinePrefix: prefixFolder,
+      wineVersion,
+      winePrefix: defaultPrefix
+    } = configStore.get('settings') as AppSettings
+    setDescription(
+      `${defaultPrefix} / ${wineVersion.name.replace('Proton - ', '')}`
+    )
+
+    if (useDefaultSettings) {
+      setWinePrefix(defaultPrefix)
+      setWineVersion(wineVersion)
+    } else {
+      const sugestedWinePrefix = `${prefixFolder}/${title}`
       setWinePrefix(sugestedWinePrefix)
       setWineVersion(wineVersion || undefined)
     }
-    getInfo()
-  }, [])
+  }, [useDefaultSettings])
 
   return (
     <>
-      <TextInputWithIconField
-        label={t('install.wineprefix', 'WinePrefix')}
-        htmlId="setinstallpath"
-        placeholder={winePrefix}
-        value={winePrefix.replaceAll("'", '')}
-        onChange={(event) => setWinePrefix(event.target.value)}
-        icon={<FontAwesomeIcon icon={faFolderOpen} />}
-        onIconClick={async () =>
-          window.api
-            .openDialog({
-              buttonLabel: t('box.choose'),
-              properties: ['openDirectory'],
-              title: t('box.wineprefix', 'Select WinePrefix Folder')
-            })
-            .then((path) => setWinePrefix(path || winePrefix))
-        }
+      <ToggleSwitch
+        htmlId="use-wine-defaults"
+        title={t(
+          'setting.use-default-wine-settings',
+          'Use Default Wine Settings'
+        )}
+        value={useDefaultSettings}
+        handleChange={() => setUseDefaultSettings(!useDefaultSettings)}
+        description={description}
       />
+      {!useDefaultSettings && (
+        <>
+          <TextInputWithIconField
+            label={t('install.wineprefix', 'WinePrefix')}
+            htmlId="setinstallpath"
+            placeholder={winePrefix}
+            value={winePrefix.replaceAll("'", '')}
+            onChange={(event) => setWinePrefix(event.target.value)}
+            icon={<FontAwesomeIcon icon={faFolderOpen} />}
+            onIconClick={async () =>
+              window.api
+                .openDialog({
+                  buttonLabel: t('box.choose'),
+                  properties: ['openDirectory'],
+                  title: t('box.wineprefix', 'Select WinePrefix Folder')
+                })
+                .then((path) => setWinePrefix(path || winePrefix))
+            }
+          />
 
-      <SelectField
-        label={`${t('install.wineversion')}:`}
-        htmlId="wineVersion"
-        value={wineVersion?.bin || ''}
-        onChange={(e) =>
-          setWineVersion(
-            wineVersionList.find((version) => version.bin === e.target.value)
-          )
-        }
-      >
-        {wineVersionList &&
-          wineVersionList.map((version) => (
-            <option value={version.bin} key={version.bin}>
-              {version.name}
-            </option>
-          ))}
-      </SelectField>
+          <SelectField
+            label={`${t('install.wineversion')}:`}
+            htmlId="wineVersion"
+            value={wineVersion?.bin || ''}
+            onChange={(e) =>
+              setWineVersion(
+                wineVersionList.find(
+                  (version) => version.bin === e.target.value
+                )
+              )
+            }
+          >
+            {wineVersionList &&
+              wineVersionList.map((version) => (
+                <option value={version.bin} key={version.bin}>
+                  {version.name}
+                </option>
+              ))}
+          </SelectField>
+        </>
+      )}
     </>
   )
 }

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -170,8 +170,7 @@ export default React.memo(function InstallModal({
                 winePrefix={winePrefix}
                 wineVersion={wineVersion}
                 wineVersionList={wineVersionList}
-                appName={appName}
-                runner={runner}
+                title={gameInfo?.title}
                 setWinePrefix={setWinePrefix}
                 setWineVersion={setWineVersion}
               />
@@ -193,8 +192,6 @@ export default React.memo(function InstallModal({
                 winePrefix={winePrefix}
                 wineVersion={wineVersion}
                 wineVersionList={wineVersionList}
-                appName={appName}
-                runner={runner}
                 setWinePrefix={setWinePrefix}
                 setWineVersion={setWineVersion}
               />

--- a/src/frontend/screens/Settings/components/WinePrefix.tsx
+++ b/src/frontend/screens/Settings/components/WinePrefix.tsx
@@ -6,15 +6,13 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import useSetting from 'frontend/hooks/useSetting'
 import { configStore } from 'frontend/helpers/electronStores'
 import { InfoBox, TextInputWithIconField } from 'frontend/components/UI'
-import SettingsContext from 'frontend/screens/Settings/SettingsContext'
 
 const WinePrefix = () => {
   const { t } = useTranslation()
   const { platform } = useContext(ContextProvider)
-  const { isDefault } = useContext(SettingsContext)
   const isLinux = platform === 'linux'
 
-  if (isDefault || !isLinux) {
+  if (!isLinux) {
     return <></>
   }
 

--- a/src/frontend/screens/Settings/index.tsx
+++ b/src/frontend/screens/Settings/index.tsx
@@ -16,13 +16,8 @@ import {
   SyncSaves,
   AdvancedSettings
 } from './sections'
-import {
-  AppSettings,
-  GameInfo,
-  GameSettings,
-  WineInstallation
-} from 'common/types'
-import { getGameInfo, writeConfig } from 'frontend/helpers'
+import { AppSettings, GameSettings, WineInstallation } from 'common/types'
+import { writeConfig } from 'frontend/helpers'
 import { UpdateComponent } from 'frontend/components/UI'
 import { LocationState, SettingsContextType } from 'frontend/types'
 import ContextProvider from 'frontend/state/ContextProvider'
@@ -45,8 +40,6 @@ function Settings() {
     AppSettings | GameSettings | null
   >(null)
 
-  const [gameInfo, setGameInfo] = useState<GameInfo | null>(null)
-
   const { appName = '', type = '' } = useParams()
   const isDefault = appName === 'default'
   const isGeneralSettings = type === 'general'
@@ -68,9 +61,7 @@ function Settings() {
       setCurrentConfig(config)
 
       if (!isDefault) {
-        const info = await getGameInfo(appName, runner)
-        setGameInfo(info)
-        setTitle(info?.title ?? appName)
+        setTitle(gameInfo?.title ?? appName)
       } else {
         setTitle(t('globalSettings', 'Global Settings'))
       }

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -12,7 +12,8 @@ import {
   WineVersionInfo,
   UserInfo,
   InstallParams,
-  LibraryTopSectionOptions
+  LibraryTopSectionOptions,
+  AppSettings
 } from 'common/types'
 import { Category, DialogModalOptions } from 'frontend/types'
 import { TFunction, withTranslation } from 'react-i18next'
@@ -39,6 +40,7 @@ import {
 import { sideloadLibrary } from 'frontend/helpers/electronStores'
 
 const storage: Storage = window.localStorage
+const globalSettings = configStore.get('settings', {}) as AppSettings
 
 const RTL_LANGUAGES = ['fa']
 
@@ -131,8 +133,7 @@ export class GlobalState extends PureComponent<Props> {
     language: this.props.i18n.language,
     layout: storage.getItem('layout') || 'grid',
     libraryStatus: [],
-    libraryTopSection:
-      storage.getItem('library_top_section') || 'recently_played',
+    libraryTopSection: globalSettings.libraryTopSection || 'disabled',
     platform: 'unknown',
     refreshing: false,
     refreshingInTheBackground: true,
@@ -674,7 +675,6 @@ export class GlobalState extends PureComponent<Props> {
       layout,
       category,
       showHidden,
-      libraryTopSection,
       showFavourites,
       sidebarCollapsed
     } = this.state
@@ -685,7 +685,6 @@ export class GlobalState extends PureComponent<Props> {
     storage.setItem('show_hidden', JSON.stringify(showHidden))
     storage.setItem('show_favorites', JSON.stringify(showFavourites))
     storage.setItem('sidebar_collapsed', JSON.stringify(sidebarCollapsed))
-    storage.setItem('library_top_section', libraryTopSection)
 
     const pendingOps = libraryStatus.filter(
       (game) => game.status !== 'playing' && game.status !== 'done'


### PR DESCRIPTION
Although having a prefix for each game is ideal, in most cases one prefix will work for most games, especially when you don't have much space like when using the Steam Deck.

So I added this option to use the default wine settings when installing a game. Checked by default, if unchecked, will create a new prefix on the default prefix folders with the game name like before.

![image](https://user-images.githubusercontent.com/26871415/201630072-a5ca9651-327a-4a81-a77c-747034b0b33f.png)

![image](https://user-images.githubusercontent.com/26871415/201630144-3cc5312b-9c79-481e-9758-8a2d0bed9d56.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
