### PR TITLE
[Legendary] Handle cases where CustomAttributes is undefined when getting cloud saved folder

### DIFF
--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -479,8 +479,20 @@ export class LegendaryLibrary {
       developer,
       dlcItemList,
       releaseInfo,
-      customAttributes
+      customAttributes,
+      categories
     } = metadata
+
+    // skip mods from the library
+    if (categories.some(({ path }) => path === 'mods')) {
+      return false
+    }
+
+    if (!customAttributes) {
+      logWarning(['Incomplete metadata for', fileName, app_name], {
+        prefix: LogPrefix.Legendary
+      })
+    }
 
     const dlcs: string[] = []
     const FolderName = customAttributes?.FolderName

--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -508,8 +508,8 @@ export class LegendaryLibrary {
 
     const saveFolder =
       (platform === 'Mac'
-        ? customAttributes.CloudSaveFolder_MAC?.value
-        : customAttributes.CloudSaveFolder?.value) ?? ''
+        ? customAttributes?.CloudSaveFolder_MAC?.value
+        : customAttributes?.CloudSaveFolder?.value) ?? ''
     const installFolder = FolderName ? FolderName.value : app_name
 
     const gameBox = keyImages.find(({ type }) => type === 'DieselGameBox')

--- a/src/common/types/legendary.ts
+++ b/src/common/types/legendary.ts
@@ -51,7 +51,7 @@ interface GameMetadataInner {
   applicationId: string
   categories: { path: string }[]
   creationDate: string
-  customAttributes: {
+  customAttributes?: {
     [key in CustomAttributeType]: CustomAttributeValue | undefined
   }
   description: string


### PR DESCRIPTION
This PR should fix an issue reported over Discord:

```
09:41:30) ERROR:   [Legendary]:        TypeError: Cannot read properties of undefined (reading 'CloudSaveFolder')
    at R.loadFile (/app/bin/heroic/resources/app.asar/build/electron/main.d61a4184.js:35:12005)
    at /app/bin/heroic/resources/app.asar/build/electron/main.d61a4184.js:35:13035
    at Set.forEach (<anonymous>)
    at R.loadAll (/app/bin/heroic/resources/app.asar/build/electron/main.d61a4184.js:35:13018)
    at R.getGames (/app/bin/heroic/resources/app.asar/build/electron/main.d61a4184.js:35:7787)
    at /app/bin/heroic/resources/app.asar/build/electron/main.d61a4184.js:112:9238
    at node:electron/js2c/browser_init:193:567
    at EventEmitter.<anonymous> (node:electron/js2c/browser_init:165:11606)
    at EventEmitter.emit (node:events:527:28)
```

Looks like CustomAttributes can be undefined but we didn't consider that in the type definition so in some cases we use `CustomAttributes?....` and in some we don't.

This PR changes the type so it can be undefined and fixes some places to use the `?` conditional method call.

EDIT: after more research, some `games` in the library are actually mods and not complete games, so this PR also adds a quick filter to ignore those from now

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
