### PR TITLE
[Fix] Save sync for native games

### DIFF
--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -648,9 +648,7 @@ export class GOGLibrary {
       app_name: String(info.id),
       art_cover: horizontalCover,
       art_square: verticalCover,
-      cloud_save_enabled: cloudSavesEnabledGames.includes(
-        String(info.id)
-      ) as never,
+      cloud_save_enabled: cloudSavesEnabledGames.includes(String(info.id)),
       extra: {
         about: { description: description, longDescription: '' },
         reqs: []

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -648,7 +648,9 @@ export class GOGLibrary {
       app_name: String(info.id),
       art_cover: horizontalCover,
       art_square: verticalCover,
-      cloud_save_enabled: cloudSavesEnabledGames.includes(String(info.id)),
+      cloud_save_enabled: cloudSavesEnabledGames.includes(
+        String(info.id)
+      ) as never,
       extra: {
         about: { description: description, longDescription: '' },
         reqs: []

--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -484,7 +484,6 @@ export class LegendaryLibrary {
     } = metadata
 
     const dlcs: string[] = []
-    const CloudSaveFolder = customAttributes?.CloudSaveFolder
     const FolderName = customAttributes?.FolderName
     const canRunOffline = customAttributes?.CanRunOffline?.value === 'true'
     const thirdPartyManagedApp =
@@ -498,8 +497,22 @@ export class LegendaryLibrary {
       })
     }
 
-    const cloud_save_enabled = Boolean(CloudSaveFolder?.value)
-    const saveFolder = cloud_save_enabled ? CloudSaveFolder.value : ''
+    const info = this.installedGames.get(app_name)
+    const {
+      executable,
+      version,
+      install_size,
+      install_path,
+      platform,
+      save_path
+    } = info ?? {}
+
+    let saveFolder
+    if (platform === 'Mac') {
+      saveFolder = customAttributes.CloudSaveFolder_MAC?.value
+    } else {
+      saveFolder = customAttributes.CloudSaveFolder?.value
+    }
     const installFolder = FolderName ? FolderName.value : app_name
 
     const gameBox = keyImages.find(({ type }) => type === 'DieselGameBox')
@@ -519,16 +532,6 @@ export class LegendaryLibrary {
     const art_square = gameBoxTall ? gameBoxTall.url : undefined
     const art_square_front = gameBoxStore ? gameBoxStore.url : undefined
 
-    const info = this.installedGames.get(app_name)
-    const {
-      executable,
-      version,
-      install_size,
-      install_path,
-      platform,
-      save_path
-    } = info ?? {}
-
     const is_dlc = Boolean(metadata.mainGameItem)
 
     const convertedSize = install_size ? getFileSize(Number(install_size)) : '0'
@@ -538,7 +541,8 @@ export class LegendaryLibrary {
       art_cover: art_cover || art_square || fallBackImage,
       art_logo,
       art_square: art_square || art_square_front || art_cover || fallBackImage,
-      cloud_save_enabled,
+      // TODO: Figure out how to make TS happy here
+      cloud_save_enabled: (typeof saveFolder !== 'undefined') as never,
       developer,
       extra: {
         about: {
@@ -561,7 +565,8 @@ export class LegendaryLibrary {
       is_mac_native: info
         ? platform === 'Mac'
         : releaseInfo[0].platform.includes('Mac'),
-      save_folder: saveFolder,
+      // TODO: Same as above
+      save_folder: saveFolder as never,
       save_path,
       title,
       canRunOffline,

--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -507,12 +507,10 @@ export class LegendaryLibrary {
       save_path
     } = info ?? {}
 
-    let saveFolder
-    if (platform === 'Mac') {
-      saveFolder = customAttributes.CloudSaveFolder_MAC?.value
-    } else {
-      saveFolder = customAttributes.CloudSaveFolder?.value
-    }
+    const saveFolder =
+      (platform === 'Mac'
+        ? customAttributes.CloudSaveFolder_MAC?.value
+        : customAttributes.CloudSaveFolder?.value) ?? ''
     const installFolder = FolderName ? FolderName.value : app_name
 
     const gameBox = keyImages.find(({ type }) => type === 'DieselGameBox')
@@ -541,8 +539,7 @@ export class LegendaryLibrary {
       art_cover: art_cover || art_square || fallBackImage,
       art_logo,
       art_square: art_square || art_square_front || art_cover || fallBackImage,
-      // TODO: Figure out how to make TS happy here
-      cloud_save_enabled: (typeof saveFolder !== 'undefined') as never,
+      cloud_save_enabled: Boolean(saveFolder),
       developer,
       extra: {
         about: {
@@ -565,8 +562,7 @@ export class LegendaryLibrary {
       is_mac_native: info
         ? platform === 'Mac'
         : releaseInfo[0].platform.includes('Mac'),
-      // TODO: Same as above
-      save_folder: saveFolder as never,
+      save_folder: saveFolder,
       save_path,
       title,
       canRunOffline,

--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -66,9 +66,10 @@ async function getDefaultLegendarySavePath(appName: string): Promise<string> {
     }
   }
 
-  await verifyWinePrefix(await game.getSettings())
+  if (!game.isNative()) {
+    await verifyWinePrefix(await game.getSettings())
+  }
 
-  // If Legendary doesn't have a save folder set yet, run it & accept its generated path
   logInfo(['Computing default save path for', appName], {
     prefix: LogPrefix.Legendary
   })
@@ -84,7 +85,7 @@ async function getDefaultLegendarySavePath(appName: string): Promise<string> {
     createAbortController(abortControllerName),
     {
       logMessagePrefix: 'Getting default save path',
-      env: setupWineEnvVars(await game.getSettings())
+      env: game.isNative() ? {} : setupWineEnvVars(await game.getSettings())
     }
   )
   deleteAbortController(abortControllerName)

--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -98,7 +98,9 @@ async function getDefaultLegendarySavePath(appName: string): Promise<string> {
     logError(['Unable to compute default save path for', appName], {
       prefix: LogPrefix.Legendary
     })
-    return save_folder
+    // NOTE: save_folder can only be undefined if the game doesn't support save sync. If that would be the case, we wouldn't
+    //       be here, so this `?? ''` is only here to make TS happy
+    return save_folder ?? ''
   }
   logInfo(['Computed save path:', new_save_path], {
     prefix: LogPrefix.Legendary

--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -98,9 +98,7 @@ async function getDefaultLegendarySavePath(appName: string): Promise<string> {
     logError(['Unable to compute default save path for', appName], {
       prefix: LogPrefix.Legendary
     })
-    // NOTE: save_folder can only be undefined if the game doesn't support save sync. If that would be the case, we wouldn't
-    //       be here, so this `?? ''` is only here to make TS happy
-    return save_folder ?? ''
+    return save_folder
   }
   logInfo(['Computed save path:', new_save_path], {
     prefix: LogPrefix.Legendary

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -86,31 +86,41 @@ export interface ExtraInfo {
 }
 
 export type GameConfigVersion = 'auto' | 'v0' | 'v0.1'
-export interface GameInfo {
+
+export type GameInfo = {
   runner: Runner
   store_url: string
   app_name: string
   art_cover: string
   art_logo?: string
   art_square: string
-  cloud_save_enabled: boolean
   developer: string
   extra: ExtraInfo
   folder_name: string
   install: Partial<InstalledInfo>
   is_installed: boolean
   namespace: string
-  // NOTE: This is the save folder without any variables filled in...
-  save_folder: string
-  // ...and this is the folder with them filled in
-  save_path?: string
   gog_save_location?: GOGCloudSavesLocation[]
   title: string
   canRunOffline: boolean
   thirdPartyManagedApp: string | undefined
   is_mac_native: boolean
   is_linux_native: boolean
-}
+} & (
+  | {
+      cloud_save_enabled: false
+      save_folder?: undefined
+      save_path?: undefined
+    }
+  | {
+      cloud_save_enabled: true
+      // NOTE: This is the save folder without any variables filled in...
+      save_folder: string
+      // ...and this is the folder with them filled in
+      save_path?: string
+    }
+)
+
 export interface GameSettings {
   autoInstallDxvk: boolean
   autoInstallVkd3d: boolean

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -87,39 +87,31 @@ export interface ExtraInfo {
 
 export type GameConfigVersion = 'auto' | 'v0' | 'v0.1'
 
-export type GameInfo = {
+export interface GameInfo {
   runner: Runner
   store_url: string
   app_name: string
   art_cover: string
   art_logo?: string
   art_square: string
+  cloud_save_enabled: boolean
   developer: string
   extra: ExtraInfo
   folder_name: string
   install: Partial<InstalledInfo>
   is_installed: boolean
   namespace: string
+  // NOTE: This is the save folder without any variables filled in...
+  save_folder: string
+  // ...and this is the folder with them filled in
+  save_path?: string
   gog_save_location?: GOGCloudSavesLocation[]
   title: string
   canRunOffline: boolean
   thirdPartyManagedApp: string | undefined
   is_mac_native: boolean
   is_linux_native: boolean
-} & (
-  | {
-      cloud_save_enabled: false
-      save_folder?: undefined
-      save_path?: undefined
-    }
-  | {
-      cloud_save_enabled: true
-      // NOTE: This is the save folder without any variables filled in...
-      save_folder: string
-      // ...and this is the folder with them filled in
-      save_path?: string
-    }
-)
+}
 
 export interface GameSettings {
   autoInstallDxvk: boolean

--- a/src/common/types/legendary.ts
+++ b/src/common/types/legendary.ts
@@ -49,9 +49,11 @@ interface GameMetadataInner {
   // TODO: So far every age gating has been {}
   ageGatings: Record<string, unknown>
   applicationId: string
-  categories: Record<'path', string>[]
+  categories: { path: string }[]
   creationDate: string
-  customAttributes: Record<CustomAttributeType, CustomAttributeValue>
+  customAttributes: {
+    [key in CustomAttributeType]: CustomAttributeValue | undefined
+  }
   description: string
   developer: string
   developerId: string
@@ -82,6 +84,7 @@ type CustomAttributeType =
   | 'CanSkipKoreanIdVerification'
   | 'CloudIncludeList'
   | 'CloudSaveFolder'
+  | 'CloudSaveFolder_MAC'
   | 'FolderName'
   | 'HasGateKeeper'
   | 'LaunchSocialOnFirstInstall'


### PR DESCRIPTION
- No longer `verifyWinePrefix` if the game is native
- No longer pass `setupWineEnvVars(...)` to Legendary if the game is native
- Store correct default save folder on Mac

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
