### PR TITLE
Prevent default settings env variables corruption

### DIFF
--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -239,7 +239,7 @@ class GameConfigV0 extends GameConfig {
       launcherArgs,
       nvidiaPrime,
       offlineMode,
-      enviromentOptions: enviromentOptions,
+      enviromentOptions: [...enviromentOptions],
       wrapperOptions,
       savesPath,
       showFps,


### PR DESCRIPTION
There's an issue in the current stable release (and probably present since a long time ago) were the list of env variables in the default settings would show env variables that are NOT configured as default values but that are configured in games.

There's no issue in github and no easy way to test the actual error if you are not currently experiencing it, but once the problem is there it seems to happen 100% of the time.

There was a discussion in the `#gaming` channel in discord ending with the confirmation that this change fixes the problem for users experiencing it https://discord.com/channels/812703221789097985/818939492244258826/1056785006833438730

The problem was: When reading settings for games, we initially get the default settings and then we override values from the actual settings of the game. I understand that the array of environment variables is being passed as reference and not as value, so then the game setting is overriding the default settings too when we override the settings for the game (at the end with the 2 spread operators).

This PR changes that to clone the default env variables instead of using the array as reference.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
