### PR TITLE
[Fix] GOG games Setup on Windows

### DIFF
--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -322,7 +322,18 @@ class GOGGame extends Game {
       logInfo('Windows os, running setup instructions on install', {
         prefix: LogPrefix.Gog
       })
-      await setup(this.appName, installedData)
+      try {
+        await setup(this.appName, installedData)
+      } catch (e) {
+        logWarning(
+          [
+            `Failed to run setup instructions on install for ${gameInfo.title}, some other step might be needed for the game to work. Check the 'goggame-${this.appName}.script' file in the game folder`,
+            'Error:',
+            e
+          ],
+          { prefix: LogPrefix.Gog }
+        )
+      }
     }
     this.addShortcuts()
     return { status: 'done' }

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -15,7 +15,13 @@ import {
 } from 'common/types'
 import * as axios from 'axios'
 import { app, dialog, shell, Notification, BrowserWindow } from 'electron'
-import { exec, ExecException, spawn, spawnSync } from 'child_process'
+import {
+  exec,
+  ExecException,
+  spawn,
+  SpawnOptions,
+  spawnSync
+} from 'child_process'
 import { existsSync, rmSync, stat } from 'graceful-fs'
 import { promisify } from 'util'
 import i18next, { t } from 'i18next'
@@ -838,6 +844,35 @@ const getShellPath = async (path: string): Promise<string> =>
 
 export const wait = async (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms))
+
+export const spawnAsync = async (
+  command: string,
+  args: string[],
+  options: SpawnOptions = {}
+): Promise<{ code: number | null; stdout: string; stderr: string } | Error> => {
+  const child = spawn(command, args, options)
+  const stdout: string[] = []
+  const stderr: string[] = []
+
+  if (child.stdout) {
+    child.stdout.on('data', (data) => stdout.push(data.toString()))
+  }
+
+  if (child.stderr) {
+    child.stderr.on('data', (data) => stderr.push(data.toString()))
+  }
+
+  return new Promise((resolve, reject) => {
+    child.on('error', (error) => reject(error))
+    child.on('close', (code) => {
+      resolve({
+        code,
+        stdout: stdout.join(''),
+        stderr: stderr.join('')
+      })
+    })
+  })
+}
 
 export {
   errorHandler,


### PR DESCRIPTION
Changed `execAsync ` for `spawn `so the Setup won't fail when there is space in the game name folder, that was the main cause of this issue. Also, `Start-Process` was not being recognized since it was being used on cmd instead of `powershell`. so it was failing because of that as well.

Another issue was that sometimes it was failing because it was trying to access Wine configurations and they were undefined since it is not Linux/mac.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
