### PR TITLE
Add a timeout when watching Legendary's `installed.json`

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -915,9 +915,16 @@ ipcMain.handle('writeConfig', (event, { appName, config }) => {
 
 // Watch the installed games file and trigger a refresh on the installed games if something changes
 if (existsSync(installed)) {
+  let watchTimeout: NodeJS.Timeout | undefined
   watch(installed, () => {
-    logInfo('Installed game list updated', { prefix: LogPrefix.Legendary })
-    LegendaryLibrary.get().refreshInstalled()
+    logInfo('installed.json updated, refreshing library', {
+      prefix: LogPrefix.Legendary
+    })
+    // `watch` might fire twice (while Legendary/we are still writing chunks of the file), which would in turn make LegendaryLibrary fail to
+    // decode the JSON data. So instead of immediately calling LegendaryLibrary.get().refreshInstalled(), call it only after no writes happen
+    // in a 500ms timespan
+    if (watchTimeout) clearTimeout(watchTimeout)
+    watchTimeout = setTimeout(LegendaryLibrary.get().refreshInstalled, 500)
   })
 }
 


### PR DESCRIPTION
After making the recent changes in #2004, I've noticed that an issue became more frequent: We're (trying to) reload our LegendaryLibrary before Legendary/we have finished writing the file.
Apparently, NodeJS' `watch` function is notorious for double-firing events like this (I initially assumed it was caused by the file being written in chunks, but I'm not so sure anymore).

One solution would be to switch to a 3rd party library, but I believe that would be overkill for such a small part of Heroic.
Instead, we now start a timeout of 500ms when a write occurs. If another write happens during this timeframe, our old timeout is stopped & a new one is started

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
