### PR TITLE
[Fix/Epic] Handle metadata files with dots in their name correctly

### DIFF
--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -85,7 +85,7 @@ export class LegendaryLibrary {
       if (!filename.endsWith('.json')) {
         return
       }
-      const appName = filename.split('.').at(0)!
+      const appName = filename.split('.').slice(0, -1).join('.')
       this.allGames.add(appName)
     })
   }


### PR DESCRIPTION
When reading out Legendary's `metadata` folder & adding the names of those files to our `allGames` set, we were assuming that there are no dots (`.`) in the actual app_name. If there were, we would fail once we try to read out the file
In practice this makes little difference, since the affected "games" are Unreal Engine-related files, which are skipped anyways, but it's still neat to get rid of those "Failed to parse ..." messages on startup

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
