### PR TITLE
[UI] Prevent flash when opening an installation dialog for the first time

### DIFF
--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -1,7 +1,6 @@
 import './index.css'
 
 import React, {
-  lazy,
   useContext,
   useEffect,
   useMemo,
@@ -33,10 +32,7 @@ import {
   sideloadedCategories
 } from 'frontend/helpers/library'
 import RecentlyPlayed from './components/RecentlyPlayed'
-
-const InstallModal = lazy(
-  async () => import('frontend/screens/Library/components/InstallModal')
-)
+import { InstallModal } from './components'
 
 const storage = window.localStorage
 


### PR DESCRIPTION
This PR changes the InstallModal import to not be lazy-loaded.

This fixes 2 problems:
- since it was lazy loaded, Suspense was triggered and rendering a Loading screen for a moment, making the UI flash
- because of the Suspense changing the content, the list was re-rendered completely after

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
