### PR TITLE
Indicate latest heroic version in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -57,6 +57,8 @@ body:
         - Latest Stable
         - Latest Beta
         - main branch from GitHub
+    validations:
+      required: true
   - type: textarea
     id: systeminfo
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -51,10 +51,13 @@ body:
       label: System Information
       value: |-
         - OS [e. g. "Ubuntu"]: 
-        - Heroic Version [e. g. 2.1.1]:
-
+        - Heroic Version [e. g. 2.5.2]:
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |-
+        ## Latest stable version of Heroic is 2.5.2. Please, update Heroic before reporting a bug if you have an older version.
   - type: textarea
     id: additional_info
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -45,19 +45,26 @@ body:
     attributes:
       label: Screenshots
       description: If applicable, add screenshots to help explain your problem.
+  - type: markdown
+    attributes:
+      value: |-
+        ## Latest stable version of Heroic is 2.5.2. Please, update Heroic before reporting a bug if you have an older version.
+  - type: dropdown
+    id: heroic_version
+    attributes:
+      label: Heroic Version
+      options:
+        - Latest Stable
+        - Latest Beta
+        - main branch from GitHub
   - type: textarea
     id: systeminfo
     attributes:
       label: System Information
       value: |-
-        - OS [e. g. "Ubuntu"]: 
-        - Heroic Version [e. g. 2.5.2]:
+        - OS [e. g. "Ubuntu"]:
     validations:
       required: true
-  - type: markdown
-    attributes:
-      value: |-
-        ## Latest stable version of Heroic is 2.5.2. Please, update Heroic before reporting a bug if you have an older version.
   - type: textarea
     id: additional_info
     attributes:


### PR DESCRIPTION
This PR adds a small change in the PR template to let users know which one is the latest version of Heroic, in case someone tries to report a bug in an older version.

Also moved the version to a dropdown so it's easier to pick between `Latest Stable` `Latest Beta` and `main branch from GitHub`.

This is how it looks:
![image](https://user-images.githubusercontent.com/188464/208220743-47fb34b8-1e1e-47c5-8781-62ae40b28585.png)

Putting this here as an idea, I understand if there's a concern that this can get outdated and you prefer not to use this.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
