### PR TITLE
[UI] Fix autoComplete list box position

### DIFF
--- a/src/frontend/components/UI/SearchBar/index.css
+++ b/src/frontend/components/UI/SearchBar/index.css
@@ -16,7 +16,7 @@
   background-color: var(--input-background);
   overflow: auto;
   list-style: none;
-  margin: 0;
+  margin: -2px -4px;
   display: none;
   padding: var(--space-xs) var(--space-md);
   text-align: left;


### PR DESCRIPTION
The result box based on the search bar input was positioned slightly to the right. This made it look out of place.

This PR aims to fix that by vertically aligning the autoComplete result box to the search box by altering the top and left margins.

![Fix-search-result-box](https://user-images.githubusercontent.com/74495920/208649803-1bb31500-c813-4f96-a5e0-2010a06e895d.png)


Old PR #2240 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
