### PR TITLE
[FIX] Not being able to change GOG saves path

### DIFF
--- a/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
@@ -108,7 +108,7 @@ export default function GOGSyncSaves({
               <TextInputWithIconField
                 htmlId="inputSavePath"
                 placeholder={t('setting.savefolder.placeholder')}
-                value={value.location}
+                value={gogSaves[index].location}
                 label={
                   t('settings.saves.label', 'Save Location:') + ' ' + value.name
                 }
@@ -141,19 +141,15 @@ export default function GOGSyncSaves({
                             title: t('box.sync.title')
                           })
                           .then((path) => {
-                            const saves = [...gogSaves]
-                            saves[index].location = path || ''
-                            setGogSaves(saves)
+                            setGogSaves([{ name: 'GOG', location: path || '' }])
                           })
                     : () => {
-                        const saves = [...gogSaves]
-                        saves[index].location = ''
-                        setGogSaves(saves)
+                        setGogSaves([{ name: 'GOG', location: '' }])
                       }
                 }
                 afterInput={
                   <span className="smallMessage">
-                    {gogSaves.length > 1
+                    {value.location.length > 1
                       ? t(
                           'setting.savefolder.warning',
                           'Please check twice if the path is correct'


### PR DESCRIPTION
Small fix, since 2.5.1 for some reason GOG saves were stuck, not sure if the best approach since I am assuming the selected path should always be the first element of the array. I mean, since the user defined it, so I believe that makes sense. But the auto discovery is working fine as well.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
