### PR TITLE
include vite in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Otherwise, download the file ending in .dmg from the [latest release](https://gi
 
 This part will walk you through setting up a development environment so you can build Heroic binaries yourself or make changes to the code.
 
-1. Make sure Git, NodeJS, and Yarn are installed
+1. Make sure Git, NodeJS, Vite (via npm), and Yarn are installed
 2. Clone the repo and enter the cloned folder, for example with these commands:
 
    ```bash


### PR DESCRIPTION
fix for #2139

adds dependency vite to build instructions

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
