### PR TITLE
[Fix] Get store links for Epic from API response

### DIFF
--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -84,8 +84,15 @@ class GOGGame extends Game {
     }
 
     const extra: ExtraInfo = {
-      about: gameInfo.extra.about,
-      reqs: await GOGLibrary.get().createReqsArray(this.appName, targetPlatform)
+      about: {
+        description: gameInfo.description || '',
+        longDescription: gameInfo.longDescription || ''
+      },
+      reqs: await GOGLibrary.get().createReqsArray(
+        this.appName,
+        targetPlatform
+      ),
+      storeUrl: gameInfo.store_url
     }
     return extra
   }

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -84,10 +84,7 @@ class GOGGame extends Game {
     }
 
     const extra: ExtraInfo = {
-      about: {
-        description: gameInfo.description || '',
-        longDescription: gameInfo.longDescription || ''
-      },
+      about: gameInfo.extra.about,
       reqs: await GOGLibrary.get().createReqsArray(
         this.appName,
         targetPlatform

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -649,7 +649,11 @@ export class GOGLibrary {
       art_cover: horizontalCover,
       art_square: verticalCover,
       cloud_save_enabled: cloudSavesEnabledGames.includes(String(info.id)),
-      description,
+      extra: {
+        about: { description: description, longDescription: '' },
+        reqs: [],
+        storeUrl: `https://gog.com${info.url}`
+      },
       folder_name: '',
       install: {
         is_dlc: false

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -649,10 +649,7 @@ export class GOGLibrary {
       art_cover: horizontalCover,
       art_square: verticalCover,
       cloud_save_enabled: cloudSavesEnabledGames.includes(String(info.id)),
-      extra: {
-        about: { description: description, longDescription: '' },
-        reqs: []
-      },
+      description,
       folder_name: '',
       install: {
         is_dlc: false

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -674,9 +674,8 @@ export class GOGLibrary {
    * @returns plain API response
    */
   public async getGamesData(appName: string, lang?: string) {
-    const url = `https://api.gog.com/v2/games/${appName}${
-      lang ?? '?locale=' + lang
-    }`
+    const url = `https://api.gog.com/v2/games/${appName}?locale=${lang || 'en'}`
+
     const response: AxiosResponse | null = await axios.get(url).catch(() => {
       return null
     })

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -155,7 +155,8 @@ class LegendaryGame extends Game {
           description: '',
           longDescription: ''
         },
-        reqs: []
+        reqs: [],
+        storeUrl: ''
       }
     }
     let lang = configStore.get('language', '') as string
@@ -189,14 +190,14 @@ class LegendaryGame extends Game {
         (e: { type: string }) => e.type === 'productHome'
       )
 
-      gameInfoStore.set(namespace, {
+      const info: ExtraInfo = {
         about: about.data.about,
-        reqs: about.data.requirements.systems[0].details
-      })
-      return {
-        about: about.data.about,
-        reqs: about.data.requirements.systems[0].details
+        reqs: about.data.requirements.systems[0].details,
+        storeUrl: `https://www.epicgames.com/store/product/${data._slug}`
       }
+
+      gameInfoStore.set(namespace, info)
+      return info
     } catch (error) {
       logError('Error Getting Info from Epic API', {
         prefix: LogPrefix.Legendary
@@ -208,7 +209,8 @@ class LegendaryGame extends Game {
           description: '',
           longDescription: ''
         },
-        reqs: []
+        reqs: [],
+        storeUrl: ''
       }
     }
   }

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -50,6 +50,7 @@ import { t } from 'i18next'
 import { isOnline } from '../online_monitor'
 import { showDialogBoxModalAuto } from '../dialog/dialog'
 import { gameAnticheatInfo } from '../anticheat/utils'
+import { Catalog, Product } from 'common/types/epic-graphql'
 
 class LegendaryGame extends Game {
   public appName: string
@@ -110,23 +111,142 @@ class LegendaryGame extends Game {
     return LegendaryLibrary.get().getInstallInfo(this.appName, installPlatform)
   }
 
-  private async getProductSlug(namespace: string) {
-    const graphql = JSON.stringify({
-      query: `{Catalog{catalogOffers( namespace:"${namespace}"){elements {productSlug}}}}`,
-      variables: {}
-    })
-    const result = await axios('https://www.epicgames.com/graphql', {
-      data: graphql,
-      headers: { 'Content-Type': 'application/json' },
-      method: 'POST'
-    })
-    const res = result.data.data.Catalog.catalogOffers
-    const slug = res.elements.find(
-      (e: { productSlug: string }) => e.productSlug
-    )
-    if (slug) {
-      return slug.productSlug.replace(/(\/.*)/, '')
-    } else {
+  private async getProductSlug(namespace: string, title: string) {
+    // If you want to change this graphql query, make sure it works for these games:
+    // Rocket League
+    // Alba - A Wildlife Adventure
+    const graphql = {
+      query: `{
+          Catalog {
+            catalogNs(namespace: "${namespace}") {
+              mappings (pageType: "productHome") {
+                pageSlug
+                pageType
+              }
+            }
+          }
+      }`
+    }
+
+    try {
+      const result = await axios('https://www.epicgames.com/graphql', {
+        data: graphql,
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST'
+      })
+
+      const res = result.data.data.Catalog as Catalog
+      const slugMapping = res.catalogNs.mappings.find(
+        (mapping) => mapping.pageType === 'productHome'
+      )
+
+      if (slugMapping) {
+        return slugMapping.pageSlug
+      } else {
+        return this.slugFromTitle(title)
+      }
+    } catch (error) {
+      logError(error, { prefix: LogPrefix.Legendary })
+      return this.slugFromTitle(title)
+    }
+  }
+
+  private async getExtraFromAPI(slug: string): Promise<ExtraInfo | null> {
+    let lang = configStore.get('language', '') as string
+    if (lang === 'pt') {
+      lang = 'pt-BR'
+    }
+    if (lang === 'zh_Hans') {
+      lang = 'zh-CN'
+    }
+
+    const epicUrl = `https://store-content.ak.epicgames.com/api/${lang}/content/products/${slug}`
+
+    try {
+      const { data } = await axios({ method: 'GET', url: epicUrl })
+      logInfo('Getting Info from Epic API', { prefix: LogPrefix.Legendary })
+
+      const about = data?.pages?.find(
+        (e: { type: string }) => e.type === 'productHome'
+      )
+
+      if (about) {
+        return {
+          about: about.data.about,
+          reqs: about.data.requirements.systems[0].details,
+          storeUrl: `https://www.epicgames.com/store/product/${slug}`
+        }
+      } else {
+        return null
+      }
+    } catch (error) {
+      return null
+    }
+  }
+
+  private async getExtraFromGraphql(
+    namespace: string,
+    slug: string
+  ): Promise<ExtraInfo | null> {
+    const graphql = {
+      query: `{
+        Product {
+          sandbox(sandboxId: "${namespace}") {
+            configuration {
+              ... on StoreConfiguration {
+                configs {
+                  shortDescription
+                  technicalRequirements {
+                    macos {
+                      minimum
+                      recommended
+                      title
+                    }
+                    windows {
+                      minimum
+                      recommended
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }`
+    }
+
+    try {
+      const result = await axios('https://www.epicgames.com/graphql', {
+        data: graphql,
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST'
+      })
+
+      const res = result.data.data.Product as Product
+
+      const configuration = res.sandbox.configuration[0]
+
+      if (!configuration) {
+        return null
+      }
+
+      const requirements = configuration.configs.technicalRequirements.windows
+
+      if (requirements) {
+        return {
+          about: {
+            description: res.sandbox.configuration[0].configs.shortDescription,
+            longDescription: ''
+          },
+          reqs: requirements,
+          storeUrl: `https://www.epicgames.com/store/product/${slug}`
+        }
+      } else {
+        return null
+      }
+    } catch (error) {
+      logError(error, { prefix: LogPrefix.Legendary })
       return null
     }
   }
@@ -159,51 +279,25 @@ class LegendaryGame extends Game {
         storeUrl: ''
       }
     }
-    let lang = configStore.get('language', '') as string
-    if (lang === 'pt') {
-      lang = 'pt-BR'
+
+    const slug = await this.getProductSlug(namespace, title)
+
+    // try the API first, it works for most games
+    let extraData = await this.getExtraFromAPI(slug)
+
+    // if the API doesn't work, try graphql
+    if (!extraData) {
+      extraData = await this.getExtraFromGraphql(namespace, slug)
     }
-    if (lang === 'zh_Hans') {
-      lang = 'zh-CN'
-    }
 
-    let productSlug = null
-    if (namespace) {
-      try {
-        productSlug = await this.getProductSlug(namespace)
-      } catch (error) {
-        logError(error, { prefix: LogPrefix.Legendary })
-      }
-    }
-    const epicUrl = `https://store-content.ak.epicgames.com/api/${lang}/content/products/${
-      productSlug || this.slugFromTitle(title)
-    }`
-
-    try {
-      const { data } = await axios({
-        method: 'GET',
-        url: epicUrl
-      })
-      logInfo('Getting Info from Epic API', { prefix: LogPrefix.Legendary })
-
-      const about = data.pages.find(
-        (e: { type: string }) => e.type === 'productHome'
-      )
-
-      const info: ExtraInfo = {
-        about: about.data.about,
-        reqs: about.data.requirements.systems[0].details,
-        storeUrl: `https://www.epicgames.com/store/product/${data._slug}`
-      }
-
-      gameInfoStore.set(namespace, info)
-      return info
-    } catch (error) {
+    // if we have data, store it and return
+    if (extraData) {
+      gameInfoStore.set(namespace, extraData)
+      return extraData
+    } else {
       logError('Error Getting Info from Epic API', {
         prefix: LogPrefix.Legendary
       })
-
-      gameInfoStore.set(namespace, { about: {}, reqs: [] })
       return {
         about: {
           description: '',

--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -472,6 +472,8 @@ export class LegendaryLibrary {
     }
 
     const {
+      description,
+      longDescription = '',
       keyImages = [],
       title,
       developer,
@@ -550,6 +552,14 @@ export class LegendaryLibrary {
       art_square: art_square || art_square_front || art_cover || fallBackImage,
       cloud_save_enabled: Boolean(saveFolder),
       developer,
+      extra: {
+        about: {
+          description,
+          longDescription
+        },
+        reqs: [],
+        storeUrl: formatEpicStoreUrl(title)
+      },
       folder_name: installFolder,
       install: {
         executable,

--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -472,8 +472,6 @@ export class LegendaryLibrary {
     }
 
     const {
-      description,
-      longDescription = '',
       keyImages = [],
       title,
       developer,
@@ -552,13 +550,6 @@ export class LegendaryLibrary {
       art_square: art_square || art_square_front || art_cover || fallBackImage,
       cloud_save_enabled: Boolean(saveFolder),
       developer,
-      extra: {
-        about: {
-          description,
-          longDescription
-        },
-        reqs: []
-      },
       folder_name: installFolder,
       install: {
         executable,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -83,6 +83,7 @@ export type ExecResult = {
 export interface ExtraInfo {
   about: About
   reqs: Reqs[]
+  storeUrl: string
 }
 
 export type GameConfigVersion = 'auto' | 'v0' | 'v0.1'
@@ -95,8 +96,9 @@ export interface GameInfo {
   art_logo?: string
   art_square: string
   cloud_save_enabled: boolean
+  description?: string
+  longDescription?: string
   developer: string
-  extra: ExtraInfo
   folder_name: string
   install: Partial<InstalledInfo>
   is_installed: boolean

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -96,9 +96,8 @@ export interface GameInfo {
   art_logo?: string
   art_square: string
   cloud_save_enabled: boolean
-  description?: string
-  longDescription?: string
   developer: string
+  extra: ExtraInfo
   folder_name: string
   install: Partial<InstalledInfo>
   is_installed: boolean

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -189,7 +189,7 @@ export interface InstalledInfo {
   buildId?: string // For verifing GOG games
 }
 
-interface Reqs {
+export interface Reqs {
   minimum: string
   recommended: string
   title: string

--- a/src/common/types/epic-graphql.ts
+++ b/src/common/types/epic-graphql.ts
@@ -1,0 +1,28 @@
+import { Reqs } from 'common/types'
+
+export interface CatalogMapping {
+  pageSlug: string
+  pageType: string
+}
+
+export interface Catalog {
+  catalogNs: {
+    mappings: CatalogMapping[]
+  }
+}
+
+export interface Product {
+  sandbox: {
+    configuration: ProductConfig[]
+  }
+}
+
+export interface ProductConfig {
+  configs: {
+    shortDescription: string
+    technicalRequirements: {
+      macos: Reqs[] | null
+      windows: Reqs[] | null
+    }
+  }
+}

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -305,7 +305,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                     appName={appName}
                     isInstalled={is_installed}
                     title={title}
-                    storeUrl={gameInfo.store_url}
+                    storeUrl={extraInfo?.storeUrl || gameInfo.store_url}
                     runner={gameInfo.runner}
                     handleUpdate={handleUpdate}
                     disableUpdate={isInstalling || isUpdating}

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -543,7 +543,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                   <div>{t('game.requirements', 'Requirements')}</div>
                 </DialogHeader>
                 <DialogContent>
-                  <GameRequirements gameInfo={gameInfo} />
+                  <GameRequirements extraInfo={extraInfo!} />
                 </DialogContent>
               </Dialog>
             )}

--- a/src/frontend/screens/Game/GameRequirements/index.tsx
+++ b/src/frontend/screens/Game/GameRequirements/index.tsx
@@ -1,18 +1,17 @@
 import React, { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
-import { GameInfo } from 'common/types'
+import { ExtraInfo } from 'common/types'
 
 import './index.css'
 
 type Props = {
-  gameInfo: GameInfo
+  extraInfo: ExtraInfo
 }
 
-function GameRequirements({ gameInfo }: Props) {
+function GameRequirements({ extraInfo }: Props) {
   const { t } = useTranslation('gamepage')
 
-  const { extra }: GameInfo = gameInfo
-  const haveSystemRequirements = Boolean(extra?.reqs?.length)
+  const haveSystemRequirements = Boolean(extraInfo?.reqs?.length)
 
   return (
     <div
@@ -30,7 +29,7 @@ function GameRequirements({ gameInfo }: Props) {
                   {t('specs.recommended').toUpperCase()}
                 </td>
               </tr>
-              {extra.reqs.map(
+              {extraInfo.reqs.map(
                 (e) =>
                   e &&
                   e.title && (


### PR DESCRIPTION
This PR fixes #1160 

Instead of trying to generate a url for an Epic game based on its title, this PR changes that to use the response of the API we use to get the requirements which also includes the `_slug` property.

It's important to clear heroic's cache to test this (or at least clear the `./config/heroic/lib-cache/gameinfo.json` file), since we cache the games extra info in an electron store.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
