### PR TITLE
[Backend] Add support for auto enabling anti cheat runtimes for legendary on linux

### DIFF
--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -515,7 +515,7 @@ class LegendaryGame extends Game {
         setAnticheatInfo(anticheatInfo)
       })
     if (anticheatInfo && isLinux) {
-        let gameSettings = await this.getSettings()
+        const gameSettings = await this.getSettings()
 
         gameSettings.eacRuntime =
           anticheatInfo.anticheats.includes('Easy Anti-Cheat')

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -7,6 +7,7 @@ import axios from 'axios'
 
 import { BrowserWindow } from 'electron'
 import {
+  AntiCheatInfo,
   ExecResult,
   ExtraInfo,
   GameInfo,
@@ -26,7 +27,8 @@ import {
   isMac,
   isWindows,
   installed,
-  configStore
+  configStore,
+  isLinux
 } from '../constants'
 import { logError, logInfo, LogPrefix } from '../logger/logger'
 import {
@@ -46,6 +48,7 @@ import shlex from 'shlex'
 import { t } from 'i18next'
 import { isOnline } from '../online_monitor'
 import { showDialogBoxModalAuto } from '../dialog/dialog'
+import { useState } from 'react'
 
 class LegendaryGame extends Game {
   public appName: string
@@ -502,6 +505,24 @@ class LegendaryGame extends Game {
       return { status: 'error', error: res.error }
     }
     this.addShortcuts()
+
+    const [anticheatInfo, setAnticheatInfo] = useState<AntiCheatInfo | null>(
+      null
+    )
+    window.api
+      .getAnticheatInfo(this.getGameInfo().namespace)
+      .then((anticheatInfo: AntiCheatInfo | null) => {
+        setAnticheatInfo(anticheatInfo)
+      })
+    if (anticheatInfo && isLinux) {
+        let gameSettings = await this.getSettings()
+
+        gameSettings.eacRuntime =
+          anticheatInfo.anticheats.includes('Easy Anti-Cheat')
+        gameSettings.battlEyeRuntime =
+          anticheatInfo.anticheats.includes('BattlEye')
+    }
+
     return { status: 'done' }
   }
 


### PR DESCRIPTION
Previously, users would have to manually enable the EAC runtimes, with this PR if the game uses EAC or Battleye (using areweanticheatyet data), we can automatically enable it

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
