### PR TITLE
Stop logging all controller interactions

### DIFF
--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -102,7 +102,7 @@ export const initGamepad = () => {
     }
 
     if (!wasActive || shouldRepeat) {
-      console.log(`Action: ${action}`)
+      // console.log(`Action: ${action}`)
 
       // set last triggeredAt timestamp, used for repeater
       data.triggeredAt[controllerIndex] = now
@@ -307,7 +307,7 @@ export const initGamepad = () => {
       const controller = gamepads[index]
       if (!controller) return
 
-      logState(index)
+      // logState(index)
 
       const buttons = controller.buttons
       const axes = controller.axes
@@ -334,24 +334,24 @@ export const initGamepad = () => {
     requestAnimationFrame(updateStatus)
   }
 
-  function logState(index: number) {
-    const controller = navigator.getGamepads()[index]
-    if (!controller) return
+  // function logState(index: number) {
+  //   const controller = navigator.getGamepads()[index]
+  //   if (!controller) return
 
-    const buttons = controller.buttons
-    const axes = controller.axes
+  //   const buttons = controller.buttons
+  //   const axes = controller.axes
 
-    for (const button in buttons) {
-      if (buttons[button].pressed)
-        console.log(`button ${button} pressed ${buttons[button].value}`)
-    }
-    for (const axis in axes) {
-      if (axes[axis] < -0.2 && axes[axis] >= -1)
-        console.log(`axis ${axis} activated negative`)
-      if (axes[axis] > 0.2 && axes[axis] <= 1)
-        console.log(`axis ${axis} activated positive`)
-    }
-  }
+  //   for (const button in buttons) {
+  //     if (buttons[button].pressed)
+  //       console.log(`button ${button} pressed ${buttons[button].value}`)
+  //   }
+  //   for (const axis in axes) {
+  //     if (axes[axis] < -0.2 && axes[axis] >= -1)
+  //       console.log(`axis ${axis} activated negative`)
+  //     if (axes[axis] > 0.2 && axes[axis] <= 1)
+  //       console.log(`axis ${axis} activated positive`)
+  //   }
+  // }
 
   function connecthandler(e: GamepadEvent) {
     addgamepad(e.gamepad)


### PR DESCRIPTION
When I implemented the gamepad support to navigate heroic, I added a bunch of `console.log` to help debug issues. We haven't had any major problem with the controller that would require logs so far and it's adding A LOT of noise in the devtools console, hiding other more important messages.

This PR just comments out the code that logs things, if we need to debug anything we can just uncomment this in the future.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
