### PR TITLE
[Logs] Add GOGdl and Legendary verbose log for any command output for better troubleshooting

### DIFF
--- a/src/backend/__tests__/utils.test.ts
+++ b/src/backend/__tests__/utils.test.ts
@@ -4,7 +4,7 @@ jest.mock('../logger/logger', () => {
   const original = jest.requireActual('../logger/logger')
   return {
     ...original,
-    createNewLogFileAndClearOldOnces: jest.fn().mockReturnValue('')
+    createNewLogFileAndClearOldOnes: jest.fn().mockReturnValue('')
   }
 })
 

--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -6,7 +6,7 @@ import { parse } from '@node-steam/vdf'
 
 import { GameConfigVersion, GlobalConfigVersion } from 'common/types'
 import { logDebug, LogPrefix } from './logger/logger'
-import { createNewLogFileAndClearOldOnces } from './logger/logfile'
+import { createNewLogFileAndClearOldOnes } from './logger/logfile'
 import { env } from 'process'
 import { app } from 'electron'
 import { existsSync, readFileSync } from 'graceful-fs'
@@ -54,8 +54,8 @@ const heroicDefaultWinePrefix = join(homedir(), 'Games', 'Heroic', 'Prefixes')
 const heroicAnticheatDataPath = join(heroicFolder, 'areweanticheatyet.json')
 const imagesCachePath = join(heroicFolder, 'images-cache')
 
-const { currentLogFile: currentLogFile, lastLogFile: lastLogFile } =
-  createNewLogFileAndClearOldOnces()
+const { currentLogFile, lastLogFile, legendaryLogFile, gogdlLogFile } =
+  createNewLogFileAndClearOldOnes()
 
 const publicDir = resolve(__dirname, '..', app.isPackaged ? '' : '../public')
 const icon = fixAsarPath(join(publicDir, 'icon.png'))
@@ -180,6 +180,8 @@ export {
   currentGlobalConfigVersion,
   currentLogFile,
   lastLogFile,
+  legendaryLogFile,
+  gogdlLogFile,
   discordLink,
   execOptions,
   fixAsarPath,

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -950,7 +950,7 @@ export async function runGogdlCommand(
     abortController,
     {
       ...options,
-      runnerStdoutLog: gogdlLogFile
+      verboseLogFile: gogdlLogFile
     }
   )
 }

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -20,7 +20,7 @@ import { existsSync, readFileSync } from 'graceful-fs'
 
 import { logError, logInfo, LogPrefix, logWarning } from '../logger/logger'
 import { getGOGdlBin, getFileSize } from '../utils'
-import { fallBackImage } from '../constants'
+import { fallBackImage, gogdlLogFile } from '../constants'
 import {
   apiInfoCache,
   libraryStore,
@@ -948,6 +948,9 @@ export async function runGogdlCommand(
     commandParts,
     { name: 'gog', logPrefix: LogPrefix.Gog, bin, dir },
     abortController,
-    options
+    {
+      ...options,
+      runnerStdoutLog: gogdlLogFile
+    }
   )
 }

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -674,6 +674,13 @@ async function callRunner(
     })
   }
 
+  if (options?.verboseLogFile) {
+    appendFileSync(
+      options.verboseLogFile,
+      `[${new Date().toLocaleString()}] ${safeCommand}\n`
+    )
+  }
+
   if (options?.logFile && existsSync(options.logFile)) {
     writeFileSync(options.logFile, '')
   }
@@ -705,6 +712,10 @@ async function callRunner(
         appendFileSync(options.logFile, data)
       }
 
+      if (options?.verboseLogFile) {
+        appendFileSync(options.verboseLogFile, data)
+      }
+
       if (options?.onOutput) {
         options.onOutput(data, child)
       }
@@ -716,6 +727,10 @@ async function callRunner(
     child.stderr.on('data', (data: string) => {
       if (options?.logFile) {
         appendFileSync(options.logFile, data)
+      }
+
+      if (options?.verboseLogFile) {
+        appendFileSync(options.verboseLogFile, data)
       }
 
       if (options?.onOutput) {
@@ -735,13 +750,6 @@ async function callRunner(
 
       if (signal && !child.killed) {
         rej('Process terminated with signal ' + signal)
-      }
-
-      if (options?.runnerStdoutLog) {
-        const f = options.runnerStdoutLog
-        appendFileSync(f, `[${new Date().toLocaleString()}] ${safeCommand}\n`)
-        appendFileSync(f, stdout.join('\n') + '\n\n')
-        appendFileSync(f, stderr.join('\n') + '\n\n')
       }
 
       res({

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -737,6 +737,13 @@ async function callRunner(
         rej('Process terminated with signal ' + signal)
       }
 
+      if (options?.runnerStdoutLog) {
+        const f = options.runnerStdoutLog
+        appendFileSync(f, `[${new Date().toLocaleString()}] ${safeCommand}\n`)
+        appendFileSync(f, stdout.join('\n') + '\n\n')
+        appendFileSync(f, stderr.join('\n') + '\n\n')
+      }
+
       res({
         stdout: stdout.join('\n'),
         stderr: stderr.join('\n')

--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -27,6 +27,7 @@ import {
 import {
   fallBackImage,
   legendaryConfigPath,
+  legendaryLogFile,
   legendaryMetadata
 } from '../constants'
 import {
@@ -610,6 +611,9 @@ export async function runLegendaryCommand(
     commandParts,
     { name: 'legendary', logPrefix: LogPrefix.Legendary, bin, dir },
     abortController,
-    options
+    {
+      ...options,
+      runnerStdoutLog: legendaryLogFile
+    }
   )
 }

--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -613,7 +613,7 @@ export async function runLegendaryCommand(
     abortController,
     {
       ...options,
-      runnerStdoutLog: legendaryLogFile
+      verboseLogFile: legendaryLogFile
     }
   )
 }

--- a/src/backend/logger/__mocks__/logfile.ts
+++ b/src/backend/logger/__mocks__/logfile.ts
@@ -1,6 +1,6 @@
 const logfile = jest.requireActual('../logfile')
 
-logfile.createNewLogFileAndClearOldOnces = jest.fn().mockReturnValue('')
+logfile.createNewLogFileAndClearOldOnes = jest.fn().mockReturnValue('')
 logfile.appendMessageToLogFile = jest.fn()
 
 module.exports = logfile

--- a/src/backend/logger/__tests__/logfile.test.ts
+++ b/src/backend/logger/__tests__/logfile.test.ts
@@ -34,11 +34,11 @@ describe('logger/logfile.ts', () => {
     tmpDir.removeCallback()
   })
 
-  test('createNewLogFileAndClearOldOnces fails because logDir does not exist', () => {
+  test('createNewLogFileAndClearOldOnes fails because logDir does not exist', () => {
     const spyAppGetPath = jest.spyOn(app, 'getPath').mockReturnValue('invalid')
     const spyOpenSync = jest.spyOn(graceful_fs, 'openSync')
 
-    logfile.createNewLogFileAndClearOldOnces()
+    logfile.createNewLogFileAndClearOldOnes()
 
     expect(spyOpenSync).toBeCalledWith(
       expect.stringContaining('invalid/heroic-'),
@@ -56,7 +56,7 @@ describe('logger/logfile.ts', () => {
     )
   })
 
-  test('createNewLogFileAndClearOldOnces success', () => {
+  test('createNewLogFileAndClearOldOnes success', () => {
     jest.spyOn(app, 'getPath').mockReturnValue(tmpDir.name)
     jest.spyOn(configStore, 'has').mockReturnValue(true)
     jest.spyOn(configStore, 'get').mockReturnValue({
@@ -64,16 +64,18 @@ describe('logger/logfile.ts', () => {
       lastLogFile: undefined
     })
 
-    const data = logfile.createNewLogFileAndClearOldOnces()
+    const data = logfile.createNewLogFileAndClearOldOnes()
 
     expect(logError).not.toBeCalled()
     expect(data).toStrictEqual({
       currentLogFile: expect.any(String),
-      lastLogFile: 'old/log/path/file.log'
+      lastLogFile: 'old/log/path/file.log',
+      legendaryLogFile: expect.any(String),
+      gogdlLogFile: expect.any(String)
     })
   })
 
-  test('createNewLogFileAndClearOldOnces removing old logs fails', () => {
+  test('createNewLogFileAndClearOldOnes removing old logs fails', () => {
     jest.spyOn(app, 'getPath').mockReturnValue(tmpDir.name)
     const spyUnlinkSync = jest
       .spyOn(graceful_fs, 'unlinkSync')
@@ -81,7 +83,7 @@ describe('logger/logfile.ts', () => {
         throw Error('unlink failed')
       })
     const date = new Date()
-    date.setMonth(date.getMonth() > 0 ? date.getMonth() - 1 : 11)
+    date.setMonth(date.getMonth() - 1)
     const monthOutdatedLogFile = join(
       tmpDir.name,
       // @ts-ignore replaceAll error
@@ -92,7 +94,7 @@ describe('logger/logfile.ts', () => {
 
     expect(graceful_fs.existsSync(monthOutdatedLogFile)).toBeTruthy()
 
-    const data = logfile.createNewLogFileAndClearOldOnces()
+    const data = logfile.createNewLogFileAndClearOldOnes()
 
     expect(logError).toBeCalledWith(
       [
@@ -104,7 +106,7 @@ describe('logger/logfile.ts', () => {
     expect(graceful_fs.existsSync(monthOutdatedLogFile)).toBeTruthy()
   })
 
-  test('createNewLogFileAndClearOldOnces removing old logs successful', () => {
+  test('createNewLogFileAndClearOldOnes removing old logs successful', () => {
     jest.spyOn(app, 'getPath').mockReturnValue(tmpDir.name)
     const date = new Date()
     date.setMonth(date.getMonth() > 0 ? date.getMonth() - 1 : 11)
@@ -126,7 +128,7 @@ describe('logger/logfile.ts', () => {
     expect(graceful_fs.existsSync(monthOutdatedLogFile)).toBeTruthy()
     expect(graceful_fs.existsSync(yearOutdatedLogFile)).toBeTruthy()
 
-    const data = logfile.createNewLogFileAndClearOldOnces()
+    const data = logfile.createNewLogFileAndClearOldOnes()
 
     expect(logError).not.toBeCalled()
     expect(graceful_fs.existsSync(monthOutdatedLogFile)).toBeFalsy()

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -338,6 +338,7 @@ export interface RpcClient {
 export interface CallRunnerOptions {
   logMessagePrefix?: string
   logFile?: string
+  runnerStdoutLog?: string
   env?: Record<string, string> | NodeJS.ProcessEnv
   wrappers?: string[]
   onOutput?: (output: string, child: ChildProcess) => void

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -338,7 +338,7 @@ export interface RpcClient {
 export interface CallRunnerOptions {
   logMessagePrefix?: string
   logFile?: string
-  runnerStdoutLog?: string
+  verboseLogFile?: string
   env?: Record<string, string> | NodeJS.ProcessEnv
   wrappers?: string[]
   onOutput?: (output: string, child: ChildProcess) => void


### PR DESCRIPTION
This PR adds new log files to store all the output of Legendary and GOGdl.

The new files are stored next to heroic's general logs but the names are `legendary-....log` and `gogdl-.....log` instead of `heroic-....log` and the same logic to delete old logs still applies to these new ones.

There's no frontend view of these logs but they can be accessed using the same `Show log file in folder` button for the general logs.

I also fixed an issue where logs were being deleted when the month changed instead of when they were a month old (the 1st of each month it was we were deleting all files from last month).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
