### PR TITLE
[WineManager] Fix status update

### DIFF
--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -77,7 +77,7 @@ export default React.memo(function WineManager(): JSX.Element | null {
     return () => {
       removeListener()
     }
-  }, [])
+  }, [repository])
 
   return (
     <>
@@ -126,8 +126,8 @@ export default React.memo(function WineManager(): JSX.Element | null {
             {refreshing && <UpdateComponent />}
             {!refreshing &&
               !!wineVersions.length &&
-              wineVersions.map((release, key) => {
-                return <WineItem key={key} {...release} />
+              wineVersions.map((release) => {
+                return <WineItem key={release.version} {...release} />
               })}
           </div>
         ) : (

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -69,11 +69,12 @@ export default React.memo(function WineManager(): JSX.Element | null {
         setWineManagerSettings(oldWineManagerSettings)
       }
     }
+  }, [])
 
+  useEffect(() => {
     const removeListener = window.api.handleWineVersionsUpdated(() => {
       setWineVersions(getWineVersions(repository))
     })
-
     return () => {
       removeListener()
     }


### PR DESCRIPTION
This PR fixes a couple of issues in the Wine Manager present in the latest release:

- Proton items were not showing any status update (installing/progress/unzipping)
- After making a change in a Proton item, it was re-rendering the list for Wine-GE instead

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
