### PR TITLE
[Library] Disable Play button while launching game

### DIFF
--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -329,7 +329,8 @@
   font-size: 40px;
 }
 
-.iconDisabled circle {
+.iconDisabled circle,
+.svg-button[disabled] circle {
   fill: var(--icon-disabled);
 }
 

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -97,11 +97,12 @@ const GameCard = ({
   // if the game supports cloud saves, check the config
   const [autoSyncSaves, setAutoSyncSaves] = useState(hasCloudSave)
   useEffect(() => {
+    const checkGameConfig = async () => {
+      const settings = await window.api.requestGameSettings(appName)
+      setAutoSyncSaves(settings.autoSyncSaves)
+    }
     if (hasCloudSave) {
-      ;(async () => {
-        const settings = await window.api.requestGameSettings(appName)
-        setAutoSyncSaves(settings.autoSyncSaves)
-      })()
+      checkGameConfig()
     }
   }, [appName])
 


### PR DESCRIPTION
This is a workaround for https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2115

There are two changes:
- added a new `isLaunching` state in the card component to be able to disable the button while we wait for the game to start (we should detect that it's doing a save sync and show that in the UI)
- only do sync saves if the user enables the option instead

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
