### PR TITLE
Extra info tweaks and improvements

### DIFF
--- a/src/backend/api/helpers.ts
+++ b/src/backend/api/helpers.ts
@@ -64,6 +64,8 @@ export const getDefaultSavePath = async (
   )
 export const getGameInfo = async (appName: string, runner: Runner) =>
   ipcRenderer.invoke('getGameInfo', appName, runner)
+export const getExtraInfo = async (appName: string, runner: Runner) =>
+  ipcRenderer.invoke('getExtraInfo', appName, runner)
 
 export const getGameSettings = async (
   appName: string,

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -85,7 +85,11 @@ class GOGGame extends Game {
 
     const extra: ExtraInfo = {
       about: gameInfo.extra.about,
-      reqs: await GOGLibrary.get().createReqsArray(this.appName, targetPlatform)
+      reqs: await GOGLibrary.get().createReqsArray(
+        this.appName,
+        targetPlatform
+      ),
+      storeUrl: gameInfo.store_url
     }
     return extra
   }

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -651,7 +651,8 @@ export class GOGLibrary {
       cloud_save_enabled: cloudSavesEnabledGames.includes(String(info.id)),
       extra: {
         about: { description: description, longDescription: '' },
-        reqs: []
+        reqs: [],
+        storeUrl: `https://gog.com${info.url}`
       },
       folder_name: '',
       install: {
@@ -677,9 +678,8 @@ export class GOGLibrary {
    * @returns plain API response
    */
   public async getGamesData(appName: string, lang?: string) {
-    const url = `https://api.gog.com/v2/games/${appName}${
-      lang ?? '?locale=' + lang
-    }`
+    const url = `https://api.gog.com/v2/games/${appName}?locale=${lang || 'en'}`
+
     const response: AxiosResponse | null = await axios.get(url).catch(() => {
       return null
     })

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -158,7 +158,7 @@ class LegendaryGame extends Game {
         reqs: []
       }
     }
-    let lang = GlobalConfig.get().config.language
+    let lang = configStore.get('language', '') as string
     if (lang === 'pt') {
       lang = 'pt-BR'
     }
@@ -174,9 +174,9 @@ class LegendaryGame extends Game {
         logError(error, { prefix: LogPrefix.Legendary })
       }
     }
-    const epicUrl = `https://store-content.ak.epicgames.com/api/${
-      lang || 'en'
-    }/content/products/${productSlug || this.slugFromTitle(title)}`
+    const epicUrl = `https://store-content.ak.epicgames.com/api/${lang}/content/products/${
+      productSlug || this.slugFromTitle(title)
+    }`
 
     try {
       const { data } = await axios({

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -127,8 +127,15 @@ class LegendaryGame extends Game {
     if (slug) {
       return slug.productSlug.replace(/(\/.*)/, '')
     } else {
-      return this.appName
+      return null
     }
+  }
+
+  private slugFromTitle(title: string): string {
+    return title
+      .toLowerCase()
+      .replace(/[^a-z ]/g, '')
+      .replaceAll(' ', '-')
   }
 
   /**
@@ -138,7 +145,7 @@ class LegendaryGame extends Game {
    * @returns
    */
   public async getExtraInfo(): Promise<ExtraInfo> {
-    const { namespace } = this.getGameInfo()
+    const { namespace, title } = this.getGameInfo()
     if (gameInfoStore.has(namespace)) {
       return gameInfoStore.get(namespace) as ExtraInfo
     }
@@ -159,19 +166,18 @@ class LegendaryGame extends Game {
       lang = 'zh-CN'
     }
 
-    let epicUrl: string
+    let productSlug = null
     if (namespace) {
-      let productSlug: string
       try {
         productSlug = await this.getProductSlug(namespace)
       } catch (error) {
         logError(error, { prefix: LogPrefix.Legendary })
-        productSlug = this.appName
       }
-      epicUrl = `https://store-content.ak.epicgames.com/api/${lang}/content/products/${productSlug}`
-    } else {
-      epicUrl = `https://store-content.ak.epicgames.com/api/${lang}/content/products/${this.appName}`
     }
+    const epicUrl = `https://store-content.ak.epicgames.com/api/${
+      lang || 'en'
+    }/content/products/${productSlug || this.slugFromTitle(title)}`
+
     try {
       const { data } = await axios({
         method: 'GET',

--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -557,7 +557,8 @@ export class LegendaryLibrary {
           description,
           longDescription
         },
-        reqs: []
+        reqs: [],
+        storeUrl: formatEpicStoreUrl(title)
       },
       folder_name: installFolder,
       install: {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -740,8 +740,25 @@ ipcMain.handle('getGameInfo', async (event, appName, runner) => {
       return null
     }
 
-    info.extra = await game.getExtraInfo()
     return info
+  } catch (error) {
+    logError(error, { prefix: LogPrefix.Backend })
+    return null
+  }
+})
+
+ipcMain.handle('getExtraInfo', async (event, appName, runner) => {
+  if (runner === 'sideload') {
+    return null
+  }
+  // Fastpath since we sometimes have to request info for a GOG game as Legendary because we don't know it's a GOG game yet
+  if (runner === 'legendary' && !LegendaryLibrary.get().hasGame(appName)) {
+    return null
+  }
+  try {
+    const game = getGame(appName, runner)
+    const extra = await game.getExtraInfo()
+    return extra
   } catch (error) {
     logError(error, { prefix: LogPrefix.Backend })
     return null

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -28,7 +28,8 @@ import {
   RuntimeName,
   DMQueueElement,
   ConnectivityStatus,
-  GamepadActionArgs
+  GamepadActionArgs,
+  ExtraInfo
 } from 'common/types'
 import { LegendaryInstallInfo } from 'common/types/legendary'
 import { GOGCloudSavesLocation, GogInstallInfo } from 'common/types/gog'
@@ -113,6 +114,7 @@ interface AsyncIPCFunctions {
   getLatestReleases: () => Promise<Release[]>
   getCurrentChangelog: () => Promise<Release | null>
   getGameInfo: (appName: string, runner: Runner) => Promise<GameInfo | null>
+  getExtraInfo: (appName: string, runner: Runner) => Promise<ExtraInfo | null>
   getGameSettings: (
     appName: string,
     runner: Runner

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -83,6 +83,7 @@ export type ExecResult = {
 export interface ExtraInfo {
   about: About
   reqs: Reqs[]
+  storeUrl: string
 }
 
 export type GameConfigVersion = 'auto' | 'v0' | 'v0.1'
@@ -187,7 +188,7 @@ export interface InstalledInfo {
   buildId?: string // For verifing GOG games
 }
 
-interface Reqs {
+export interface Reqs {
   minimum: string
   recommended: string
   title: string

--- a/src/common/types/epic-graphql.ts
+++ b/src/common/types/epic-graphql.ts
@@ -1,0 +1,28 @@
+import { Reqs } from 'common/types'
+
+export interface CatalogMapping {
+  pageSlug: string
+  pageType: string
+}
+
+export interface Catalog {
+  catalogNs: {
+    mappings: CatalogMapping[]
+  }
+}
+
+export interface Product {
+  sandbox: {
+    configuration: ProductConfig[]
+  }
+}
+
+export interface ProductConfig {
+  configs: {
+    shortDescription: string
+    technicalRequirements: {
+      macos: Reqs[] | null
+      windows: Reqs[] | null
+    }
+  }
+}

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -305,7 +305,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                     appName={appName}
                     isInstalled={is_installed}
                     title={title}
-                    storeUrl={gameInfo.store_url}
+                    storeUrl={extraInfo?.storeUrl || gameInfo.store_url}
                     runner={gameInfo.runner}
                     handleUpdate={handleUpdate}
                     disableUpdate={isInstalling || isUpdating}
@@ -543,7 +543,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                   <div>{t('game.requirements', 'Requirements')}</div>
                 </DialogHeader>
                 <DialogContent>
-                  <GameRequirements gameInfo={gameInfo} />
+                  <GameRequirements extraInfo={extraInfo!} />
                 </DialogContent>
               </Dialog>
             )}

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -19,7 +19,13 @@ import { useTranslation } from 'react-i18next'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { UpdateComponent, SelectField } from 'frontend/components/UI'
 
-import { GameInfo, GameStatus, Runner, WineInstallation } from 'common/types'
+import {
+  ExtraInfo,
+  GameInfo,
+  GameStatus,
+  Runner,
+  WineInstallation
+} from 'common/types'
 import { LegendaryInstallInfo } from 'common/types/legendary'
 import { GogInstallInfo, GOGCloudSavesLocation } from 'common/types/gog'
 
@@ -68,6 +74,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const [progress, previousProgress] = hasProgress(appName)
 
   const [gameInfo, setGameInfo] = useState(locationGameInfo)
+  const [extraInfo, setExtraInfo] = useState<ExtraInfo | null>(null)
   const [autoSyncSaves, setAutoSyncSaves] = useState(false)
   const [savesPath, setSavesPath] = useState('')
   const [gogSaves, setGOGSaves] = useState<GOGCloudSavesLocation[]>([])
@@ -124,6 +131,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       if (newInfo) {
         setGameInfo(newInfo)
       }
+      setExtraInfo(await window.api.getExtraInfo(appName, runner))
     }
     updateGameInfo()
   }, [status, gog.library, epic.library])
@@ -217,14 +225,13 @@ export default React.memo(function GamePage(): JSX.Element | null {
         platform: installPlatform
       },
       is_installed,
-      extra,
       developer,
       cloud_save_enabled,
       canRunOffline,
       folder_name
     }: GameInfo = gameInfo
 
-    hasRequirements = extra?.reqs?.length > 0
+    hasRequirements = (extraInfo?.reqs?.length || 0) > 0
     hasUpdate = is_installed && gameUpdates?.includes(appName)
     const appLocation = install_path || folder_name
 
@@ -313,11 +320,11 @@ export default React.memo(function GamePage(): JSX.Element | null {
               <div className="infoWrapper">
                 <div className="developer">{developer}</div>
                 <div className="summary">
-                  {extra && extra.about
-                    ? extra.about.description
-                      ? extra.about.description
-                      : extra.about.longDescription
-                      ? extra.about.longDescription
+                  {extraInfo && extraInfo.about
+                    ? extraInfo.about.description
+                      ? extraInfo.about.description
+                      : extraInfo.about.longDescription
+                      ? extraInfo.about.longDescription
                       : ''
                     : ''}
                 </div>

--- a/src/frontend/screens/Game/GameRequirements/index.tsx
+++ b/src/frontend/screens/Game/GameRequirements/index.tsx
@@ -1,18 +1,17 @@
 import React, { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
-import { GameInfo } from 'common/types'
+import { ExtraInfo } from 'common/types'
 
 import './index.css'
 
 type Props = {
-  gameInfo: GameInfo
+  extraInfo: ExtraInfo
 }
 
-function GameRequirements({ gameInfo }: Props) {
+function GameRequirements({ extraInfo }: Props) {
   const { t } = useTranslation('gamepage')
 
-  const { extra }: GameInfo = gameInfo
-  const haveSystemRequirements = Boolean(extra?.reqs?.length)
+  const haveSystemRequirements = Boolean(extraInfo?.reqs?.length)
 
   return (
     <div
@@ -30,7 +29,7 @@ function GameRequirements({ gameInfo }: Props) {
                   {t('specs.recommended').toUpperCase()}
                 </td>
               </tr>
-              {extra.reqs.map(
+              {extraInfo.reqs.map(
                 (e) =>
                   e &&
                   e.title && (


### PR DESCRIPTION
This PR includes a few tweaks and fixes related to the extra info of games:

- The extra info is now only fetched when entering the game page and not when fetching any gameInfo data, that should reduce the first render of the library significantly since we where waiting for 2 extra requests per epic game to get the extra info (one graphql request to get a page slug and one to get the actual info)
- We were using `language` from the app config but the language value is stored in the configStore actually
- If the language was undefined for any reason, the url was invalid, now it has an `en` fallback
- If we couldn't find a page slug we were falling back to the appName but that's probably never valid, now it converts the game title into a slug (it fixes a missing description for rocket league for example)

Note that some games (I only found Alba - A Wildlife Adventure) don't seem to return a page slug and I couldn't find what to put in the api query, so some games will still not show description/requirements, but I'll investigate those more at a different time.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
