### PR TITLE
Remove `lastPlay` log when uninstalling a game

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1090,30 +1090,17 @@ ipcMain.handle(
       }
     }
     if (shouldRemoveSetting) {
-      logInfo(`Removing ${appName.concat('.json')}`, {
-        prefix: LogPrefix.Backend
-      })
-      // remove setting json if exists
-      const gameSettingsFile = join(
-        heroicGamesConfigPath,
-        appName.concat('.json')
-      )
-      if (existsSync(gameSettingsFile)) {
-        rmSync(join(heroicGamesConfigPath, appName.concat('.json')), {
-          recursive: true
-        })
+      const removeIfExists = (filename: string) => {
+        logInfo(`Removing ${filename}`, { prefix: LogPrefix.Backend })
+        const gameSettingsFile = join(heroicGamesConfigPath, filename)
+        if (existsSync(gameSettingsFile)) {
+          rmSync(gameSettingsFile)
+        }
       }
 
-      logInfo(`Removing ${appName.concat('.log')}`, {
-        prefix: LogPrefix.Backend
-      })
-      // remove log if exists
-      const gameLogFile = join(heroicGamesConfigPath, appName.concat('.log'))
-      if (existsSync(gameLogFile)) {
-        rmSync(join(heroicGamesConfigPath, appName.concat('.log')), {
-          recursive: true
-        })
-      }
+      removeIfExists(appName.concat('.json'))
+      removeIfExists(appName.concat('.log'))
+      removeIfExists(appName.concat('-lastPlay.log'))
     }
 
     notify({ title, body: i18next.t('notify.uninstalled') })


### PR DESCRIPTION
We have the new feature to remove the game settings/logs when uninstalling a game and I noticed it was not deleting the `...-lastPlay.log` file.

This PR adds that and a small refactor since I was adding a third block or similar code.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
