### PR TITLE
[UI] Remove 'active' color from library icons

### DIFF
--- a/src/frontend/components/UI/ActionIcons/index.tsx
+++ b/src/frontend/components/UI/ActionIcons/index.tsx
@@ -67,9 +67,7 @@ export default React.memo(function ActionIcons({
       <FormControl segmented small>
         {layout === 'grid' ? (
           <button
-            className={classNames('FormControl__button', {
-              active: layout === 'grid'
-            })}
+            className="FormControl__button"
             title={t('library.toggleLayout.list', 'Toggle to a list layout')}
             onClick={() => handleLayout('list')}
           >
@@ -80,7 +78,7 @@ export default React.memo(function ActionIcons({
           </button>
         ) : (
           <button
-            className={classNames('FormControl__button')}
+            className="FormControl__button"
             title={t('library.toggleLayout.grid', 'Toggle to a grid layout')}
             onClick={() => handleLayout('grid')}
           >
@@ -91,9 +89,7 @@ export default React.memo(function ActionIcons({
           </button>
         )}
         <button
-          className={classNames('FormControl__button', {
-            active: !sortDescending
-          })}
+          className="FormControl__button"
           title={
             sortDescending
               ? t('library.sortDescending', 'Sort Descending')
@@ -107,9 +103,7 @@ export default React.memo(function ActionIcons({
           />
         </button>
         <button
-          className={classNames('FormControl__button', {
-            active: sortInstalled
-          })}
+          className="FormControl__button"
           title={t('library.sortByStatus', 'Sort by Status')}
           onClick={() => toggleSortinstalled()}
         >
@@ -131,7 +125,7 @@ export default React.memo(function ActionIcons({
           />
         </button>
         <button
-          className={classNames('FormControl__button', { active: showHidden })}
+          className="FormControl__button"
           title={showHiddenTitle}
           onClick={toggleShowHidden}
         >


### PR DESCRIPTION
This PR fixes #1878 

Icons in the library had an `active` color that had no real meaning, since the meaning is the icon itself and not the color.

Now icons are always white except when hovered.

![image](https://user-images.githubusercontent.com/188464/208219627-ec905b94-f522-4db5-9612-137e9d943a71.png)

Only exception for this change was the Favorites icon that should eventually be moved to a `filters` dropdown to turn filters on/off instead as described here https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1881#issuecomment-1272342402 by billie.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
