### PR TITLE
[FIX] Crossover not found on macOS

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -191,25 +191,30 @@ abstract class GlobalConfig {
     if (!isMac) {
       return wineSet
     }
-    const apps = readdirSync(`${userHome}/Applications/Wineskin`)
-    for (const app of apps) {
-      if (app.includes('.app')) {
-        const wineBin = `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/bin/wine64`
-        try {
-          const { stdout: out } = await execAsync(`'${wineBin}' --version`)
-          const version = out.split('\n')[0]
-          wineSet.add({
-            ...this.getWineExecs(wineBin),
-            lib: `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/lib`,
-            lib32: `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/lib`,
-            name: `Wineskin - ${version}`,
-            type: 'wine',
-            bin: wineBin
-          })
-        } catch (error) {
-          logError(`Error getting wine version for ${wineBin}`, {
-            prefix: LogPrefix.GlobalConfig
-          })
+    const wineSkinPath = `${userHome}/Applications/Wineskin`
+    if (existsSync(wineSkinPath)) {
+      const apps = readdirSync(wineSkinPath)
+      for (const app of apps) {
+        if (app.includes('.app')) {
+          const wineBin = `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/bin/wine64`
+          if (existsSync(wineBin)) {
+            try {
+              const { stdout: out } = await execAsync(`'${wineBin}' --version`)
+              const version = out.split('\n')[0]
+              wineSet.add({
+                ...this.getWineExecs(wineBin),
+                lib: `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/lib`,
+                lib32: `${userHome}/Applications/Wineskin/${app}/Contents/SharedSupport/wine/lib`,
+                name: `Wineskin - ${version}`,
+                type: 'wine',
+                bin: wineBin
+              })
+            } catch (error) {
+              logError(`Error getting wine version for ${wineBin}`, {
+                prefix: LogPrefix.GlobalConfig
+              })
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
The promise to get all wine versions for macOS was failing when no WineSkin folder was found due to a missing check to see if the folder exists or not.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
