### PR TITLE
[Refactor] Push status updates from the backend to the frontend

### DIFF
--- a/src/backend/legendary/eos_overlay/eos_overlay.ts
+++ b/src/backend/legendary/eos_overlay/eos_overlay.ts
@@ -14,7 +14,7 @@ import { runLegendaryCommand } from '../library'
 import { LegendaryGame } from '../games'
 import { getGame } from '../../utils'
 import { verifyWinePrefix } from '../../launcher'
-import { sendFrontendMessage } from 'backend/main_window'
+import { sendFrontendMessage } from '../../main_window'
 
 const currentVersionPath = join(legendaryConfigPath, 'overlay_version.json')
 const installedVersionPath = join(legendaryConfigPath, 'overlay_install.json')

--- a/src/backend/legendary/eos_overlay/eos_overlay.ts
+++ b/src/backend/legendary/eos_overlay/eos_overlay.ts
@@ -14,6 +14,7 @@ import { runLegendaryCommand } from '../library'
 import { LegendaryGame } from '../games'
 import { getGame } from '../../utils'
 import { verifyWinePrefix } from '../../launcher'
+import { sendFrontendMessage } from 'backend/main_window'
 
 const currentVersionPath = join(legendaryConfigPath, 'overlay_version.json')
 const installedVersionPath = join(legendaryConfigPath, 'overlay_install.json')
@@ -87,6 +88,12 @@ async function updateInfo() {
  * @returns The error encountered when installing, if any
  */
 async function install() {
+  sendFrontendMessage('gameStatusUpdate', {
+    appName: eosOverlayAppName,
+    runner: 'legendary',
+    status: isInstalled() ? 'updating' : 'installing'
+  })
+
   const game = LegendaryGame.get(eosOverlayAppName)
   let downloadSize = 0
   // Run download without -y to get the install size
@@ -125,6 +132,12 @@ async function install() {
   )
 
   deleteAbortController(eosOverlayAppName)
+
+  sendFrontendMessage('gameStatusUpdate', {
+    appName: eosOverlayAppName,
+    runner: 'legendary',
+    status: 'done'
+  })
 
   return error
 }

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1027,46 +1027,63 @@ ipcMain.on('showItemInFolder', async (e, item) => showItemInFolder(item))
 ipcMain.handle(
   'uninstall',
   async (event, appName, runner, shouldRemovePrefix, shouldRemoveSetting) => {
+    sendFrontendMessage('gameStatusUpdate', {
+      appName,
+      runner,
+      status: 'uninstalling'
+    })
+
     const game = getGame(appName, runner)
 
     const { title } = game.getGameInfo()
 
+    let uninstalled = false
+
     try {
       await game.uninstall()
+      uninstalled = true
     } catch (error) {
       notify({
         title,
         body: i18next.t('notify.uninstalled.error', 'Error uninstalling')
       })
       logError(error, { prefix: LogPrefix.Backend })
-      return
     }
-    if (shouldRemovePrefix) {
-      const { winePrefix } = await game.getSettings()
-      logInfo(`Removing prefix ${winePrefix}`, {
-        prefix: LogPrefix.Backend
-      })
-      // remove prefix if exists
-      if (existsSync(winePrefix)) {
-        rmSync(winePrefix, { recursive: true })
-      }
-    }
-    if (shouldRemoveSetting) {
-      const removeIfExists = (filename: string) => {
-        logInfo(`Removing ${filename}`, { prefix: LogPrefix.Backend })
-        const gameSettingsFile = join(heroicGamesConfigPath, filename)
-        if (existsSync(gameSettingsFile)) {
-          rmSync(gameSettingsFile)
+
+    if (uninstalled) {
+      if (shouldRemovePrefix) {
+        const { winePrefix } = await game.getSettings()
+        logInfo(`Removing prefix ${winePrefix}`, {
+          prefix: LogPrefix.Backend
+        })
+        // remove prefix if exists
+        if (existsSync(winePrefix)) {
+          rmSync(winePrefix, { recursive: true })
         }
       }
+      if (shouldRemoveSetting) {
+        const removeIfExists = (filename: string) => {
+          logInfo(`Removing ${filename}`, { prefix: LogPrefix.Backend })
+          const gameSettingsFile = join(heroicGamesConfigPath, filename)
+          if (existsSync(gameSettingsFile)) {
+            rmSync(gameSettingsFile)
+          }
+        }
 
-      removeIfExists(appName.concat('.json'))
-      removeIfExists(appName.concat('.log'))
-      removeIfExists(appName.concat('-lastPlay.log'))
+        removeIfExists(appName.concat('.json'))
+        removeIfExists(appName.concat('.log'))
+        removeIfExists(appName.concat('-lastPlay.log'))
+      }
+
+      notify({ title, body: i18next.t('notify.uninstalled') })
+      logInfo('Finished uninstalling', { prefix: LogPrefix.Backend })
     }
 
-    notify({ title, body: i18next.t('notify.uninstalled') })
-    logInfo('Finished uninstalling', { prefix: LogPrefix.Backend })
+    sendFrontendMessage('gameStatusUpdate', {
+      appName,
+      runner,
+      status: 'done'
+    })
   }
 )
 
@@ -1077,6 +1094,13 @@ ipcMain.handle('repair', async (event, appName, runner) => {
     })
     return
   }
+
+  sendFrontendMessage('gameStatusUpdate', {
+    appName,
+    runner,
+    status: 'repairing'
+  })
+
   const game = getGame(appName, runner)
   const { title } = game.getGameInfo()
 
@@ -1091,30 +1115,46 @@ ipcMain.handle('repair', async (event, appName, runner) => {
   }
   notify({ title, body: i18next.t('notify.finished.reparing') })
   logInfo('Finished repairing', { prefix: LogPrefix.Backend })
+
+  sendFrontendMessage('gameStatusUpdate', {
+    appName,
+    runner,
+    status: 'done'
+  })
 })
 
 ipcMain.handle(
   'moveInstall',
-  async (event, { appName, path, runner }): StatusPromise => {
+  async (event, { appName, path, runner }): Promise<void> => {
+    sendFrontendMessage('gameStatusUpdate', {
+      appName,
+      runner,
+      status: 'moving'
+    })
+
     const game = getGame(appName, runner)
     const { title } = game.getGameInfo()
     notify({ title, body: i18next.t('notify.moving', 'Moving Game') })
-    let newPath: string
+
     try {
-      newPath = await game.moveInstall(path)
+      const newPath = await game.moveInstall(path)
+      notify({ title, body: i18next.t('notify.moved') })
+      logInfo(`Finished moving ${appName} to ${newPath}.`, {
+        prefix: LogPrefix.Backend
+      })
     } catch (error) {
       notify({
         title,
         body: i18next.t('notify.error.move', 'Error Moving the Game')
       })
       logError(error, { prefix: LogPrefix.Backend })
-      return { status: 'error' }
     }
-    notify({ title, body: i18next.t('notify.moved') })
-    logInfo(`Finished moving ${appName} to ${newPath}.`, {
-      prefix: LogPrefix.Backend
+
+    sendFrontendMessage('gameStatusUpdate', {
+      appName,
+      runner,
+      status: 'done'
     })
-    return { status: 'done' }
   }
 )
 

--- a/src/backend/sideload/games.ts
+++ b/src/backend/sideload/games.ts
@@ -37,7 +37,7 @@ import { addShortcuts, removeShortcuts } from '../shortcuts/shortcuts/shortcuts'
 import shlex from 'shlex'
 import { showDialogBoxModalAuto } from '../dialog/dialog'
 import { createAbortController } from '../utils/aborthandler/aborthandler'
-import { sendFrontendMessage } from 'backend/main_window'
+import { sendFrontendMessage } from '../main_window'
 
 export function appLogFileLocation(appName: string) {
   return join(heroicGamesConfigPath, `${appName}-lastPlay.log`)

--- a/src/backend/sideload/games.ts
+++ b/src/backend/sideload/games.ts
@@ -37,6 +37,7 @@ import { addShortcuts, removeShortcuts } from '../shortcuts/shortcuts/shortcuts'
 import shlex from 'shlex'
 import { showDialogBoxModalAuto } from '../dialog/dialog'
 import { createAbortController } from '../utils/aborthandler/aborthandler'
+import { sendFrontendMessage } from 'backend/main_window'
 
 export function appLogFileLocation(appName: string) {
   return join(heroicGamesConfigPath, `${appName}-lastPlay.log`)
@@ -295,6 +296,12 @@ export async function removeApp({
   appName,
   shouldRemovePrefix
 }: RemoveArgs): Promise<void> {
+  sendFrontendMessage('gameStatusUpdate', {
+    appName,
+    runner: 'sideload',
+    status: 'uninstalling'
+  })
+
   const old = libraryStore.get('games', []) as SideloadGame[]
   const current = old.filter((a: SideloadGame) => a.app_name !== appName)
   libraryStore.set('games', current)
@@ -313,7 +320,13 @@ export async function removeApp({
 
   removeAppShortcuts(appName)
 
-  return logInfo('finished uninstalling', { prefix: LogPrefix.Backend })
+  sendFrontendMessage('gameStatusUpdate', {
+    appName,
+    runner: 'sideload',
+    status: 'done'
+  })
+
+  logInfo('finished uninstalling', { prefix: LogPrefix.Backend })
 }
 
 export function isNativeApp(appName: string): boolean {

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -156,7 +156,7 @@ interface AsyncIPCFunctions {
     shoudlRemoveSetting: boolean
   ) => Promise<void>
   repair: (appName: string, runner: Runner) => Promise<void>
-  moveInstall: (args: MoveGameArgs) => StatusPromise
+  moveInstall: (args: MoveGameArgs) => Promise<void>
   importGame: (args: ImportGameArgs) => StatusPromise
   updateGame: (appName: string, runner: Runner) => StatusPromise
   changeInstallPath: (args: MoveGameArgs) => Promise<void>

--- a/src/frontend/components/UI/UninstallModal/index.tsx
+++ b/src/frontend/components/UI/UninstallModal/index.tsx
@@ -19,7 +19,7 @@ interface UninstallModalProps {
 }
 
 const UninstallModal: React.FC<UninstallModalProps> = function (props) {
-  const { handleGameStatus, platform } = useContext(ContextProvider)
+  const { platform } = useContext(ContextProvider)
   const [isWindowsOnLinux, setIsWindowsOnLinux] = useState(false)
   const [winePrefix, setWinePrefix] = useState('')
   const [checkboxChecked, setCheckboxChecked] = useState(false)
@@ -63,11 +63,6 @@ const UninstallModal: React.FC<UninstallModalProps> = function (props) {
   const uninstallGame = async () => {
     props.onClose()
 
-    await handleGameStatus({
-      appName: props.appName,
-      runner: props.runner,
-      status: 'uninstalling'
-    })
     await window.api.uninstall(
       props.appName,
       props.runner,
@@ -78,11 +73,6 @@ const UninstallModal: React.FC<UninstallModalProps> = function (props) {
       navigate('/')
     }
     storage.removeItem(props.appName)
-    handleGameStatus({
-      appName: props.appName,
-      runner: props.runner,
-      status: 'done'
-    })
   }
 
   return (

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -34,13 +34,8 @@ export default function GamesSubmenu({
   disableUpdate,
   onShowRequirements
 }: Props) {
-  const {
-    handleGameStatus,
-    refresh,
-    platform,
-    libraryStatus,
-    showDialogModal
-  } = useContext(ContextProvider)
+  const { refresh, platform, libraryStatus, showDialogModal } =
+    useContext(ContextProvider)
   const isWin = platform === 'win32'
   const isLinux = platform === 'linux'
 
@@ -66,9 +61,7 @@ export default function GamesSubmenu({
       defaultPath: defaultInstallPath
     })
     if (path) {
-      await handleGameStatus({ appName, runner, status: 'moving' })
       await window.api.moveInstall({ appName, path, runner })
-      await handleGameStatus({ appName, runner, status: 'done' })
     }
   }
 
@@ -111,9 +104,7 @@ export default function GamesSubmenu({
   }
 
   async function onRepairYesClick(appName: string) {
-    await handleGameStatus({ appName, runner, status: 'repairing' })
     await repair(appName, runner)
-    await handleGameStatus({ appName, runner, status: 'done' })
   }
 
   function handleRepair(appName: string) {
@@ -153,19 +144,7 @@ export default function GamesSubmenu({
       let { wasEnabled } = initialEnableResult
 
       if (installNow) {
-        await handleGameStatus({
-          appName: eosOverlayAppName,
-          runner: 'legendary',
-          status: 'installing'
-        })
-
         await window.api.installEosOverlay()
-        await handleGameStatus({
-          appName: eosOverlayAppName,
-          runner: 'legendary',
-          status: 'done'
-        })
-
         wasEnabled = (await window.api.enableEosOverlay(appName)).wasEnabled
       }
       setEosOverlayEnabled(wasEnabled)

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -75,7 +75,6 @@ const GameCard = ({
   const {
     libraryStatus,
     layout,
-    handleGameStatus,
     hiddenGames,
     favouriteGames,
     allTilesInColor,
@@ -216,7 +215,6 @@ const GameCard = ({
 
   const handleRemoveFromQueue = () => {
     window.api.removeFromDMQueue(appName)
-    handleGameStatus({ appName, status: 'done' })
   }
 
   const renderIcon = () => {
@@ -544,11 +542,6 @@ const GameCard = ({
     }
 
     if (isQueued) {
-      handleGameStatus({
-        appName,
-        runner,
-        status: 'done'
-      })
       storage.removeItem(appName)
       return window.api.removeFromDMQueue(appName)
     }

--- a/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
@@ -33,13 +33,8 @@ export default function AdvancedSettings() {
     useState(false)
   const eosOverlayAppName = '98bc04bc842e4906993fd6d6644ffb8d'
 
-  const {
-    libraryStatus,
-    handleGameStatus,
-    platform,
-    refreshLibrary,
-    showResetDialog
-  } = useContext(ContextProvider)
+  const { libraryStatus, platform, refreshLibrary, showResetDialog } =
+    useContext(ContextProvider)
   const { t } = useTranslation()
   const isWindows = platform === 'win32'
 
@@ -113,18 +108,8 @@ export default function AdvancedSettings() {
   }
 
   async function installEosOverlay() {
-    await handleGameStatus({
-      appName: eosOverlayAppName,
-      runner: 'legendary',
-      status: 'installing'
-    })
     setEosOverlayInstallingOrUpdating(true)
     const installError = await window.api.installEosOverlay()
-    await handleGameStatus({
-      appName: eosOverlayAppName,
-      runner: 'legendary',
-      status: 'done'
-    })
     setEosOverlayInstallingOrUpdating(false)
     setEosOverlayInstalled(!installError)
     // `eos-overlay install` enables the overlay by default on Windows
@@ -139,18 +124,8 @@ export default function AdvancedSettings() {
   }
 
   async function updateEosOverlay() {
-    await handleGameStatus({
-      appName: eosOverlayAppName,
-      runner: 'legendary',
-      status: 'updating'
-    })
     setEosOverlayInstallingOrUpdating(true)
     await window.api.installEosOverlay()
-    await handleGameStatus({
-      appName: eosOverlayAppName,
-      runner: 'legendary',
-      status: 'done'
-    })
     setEosOverlayInstallingOrUpdating(false)
     const { version: newVersion } = await window.api.getEosOverlayStatus()
     setEosOverlayVersion(newVersion ?? '')
@@ -158,11 +133,6 @@ export default function AdvancedSettings() {
 
   async function cancelEosOverlayInstallOrUpdate() {
     await window.api.abort(eosOverlayAppName)
-    await handleGameStatus({
-      appName: eosOverlayAppName,
-      runner: 'legendary',
-      status: 'canceled'
-    })
     setEosOverlayInstallingOrUpdating(false)
   }
 

--- a/src/frontend/state/ContextProvider.tsx
+++ b/src/frontend/state/ContextProvider.tsx
@@ -22,7 +22,6 @@ const initialContext: ContextType = {
   filterPlatform: 'all',
   gameUpdates: [],
   handleCategory: () => null,
-  handleGameStatus: async () => Promise.resolve(),
   handleLayout: () => null,
   handlePlatformFilter: () => null,
   handleSearch: () => null,

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -618,8 +618,7 @@ export class GlobalState extends PureComponent<Props> {
     })
 
     window.api.handleGameStatus(async (e: Event, args: GameStatus) => {
-      const { libraryStatus } = this.state
-      return this.handleGameStatus({ ...libraryStatus, ...args })
+      return this.handleGameStatus({ ...args })
     })
 
     window.api.handleRefreshLibrary(async (e: Event, runner: Runner) => {

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -729,7 +729,6 @@ export class GlobalState extends PureComponent<Props> {
             logout: this.gogLogout
           },
           handleCategory: this.handleCategory,
-          handleGameStatus: this.handleGameStatus,
           handleLayout: this.handleLayout,
           handlePlatformFilter: this.handlePlatformFilter,
           handleSearch: this.handleSearch,

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -24,7 +24,6 @@ export interface ContextType {
   setLanguage: (newLanguage: string) => void
   handleCategory: (value: Category) => void
   handlePlatformFilter: (value: string) => void
-  handleGameStatus: (game: GameStatus) => Promise<void>
   handleLayout: (value: string) => void
   handleSearch: (input: string) => void
   layout: string


### PR DESCRIPTION
This is another PR that I'm extracting from the original game status refactor PR https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/1857

Since that PR got too out of date and it's hard to rebase it, I found it easier to extract smaller and easier-to-review PRs to eventually move all that code.

With these changes, status updates for uninstalling/moving/repairing games and installing/updating/uninstalling the EOSOverlay installation are pushed from the backend to the frontend, the same way other status updates are handled for game installation or game progress.

This makes it more consistent to always push updates from the backend and the updates are pushed closer to the source of actual action.

With this I was also able to remove the `handleGameStatus` function in the ContextProvider, to have less stuff there.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
