### PR TITLE
[Fix] errorHandler: Handle `grep` exit code of 1 better

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -15,7 +15,7 @@ import {
 } from 'common/types'
 import * as axios from 'axios'
 import { app, dialog, shell, Notification, BrowserWindow } from 'electron'
-import { exec, spawn, spawnSync } from 'child_process'
+import { exec, ExecException, spawn, spawnSync } from 'child_process'
 import { existsSync, rmSync, stat } from 'graceful-fs'
 import { promisify } from 'util'
 import i18next, { t } from 'i18next'
@@ -353,9 +353,11 @@ async function errorHandler(
           })
         }
       })
-      .catch(() =>
-        logInfo('operation interrupted', { prefix: LogPrefix.Backend })
-      )
+      .catch((err: ExecException) => {
+        // Grep returns 1 when it didn't find any text, which is fine in this case
+        if (err.code !== 1)
+          logInfo('operation interrupted', { prefix: LogPrefix.Backend })
+      })
   }
   if (error) {
     if (error.includes(deletedFolderMsg) && appName) {


### PR DESCRIPTION
`grep` exits with a return code of 1 when no lines were found, making Node assume that it failed. However, in this case, it's absolutely fine for it to not find anything

In practice, this gets rid of the "Operation interrupted" message which was showing up in my logs after installing any game

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
