### PR TITLE
[UI] Add scaling effect on sidebar hover

### DIFF
--- a/src/frontend/components/UI/Sidebar/index.css
+++ b/src/frontend/components/UI/Sidebar/index.css
@@ -13,6 +13,7 @@
   text-align: left;
   background: var(--navbar-background);
   overflow: auto;
+  overflow-x: hidden;
 }
 
 .Sidebar.collapsed {
@@ -62,12 +63,10 @@
   background-color: var(--navbar-active-background);
   transition: 0.2s;
   scale: 1.02;
-  width: 99%;
 }
 
 .Sidebar__item.SidebarLinks__subItem:hover {
   scale: 1;
-  width: 100%;
 }
 
 .Sidebar__item.active {

--- a/src/frontend/components/UI/Sidebar/index.css
+++ b/src/frontend/components/UI/Sidebar/index.css
@@ -60,6 +60,14 @@
 
 .Sidebar__item:hover {
   background-color: var(--navbar-active-background);
+  transition: 0.2s;
+  scale: 1.02;
+  width: 99%;
+}
+
+.Sidebar__item.SidebarLinks__subItem:hover {
+  scale: 1;
+  width: 100%;
 }
 
 .Sidebar__item.active {


### PR DESCRIPTION
The sidebar's main items undergo a minimal scaling effect when hovered, just like the game cards.
This effect does not apply to the sub-items. 

_Demo:_

https://user-images.githubusercontent.com/74495920/209443184-1279f2f5-d0d1-4567-b61d-e9a6bbb44674.mp4



---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
