### PR TITLE
Theme selector in general settings

### DIFF
--- a/src/frontend/screens/Settings/sections/GeneralSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GeneralSettings/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import LanguageSelector from 'frontend/components/UI/LanguageSelector'
+import { ThemeSelector } from 'frontend/components/UI/ThemeSelector'
 import {
   CheckUpdatesOnStartup,
   CustomWineProton,
@@ -28,6 +29,8 @@ export default function GeneralSettings() {
       <h3 className="settingSubheader">{t('settings.navbar.general')}</h3>
 
       <LanguageSelector />
+
+      <ThemeSelector />
 
       <DefaultInstallPath />
 


### PR DESCRIPTION
This PR adds the theme-related options in the General Settings screen.

It was reported a few times that some people cannot find the theme selector because they expect it to be in the general settings and don't think it would be in the accessibility screen. With this change it shows in both places so it's in a common place for most users and it's also in the Accessibility screen for users that need to change the theme for accessibility reasons.

![image](https://user-images.githubusercontent.com/188464/206933046-ac9cebbb-bdd6-4508-a538-e2b6eb26d289.png)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
