### PR TITLE
[Fix/Epic] Only delete `userInfo` key from configStore when logging out

### DIFF
--- a/src/backend/legendary/user.ts
+++ b/src/backend/legendary/user.ts
@@ -78,7 +78,7 @@ export class LegendaryUser {
     await ses.clearCache()
     await ses.clearAuthCache()
     await ses.clearHostResolverCache()
-    configStore.clear()
+    configStore.delete('userInfo')
     clearCache()
   }
 


### PR DESCRIPTION
When logging out from Legendary, we were **clearing out our entire configStore**, which in turn reset all settings and, since the `settings` key was no longer present in the store, lead to issues where this new functionality was used
As far as I can tell, the only thing that actually needs to be deleted when logging out is the `userInfo` key. So let's only delete that

Closes #1965

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
