### PR TITLE
[macOS] Add arm64 build

### DIFF
--- a/.github/workflows/build-prs-linux.yml
+++ b/.github/workflows/build-prs-linux.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install modules.
         run: yarn
       - name: Build artifacts.
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       - name: Upload AppImage.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux-appimage
           path: dist/Heroic-*.AppImage

--- a/.github/workflows/build-prs-mac.yml
+++ b/.github/workflows/build-prs-mac.yml
@@ -29,10 +29,12 @@ jobs:
       - name: Upload x64.
         uses: actions/upload-artifact@v3
         with:
+          name: mac-x64
           path: dist/Heroic*x64.dmg
           retention-days: 14
       - name: Upload ARM64.
         uses: actions/upload-artifact@v3
         with:
+        name: mac-arm64
           path: dist/Heroic*arm64.dmg
           retention-days: 14

--- a/.github/workflows/build-prs-mac.yml
+++ b/.github/workflows/build-prs-mac.yml
@@ -26,15 +26,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-      - name: Upload x64 DMG.
+      - name: Upload x64 ZIP.
         uses: actions/upload-artifact@v2
         with:
           name: mac-x64-build
-          path: dist/Heroic*x64.dmg
+          path: dist/Heroic*x64.zip
           retention-days: 14
-      - name: Upload ARM DMG.
+      - name: Upload ARM ZIP.
         uses: actions/upload-artifact@v2
         with:
           name: mac-arm64-build
-          path: dist/Heroic*arm64.dmg
+          path: dist/Heroic*arm64.zip
           retention-days: 14

--- a/.github/workflows/build-prs-mac.yml
+++ b/.github/workflows/build-prs-mac.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout repository.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install modules.
         run: yarn
       - name: Build artifacts.
@@ -26,15 +26,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-      - name: Upload x64 ZIP.
-        uses: actions/upload-artifact@v2
+      - name: Upload x64.
+        uses: actions/upload-artifact@v3
         with:
-          name: mac-x64-build
-          path: dist/Heroic*x64.zip
+          path: dist/Heroic*x64.dmg
           retention-days: 14
-      - name: Upload ARM ZIP.
-        uses: actions/upload-artifact@v2
+      - name: Upload ARM64.
+        uses: actions/upload-artifact@v3
         with:
-          name: mac-arm64-build
-          path: dist/Heroic*arm64.zip
+          path: dist/Heroic*arm64.dmg
           retention-days: 14

--- a/.github/workflows/build-prs-mac.yml
+++ b/.github/workflows/build-prs-mac.yml
@@ -26,15 +26,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-      - name: Upload x64 PKG.
+      - name: Upload x64 DMG.
         uses: actions/upload-artifact@v2
         with:
           name: mac-x64-build
-          path: dist/Heroic*x64.pkg
+          path: dist/Heroic*x64.dmg
           retention-days: 14
-      - name: Upload ARM PKG.
+      - name: Upload ARM DMG.
         uses: actions/upload-artifact@v2
         with:
           name: mac-arm64-build
-          path: dist/Heroic*arm64.pkg
+          path: dist/Heroic*arm64.dmg
           retention-days: 14

--- a/.github/workflows/build-prs-mac.yml
+++ b/.github/workflows/build-prs-mac.yml
@@ -26,9 +26,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-      - name: Upload DMG.
+      - name: Upload x64 PKG.
         uses: actions/upload-artifact@v2
         with:
-          name: mac-dmg
-          path: dist/Heroic*.dmg
+          name: mac-x64-build
+          path: dist/Heroic*x64.pkg
+          retention-days: 14
+      - name: Upload ARM PKG.
+        uses: actions/upload-artifact@v2
+        with:
+          name: mac-arm64-build
+          path: dist/Heroic*arm64.pkg
           retention-days: 14

--- a/.github/workflows/build-prs-mac.yml
+++ b/.github/workflows/build-prs-mac.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Upload ARM64.
         uses: actions/upload-artifact@v3
         with:
-        name: mac-arm64
+          name: mac-arm64
           path: dist/Heroic*arm64.dmg
           retention-days: 14

--- a/.github/workflows/build-prs-mac.yml
+++ b/.github/workflows/build-prs-mac.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - name: Checkout repository.
         uses: actions/checkout@v2

--- a/.github/workflows/build-prs-windows.yml
+++ b/.github/workflows/build-prs-windows.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install modules.
         run: npm i --legacy-peer-deps
       - name: Build artifacts.
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       - name: Upload EXE.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: win-portable
           path: dist/Heroic*.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           path: dist/Heroic-*.AppImage
           retention-days: 14
   build_mac:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - name: Checkout repository.
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,9 +59,13 @@ jobs:
         run: yarn
       - name: Build artifacts.
         run: yarn dist:mac --publish=never
-      - name: Upload DMG.
+      - name: Upload x64.
         uses: actions/upload-artifact@v3
         with:
-          name: mac-dmg
-          path: dist/Heroic*.dmg
+          path: dist/Heroic*x64.dmg
+          retention-days: 14
+      - name: Upload ARM64.
+        uses: actions/upload-artifact@v3
+        with:
+          path: dist/Heroic*arm64.dmg
           retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,10 +62,12 @@ jobs:
       - name: Upload x64.
         uses: actions/upload-artifact@v3
         with:
+          name: mac-x64
           path: dist/Heroic*x64.dmg
           retention-days: 14
       - name: Upload ARM64.
         uses: actions/upload-artifact@v3
         with:
+          name: mac-arm64
           path: dist/Heroic*arm64.dmg
           retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,17 +12,17 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install modules.
         run: npm i --legacy-peer-deps
       - name: Build artifacts.
         run: npm run dist:win portable
       - name: Upload EXE.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: win-portable
           path: dist/Heroic*.exe
@@ -31,17 +31,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install modules.
         run: yarn
       - name: Build artifacts.
         run: yarn dist:linux appimage --publish=never
       - name: Upload AppImage.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux-appimage
           path: dist/Heroic-*.AppImage
@@ -50,17 +50,17 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout repository.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install modules.
         run: yarn
       - name: Build artifacts.
         run: yarn dist:mac --publish=never
       - name: Upload DMG.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mac-dmg
           path: dist/Heroic*.dmg

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -9,10 +9,10 @@ jobs:
   codecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install modules.
         run: yarn
       - name: Check Typescript syntax

--- a/.github/workflows/draft-release-linux.yml
+++ b/.github/workflows/draft-release-linux.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - run: npm install --legacy-peer-deps
       - run: npm run release:linux
         env:

--- a/.github/workflows/draft-release-mac.yml
+++ b/.github/workflows/draft-release-mac.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   draft-releases:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/draft-release-mac.yml
+++ b/.github/workflows/draft-release-mac.yml
@@ -10,10 +10,10 @@ jobs:
   draft-releases:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - run: npm install --legacy-peer-deps
       - run: npm run release:mac
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install modules.
         run: yarn
       - name: Lint code.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository.
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install modules.
         run: yarn
       - name: Test

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     },
     "mac": {
       "artifactName": "${productName}-${version}-macOS-${arch}.${ext}",
-      "target": "zip",
+      "target": "dmg",
       "category": "public.app-category.games",
       "icon": "build/icon.icns",
       "asarUnpack": [

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     },
     "mac": {
       "artifactName": "${productName}-${version}-macOS-${arch}.${ext}",
-      "target": "dmg",
+      "target": "zip",
       "category": "public.app-category.games",
       "icon": "build/icon.icns",
       "asarUnpack": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
       "artifactName": "${productName}-${version}-Portable.${ext}"
     },
     "mac": {
-      "target": "dmg",
+      "artifactName": "${productName}-${version}-macOS-${arch}.${ext}",
+      "target": "pkg",
       "category": "public.app-category.games",
       "icon": "build/icon.icns",
       "asarUnpack": [

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "release:mac": "vite build && electron-builder -p always --mac",
     "release:win": "vite build && electron-builder -p always --win nsis portable",
     "dist:linux": "vite build && electron-builder --linux",
-    "dist:mac": "vite build && electron-builder --mac",
+    "dist:mac": "vite build && electron-builder --mac --x64 --arm64",
     "dist:win": "vite build && electron-builder --win",
     "lint": "eslint --cache -c .eslintrc --ext .tsx,ts ./src",
     "lint-fix": "eslint --fix -c .eslintrc --ext .tsx,ts ./src",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     },
     "mac": {
       "artifactName": "${productName}-${version}-macOS-${arch}.${ext}",
-      "target": "pkg",
+      "target": "dmg",
       "category": "public.app-category.games",
       "icon": "build/icon.icns",
       "asarUnpack": [
@@ -213,7 +213,7 @@
     "@typescript-eslint/parser": "^5.20.0",
     "@vitejs/plugin-react": "^2.2.0",
     "electron": "^21.2.1",
-    "electron-builder": "^23.1.0",
+    "electron-builder": "^23.6.0",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.13.0",
     "eslint-config-prettier": "^8.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3094,7 +3094,7 @@ ejs@^3.1.7:
   dependencies:
     jake "^10.8.5"
 
-electron-builder@^23.1.0:
+electron-builder@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-23.6.0.tgz#c79050cbdce90ed96c5feb67c34e9e0a21b5331b"
   integrity sha512-y8D4zO+HXGCNxFBV/JlyhFnoQ0Y0K7/sFH+XwIbj47pqaW8S6PGYQbjoObolKBR1ddQFPt4rwp4CnwMJrW3HAw==


### PR DESCRIPTION
This adds an arm64-optimized build for macOS.

Note:
ARM packages will show as damaged since they are not signed by an Apple ID certified Developer, so this command is required to make it work:
`xattr -d com.apple.quarantine | mdfind kMDItemCFBundleIdentifier = "*heroic"`


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
