### PR TITLE
[FIX] Game status detection when uninstalling/running games

### DIFF
--- a/src/frontend/components/UI/UninstallModal/index.tsx
+++ b/src/frontend/components/UI/UninstallModal/index.tsx
@@ -19,7 +19,8 @@ interface UninstallModalProps {
 }
 
 const UninstallModal: React.FC<UninstallModalProps> = function (props) {
-  const { handleGameStatus, platform } = useContext(ContextProvider)
+  const { handleGameStatus, platform, refreshLibrary } =
+    useContext(ContextProvider)
   const [isWindowsOnLinux, setIsWindowsOnLinux] = useState(false)
   const [winePrefix, setWinePrefix] = useState('')
   const [checkboxChecked, setCheckboxChecked] = useState(false)
@@ -83,6 +84,7 @@ const UninstallModal: React.FC<UninstallModalProps> = function (props) {
       runner: props.runner,
       status: 'done'
     })
+    refreshLibrary({ fullRefresh: true, checkForUpdates: false })
   }
 
   return (

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -92,7 +92,7 @@ const GameCard = ({
     cloud_save_enabled: hasCloudSave,
     install: gameInstallInfo,
     thirdPartyManagedApp
-  } = gameInfo
+  } = gameInfoFromProps
 
   // if the game supports cloud saves, check the config
   const [autoSyncSaves, setAutoSyncSaves] = useState(hasCloudSave)

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -531,7 +531,7 @@ export class GlobalState extends PureComponent<Props> {
     }
 
     // if the app is done installing or errored
-    if (['error', 'done'].includes(status)) {
+    if (['error', 'done', 'playing'].includes(status)) {
       // if the app was updating, remove from the available game updates
       newLibraryStatus = libraryStatus.filter(
         (game) => game.appName !== appName


### PR DESCRIPTION
I found some issues when uninstalling and running games and the frontend not updating the status accordingly. The issues seem to happen when trying to uninstall/run a game in the same Heroic session when the game was installed (but from the solutions I think it some problems could affect other cases that I couldn't identify better).

The may problems were:
- we were not triggering a new refresh from the frontend after a game was uninstalled
- the GameCard's game info was not updating properly when a game was uninstalled
- the game card was not updating the status to the `playing` status (button was not changing properly)


How to test the original issue in the current `stable` branch:
- install a game
- without closing heroic, uninstall the game (game still shows up as installed, sometimes it shows up as not available)
- OR, without closing heroic, run the game (game starts but the `Play` button never changes to the `Stop (Playing)` status)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
