### PR TITLE
Ignore remove from steam notification only if no errors

### DIFF
--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -454,13 +454,13 @@ async function removeNonSteamGame(props: {
     })
   }
 
-  // game was not on any steam shortcut
-  // nothing to notify
-  if (!removed) {
-    return
-  }
-
   if (errors.length === 0) {
+    // game was not on any steam shortcut
+    // nothing to notify
+    if (!removed) {
+      return
+    }
+
     logInfo(`${props.gameInfo.title} was successfully removed from Steam.`, {
       prefix: LogPrefix.Shortcuts
     })


### PR DESCRIPTION
When removing games from steam, if the shortcut cannot be removed because of an error, we are currently not logging the error because there's a check to avoid notifications that happens too soon.

This PR changes that a bit to only ignore the notification IF there's no errors during the removal. If there's any error, show the notification and log the information.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
