### PR TITLE
[UI/UX] Cache HowLongtoBeat Data and move squares down

### DIFF
--- a/src/backend/howlongtobeat/electronStores.ts
+++ b/src/backend/howlongtobeat/electronStores.ts
@@ -1,0 +1,7 @@
+import Store from 'electron-store'
+
+export const howLongToBeatStore = new Store({
+  cwd: 'store',
+  name: 'howlongtobeat',
+  clearInvalidConfig: true
+})

--- a/src/backend/howlongtobeat/utils.ts
+++ b/src/backend/howlongtobeat/utils.ts
@@ -18,7 +18,7 @@ export async function getHowLongToBeat(
       return cachedResponse as HowLongToBeatEntry
     }
 
-    logInfo([`Getting HowLongToBeat data for ${title}`, ''], {
+    logInfo(`Getting HowLongToBeat data for ${title}`, {
       prefix: LogPrefix.Backend
     })
 

--- a/src/backend/howlongtobeat/utils.ts
+++ b/src/backend/howlongtobeat/utils.ts
@@ -1,12 +1,35 @@
-import { logError, LogPrefix } from 'backend/logger/logger'
+import { logError, logInfo, LogPrefix } from 'backend/logger/logger'
+import { removeSpecialcharacters } from 'backend/utils'
 import { HowLongToBeatEntry, HowLongToBeatService } from 'howlongtobeat'
+import { howLongToBeatStore } from './electronStores'
 
 export async function getHowLongToBeat(
   title: string
 ): Promise<HowLongToBeatEntry | null> {
   try {
+    title = removeSpecialcharacters(title)
+
+    // check if we have a cached response
+    const cachedResponse = howLongToBeatStore.get(title)
+    if (cachedResponse) {
+      logInfo([`Using cached HowLongToBeat data for ${title}`, ''], {
+        prefix: LogPrefix.Backend
+      })
+      return cachedResponse as HowLongToBeatEntry
+    }
+
+    logInfo([`Getting HowLongToBeat data for ${title}`, ''], {
+      prefix: LogPrefix.Backend
+    })
+
     const hltb = new HowLongToBeatService()
     const results = await hltb.search(title)
+
+    if (results.length > 0) {
+      // cache response on electron store
+      howLongToBeatStore.set(title, results[0])
+    }
+
     return results[0]
   } catch (error) {
     logError(['Was not able to get HowLongToBeat data', error], {

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -397,7 +397,7 @@ async function errorHandler(
 }
 
 function removeSpecialcharacters(text: string): string {
-  const regexp = new RegExp('[:|/|*|?|<|>|\\|&|{|}|%|$|@|`|!|™|+]', 'gi')
+  const regexp = new RegExp(/[:|/|*|?|<|>|\\|&|{|}|%|$|@|`|!|™|+|'|"|®]/, 'gi')
   return text.replaceAll(regexp, '')
 }
 

--- a/src/frontend/components/UI/HowLongToBeat/index.tsx
+++ b/src/frontend/components/UI/HowLongToBeat/index.tsx
@@ -28,8 +28,8 @@ export default function HowLongToBeat({ title }: Props) {
     howLongToBeatInfo
 
   return (
-    <>
-      <h5>{t('howLongToBeat', 'How Long To Beat')}</h5>
+    <div>
+      <p>{t('howLongToBeat', 'How Long To Beat')}</p>
       <div className="howLongToBeat">
         <div className="howLongToBeat__square">
           <div className="howLongToBeat__square__title">
@@ -56,6 +56,6 @@ export default function HowLongToBeat({ title }: Props) {
           </div>
         </div>
       </div>
-    </>
+    </div>
   )
 }

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -321,8 +321,6 @@ export default React.memo(function GamePage(): JSX.Element | null {
                       : ''
                     : ''}
                 </div>
-                <HowLongToBeat title={title} />
-
                 {is_installed && showCloudSaveInfo && (
                   <div
                     style={{
@@ -507,6 +505,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                   </button>
                 )}
               </div>
+              <HowLongToBeat title={title} />
               {is_installed && (
                 <NavLink
                   to={`/settings/${runner}/${appName}/log`}


### PR DESCRIPTION
Moved the squares with the info a bit down since it was causing a annoying layout shift when opening the game page, even with cached data.

<img width="1057" alt="Screenshot 2022-12-11 at 16 49 49" src="https://user-images.githubusercontent.com/26871415/206913737-0103ae4d-f7d1-407e-89a7-405113b26aa5.png">

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
