### PR TITLE
[Tech] Frontend performance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroic",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0-beta.3",
   "private": true,
   "main": "build/electron/main.js",
   "homepage": "./",

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,20 +1,21 @@
-import React, { useContext } from 'react'
+import React, { useContext, lazy } from 'react'
 
 import './App.css'
 import { HashRouter, Navigate, Route, Routes } from 'react-router-dom'
-import Login from './screens/Login'
-import WebView from './screens/WebView'
-import { GamePage } from './screens/Game'
-import Library from './screens/Library'
-import WineManager from './screens/WineManager'
 import Sidebar from './components/UI/Sidebar'
-import Settings from './screens/Settings'
-import Accessibility from './screens/Accessibility'
 import ContextProvider from './state/ContextProvider'
 import classNames from 'classnames'
 import { ControllerHints, OfflineMessage } from './components/UI'
-import DownloadManager from './screens/DownloadManager'
 import DialogHandler from './components/UI/DialogHandler'
+import Library from './screens/Library'
+
+const Settings = lazy(async () => import('./screens/Settings'))
+const Accessibility = lazy(async () => import('./screens/Accessibility'))
+const DownloadManager = lazy(async () => import('./screens/DownloadManager'))
+const WineManager = lazy(async () => import('./screens/WineManager'))
+const GamePage = lazy(async () => import('./screens/Game/GamePage'))
+const WebView = lazy(async () => import('./screens/WebView'))
+const Login = lazy(async () => import('./screens/Login'))
 
 function App() {
   const { sidebarCollapsed } = useContext(ContextProvider)

--- a/src/frontend/hooks/useWhyDidYouUpdate.ts
+++ b/src/frontend/hooks/useWhyDidYouUpdate.ts
@@ -1,0 +1,35 @@
+import { useRef, useEffect } from 'react'
+
+export function useWhyDidYouUpdate(
+  name: string,
+  props: Record<string, string>
+) {
+  // Get a mutable ref object where we can store props ...
+  // ... for comparison next time this hook runs.
+  const previousProps = useRef({})
+  useEffect(() => {
+    if (previousProps.current) {
+      // Get all keys from previous and current props
+      const allKeys = Object.keys({ ...previousProps.current, ...props })
+      // Use this object to keep track of changed props
+      const changesObj = {}
+      // Iterate through keys
+      allKeys.forEach((key) => {
+        // If previous is different from current
+        if (previousProps.current[key] !== props[key]) {
+          // Add to changesObj
+          changesObj[key] = {
+            from: previousProps.current[key],
+            to: props[key]
+          }
+        }
+      })
+      // If changesObj not empty then output to console
+      if (Object.keys(changesObj).length) {
+        console.log('[why-did-you-update]', name, changesObj)
+      }
+    }
+    // Finally update previousProps with current props for next hook call
+    previousProps.current = props
+  })
+}

--- a/src/frontend/screens/DownloadManager/index.tsx
+++ b/src/frontend/screens/DownloadManager/index.tsx
@@ -3,12 +3,14 @@ import './index.css'
 import React, { lazy, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DMQueueElement } from 'common/types'
-import { UpdateComponent } from 'frontend/components/UI'
-import ProgressHeader from './components/ProgressHeader'
-import DownloadManagerHeader from './DownloadManagerHeader'
-import { downloadManagerStore } from 'frontend/helpers/electronStores'
-import { DMQueue } from 'frontend/types'
 
+import { DMQueue } from 'frontend/types'
+import { downloadManagerStore } from 'frontend/helpers/electronStores'
+
+const DownloadManagerHeader = lazy(
+  async () => import('./DownloadManagerHeader')
+)
+const ProgressHeader = lazy(async () => import('./components/ProgressHeader'))
 const DownloadManagerItem = lazy(
   async () =>
     import('frontend/screens/DownloadManager/components/DownloadManagerItem')
@@ -16,17 +18,14 @@ const DownloadManagerItem = lazy(
 
 export default React.memo(function DownloadManager(): JSX.Element | null {
   const { t } = useTranslation()
-  const [refreshing, setRefreshing] = useState(false)
   const [plannendElements, setPlannendElements] = useState<DMQueueElement[]>([])
   const [currentElement, setCurrentElement] = useState<DMQueueElement>()
   const [finishedElem, setFinishedElem] = useState<DMQueueElement[]>()
 
   useEffect(() => {
-    setRefreshing(true)
     window.api.getDMQueueInformation().then(({ elements }: DMQueue) => {
       setCurrentElement(elements[0])
       setPlannendElements([...elements.slice(1)])
-      setRefreshing(false)
     })
 
     const removeHandleDMQueueInformation = window.api.handleDMQueueInformation(
@@ -48,10 +47,6 @@ export default React.memo(function DownloadManager(): JSX.Element | null {
       setFinishedElem(finished)
     })
   }, [plannendElements.length, currentElement?.params.appName])
-
-  if (refreshing) {
-    return <UpdateComponent />
-  }
 
   const handleClearList = () => {
     setFinishedElem([])

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -3,6 +3,7 @@ import './index.css'
 import React, {
   useContext,
   CSSProperties,
+  lazy,
   useMemo,
   useState,
   useEffect
@@ -42,7 +43,10 @@ import RemoveCircleIcon from '@mui/icons-material/RemoveCircle'
 
 import classNames from 'classnames'
 import StoreLogos from 'frontend/components/UI/StoreLogos'
-import UninstallModal from 'frontend/components/UI/UninstallModal'
+
+const UninstallModal = lazy(
+  async () => import('frontend/components/UI/UninstallModal')
+)
 
 interface Card {
   buttonClick: () => void
@@ -53,9 +57,9 @@ interface Card {
 }
 
 const GameCard = ({
-  hasUpdate,
+  hasUpdate = false,
   buttonClick,
-  forceCard,
+  forceCard = false,
   isRecent = false,
   gameInfo
 }: Card) => {
@@ -104,7 +108,10 @@ const GameCard = ({
   const grid = forceCard || layout === 'grid'
 
   const { status, folder } =
-    libraryStatus.find((game: GameStatus) => game.appName === appName) || {}
+    (libraryStatus.length &&
+      libraryStatus.find((game: GameStatus) => game.appName === appName)) ||
+    {}
+
   const isInstalling = status === 'installing' || status === 'updating'
   const isUpdating = status === 'updating'
   const isReparing = status === 'repairing'
@@ -365,6 +372,10 @@ const GameCard = ({
   const { activeController } = useContext(ContextProvider)
 
   const showUpdateButton = hasUpdate && !isUpdating && !isQueued
+
+  if (!gameInfo) {
+    return null
+  }
 
   return (
     <div>

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -4,16 +4,19 @@ import cx from 'classnames'
 import GameCard from '../GameCard'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { useTranslation } from 'react-i18next'
+import { ModalState } from '../..'
 
 interface Props {
   library: GameInfo[]
   layout?: string
   isFirstLane?: boolean
   handleGameCardClick: (
-    app_name: string,
+    appName: string,
     runner: Runner,
-    gameInfo: GameInfo
+    gameInfo: GameInfo | null,
+    callback: (value: React.SetStateAction<ModalState>) => void
   ) => void
+  setShowModal: React.Dispatch<React.SetStateAction<ModalState>>
   onlyInstalled?: boolean
   isRecent?: boolean
 }
@@ -24,7 +27,8 @@ const GamesList = ({
   handleGameCardClick,
   isFirstLane = false,
   onlyInstalled = false,
-  isRecent = false
+  isRecent = false,
+  setShowModal
 }: Props): JSX.Element => {
   const { gameUpdates } = useContext(ContextProvider)
   const { t } = useTranslation()
@@ -60,6 +64,9 @@ const GamesList = ({
           if (!is_installed && onlyInstalled) {
             return null
           }
+          if (!gameInfo || !handleGameCardClick) {
+            return null
+          }
 
           const hasUpdate = is_installed && gameUpdates?.includes(app_name)
           return (
@@ -67,7 +74,7 @@ const GamesList = ({
               key={app_name}
               hasUpdate={hasUpdate}
               buttonClick={() =>
-                handleGameCardClick(app_name, runner, gameInfo)
+                handleGameCardClick(app_name, runner, gameInfo, setShowModal)
               }
               forceCard={layout === 'grid'}
               isRecent={isRecent}

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -215,7 +215,10 @@ export default function DownloadDialog({
         )
         setGameInstallInfo(gameInstallInfo)
 
-        if (gameInstallInfo && 'languages' in gameInstallInfo.manifest) {
+        if (
+          gameInstallInfo?.manifest &&
+          'languages' in gameInstallInfo.manifest
+        ) {
           setInstallLanguages(gameInstallInfo.manifest.languages)
           setInstallLanguage(
             getInstallLanguage(
@@ -237,7 +240,7 @@ export default function DownloadDialog({
         showDialogModal({
           type: 'ERROR',
           title: tr('box.error.generic.title', 'Error!'),
-          message: `tr('box.error.generic.message', 'Something Went Wrong!')
+          message: `${tr('box.error.generic.message', 'Something Went Wrong!')}
           ${error}`
         })
         backdropClick()
@@ -291,45 +294,6 @@ export default function DownloadDialog({
     }
     getSpace()
   }, [installPath, gameInstallInfo?.manifest?.disk_size])
-
-  useEffect(() => {
-    const getIinstallInfo = async () => {
-      const gameInstallInfo = await getInstallInfo(
-        appName,
-        runner,
-        platformToInstall
-      )
-
-      if (!gameInstallInfo) {
-        showDialogModal({
-          type: 'ERROR',
-          title: tr('box.error.generic.title', 'Error!'),
-          message: tr('box.error.generic.message', 'Something Went Wrong!')
-        })
-        backdropClick()
-        return
-      }
-
-      setGameInstallInfo(gameInstallInfo)
-      if (gameInstallInfo && 'languages' in gameInstallInfo.manifest) {
-        setInstallLanguages(gameInstallInfo.manifest.languages)
-        setInstallLanguage(
-          getInstallLanguage(gameInstallInfo.manifest.languages, i18n.languages)
-        )
-      }
-
-      if (platformToInstall === 'linux' && runner === 'gog') {
-        const installer_languages = await window.api.getGOGLinuxInstallersLangs(
-          appName
-        )
-        setInstallLanguages(installer_languages)
-        setInstallLanguage(
-          getInstallLanguage(installer_languages, i18n.languages)
-        )
-      }
-    }
-    getIinstallInfo()
-  }, [appName, i18n.languages, platformToInstall])
 
   useEffect(() => {
     const getCacheInfo = async () => {
@@ -403,7 +367,7 @@ export default function DownloadDialog({
     return t('button.no-path-selected', 'No path selected')
   }
 
-  const readyToInstall = installPath && gameInstallInfo?.manifest.download_size
+  const readyToInstall = installPath && gameInstallInfo?.manifest?.download_size
 
   return (
     <>
@@ -505,7 +469,7 @@ export default function DownloadDialog({
               .then((path) => setInstallPath(path || defaultInstallPath))
           }
           afterInput={
-            gameInstallInfo?.manifest.download_size ? (
+            gameInstallInfo?.manifest?.download_size ? (
               <span className="diskSpaceInfo">
                 {validPath && (
                   <>

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -1,7 +1,7 @@
 import { faApple, faLinux, faWindows } from '@fortawesome/free-brands-svg-icons'
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons'
 
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState, lazy } from 'react'
 
 import ContextProvider from 'frontend/state/ContextProvider'
 import {
@@ -14,11 +14,12 @@ import { Dialog } from 'frontend/components/UI/Dialog'
 
 import './index.css'
 
-import DownloadDialog from './DownloadDialog'
-import SideloadDialog from './SideloadDialog'
-import WineSelector from './WineSelector'
 import { SelectField } from 'frontend/components/UI'
 import { useTranslation } from 'react-i18next'
+
+const DownloadDialog = lazy(async () => import('./DownloadDialog'))
+const SideloadDialog = lazy(async () => import('./SideloadDialog'))
+const WineSelector = lazy(async () => import('./WineSelector'))
 
 type Props = {
   appName: string

--- a/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
+++ b/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
@@ -4,10 +4,17 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import { GameInfo, RecentGame, Runner } from 'common/types'
 import GamesList from '../GamesList'
 import { configStore } from 'frontend/helpers/electronStores'
+import { ModalState } from '../..'
 
 interface Props {
-  handleModal: (appName: string, runner: Runner, gameInfo: GameInfo) => void
   onlyInstalled: boolean
+  setShowModal: React.Dispatch<React.SetStateAction<ModalState>>
+  handleModal: (
+    appName: string,
+    runner: Runner,
+    gameInfo: GameInfo | null,
+    callback: (value: React.SetStateAction<ModalState>) => void
+  ) => void
 }
 
 function getRecentGames(libraries: GameInfo[], limit: number): GameInfo[] {
@@ -31,7 +38,8 @@ function getRecentGames(libraries: GameInfo[], limit: number): GameInfo[] {
 
 export default React.memo(function RecentlyPlayed({
   handleModal,
-  onlyInstalled
+  onlyInstalled,
+  setShowModal
 }: Props) {
   const { t } = useTranslation()
   const { epic, gog, sideloadedLibrary } = useContext(ContextProvider)
@@ -75,6 +83,7 @@ export default React.memo(function RecentlyPlayed({
         handleGameCardClick={handleModal}
         onlyInstalled={onlyInstalled}
         isRecent={true}
+        setShowModal={setShowModal}
       />
     </>
   )

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -17,7 +17,6 @@ import Fuse from 'fuse.js'
 
 import ContextProvider from 'frontend/state/ContextProvider'
 
-import GamesList from './components/GamesList'
 import {
   FavouriteGame,
   GameInfo,
@@ -25,15 +24,19 @@ import {
   HiddenGame,
   Runner
 } from 'common/types'
-import ErrorComponent from 'frontend/components/UI/ErrorComponent'
+
 import LibraryHeader from './components/LibraryHeader'
 import {
   epicCategories,
   gogCategories,
   sideloadedCategories
 } from 'frontend/helpers/library'
-import RecentlyPlayed from './components/RecentlyPlayed'
 
+const RecentlyPlayed = lazy(async () => import('./components/RecentlyPlayed'))
+const GamesList = lazy(async () => import('./components/GamesList'))
+const ErrorComponent = lazy(
+  async () => import('frontend/components/UI/ErrorComponent')
+)
 const InstallModal = lazy(
   async () => import('frontend/screens/Library/components/InstallModal')
 )
@@ -212,7 +215,7 @@ export default React.memo(function Library(): JSX.Element {
       })
     }
     return tempArray
-  }, [showFavourites, favouriteGames, epic, gog])
+  }, [showFavourites, favouriteGames, epic.library, gog.library])
 
   // select library
   const libraryToShow = useMemo(() => {

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -31,9 +31,9 @@ import {
   gogCategories,
   sideloadedCategories
 } from 'frontend/helpers/library'
+import GamesList from './components/GamesList'
 
 const RecentlyPlayed = lazy(async () => import('./components/RecentlyPlayed'))
-const GamesList = lazy(async () => import('./components/GamesList'))
 const ErrorComponent = lazy(
   async () => import('frontend/components/UI/ErrorComponent')
 )
@@ -43,11 +43,20 @@ const InstallModal = lazy(
 
 const storage = window.localStorage
 
-type ModalState = {
+export type ModalState = {
   game: string
   show: boolean
   runner: Runner
   gameInfo: GameInfo | null
+}
+
+function handleModal(
+  appName: string,
+  runner: Runner,
+  gameInfo: GameInfo | null,
+  callback: (value: React.SetStateAction<ModalState>) => void
+) {
+  callback({ game: appName, show: true, runner, gameInfo })
 }
 
 export default React.memo(function Library(): JSX.Element {
@@ -123,14 +132,6 @@ export default React.memo(function Library(): JSX.Element {
     if (anchor) {
       anchor.scrollIntoView({ behavior: 'smooth', block: 'center' })
     }
-  }
-
-  function handleModal(
-    appName: string,
-    runner: Runner,
-    gameInfo: GameInfo | null
-  ) {
-    setShowModal({ game: appName, show: true, runner, gameInfo })
   }
 
   // cache list of games being installed
@@ -317,6 +318,7 @@ export default React.memo(function Library(): JSX.Element {
           <RecentlyPlayed
             handleModal={handleModal}
             onlyInstalled={libraryTopSection.endsWith('installed')}
+            setShowModal={setShowModal}
           />
         )}
 
@@ -327,6 +329,7 @@ export default React.memo(function Library(): JSX.Element {
               library={favourites}
               handleGameCardClick={handleModal}
               isFirstLane
+              setShowModal={setShowModal}
             />
           </>
         )}
@@ -337,7 +340,9 @@ export default React.memo(function Library(): JSX.Element {
           setSortInstalled={setSortInstalled}
           sortDescending={sortDescending}
           sortInstalled={sortInstalled}
-          handleAddGameButtonClick={() => handleModal('', 'sideload', null)}
+          handleAddGameButtonClick={() =>
+            handleModal('', 'sideload', null, setShowModal)
+          }
         />
 
         {!!libraryToShow.length ||
@@ -350,6 +355,7 @@ export default React.memo(function Library(): JSX.Element {
             library={libraryToShow}
             layout={layout}
             handleGameCardClick={handleModal}
+            setShowModal={setShowModal}
           />
         )}
       </div>

--- a/src/frontend/state/ContextProvider.tsx
+++ b/src/frontend/state/ContextProvider.tsx
@@ -31,7 +31,7 @@ const initialContext: ContextType = {
   libraryStatus: [],
   libraryTopSection: 'disabled',
   handleLibraryTopSection: () => null,
-  platform: 'unknown',
+  platform: 'linux',
   refresh: async () => Promise.resolve(),
   refreshLibrary: async () => Promise.resolve(),
   refreshWineVersionInfo: async () => Promise.resolve(),

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -129,13 +129,14 @@ export class GlobalState extends PureComponent<Props> {
     error: false,
     filterText: '',
     filterPlatform: 'all',
-    gameUpdates: [],
+    gameUpdates:
+      (JSON.parse(storage.getItem('updates') || '[]') as string[]) || [],
     language: this.props.i18n.language,
     layout: storage.getItem('layout') || 'grid',
     libraryStatus: [],
     libraryTopSection: globalSettings.libraryTopSection || 'disabled',
-    platform: 'unknown',
-    refreshing: false,
+    platform: (storage.getItem('platform') as NodeJS.Platform) || 'linux',
+    refreshing: true,
     refreshingInTheBackground: true,
     hiddenGames:
       (configStore.get('games.hidden', []) as Array<HiddenGame>) || [],
@@ -635,6 +636,7 @@ export class GlobalState extends PureComponent<Props> {
     }
 
     this.setState({ platform })
+    storage.setItem('platform', platform)
 
     if (legendaryUser || gogUser) {
       this.refreshLibrary({
@@ -652,9 +654,9 @@ export class GlobalState extends PureComponent<Props> {
     )
 
     // listen to custom connectivity-changed event to update state
-    window.api.onConnectivityChanged((_, connectivity) => {
+    window.api.onConnectivityChanged((_, connectivity) =>
       this.setState({ connectivity })
-    })
+    )
 
     // get the current status
     window.api

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -136,7 +136,7 @@ export class GlobalState extends PureComponent<Props> {
     libraryStatus: [],
     libraryTopSection: globalSettings.libraryTopSection || 'disabled',
     platform: (storage.getItem('platform') as NodeJS.Platform) || 'linux',
-    refreshing: true,
+    refreshing: false,
     refreshingInTheBackground: true,
     hiddenGames:
       (configStore.get('games.hidden', []) as Array<HiddenGame>) || [],


### PR DESCRIPTION
After doing some benchmarks and performance testing on the frontend I noticed that Heroic was loading on start some components that are not needed right away, for instance, components from Downloads, wine manager, and settings screen and also some others like the DownloadDialog and so on. So I lazy loaded all components that are not needed on startup, basically all but the ones on Library Screen.

Besides that, I noticed that the `Library` and `GameList` was being re-rendered up to 4 times and causing the Gamecards to re-renders up to 6 times so I started on a hunt for what was causing that.
The root problem is the context provider, but also some bad practices when defining methods and using `useState` and `useEffect` as well.

So with this changes I was able to get a bit more performance on frontend, but ideally we need to change to a state management library like Redux so we can avoid all those re-renders that are related with the context.

The branch name implies that I wanted to implement a way of Virtualize the game list, that was the idea but I was not able to find a way of doing that yet. I tested a few libraries but, althought they were working in the sense of making the cards render only on viewPort, the other issues with the context were still making the whole list of games to load at once so were not making any difference in the end. I am still investigating on that though.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
