### PR TITLE
[GOG] Retry GOG install info if invalid language

### DIFF
--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -1,3 +1,4 @@
+import { install } from 'frontend/helpers/library'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import { GOGUser } from './user'
 import {
@@ -316,7 +317,8 @@ export class GOGLibrary {
    */
   public async getInstallInfo(
     appName: string,
-    installPlatform = 'windows'
+    installPlatform = 'windows',
+    lang = 'en-US'
   ): Promise<GogInstallInfo | undefined> {
     const credentials = await GOGUser.getCredentials()
     if (!credentials) {
@@ -345,7 +347,7 @@ export class GOGLibrary {
       appName,
       '--token',
       `"${credentials.access_token}"`,
-      '--lang=en-US',
+      `--lang=${lang}`,
       '--os',
       installPlatform
     ]
@@ -383,6 +385,23 @@ export class GOGLibrary {
       })
       return
     }
+
+    // some games don't support `en-US`
+    if (!gogInfo.languages.includes(lang)) {
+      // if the game supports `en-us`, use it, else use the first valid language
+      const newLang = gogInfo.languages.includes('en-us')
+        ? 'en-us'
+        : gogInfo.languages[0]
+
+      // call itself with the new language and return
+      const infoWithLang = await this.getInstallInfo(
+        appName,
+        installPlatform,
+        newLang
+      )
+      return infoWithLang
+    }
+
     let libraryArray = libraryStore.get('games', []) as GameInfo[]
     let gameObjectIndex = libraryArray.findIndex(
       (value) => value.app_name === appName

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -1,4 +1,3 @@
-import { install } from 'frontend/helpers/library'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import { GOGUser } from './user'
 import {

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -293,45 +293,6 @@ export default function DownloadDialog({
   }, [installPath, gameInstallInfo?.manifest?.disk_size])
 
   useEffect(() => {
-    const getIinstallInfo = async () => {
-      const gameInstallInfo = await getInstallInfo(
-        appName,
-        runner,
-        platformToInstall
-      )
-
-      if (!gameInstallInfo) {
-        showDialogModal({
-          type: 'ERROR',
-          title: tr('box.error.generic.title', 'Error!'),
-          message: tr('box.error.generic.message', 'Something Went Wrong!')
-        })
-        backdropClick()
-        return
-      }
-
-      setGameInstallInfo(gameInstallInfo)
-      if (gameInstallInfo && 'languages' in gameInstallInfo.manifest) {
-        setInstallLanguages(gameInstallInfo.manifest.languages)
-        setInstallLanguage(
-          getInstallLanguage(gameInstallInfo.manifest.languages, i18n.languages)
-        )
-      }
-
-      if (platformToInstall === 'linux' && runner === 'gog') {
-        const installer_languages = await window.api.getGOGLinuxInstallersLangs(
-          appName
-        )
-        setInstallLanguages(installer_languages)
-        setInstallLanguage(
-          getInstallLanguage(installer_languages, i18n.languages)
-        )
-      }
-    }
-    getIinstallInfo()
-  }, [appName, i18n.languages, platformToInstall])
-
-  useEffect(() => {
     const getCacheInfo = async () => {
       if (gameInfo) {
         setIsLinuxNative(gameInfo.is_linux_native && isLinux)


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2112 (and probably that problem for other games).

We were passing `en-US` for all games when getting the download info, but some games like Roller Coaster Tycoon display `0`. When using `en-us` it works fine.

What this PR is doing is:
- first try with `en-US` (most games are fine with this from my tests)
- if the list of languages in the install info does NOT include `en-US`, check which languages are valid
- if `en-us` is a valid language, use it, else, use the first language in the list

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
