### PR TITLE
[WineManager] Update wine item status after install/uninstall

### DIFF
--- a/src/backend/api/wine.ts
+++ b/src/backend/api/wine.ts
@@ -51,3 +51,12 @@ export const handleProgressOfWineManager = (
     ipcRenderer.removeListener('progressOfWineManager' + version, callback)
   }
 }
+
+export const handleWineVersionsUpdated = (
+  callback: () => void
+): (() => void) => {
+  ipcRenderer.on('wineVersionsUpdated', callback)
+  return () => {
+    ipcRenderer.removeListener('wineVersionsUpdated', callback)
+  }
+}

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -7,6 +7,7 @@ import Store from 'electron-store'
 import { existsSync, mkdirSync, rmSync } from 'graceful-fs'
 import { logError, logInfo, LogPrefix, logWarning } from '../../logger/logger'
 import { WineVersionInfo } from 'common/types'
+import { BrowserWindow } from 'electron'
 
 import {
   getAvailableVersions,
@@ -88,6 +89,7 @@ async function updateWineVersionInfos(
   }
 
   logInfo('wine versions updated', { prefix: LogPrefix.WineDownloader })
+  BrowserWindow.getAllWindows()[0].webContents.send('wineVersionsUpdated')
   return releases
 }
 
@@ -170,6 +172,8 @@ async function installWineVersion(
   logInfo(`Finished installation of wine version ${release.version}`, {
     prefix: LogPrefix.WineDownloader
   })
+
+  BrowserWindow.getAllWindows()[0].webContents.send('wineVersionsUpdated')
   return 'success'
 }
 
@@ -222,6 +226,8 @@ async function removeWineVersion(release: WineVersionInfo): Promise<boolean> {
   logInfo(`Removed wine version ${release.version} succesfully.`, {
     prefix: LogPrefix.WineDownloader
   })
+
+  BrowserWindow.getAllWindows()[0].webContents.send('wineVersionsUpdated')
   return true
 }
 

--- a/src/frontend/screens/WineManager/components/WineItem/index.tsx
+++ b/src/frontend/screens/WineManager/components/WineItem/index.tsx
@@ -1,12 +1,11 @@
 import './index.css'
 
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { WineVersionInfo } from 'common/types'
 import { ReactComponent as DownIcon } from 'frontend/assets/down-icon.svg'
 import { ReactComponent as StopIcon } from 'frontend/assets/stop-icon.svg'
 import { SvgButton } from 'frontend/components/UI'
-import ContextProvider from 'frontend/state/ContextProvider'
 import { useTranslation } from 'react-i18next'
 import { ProgressInfo, State } from 'heroic-wine-downloader'
 
@@ -27,7 +26,6 @@ const WineItem = ({
   type
 }: WineVersionInfo) => {
   const { t } = useTranslation()
-  const { refreshWineVersionInfo } = useContext(ContextProvider)
   const [progress, setProgress] = useState<{
     state: State
     progress: ProgressInfo
@@ -85,7 +83,6 @@ const WineItem = ({
             notify({ title: `${version}`, body: t('notify.install.canceled') })
             break
           case 'success':
-            refreshWineVersionInfo(false)
             notify({ title: `${version}`, body: t('notify.install.finished') })
             break
           default:
@@ -110,7 +107,6 @@ const WineItem = ({
       })
       .then((response) => {
         if (response) {
-          refreshWineVersionInfo(false)
           notify({ title: `${version}`, body: t('notify.uninstalled') })
         }
       })


### PR DESCRIPTION
This PR fixes #2159

After installing/uninstalling/refreshing, a message is sent from the backend to the frontend to re-read the store.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
