### PR TITLE
Alternative Login visibility fixes

### DIFF
--- a/src/frontend/themes.css
+++ b/src/frontend/themes.css
@@ -71,6 +71,10 @@ body.nord-light {
   --action-icon-active: var(--text-default);
 }
 
+body.nord-light .alternative > svg {
+  fill: var(--accent) !important;
+}
+
 body.nord-dark {
   --accent: #88c0d0;
   --accent-overlay: #bdeaf7;
@@ -188,6 +192,10 @@ body.old-school {
   --action-icon: var(--text-default);
   --action-icon-hover: var(--text-hover);
   --action-icon-active: var(--accent);
+}
+body.classic .sid-input,
+body.old-school .sid-input {
+  background: var(--background);
 }
 
 body.classic,


### PR DESCRIPTION
This PR fixes two issues with the visibility of elements in the Alternative Login flow in 2 themes.

1 - It fixes #2244 by using a lighter color for the input field in the Default themes

before:

![image](https://user-images.githubusercontent.com/188464/209265446-6486d1f3-bfb8-4048-9586-4c9c1d7073dd.png)

after:

![image](https://user-images.githubusercontent.com/188464/209265458-6efa876f-49d2-4823-97a9-995d91fb7937.png)

2 - It fixes the `alternative login` epic logo in the Nord Light theme:

before:

![image](https://user-images.githubusercontent.com/188464/209265582-86d32d67-c8ad-4ef8-8f5a-ada6cf5dd3c4.png)

after:

![image](https://user-images.githubusercontent.com/188464/209265588-041950d5-ed51-427b-b9d3-427186721325.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
