### PR TITLE
[Refactor] Main window creating and send message to the frontend

### DIFF
--- a/src/backend/__mocks__/electron.ts
+++ b/src/backend/__mocks__/electron.ts
@@ -1,5 +1,9 @@
 import { EventEmitter } from 'node:events'
-import { MenuItemConstructorOptions } from 'electron'
+import {
+  BrowserWindowConstructorOptions,
+  Display,
+  MenuItemConstructorOptions
+} from 'electron'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -28,8 +32,23 @@ class Notification {
 }
 
 class BrowserWindow {
-  public constructor() {
-    return {}
+  static windows: BrowserWindow[] = []
+  options: BrowserWindowConstructorOptions = {}
+
+  constructor(options: BrowserWindowConstructorOptions) {
+    this.options = options
+  }
+
+  static getAllWindows() {
+    return this.windows
+  }
+
+  static setAllWindows(windows: BrowserWindow[]) {
+    this.windows = windows
+  }
+
+  public getOptions() {
+    return this.options
   }
 }
 
@@ -44,6 +63,17 @@ const nativeImage = {
     resize: (size: { width: number; height: number }) =>
       `${path} width=${size.width} height=${size.height}`
   })
+}
+
+const screen = {
+  getPrimaryDisplay: () => {
+    return {
+      workAreaSize: {
+        height: 1280,
+        width: 1920
+      }
+    }
+  }
 }
 
 class Tray {
@@ -76,5 +106,6 @@ export {
   Menu,
   nativeImage,
   Tray,
-  ipcMain
+  ipcMain,
+  screen
 }

--- a/src/backend/__tests__/main_window.test.ts
+++ b/src/backend/__tests__/main_window.test.ts
@@ -1,0 +1,131 @@
+import {
+  createMainWindow,
+  setMainWindow,
+  sendFrontendMessage
+} from '../main_window'
+import { BrowserWindow, Display, screen } from 'electron'
+import { configStore } from '../constants'
+
+jest.mock('../logger/logfile')
+
+describe('main_window', () => {
+  describe('sendFrontendMessage', () => {
+    describe('if no main window', () => {
+      beforeAll(() => {
+        BrowserWindow['setAllWindows']([])
+        setMainWindow(null)
+      })
+
+      it('returns false', () => {
+        expect(sendFrontendMessage('message')).toBe(false)
+      })
+    })
+
+    describe('if there is a main window', () => {
+      let window = {
+        webContents: {
+          send: jest.fn()
+        }
+      }
+
+      // stub windows
+      beforeAll(() => {
+        setMainWindow(null)
+        BrowserWindow['setAllWindows']([window])
+      })
+
+      // spy the `send` method
+      beforeEach(() => {
+        window.webContents.send = jest.fn()
+      })
+
+      // cleanup stubs
+      afterAll(() => {
+        setMainWindow(null)
+        BrowserWindow['setAllWindows']([])
+      })
+
+      it('sends a message to its webContents', () => {
+        sendFrontendMessage('message', 'param1', 'param2')
+
+        expect(window.webContents.send).toBeCalledWith(
+          'message',
+          'param1',
+          'param2'
+        )
+      })
+    })
+  })
+
+  describe('createMainWindow', () => {
+    describe('with stored window geometry', () => {
+      beforeEach(() => {
+        configStore.has = jest.fn(() => true)
+        configStore.get = jest.fn(() => {
+          return {
+            width: 800,
+            height: 600,
+            x: 0,
+            y: 0
+          }
+        })
+      })
+
+      afterAll(() => {
+        configStore.has = jest.fn()
+        configStore.get = jest.fn()
+      })
+
+      it('creates the new window with the given geometry', () => {
+        const window = createMainWindow()
+        const options = window['options']
+
+        expect(configStore.has).toBeCalledWith('window-props')
+        expect(options.height).toBe(600)
+        expect(options.width).toBe(800)
+        expect(options.x).toBe(0)
+        expect(options.y).toBe(0)
+      })
+    })
+
+    describe('without stored window geometry', () => {
+      beforeAll(() => {
+        configStore.has = () => false
+      })
+
+      it('creates the new window with the default geometry', () => {
+        const window = createMainWindow()
+        const options = window['options']
+
+        expect(options.height).toBe(690)
+        expect(options.width).toBe(1200)
+        expect(options.x).toBe(0)
+        expect(options.y).toBe(0)
+      })
+
+      it('ensures windows is not bigger than the screen', () => {
+        // mock a smaller screen info
+        const originalScreenSize = screen.getPrimaryDisplay
+        screen.getPrimaryDisplay = () => {
+          return {
+            workAreaSize: {
+              height: 768,
+              width: 1024
+            }
+          } as Display
+        }
+
+        const window = createMainWindow()
+        const options = window['options']
+
+        expect(options.height).toBe(690)
+        expect(options.width).toBe(1024 * 0.8) // 80% of the workAreaSize.width
+        expect(options.x).toBe(0)
+        expect(options.y).toBe(0)
+
+        // revert mock
+        screen.getPrimaryDisplay = originalScreenSize
+      })
+    })
+  })
+})

--- a/src/backend/dialog/dialog.ts
+++ b/src/backend/dialog/dialog.ts
@@ -1,6 +1,7 @@
 import { LogPrefix, logWarning } from '../logger/logger'
-import { BrowserWindow, dialog } from 'electron'
+import { dialog } from 'electron'
 import { ButtonOptions, DialogType } from 'common/types'
+import { getMainWindow, sendFrontendMessage } from '../main_window'
 
 const { showErrorBox, showMessageBox } = dialog
 
@@ -20,13 +21,8 @@ function showDialogBoxModalAuto(props: {
       props.buttons
     )
   } else {
-    let window: BrowserWindow | null
     try {
-      window = BrowserWindow.getFocusedWindow()
-      if (!window) {
-        window = BrowserWindow.getAllWindows()[0]
-      }
-      window.webContents.send(
+      sendFrontendMessage(
         'showDialog',
         props.title,
         props.message,
@@ -37,12 +33,18 @@ function showDialogBoxModalAuto(props: {
       logWarning(['showDialogBoxModalAuto:', error], {
         prefix: LogPrefix.Backend
       })
+
+      const window = getMainWindow()
+
       switch (props.type) {
         case 'ERROR':
           showErrorBox(props.title, props.message)
           break
         default:
-          showMessageBox(BrowserWindow.getAllWindows()[0], {
+          if (!window) {
+            break
+          }
+          showMessageBox(window, {
             title: props.title,
             message: props.message
           })

--- a/src/backend/downloadmanager/downloadqueue.ts
+++ b/src/backend/downloadmanager/downloadqueue.ts
@@ -1,8 +1,9 @@
 import { logError, logInfo, LogPrefix } from '../logger/logger'
-import { getFileSize, getGame, getMainWindow } from '../utils'
+import { getFileSize, getGame } from '../utils'
 import Store from 'electron-store'
 import { DMQueueElement } from 'common/types'
 import { installQueueElement, updateQueueElement } from './utils'
+import { sendFrontendMessage } from '../main_window'
 
 const downloadManager = new Store({
   cwd: 'store',
@@ -53,13 +54,12 @@ function addToFinished(element: DMQueueElement, status: DMStatus) {
 */
 
 async function initQueue() {
-  const window = getMainWindow()
   let element = getFirstQueueElement()
   queueState = element ? 'running' : 'idle'
 
   while (element) {
     const queuedElements = downloadManager.get('queue') as DMQueueElement[]
-    window.webContents.send('changedDMQueueInformation', queuedElements)
+    sendFrontendMessage('changedDMQueueInformation', queuedElements)
     const game = getGame(element.params.appName, element.params.runner)
     const installInfo = await game.getInstallInfo(
       element.params.platformToInstall
@@ -73,8 +73,8 @@ async function initQueue() {
 
     const { status } =
       element.type === 'install'
-        ? await installQueueElement(window, element.params)
-        : await updateQueueElement(window, element.params)
+        ? await installQueueElement(element.params)
+        : await updateQueueElement(element.params)
     element.endTime = Date.now()
     addToFinished(element, status)
     removeFromQueue(element.params.appName)
@@ -91,8 +91,7 @@ function addToQueue(element: DMQueueElement) {
     return
   }
 
-  const mainWindow = getMainWindow()
-  mainWindow.webContents.send('setGameStatus', {
+  sendFrontendMessage('setGameStatus', {
     appName: element.params.appName,
     runner: element.params.runner,
     folder: element.params.path,
@@ -119,7 +118,7 @@ function addToQueue(element: DMQueueElement) {
     prefix: LogPrefix.DownloadManager
   })
 
-  getMainWindow().webContents.send('changedDMQueueInformation', elements)
+  sendFrontendMessage('changedDMQueueInformation', elements)
 
   if (queueState === 'idle') {
     initQueue()
@@ -127,8 +126,6 @@ function addToQueue(element: DMQueueElement) {
 }
 
 function removeFromQueue(appName: string) {
-  const mainWindow = getMainWindow()
-
   if (appName && downloadManager.has('queue')) {
     let elements: DMQueueElement[] = []
     elements = downloadManager.get('queue') as DMQueueElement[]
@@ -141,7 +138,7 @@ function removeFromQueue(appName: string) {
       downloadManager.set('queue', elements)
     }
 
-    mainWindow.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName,
       status: 'done'
     })
@@ -150,7 +147,7 @@ function removeFromQueue(appName: string) {
       prefix: LogPrefix.DownloadManager
     })
 
-    getMainWindow().webContents.send('changedDMQueueInformation', elements)
+    sendFrontendMessage('changedDMQueueInformation', elements)
   }
 }
 

--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -1,15 +1,12 @@
-import { BrowserWindow } from 'electron'
 import { logError, logInfo, LogPrefix, logWarning } from '../logger/logger'
 import { getGame, isEpicServiceOffline, notify } from '../utils'
 import { InstallParams } from 'common/types'
 import i18next from 'i18next'
 import { showDialogBoxModalAuto } from '../dialog/dialog'
 import { isOnline } from '../online_monitor'
+import { sendFrontendMessage } from '../main_window'
 
-async function installQueueElement(
-  mainWindow: BrowserWindow,
-  params: InstallParams
-): Promise<{
+async function installQueueElement(params: InstallParams): Promise<{
   status: 'done' | 'error' | 'abort'
   error?: string | undefined
 }> {
@@ -47,7 +44,7 @@ async function installQueueElement(
     }
   }
 
-  mainWindow.webContents.send('setGameStatus', {
+  sendFrontendMessage('setGameStatus', {
     appName,
     runner,
     status: 'installing',
@@ -64,7 +61,7 @@ async function installQueueElement(
       prefix: LogPrefix.DownloadManager
     })
 
-    mainWindow.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName,
       runner,
       status: 'done'
@@ -100,7 +97,7 @@ async function installQueueElement(
       return { status: 'error' }
     }
 
-    mainWindow.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName,
       runner,
       status: 'done'
@@ -113,10 +110,7 @@ async function installQueueElement(
   }
 }
 
-async function updateQueueElement(
-  mainWindow: BrowserWindow,
-  params: InstallParams
-): Promise<{
+async function updateQueueElement(params: InstallParams): Promise<{
   status: 'done' | 'error'
   error?: string | undefined
 }> {
@@ -146,7 +140,7 @@ async function updateQueueElement(
     }
   }
 
-  mainWindow.webContents.send('setGameStatus', {
+  sendFrontendMessage('setGameStatus', {
     appName,
     runner,
     status: 'updating'
@@ -181,7 +175,7 @@ async function updateQueueElement(
       prefix: LogPrefix.DownloadManager
     })
 
-    mainWindow.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName,
       runner,
       status: 'done'

--- a/src/backend/games.ts
+++ b/src/backend/games.ts
@@ -10,7 +10,6 @@ import {
   InstallPlatform
 } from 'common/types'
 
-import { BrowserWindow } from 'electron'
 import { join } from 'path'
 import { heroicGamesConfigPath } from './constants'
 
@@ -20,7 +19,6 @@ abstract class Game {
   }
 
   abstract appName: string
-  abstract window: BrowserWindow
   abstract getExtraInfo(): Promise<ExtraInfo>
   abstract getGameInfo(installPlatform?: string): GameInfo
   abstract getInstallInfo(

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -3,7 +3,6 @@ import {
   deleteAbortController
 } from '../utils/aborthandler/aborthandler'
 import { GOGLibrary, runGogdlCommand } from './library'
-import { BrowserWindow } from 'electron'
 import { join } from 'path'
 import { Game } from '../games'
 import { GameConfig } from '../game_config'
@@ -56,10 +55,10 @@ import {
 } from 'common/types/gog'
 import { t } from 'i18next'
 import { showDialogBoxModalAuto } from '../dialog/dialog'
+import { sendFrontendMessage } from '../main_window'
 
 class GOGGame extends Game {
   public appName: string
-  public window = BrowserWindow.getAllWindows()[0]
   private static instances = new Map<string, GOGGame>()
   private constructor(appName: string) {
     super()
@@ -205,7 +204,7 @@ class GOGGame extends Game {
         { prefix: LogPrefix.Gog }
       )
 
-      this.window.webContents.send('setGameStatus', {
+      sendFrontendMessage('setGameStatus', {
         appName: this.appName,
         runner: 'gog',
         status: action,
@@ -738,7 +737,7 @@ class GOGGame extends Game {
     )
 
     // This always has to be done, so we do it before checking for res.error
-    this.window.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName: this.appName,
       runner: 'gog',
       status: 'done'
@@ -843,9 +842,7 @@ class GOGGame extends Game {
     ) as Array<InstalledInfo>
     const newInstalled = installed.filter((g) => g.appName !== this.appName)
     installedGamesStore.set('installed', newInstalled)
-    const mainWindow =
-      BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
-    mainWindow.webContents.send('refreshLibrary', 'gog')
+    sendFrontendMessage('refreshLibrary', 'gog')
   }
 
   // Could be removed if gogdl handles SIGKILL and SIGTERM for us

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -5,7 +5,6 @@ import {
 import { appendFileSync, existsSync, mkdirSync } from 'graceful-fs'
 import axios from 'axios'
 
-import { BrowserWindow } from 'electron'
 import {
   ExecResult,
   ExtraInfo,
@@ -50,10 +49,10 @@ import { t } from 'i18next'
 import { isOnline } from '../online_monitor'
 import { showDialogBoxModalAuto } from '../dialog/dialog'
 import { gameAnticheatInfo } from '../anticheat/utils'
+import { sendFrontendMessage } from '../main_window'
 
 class LegendaryGame extends Game {
   public appName: string
-  public window = BrowserWindow.getAllWindows()[0]
   private static instances: Map<string, LegendaryGame> = new Map()
 
   private constructor(appName: string) {
@@ -323,7 +322,7 @@ class LegendaryGame extends Game {
       { prefix: LogPrefix.Legendary }
     )
 
-    this.window.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName: this.appName,
       runner: 'legendary',
       status: action,
@@ -342,7 +341,7 @@ class LegendaryGame extends Game {
    * Does NOT check for online connectivity.
    */
   public async update(): Promise<{ status: 'done' | 'error' }> {
-    this.window.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName: this.appName,
       runner: 'legendary',
       status: 'updating'
@@ -377,7 +376,7 @@ class LegendaryGame extends Game {
 
     deleteAbortController(this.appName)
 
-    this.window.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName: this.appName,
       runner: 'legendary',
       status: 'done'
@@ -871,9 +870,7 @@ class LegendaryGame extends Game {
 
       deleteAbortController(this.appName)
 
-      const mainWindow =
-        BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
-      mainWindow.webContents.send('refreshLibrary', 'legendary')
+      sendFrontendMessage('refreshLibrary', 'legendary')
     } catch (error) {
       logError(`Error reading ${installed}, could not complete operation`, {
         prefix: LogPrefix.Legendary

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -77,6 +77,7 @@ import {
   discordLink,
   heroicGamesConfigPath,
   heroicGithubURL,
+  userHome,
   icon,
   installed,
   kofiPage,
@@ -96,8 +97,7 @@ import {
   isFlatpak,
   publicDir,
   wineprefixFAQ,
-  customThemesWikiLink,
-  userHome
+  customThemesWikiLink
 } from './constants'
 import { handleProtocol } from './protocol'
 import {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -77,7 +77,6 @@ import {
   discordLink,
   heroicGamesConfigPath,
   heroicGithubURL,
-  userHome,
   icon,
   installed,
   kofiPage,
@@ -135,64 +134,17 @@ import { callAbortController } from './utils/aborthandler/aborthandler'
 import { getDefaultSavePath } from './save_sync'
 import si from 'systeminformation'
 import { initTrayIcon } from './tray_icon/tray_icon'
+import {
+  createMainWindow,
+  getMainWindow,
+  sendFrontendMessage
+} from './main_window'
 
 const { showOpenDialog } = dialog
 const isWindows = platform() === 'win32'
 
-let mainWindow: BrowserWindow
-
-async function createWindow(): Promise<BrowserWindow> {
-  configStore.set('userHome', userHome)
-
-  let windowProps: Electron.Rectangle = {
-    height: 690,
-    width: 1200,
-    x: 0,
-    y: 0
-  }
-
-  if (configStore.has('window-props')) {
-    const tmpWindowProps = configStore.get(
-      'window-props',
-      {}
-    ) as Electron.Rectangle
-    if (
-      tmpWindowProps &&
-      tmpWindowProps.width &&
-      tmpWindowProps.height &&
-      tmpWindowProps.y !== undefined &&
-      tmpWindowProps.x !== undefined
-    ) {
-      windowProps = tmpWindowProps
-    }
-  } else {
-    // make sure initial screen size is not bigger than the available screen space
-    const screenInfo = screen.getPrimaryDisplay()
-
-    if (screenInfo.workAreaSize.height > windowProps.height) {
-      windowProps.height = screenInfo.workAreaSize.height * 0.8
-    }
-
-    if (screenInfo.workAreaSize.width > windowProps.width) {
-      windowProps.width = screenInfo.workAreaSize.width * 0.8
-    }
-  }
-
-  // Create the browser window.
-  mainWindow = new BrowserWindow({
-    ...windowProps,
-    minHeight: 345,
-    minWidth: 600,
-    show: false,
-
-    webPreferences: {
-      webviewTag: true,
-      contextIsolation: true,
-      nodeIntegration: true,
-      // sandbox: false,
-      preload: path.join(__dirname, 'preload.js')
-    }
-  })
+async function initializeWindow(): Promise<BrowserWindow> {
+  const mainWindow = createMainWindow()
 
   if ((isSteamDeckGameMode || isCLIFullscreen) && !isCLINoGui) {
     logInfo(
@@ -237,7 +189,7 @@ async function createWindow(): Promise<BrowserWindow> {
       return mainWindow.hide()
     }
 
-    handleExit(mainWindow)
+    handleExit()
   })
 
   if (isWindows) {
@@ -266,6 +218,13 @@ async function createWindow(): Promise<BrowserWindow> {
       autoUpdater.checkForUpdates()
     }
   }
+
+  ipcMain.on('setZoomFactor', async (event, zoomFactor) => {
+    mainWindow.webContents.setZoomFactor(
+      processZoomForScreen(parseFloat(zoomFactor))
+    )
+  })
+
   return mainWindow
 }
 
@@ -285,22 +244,16 @@ const processZoomForScreen = (zoomFactor: number) => {
   }
 }
 
-ipcMain.on('setZoomFactor', async (event, zoomFactor) => {
-  const window = BrowserWindow.getAllWindows()[0]
-  window.webContents.setZoomFactor(processZoomForScreen(parseFloat(zoomFactor)))
-})
-
 if (!gotTheLock) {
   logInfo('Heroic is already running, quitting this instance')
   app.quit()
 } else {
   app.on('second-instance', (event, argv) => {
     // Someone tried to run a second instance, we should focus our window.
-    if (mainWindow) {
-      mainWindow.show()
-    }
+    const mainWindow = getMainWindow()
+    mainWindow?.show()
 
-    handleProtocol(mainWindow, argv)
+    handleProtocol(argv)
   })
   app.whenReady().then(async () => {
     initOnlineMonitor()
@@ -396,10 +349,10 @@ if (!gotTheLock) {
       ]
     })
 
-    await createWindow()
+    const mainWindow = await initializeWindow()
 
     protocol.registerStringProtocol('heroic', (request, callback) => {
-      handleProtocol(mainWindow, [request.url])
+      handleProtocol([request.url])
       callback('Operation initiated.')
     })
     if (!app.isDefaultProtocolClient('heroic')) {
@@ -448,7 +401,7 @@ ipcMain.on('notify', (event, args) => notify(args))
 
 ipcMain.once('frontendReady', () => {
   logInfo('Frontend Ready', { prefix: LogPrefix.Backend })
-  handleProtocol(mainWindow, [openUrlArgument, ...process.argv])
+  handleProtocol([openUrlArgument, ...process.argv])
   setTimeout(() => {
     logInfo('Starting the Download Queue', { prefix: LogPrefix.Backend })
     initQueue()
@@ -535,7 +488,7 @@ ipcMain.handle('checkDiskSpace', async (event, folder) => {
   })
 })
 
-ipcMain.on('quit', async () => handleExit(mainWindow))
+ipcMain.on('quit', async () => handleExit())
 
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
@@ -548,8 +501,10 @@ app.on('window-all-closed', () => {
 
 app.on('open-url', (event, url) => {
   event.preventDefault()
+  const mainWindow = getMainWindow()
+
   if (mainWindow) {
-    handleProtocol(mainWindow, [url])
+    handleProtocol([url])
   } else {
     openUrlArgument = url
   }
@@ -925,7 +880,6 @@ let powerDisplayId: number | null
 ipcMain.handle(
   'launch',
   async (event, { appName, launchArguments, runner }): StatusPromise => {
-    const window = BrowserWindow.getAllWindows()[0]
     const isSideloaded = runner === 'sideload'
     const extGame = getGame(appName, runner)
     const game = isSideloaded ? getAppInfo(appName) : extGame.getGameInfo()
@@ -945,14 +899,15 @@ ipcMain.handle(
 
     addRecentGame(game)
 
-    window.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName,
       runner,
       status: 'playing'
     })
 
+    const mainWindow = getMainWindow()
     if (minimizeOnLaunch) {
-      mainWindow.hide()
+      mainWindow?.hide()
     }
 
     // Prevent display from sleep
@@ -1014,7 +969,7 @@ ipcMain.handle(
     }
     tsStore.set(`${appName}.totalPlayed`, Math.floor(totalPlaytime))
 
-    window.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName,
       runner,
       status: 'done'
@@ -1024,7 +979,7 @@ ipcMain.handle(
     if (isCLINoGui) {
       app.exit()
     } else {
-      mainWindow.show()
+      mainWindow?.show()
     }
 
     return { status: launchResult ? 'done' : 'error' }
@@ -1032,6 +987,11 @@ ipcMain.handle(
 )
 
 ipcMain.handle('openDialog', async (e, args) => {
+  const mainWindow = getMainWindow()
+  if (!mainWindow) {
+    return false
+  }
+
   const { filePaths, canceled } = await showOpenDialog(mainWindow, args)
   if (!canceled) {
     return filePaths[0]
@@ -1140,7 +1100,7 @@ ipcMain.handle(
     }
     const game = getGame(appName, runner)
     const { title } = game.getGameInfo()
-    mainWindow.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName,
       runner,
       status: 'installing'
@@ -1148,7 +1108,7 @@ ipcMain.handle(
 
     const abortMessage = () => {
       notify({ title, body: i18next.t('notify.install.canceled') })
-      mainWindow.webContents.send('setGameStatus', {
+      sendFrontendMessage('setGameStatus', {
         appName,
         runner,
         status: 'done'
@@ -1171,7 +1131,7 @@ ipcMain.handle(
       title,
       body: i18next.t('notify.install.imported', 'Game Imported')
     })
-    mainWindow.webContents.send('setGameStatus', {
+    sendFrontendMessage('setGameStatus', {
       appName,
       runner,
       status: 'done'
@@ -1334,8 +1294,10 @@ ipcMain.handle(
 
 // Simulate keyboard and mouse actions as if the real input device is used
 ipcMain.handle('gamepadAction', async (event, args) => {
+  // we can only receive gamepad events if the main window exists
+  const mainWindow = getMainWindow()!
+
   const { action, metadata } = args
-  const window = BrowserWindow.getAllWindows()[0]
   const inputEvents: GamepadInputEvent[] = []
 
   /*
@@ -1351,16 +1313,16 @@ ipcMain.handle('gamepadAction', async (event, args) => {
       inputEvents.push({
         type: 'mouseWheel',
         deltaY: 50,
-        x: window.getBounds().width / 2,
-        y: window.getBounds().height / 2
+        x: mainWindow.getBounds().width / 2,
+        y: mainWindow.getBounds().height / 2
       })
       break
     case 'rightStickDown':
       inputEvents.push({
         type: 'mouseWheel',
         deltaY: -50,
-        x: window.getBounds().width / 2,
-        y: window.getBounds().height / 2
+        x: mainWindow.getBounds().width / 2,
+        y: mainWindow.getBounds().height / 2
       })
       break
     case 'leftStickUp':
@@ -1410,7 +1372,7 @@ ipcMain.handle('gamepadAction', async (event, args) => {
       })
       break
     case 'back':
-      window.webContents.goBack()
+      mainWindow.webContents.goBack()
       break
     case 'esc':
       inputEvents.push({
@@ -1425,7 +1387,7 @@ ipcMain.handle('gamepadAction', async (event, args) => {
   }
 
   if (inputEvents.length) {
-    inputEvents.forEach((event) => window.webContents.sendInputEvent(event))
+    inputEvents.forEach((event) => mainWindow.webContents.sendInputEvent(event))
   }
 })
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -96,7 +96,8 @@ import {
   isFlatpak,
   publicDir,
   wineprefixFAQ,
-  customThemesWikiLink
+  customThemesWikiLink,
+  userHome
 } from './constants'
 import { handleProtocol } from './protocol'
 import {
@@ -144,6 +145,7 @@ const { showOpenDialog } = dialog
 const isWindows = platform() === 'win32'
 
 async function initializeWindow(): Promise<BrowserWindow> {
+  configStore.set('userHome', userHome)
   const mainWindow = createMainWindow()
 
   if ((isSteamDeckGameMode || isCLIFullscreen) && !isCLINoGui) {

--- a/src/backend/main_window.ts
+++ b/src/backend/main_window.ts
@@ -16,10 +16,12 @@ export const getMainWindow = () => {
 // returns `false` if no mainWindow or no webContents
 // returns `true` if the message was sent to the webContents
 export const sendFrontendMessage = (message: string, ...payload: unknown[]) => {
+  // get the first BrowserWindow if for some reason we don't have a webContents
   if (!mainWindow?.webContents) {
     mainWindow = BrowserWindow.getAllWindows()[0]
   }
 
+  // return false if we still don't have a webContents
   if (!mainWindow?.webContents) {
     return false
   }

--- a/src/backend/main_window.ts
+++ b/src/backend/main_window.ts
@@ -1,32 +1,35 @@
 import { BrowserWindow, screen } from 'electron'
 import path from 'path'
-import { configStore, userHome } from './constants'
+import { configStore } from './constants'
 
 let mainWindow: BrowserWindow | null = null
+
+export const setMainWindow = (window: BrowserWindow | null = null) => {
+  mainWindow = window
+}
 
 export const getMainWindow = () => {
   return mainWindow
 }
 
+// send a message to the main window's webContents if available
+// returns `false` if no mainWindow or no webContents
+// returns `true` if the message was sent to the webContents
 export const sendFrontendMessage = (message: string, ...payload: unknown[]) => {
-  if (!mainWindow) {
+  if (!mainWindow?.webContents) {
     mainWindow = BrowserWindow.getAllWindows()[0]
   }
 
-  if (!mainWindow) {
+  if (!mainWindow?.webContents) {
     return false
   }
 
-  if (!mainWindow.webContents) {
-    return false
-  }
-
-  return mainWindow.webContents.send(message, ...payload)
+  mainWindow.webContents.send(message, ...payload)
+  return true
 }
 
+// creates the mainWindow based on the configuration
 export const createMainWindow = () => {
-  configStore.set('userHome', userHome)
-
   let windowProps: Electron.Rectangle = {
     height: 690,
     width: 1200,
@@ -52,11 +55,11 @@ export const createMainWindow = () => {
     // make sure initial screen size is not bigger than the available screen space
     const screenInfo = screen.getPrimaryDisplay()
 
-    if (screenInfo.workAreaSize.height > windowProps.height) {
+    if (screenInfo.workAreaSize.height < windowProps.height) {
       windowProps.height = screenInfo.workAreaSize.height * 0.8
     }
 
-    if (screenInfo.workAreaSize.width > windowProps.width) {
+    if (screenInfo.workAreaSize.width < windowProps.width) {
       windowProps.width = screenInfo.workAreaSize.width * 0.8
     }
   }

--- a/src/backend/main_window.ts
+++ b/src/backend/main_window.ts
@@ -1,0 +1,81 @@
+import { BrowserWindow, screen } from 'electron'
+import path from 'path'
+import { configStore, userHome } from './constants'
+
+let mainWindow: BrowserWindow | null = null
+
+export const getMainWindow = () => {
+  return mainWindow
+}
+
+export const sendFrontendMessage = (message: string, ...payload: unknown[]) => {
+  if (!mainWindow) {
+    mainWindow = BrowserWindow.getAllWindows()[0]
+  }
+
+  if (!mainWindow) {
+    return false
+  }
+
+  if (!mainWindow.webContents) {
+    return false
+  }
+
+  return mainWindow.webContents.send(message, ...payload)
+}
+
+export const createMainWindow = () => {
+  configStore.set('userHome', userHome)
+
+  let windowProps: Electron.Rectangle = {
+    height: 690,
+    width: 1200,
+    x: 0,
+    y: 0
+  }
+
+  if (configStore.has('window-props')) {
+    const tmpWindowProps = configStore.get(
+      'window-props',
+      {}
+    ) as Electron.Rectangle
+    if (
+      tmpWindowProps &&
+      tmpWindowProps.width &&
+      tmpWindowProps.height &&
+      tmpWindowProps.y !== undefined &&
+      tmpWindowProps.x !== undefined
+    ) {
+      windowProps = tmpWindowProps
+    }
+  } else {
+    // make sure initial screen size is not bigger than the available screen space
+    const screenInfo = screen.getPrimaryDisplay()
+
+    if (screenInfo.workAreaSize.height > windowProps.height) {
+      windowProps.height = screenInfo.workAreaSize.height * 0.8
+    }
+
+    if (screenInfo.workAreaSize.width > windowProps.width) {
+      windowProps.width = screenInfo.workAreaSize.width * 0.8
+    }
+  }
+
+  // Create the browser window.
+  mainWindow = new BrowserWindow({
+    ...windowProps,
+    minHeight: 345,
+    minWidth: 600,
+    show: false,
+
+    webPreferences: {
+      webviewTag: true,
+      contextIsolation: true,
+      nodeIntegration: true,
+      // sandbox: false,
+      preload: path.join(__dirname, 'preload.js')
+    }
+  })
+
+  return mainWindow
+}

--- a/src/backend/online_monitor.ts
+++ b/src/backend/online_monitor.ts
@@ -1,8 +1,9 @@
 import { ConnectivityStatus } from 'common/types'
-import { BrowserWindow, ipcMain, net } from 'electron'
+import { ipcMain, net } from 'electron'
 import { logInfo, LogPrefix } from './logger/logger'
 import axios from 'axios'
 import EventEmitter from 'node:events'
+import { sendFrontendMessage } from './main_window'
 
 let status: ConnectivityStatus
 let abortController: AbortController
@@ -35,10 +36,7 @@ const setStatus = (newStatus: ConnectivityStatus) => {
   }
 
   // events
-  const mainWindow = BrowserWindow.getAllWindows()[0]
-  if (mainWindow) {
-    mainWindow.webContents.send('connectivity-changed', { status, retryIn })
-  }
+  sendFrontendMessage('connectivity-changed', { status, retryIn })
   connectivityEmitter.emit(status)
 }
 
@@ -46,13 +44,10 @@ const retry = (seconds: number) => {
   retryIn = seconds
   // logInfo(`Retrying in: ${retryIn} seconds`, { prefix: LogPrefix.Connection })
   // dispatch event with retry countdown
-  const mainWindow = BrowserWindow.getAllWindows()[0]
-  if (mainWindow) {
-    mainWindow.webContents.send('connectivity-changed', {
-      status: 'check-online',
-      retryIn: seconds
-    })
-  }
+  sendFrontendMessage('connectivity-changed', {
+    status: 'check-online',
+    retryIn: seconds
+  })
 
   if (seconds) {
     // if still counting down, repeat

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -1,10 +1,13 @@
-import { BrowserWindow, dialog } from 'electron'
+import { dialog } from 'electron'
 import { logError, logInfo, LogPrefix } from './logger/logger'
 import i18next from 'i18next'
 import { getInfo } from './utils'
 import { Runner } from 'common/types'
+import { getMainWindow, sendFrontendMessage } from './main_window'
 
-export async function handleProtocol(window: BrowserWindow, args: string[]) {
+export async function handleProtocol(args: string[]) {
+  const mainWindow = getMainWindow()
+
   // Figure out which argv element is our protocol
   let url = ''
   args.forEach((val) => {
@@ -48,7 +51,12 @@ export async function handleProtocol(window: BrowserWindow, args: string[]) {
     const { is_installed, title, app_name, runner } = game
     if (!is_installed) {
       logInfo(`"${arg}" not installed.`, { prefix: LogPrefix.ProtocolHandler })
-      const { response } = await dialog.showMessageBox(window, {
+
+      if (!mainWindow) {
+        return
+      }
+
+      const { response } = await dialog.showMessageBox(mainWindow, {
         buttons: [i18next.t('box.yes'), i18next.t('box.no')],
         cancelId: 1,
         message: `${title} ${i18next.t(
@@ -67,7 +75,7 @@ export async function handleProtocol(window: BrowserWindow, args: string[]) {
           return
         }
         if (filePaths[0]) {
-          return window.webContents.send('installGame', {
+          return sendFrontendMessage('installGame', {
             appName: app_name,
             runner,
             path: filePaths[0]
@@ -80,7 +88,8 @@ export async function handleProtocol(window: BrowserWindow, args: string[]) {
         })
       }
     }
-    window.hide()
-    window.webContents.send('launchGame', arg, runner)
+
+    mainWindow?.hide()
+    sendFrontendMessage('launchGame', arg, runner)
   }
 }

--- a/src/backend/recent_games/recent_games.ts
+++ b/src/backend/recent_games/recent_games.ts
@@ -1,6 +1,6 @@
 import { GameInfo, RecentGame } from 'common/types'
-import { BrowserWindow } from 'electron'
 import { backendEvents } from '../backend_events'
+import { sendFrontendMessage } from '../main_window'
 import { GlobalConfig } from '../config'
 import { configStore } from '../constants'
 
@@ -20,8 +20,7 @@ const setRecentGames = (recentGames: RecentGame[]) => {
   configStore.set('games.recent', recentGames)
 
   // emit
-  const window = BrowserWindow.getAllWindows()[0]
-  window.webContents.send('recentGamesChanged', recentGames)
+  sendFrontendMessage('recentGamesChanged', recentGames)
   backendEvents.emit('recentGamesChanged', recentGames)
 }
 

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -18,12 +18,13 @@ import {
   generateShortAppId,
   removeImagesFromSteam
 } from './steamhelper'
-import { app, BrowserWindow } from 'electron'
+import { app } from 'electron'
 import { isFlatpak, isWindows, tsStore } from '../../constants'
 import { logError, logInfo, LogPrefix, logWarning } from '../../logger/logger'
 import i18next from 'i18next'
 import { showDialogBoxModalAuto } from '../../dialog/dialog'
-import { GlobalConfig } from '../../../backend/config'
+import { GlobalConfig } from '../../config'
+import { getMainWindow } from '../../main_window'
 
 const getSteamUserdataDir = async () => {
   const { defaultSteamPath } = await GlobalConfig.get().getSettings()
@@ -35,7 +36,7 @@ const generateImage = async (
   width: number,
   height: number
 ): Promise<string> => {
-  const window = BrowserWindow.getAllWindows()[0]
+  const window = getMainWindow()
 
   if (!window) {
     return Promise.resolve('')

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -83,7 +83,7 @@ export const contextMenu = (
   const recentsMenu = recentGames.map((game) => {
     return {
       click: function () {
-        handleProtocol(mainWindow, [`heroic://launch/${game.appName}`])
+        handleProtocol([`heroic://launch/${game.appName}`])
       },
       label: game.title
     }
@@ -120,7 +120,7 @@ export const contextMenu = (
     },
     {
       click: function () {
-        handleExit(mainWindow)
+        handleExit()
       },
       label: i18next.t('tray.quit', 'Quit'),
       accelerator: platform === 'darwin' ? 'Cmd+Q' : 'Ctrl+Q'

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -51,6 +51,7 @@ import fileSize from 'filesize'
 import makeClient from 'discord-rich-presence-typescript'
 import { showDialogBoxModalAuto } from './dialog/dialog'
 import { getAppInfo } from './sideload/games'
+import { getMainWindow } from './main_window'
 
 const execAsync = promisify(exec)
 const statAsync = promisify(stat)
@@ -236,11 +237,12 @@ const showAboutWindow = () => {
   return app.showAboutPanel()
 }
 
-async function handleExit(window: BrowserWindow) {
+async function handleExit() {
   const isLocked = existsSync(join(heroicGamesConfigPath, 'lock'))
+  const mainWindow = getMainWindow()
 
-  if (isLocked) {
-    const { response } = await showMessageBox(window, {
+  if (isLocked && mainWindow) {
+    const { response } = await showMessageBox(mainWindow, {
       buttons: [i18next.t('box.no'), i18next.t('box.yes')],
       message: i18next.t(
         'box.quit.message',
@@ -327,18 +329,16 @@ type ErrorHandlerMessage = {
   runner: string
 }
 
-async function errorHandler(
-  { error, logPath, runner: r, appName }: ErrorHandlerMessage,
-  window?: BrowserWindow
-): Promise<void> {
+async function errorHandler({
+  error,
+  logPath,
+  runner: r,
+  appName
+}: ErrorHandlerMessage): Promise<void> {
   const noSpaceMsg = 'Not enough available disk space'
   const plat = r === 'legendary' ? 'Legendary (Epic Games)' : r
   const deletedFolderMsg = 'appears to be deleted'
   const otherErrorMessages = ['No saved credentials', 'No credentials']
-
-  if (!window) {
-    window = getMainWindow()
-  }
 
   if (logPath) {
     execAsync(`tail "${logPath}" | grep 'disk space'`)
@@ -703,13 +703,12 @@ function detectVCRedist(mainWindow: BrowserWindow) {
 
 export function notify({ body, title }: NotifyType) {
   if (Notification.isSupported() && !isSteamDeckGameMode) {
-    const mainWindow = BrowserWindow.getAllWindows()[0]
     const notify = new Notification({
       body,
       title
     })
 
-    notify.on('click', () => mainWindow.show())
+    notify.on('click', () => getMainWindow()?.show())
     notify.show()
   }
 }
@@ -811,10 +810,6 @@ function getInfo(appName: string, runner: Runner): GameInfo {
 type NotifyType = {
   title: string
   body: string
-}
-
-function getMainWindow(): BrowserWindow {
-  return BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
 }
 
 // can be removed if legendary and gogdl handle SIGTERM and SIGKILL

--- a/src/backend/wine/manager/ipc_handler.ts
+++ b/src/backend/wine/manager/ipc_handler.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow } from 'electron'
+import { ipcMain } from 'electron'
 import { ProgressInfo, State } from 'heroic-wine-downloader'
 import {
   installWineVersion,
@@ -10,11 +10,11 @@ import {
   createAbortController,
   deleteAbortController
 } from '../../utils/aborthandler/aborthandler'
+import { sendFrontendMessage } from '../../main_window'
 
 ipcMain.handle('installWineVersion', async (e, release) => {
-  const window = BrowserWindow.getAllWindows()[0]
   const onProgress = (state: State, progress?: ProgressInfo) => {
-    window.webContents.send('progressOfWineManager' + release.version, {
+    sendFrontendMessage('progressOfWineManager' + release.version, {
       state,
       progress
     })

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -7,7 +7,6 @@ import Store from 'electron-store'
 import { existsSync, mkdirSync, rmSync } from 'graceful-fs'
 import { logError, logInfo, LogPrefix, logWarning } from '../../logger/logger'
 import { WineVersionInfo } from 'common/types'
-import { BrowserWindow } from 'electron'
 
 import {
   getAvailableVersions,
@@ -18,6 +17,7 @@ import {
   VersionInfo
 } from 'heroic-wine-downloader'
 import { heroicToolsPath } from '../../constants'
+import { sendFrontendMessage } from '../../main_window'
 
 const wineDownloaderInfoStore = new Store({
   cwd: 'store',
@@ -89,7 +89,7 @@ async function updateWineVersionInfos(
   }
 
   logInfo('wine versions updated', { prefix: LogPrefix.WineDownloader })
-  BrowserWindow.getAllWindows()[0].webContents.send('wineVersionsUpdated')
+  sendFrontendMessage('wineVersionsUpdated')
   return releases
 }
 
@@ -173,7 +173,7 @@ async function installWineVersion(
     prefix: LogPrefix.WineDownloader
   })
 
-  BrowserWindow.getAllWindows()[0].webContents.send('wineVersionsUpdated')
+  sendFrontendMessage('wineVersionsUpdated')
   return 'success'
 }
 
@@ -227,7 +227,7 @@ async function removeWineVersion(release: WineVersionInfo): Promise<boolean> {
     prefix: LogPrefix.WineDownloader
   })
 
-  BrowserWindow.getAllWindows()[0].webContents.send('wineVersionsUpdated')
+  sendFrontendMessage('wineVersionsUpdated')
   return true
 }
 


### PR DESCRIPTION
This PR is a refactor related to how we interact with the main window. It removes some duplication and also while adding tests I found a bug.

Some comments on the changes:
- moved the code that creates the main BrowserWindow object into its own module
- the module takes care of the BrowserWindow object creation with the saved size/position and the sending of the messages to the frontend (abstracting the `window.webContents.send` logic)
- the module takes care of the logic of checking if a window exists before sending a message, so we can remove a lot of duplication
- by doing this I was able to remove the reference to the main window that Game objects had as `this.window`, it makes more sense for games to not depend on that
- I found a bug in the window creation logic, the condition to check if the window size fits the screen was backwards
- I added some more code and patterns to test more things

I'll add more comments in the diff

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
