### PR TITLE
[Tech] Adds useLibrary hook to manage the library

### DIFF
--- a/src/frontend/components/UI/SearchBar/index.tsx
+++ b/src/frontend/components/UI/SearchBar/index.tsx
@@ -11,6 +11,7 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import './index.css'
 import { faXmark } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import useLibrary from 'frontend/hooks/useLibrary'
 
 function fixFilter(text: string) {
   const regex = new RegExp(/([?\\|*|+|(|)|[|]|])+/, 'g')
@@ -18,14 +19,14 @@ function fixFilter(text: string) {
 }
 
 export default React.memo(function SearchBar() {
-  const { handleSearch, filterText, epic, gog, sideloadedLibrary } =
-    useContext(ContextProvider)
+  const { handleSearch, filterText } = useContext(ContextProvider)
+  const gamesLibrary = useLibrary({ category: 'all' })
   const { t } = useTranslation()
   const input = useRef<HTMLInputElement>(null)
 
   const list = useMemo(() => {
     const library = new Set(
-      [...epic.library, ...gog.library, ...sideloadedLibrary]
+      [...gamesLibrary]
         .filter(Boolean)
         .map((g) => g.title)
         .sort()
@@ -33,7 +34,7 @@ export default React.memo(function SearchBar() {
     return [...library].filter((i) =>
       new RegExp(fixFilter(filterText), 'i').test(i)
     )
-  }, [epic.library, gog.library, filterText])
+  }, [gamesLibrary, filterText])
 
   // we have to use an event listener instead of the react
   // onChange callback so it works with the virtual keyboard

--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -23,6 +23,7 @@ import { Runner, GameInfo } from 'common/types'
 import './index.css'
 import QuitButton from '../QuitButton'
 import { LocationState } from 'frontend/types'
+import useLibrary from 'frontend/hooks/useLibrary'
 
 type PathSplit = [
   a: undefined,
@@ -41,6 +42,7 @@ export default function SidebarLinks() {
   const { state } = useLocation() as { state: LocationState }
   const location = useLocation() as { pathname: string }
   const [, , runner, appName, type] = location.pathname.split('/') as PathSplit
+  const gamesLibrary = useLibrary({ category: 'all' })
 
   const { epic, gog, platform, activeController, refreshLibrary } =
     useContext(ContextProvider)
@@ -94,8 +96,8 @@ export default function SidebarLinks() {
     localStorage.setItem('scrollPosition', '0')
 
     const shouldRefresh =
-      (epic.username && !epic.library.length) ||
-      (gog.username && !gog.library.length)
+      (epic.username && !gamesLibrary.length) ||
+      (gog.username && !gamesLibrary.length)
     if (shouldRefresh) {
       return refreshLibrary({ runInBackground: true, fullRefresh: true })
     }

--- a/src/frontend/components/UI/UninstallModal/index.tsx
+++ b/src/frontend/components/UI/UninstallModal/index.tsx
@@ -19,7 +19,8 @@ interface UninstallModalProps {
 }
 
 const UninstallModal: React.FC<UninstallModalProps> = function (props) {
-  const { handleGameStatus, platform } = useContext(ContextProvider)
+  const { handleGameStatus, platform, refreshLibrary } =
+    useContext(ContextProvider)
   const [isWindowsOnLinux, setIsWindowsOnLinux] = useState(false)
   const [winePrefix, setWinePrefix] = useState('')
   const [checkboxChecked, setCheckboxChecked] = useState(false)
@@ -77,6 +78,7 @@ const UninstallModal: React.FC<UninstallModalProps> = function (props) {
       runner: props.runner,
       status: 'done'
     })
+    refreshLibrary({ fullRefresh: true, runInBackground: true })
   }
 
   return (

--- a/src/frontend/hooks/useLibrary.ts
+++ b/src/frontend/hooks/useLibrary.ts
@@ -23,7 +23,10 @@ const useLibrary = ({ category }: Props): Array<GameInfo> => {
 
   const getLibrary = (): Array<GameInfo> => {
     const games = gogLibraryStore.get('games', []) as GameInfo[]
-    const installedGames = gogInstalledGamesStore.get('installed', []) as Array<InstalledInfo>
+    const installedGames = gogInstalledGamesStore.get(
+      'installed',
+      []
+    ) as Array<InstalledInfo>
     for (const igame in games) {
       for (const installedGame of installedGames) {
         if (installedGame.appName === games[igame].app_name) {

--- a/src/frontend/hooks/useLibrary.ts
+++ b/src/frontend/hooks/useLibrary.ts
@@ -1,0 +1,72 @@
+import { Category } from 'frontend/types'
+import React from 'react'
+
+import { GameInfo, InstalledInfo } from 'common/types'
+import {
+  gogLibraryStore,
+  gogInstalledGamesStore,
+  sideloadLibrary,
+  libraryStore
+} from 'frontend/helpers/electronStores'
+
+type Props = {
+  category: Category
+}
+
+const useLibrary = ({ category }: Props): Array<GameInfo> => {
+  const [library, setLibrary] = React.useState<Array<GameInfo>>([])
+  const [gogLibrary, setGogLibrary] = React.useState<Array<GameInfo>>([])
+  const [epicLibrary, setEpicLibrary] = React.useState<Array<GameInfo>>([])
+  const [sideloadedLibrary, setSideloadedLibrary] = React.useState<
+    Array<GameInfo>
+  >([])
+
+  const getLibrary = (): Array<GameInfo> => {
+    const games = gogLibraryStore.has('games')
+      ? (gogLibraryStore.get('games', []) as GameInfo[])
+      : []
+    const installedGames =
+      (gogInstalledGamesStore.get('installed', []) as Array<InstalledInfo>) ||
+      []
+    for (const igame in games) {
+      for (const installedGame of installedGames) {
+        if (installedGame.appName === games[igame].app_name) {
+          games[igame].install = installedGame
+          games[igame].is_installed = true
+        }
+      }
+    }
+
+    return games
+  }
+
+  React.useEffect(() => {
+    setGogLibrary(getLibrary())
+    setEpicLibrary(libraryStore.get('library', []) as GameInfo[])
+    setSideloadedLibrary(sideloadLibrary.get('games', []) as GameInfo[])
+  }, [])
+
+  React.useEffect(() => {
+    switch (category) {
+      case 'all':
+        setLibrary([...gogLibrary, ...epicLibrary, ...sideloadedLibrary])
+        break
+      case 'gog':
+        setLibrary(gogLibrary)
+        break
+      case 'legendary':
+        setLibrary(epicLibrary)
+        break
+      case 'sideload':
+        setLibrary(sideloadedLibrary)
+        break
+      default:
+        setLibrary([])
+        break
+    }
+  }, [gogLibrary, epicLibrary, sideloadedLibrary, category])
+
+  return library
+}
+
+export default useLibrary

--- a/src/frontend/hooks/useLibrary.ts
+++ b/src/frontend/hooks/useLibrary.ts
@@ -21,7 +21,7 @@ const useLibrary = ({ category }: Props): Array<GameInfo> => {
     Array<GameInfo>
   >([])
 
-  const getLibrary = (): Array<GameInfo> => {
+  const getGogLibrary = (): Array<GameInfo> => {
     const games = gogLibraryStore.get('games', []) as GameInfo[]
     const installedGames = gogInstalledGamesStore.get(
       'installed',
@@ -40,7 +40,7 @@ const useLibrary = ({ category }: Props): Array<GameInfo> => {
   }
 
   React.useEffect(() => {
-    setGogLibrary(getLibrary())
+    setGogLibrary(getGogLibrary())
     setEpicLibrary(libraryStore.get('library', []) as GameInfo[])
     setSideloadedLibrary(sideloadLibrary.get('games', []) as GameInfo[])
   }, [])
@@ -58,9 +58,6 @@ const useLibrary = ({ category }: Props): Array<GameInfo> => {
         break
       case 'sideload':
         setLibrary(sideloadedLibrary)
-        break
-      default:
-        setLibrary([])
         break
     }
   }, [gogLibrary, epicLibrary, sideloadedLibrary, category])

--- a/src/frontend/hooks/useLibrary.ts
+++ b/src/frontend/hooks/useLibrary.ts
@@ -23,9 +23,7 @@ const useLibrary = ({ category }: Props): Array<GameInfo> => {
 
   const getLibrary = (): Array<GameInfo> => {
     const games = gogLibraryStore.get('games', []) as GameInfo[]
-    const installedGames =
-      (gogInstalledGamesStore.get('installed', []) as Array<InstalledInfo>) ||
-      []
+    const installedGames = gogInstalledGamesStore.get('installed', []) as Array<InstalledInfo>
     for (const igame in games) {
       for (const installedGame of installedGames) {
         if (installedGame.appName === games[igame].app_name) {

--- a/src/frontend/hooks/useLibrary.ts
+++ b/src/frontend/hooks/useLibrary.ts
@@ -22,9 +22,7 @@ const useLibrary = ({ category }: Props): Array<GameInfo> => {
   >([])
 
   const getLibrary = (): Array<GameInfo> => {
-    const games = gogLibraryStore.has('games')
-      ? (gogLibraryStore.get('games', []) as GameInfo[])
-      : []
+    const games = gogLibraryStore.get('games', []) as GameInfo[]
     const installedGames =
       (gogInstalledGamesStore.get('installed', []) as Array<InstalledInfo>) ||
       []

--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
@@ -20,6 +20,7 @@ import { LegendaryInstallInfo } from 'common/types/legendary'
 import { GogInstallInfo } from 'common/types/gog'
 import { ReactComponent as PlayIcon } from 'frontend/assets/play-icon.svg'
 import { ReactComponent as DownIcon } from 'frontend/assets/down-icon.svg'
+import useLibrary from 'frontend/hooks/useLibrary'
 
 type Props = {
   element?: DMQueueElement
@@ -38,9 +39,11 @@ function convertToTime(time: number) {
 }
 
 const DownloadManagerItem = ({ element, current }: Props) => {
-  const { epic, gog, showDialogModal } = useContext(ContextProvider)
+  const { showDialogModal } = useContext(ContextProvider)
   const { t } = useTranslation('gamepage')
   const { t: t2 } = useTranslation('translation')
+
+  const gamesLibrary = useLibrary({ category: 'all' })
 
   const navigate = useNavigate()
 
@@ -51,8 +54,6 @@ const DownloadManagerItem = ({ element, current }: Props) => {
       </h5>
     )
   }
-
-  const library = [...epic.library, ...gog.library]
 
   const { params, addToQueueTime, endTime, type, startTime } = element
   const {
@@ -173,7 +174,7 @@ const DownloadManagerItem = ({ element, current }: Props) => {
     return current ? 'var(--text-default)' : 'var(--accent)'
   }
 
-  const currentApp = library.find((val) => val.app_name === appName)
+  const currentApp = gamesLibrary.find((val) => val.app_name === appName)
 
   if (!currentApp) {
     return null

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -46,6 +46,7 @@ import {
 
 import StoreLogos from 'frontend/components/UI/StoreLogos'
 import HowLongToBeat from 'frontend/components/UI/HowLongToBeat'
+import useLibrary from 'frontend/hooks/useLibrary'
 
 export default React.memo(function GamePage(): JSX.Element | null {
   const { appName, runner } = useParams() as { appName: string; runner: Runner }
@@ -59,8 +60,10 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
   const [showModal, setShowModal] = useState({ game: '', show: false })
 
-  const { libraryStatus, epic, gog, gameUpdates, platform, showDialogModal } =
+  const { libraryStatus, gameUpdates, platform, showDialogModal } =
     useContext(ContextProvider)
+
+  const gamesLibrary = useLibrary({ category: runner })
 
   const { status } =
     libraryStatus.find((game) => game.appName === appName) || {}
@@ -126,7 +129,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       }
     }
     updateGameInfo()
-  }, [status, gog.library, epic.library])
+  }, [status, gamesLibrary])
 
   useEffect(() => {
     const updateConfig = async () => {
@@ -187,7 +190,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       }
     }
     updateConfig()
-  }, [status, epic.library, gog.library, gameInfo])
+  }, [status, gamesLibrary, gameInfo])
 
   function handleUpdate() {
     updateGame({ appName, runner, gameInfo })

--- a/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
+++ b/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
@@ -1,9 +1,9 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import ContextProvider from 'frontend/state/ContextProvider'
 import { GameInfo, RecentGame, Runner } from 'common/types'
 import GamesList from '../GamesList'
 import { configStore } from 'frontend/helpers/electronStores'
+import useLibrary from 'frontend/hooks/useLibrary'
 
 interface Props {
   handleModal: (appName: string, runner: Runner, gameInfo: GameInfo) => void
@@ -34,15 +34,12 @@ export default React.memo(function RecentlyPlayed({
   onlyInstalled
 }: Props) {
   const { t } = useTranslation()
-  const { epic, gog, sideloadedLibrary } = useContext(ContextProvider)
   const [recentGames, setRecentGames] = useState<GameInfo[]>([])
+  const gamesLibrary = useLibrary({ category: 'all' })
 
   const loadRecentGames = async () => {
     const { maxRecentGames } = await window.api.requestAppSettings()
-    const newRecentGames = getRecentGames(
-      [...epic.library, ...gog.library, ...sideloadedLibrary],
-      maxRecentGames
-    )
+    const newRecentGames = getRecentGames(gamesLibrary, maxRecentGames)
 
     setRecentGames(newRecentGames)
   }
@@ -60,7 +57,7 @@ export default React.memo(function RecentlyPlayed({
     return () => {
       recentGamesChangedRemoveListener()
     }
-  }, [epic.library, gog.library, sideloadedLibrary])
+  }, [gamesLibrary])
 
   if (!recentGames.length) {
     return null

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -27,12 +27,9 @@ import {
 } from 'common/types'
 import ErrorComponent from 'frontend/components/UI/ErrorComponent'
 import LibraryHeader from './components/LibraryHeader'
-import {
-  epicCategories,
-  gogCategories,
-  sideloadedCategories
-} from 'frontend/helpers/library'
+import { epicCategories, gogCategories } from 'frontend/helpers/library'
 import RecentlyPlayed from './components/RecentlyPlayed'
+import useLibrary from 'frontend/hooks/useLibrary'
 
 const InstallModal = lazy(
   async () => import('frontend/screens/Library/components/InstallModal')
@@ -56,7 +53,6 @@ export default React.memo(function Library(): JSX.Element {
     category,
     epic,
     gog,
-    sideloadedLibrary,
     favouriteGames,
     libraryTopSection,
     filterText,
@@ -67,6 +63,8 @@ export default React.memo(function Library(): JSX.Element {
     handleCategory,
     showFavourites: showFavouritesLibrary
   } = useContext(ContextProvider)
+
+  const gamesLibrary = useLibrary({ category })
 
   const [showModal, setShowModal] = useState<ModalState>({
     game: '',
@@ -202,13 +200,7 @@ export default React.memo(function Library(): JSX.Element {
       const favouriteAppNames = favouriteGames.list.map(
         (favourite: FavouriteGame) => favourite.appName
       )
-      epic.library.forEach((game: GameInfo) => {
-        if (favouriteAppNames.includes(game.app_name)) tempArray.push(game)
-      })
-      gog.library.forEach((game: GameInfo) => {
-        if (favouriteAppNames.includes(game.app_name)) tempArray.push(game)
-      })
-      sideloadedLibrary.forEach((game: GameInfo) => {
+      gamesLibrary.forEach((game: GameInfo) => {
         if (favouriteAppNames.includes(game.app_name)) tempArray.push(game)
       })
     }
@@ -223,14 +215,7 @@ export default React.memo(function Library(): JSX.Element {
         category === 'all' ? game : game?.runner === category
       )
     } else {
-      const isEpic = epic.username && epicCategories.includes(category)
-      const isGog = gog.username && gogCategories.includes(category)
-      const epicLibrary = isEpic ? epic.library : []
-      const gogLibrary = isGog ? gog.library : []
-      const sideloadedApps = sideloadedCategories.includes(category)
-        ? sideloadedLibrary
-        : []
-      library = [...sideloadedApps, ...epicLibrary, ...gogLibrary]
+      library = [...gamesLibrary]
     }
 
     // filter
@@ -285,8 +270,7 @@ export default React.memo(function Library(): JSX.Element {
     return [...library]
   }, [
     category,
-    epic.library,
-    gog.library,
+    gamesLibrary,
     filterText,
     filterPlatform,
     sortDescending,

--- a/src/frontend/state/ContextProvider.tsx
+++ b/src/frontend/state/ContextProvider.tsx
@@ -5,18 +5,15 @@ import { ContextType } from 'frontend/types'
 const initialContext: ContextType = {
   category: 'all',
   epic: {
-    library: [],
     username: null,
     login: async () => Promise.resolve(''),
     logout: async () => Promise.resolve()
   },
   gog: {
-    library: [],
     username: null,
     login: async () => Promise.resolve(''),
     logout: async () => Promise.resolve()
   },
-  sideloadedLibrary: [],
   wineVersions: [],
   error: false,
   filterText: '',

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -57,13 +57,11 @@ export interface ContextType {
   zoomPercent: number
   setZoomPercent: (newZoomPercent: number) => void
   epic: {
-    library: GameInfo[]
     username: string | null
     login: (sid: string) => Promise<string>
     logout: () => Promise<void>
   }
   gog: {
-    library: GameInfo[]
     username: string | null
     login: (token: string) => Promise<string>
     logout: () => Promise<void>
@@ -79,7 +77,6 @@ export interface ContextType {
   dialogModalOptions: DialogModalOptions
   showDialogModal: (options: DialogModalOptions) => void
   showResetDialog: () => void
-  sideloadedLibrary: GameInfo[]
   hideChangelogsOnStartup: boolean
   setHideChangelogsOnStartup: (value: boolean) => void
   lastChangelogShown: string | null


### PR DESCRIPTION
This PR adds a new hook called `useLibrary` so this way we can get rid of it on the context and improve the loading and avoid re-renders.
Most of the computation is done by the hook as well as changing the category.

the library component is still handling the other filters since I could not think the performance will improve by adding them to the hook, but we can discuss that to see what is the best approach.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
