### PR TITLE
[Refactor] Load settings synchronously

### DIFF
--- a/src/backend/__mocks__/config.ts
+++ b/src/backend/__mocks__/config.ts
@@ -11,7 +11,7 @@ const GlobalConfig = (() => {
     setConfigValue,
     get: () => {
       return {
-        getSettings: async () => config
+        getSettings: () => config
       }
     }
   }

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -48,6 +48,10 @@ abstract class GlobalConfig {
 
   protected config: AppSettings | undefined
 
+  public set(config: AppSettings) {
+    this.config = config
+  }
+
   /**
    * Get the global configuartion handler.
    * If one doesn't exist, create one.

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -46,7 +46,7 @@ abstract class GlobalConfig {
 
   public abstract version: GlobalConfigVersion
 
-  public config: AppSettings | undefined
+  protected config: AppSettings | undefined
 
   /**
    * Get the global configuartion handler.

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -30,6 +30,7 @@ import {
   configStore
 } from './constants'
 import { execAsync } from './utils'
+import { execSync } from 'child_process'
 import { logError, logInfo, LogPrefix } from './logger/logger'
 import { dirname, join } from 'path'
 
@@ -45,8 +46,7 @@ abstract class GlobalConfig {
 
   public abstract version: GlobalConfigVersion
 
-  // @ts-expect-error TODO: Somehow figure out how to synchronously load the config
-  public config: AppSettings
+  public config: AppSettings | undefined
 
   /**
    * Get the global configuartion handler.
@@ -124,29 +124,29 @@ abstract class GlobalConfig {
    *
    * @returns Promise<WineInstallation>
    */
-  public async getDefaultWine(): Promise<WineInstallation> {
+  public getDefaultWine(): WineInstallation {
     const defaultWine: WineInstallation = {
       bin: '',
       name: 'Default Wine - Not Found',
       type: 'wine'
     }
-    return execAsync(`which wine`)
-      .then(async ({ stdout }) => {
-        const wineBin = stdout.split('\n')[0]
-        defaultWine.bin = wineBin
 
-        const { stdout: out } = await execAsync(`wine --version`)
-        const version = out.split('\n')[0]
-        defaultWine.name = `Wine Default - ${version}`
+    try {
+      let stdout = execSync(`which wine`).toString()
+      const wineBin = stdout.split('\n')[0]
+      defaultWine.bin = wineBin
 
-        return {
-          ...defaultWine,
-          ...this.getWineExecs(wineBin)
-        }
-      })
-      .catch(() => {
-        return defaultWine
-      })
+      stdout = execSync(`wine --version`).toString()
+      const version = stdout.split('\n')[0]
+      defaultWine.name = `Wine Default - ${version}`
+
+      return {
+        ...defaultWine,
+        ...this.getWineExecs(wineBin)
+      }
+    } catch {
+      return defaultWine
+    }
   }
 
   /**
@@ -361,7 +361,7 @@ abstract class GlobalConfig {
 
     let customWineSet = new Set<WineInstallation>()
     if (scanCustom) {
-      customWineSet = await this.getCustomWinePaths()
+      customWineSet = this.getCustomWinePaths()
     }
 
     return [
@@ -424,7 +424,7 @@ abstract class GlobalConfig {
    *
    * @returns Settings present in config file.
    */
-  public abstract getSettings(): Promise<AppSettings>
+  public abstract getSettings(): AppSettings
 
   /**
    * Updates this.config, this.version to upgrade the current config file.
@@ -441,7 +441,7 @@ abstract class GlobalConfig {
    *
    * @returns Set of Wine installations.
    */
-  public abstract getCustomWinePaths(): Promise<Set<WineInstallation>>
+  public abstract getCustomWinePaths(): Set<WineInstallation>
 
   /**
    * Get default settings as if the user's config file doesn't exist.
@@ -450,7 +450,7 @@ abstract class GlobalConfig {
    *
    * @returns AppSettings
    */
-  public abstract getFactoryDefaults(): Promise<AppSettings>
+  public abstract getFactoryDefaults(): AppSettings
 
   /**
    * Reset `this.config` to `getFactoryDefaults()` and flush.
@@ -470,7 +470,7 @@ abstract class GlobalConfig {
   /**
    * Load the config file, upgrade if needed.
    */
-  protected async load() {
+  protected load() {
     // Config file doesn't exist, make one.
     if (!existsSync(heroicConfigPath)) {
       this.resetToDefaults()
@@ -483,7 +483,7 @@ abstract class GlobalConfig {
     } else {
       // No upgrades necessary, load config.
       // `this.version` should be `currentGlobalConfigVersion` at this point.
-      this.config = (await this.getSettings()) as AppSettings
+      this.config = this.getSettings() as AppSettings
     }
   }
 }
@@ -502,7 +502,11 @@ class GlobalConfigV0 extends GlobalConfig {
     return false
   }
 
-  public async getSettings(): Promise<AppSettings> {
+  public getSettings(): AppSettings {
+    if (this.config) {
+      return this.config
+    }
+
     if (!existsSync(heroicGamesConfigPath)) {
       mkdirSync(heroicGamesConfigPath, { recursive: true })
     }
@@ -520,7 +524,7 @@ class GlobalConfigV0 extends GlobalConfig {
       : ''
 
     settings = {
-      ...(await this.getFactoryDefaults()),
+      ...this.getFactoryDefaults(),
       ...settings.defaultSettings,
       winePrefix
     } as AppSettings
@@ -535,11 +539,11 @@ class GlobalConfigV0 extends GlobalConfig {
     return settings
   }
 
-  public async getCustomWinePaths(): Promise<Set<WineInstallation>> {
+  public getCustomWinePaths(): Set<WineInstallation> {
     const customPaths = new Set<WineInstallation>()
     // skips this on new installations to avoid infinite loops
     if (existsSync(heroicConfigPath)) {
-      const { customWinePaths = [] } = await this.getSettings()
+      const { customWinePaths = [] } = this.getSettings()
       customWinePaths.forEach((path: string) => {
         if (path.endsWith('proton')) {
           return customPaths.add({
@@ -559,10 +563,10 @@ class GlobalConfigV0 extends GlobalConfig {
     return customPaths
   }
 
-  public async getFactoryDefaults(): Promise<AppSettings> {
-    const account_id = (await LegendaryUser.getUserInfo())?.account_id
+  public getFactoryDefaults(): AppSettings {
+    const account_id = LegendaryUser.getUserInfo()?.account_id
     const userName = user().username
-    const defaultWine = isWindows ? {} : await this.getDefaultWine()
+    const defaultWine = isWindows ? {} : this.getDefaultWine()
 
     // @ts-expect-error TODO: We need to settle on *one* place to define settings defaults
     return {
@@ -600,7 +604,7 @@ class GlobalConfigV0 extends GlobalConfig {
   }
 
   public async resetToDefaults() {
-    this.config = await this.getFactoryDefaults()
+    this.config = this.getFactoryDefaults()
     return this.flush()
   }
 

--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -145,7 +145,7 @@ export function getSteamCompatFolder() {
 }
 
 export async function getSteamLibraries(): Promise<string[]> {
-  const { defaultSteamPath } = await GlobalConfig.get().getSettings()
+  const { defaultSteamPath } = GlobalConfig.get().getSettings()
   const path = defaultSteamPath.replaceAll("'", '')
   const vdfFile = join(path, 'steamapps', 'libraryfolders.vdf')
   const libraries = ['/usr/share/steam']

--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -223,7 +223,7 @@ class GameConfigV0 extends GameConfig {
       wineCrossoverBottle,
       wineVersion,
       useSteamRuntime
-    } = GlobalConfig.get().config
+    } = GlobalConfig.get().getSettings()
 
     // initialize generic defaults
     // TODO: I know more values can be moved that are not used in windows
@@ -307,7 +307,9 @@ class GameConfigV0 extends GameConfig {
     // If the defaults change, they will automatically change.
     // Explicit overrides CANNOT be the same as defaults.
     // TODO(adityaruplaha): fix this
-    const globalConfig = new Map(Object.entries(GlobalConfig.get().config))
+    const globalConfig = new Map(
+      Object.entries(GlobalConfig.get().getSettings())
+    )
     const defaultedKeys = Object.entries(this.config)
       .filter(([key, value]) => globalConfig.get(key) === value)
       .map(([k]) => k)

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -232,7 +232,7 @@ class GOGGame extends Game {
     status: 'done' | 'error' | 'abort'
     error?: string
   }> {
-    const { maxWorkers } = await GlobalConfig.get().getSettings()
+    const { maxWorkers } = GlobalConfig.get().getSettings()
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
     const withDlcs = installDlcs ? '--with-dlcs' : '--skip-dlcs'
 
@@ -802,7 +802,7 @@ class GOGGame extends Game {
    * Useful for Update and Repair
    */
   public async getCommandParameters() {
-    const { maxWorkers } = await GlobalConfig.get().getSettings()
+    const { maxWorkers } = GlobalConfig.get().getSettings()
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
     const gameData = this.getGameInfo()
     const logPath = join(heroicGamesConfigPath, this.appName + '.log')

--- a/src/backend/gog/setup.ts
+++ b/src/backend/gog/setup.ts
@@ -55,7 +55,7 @@ async function setup(
     const crossoverEnv =
       isCrossover && crossoverBottle ? `CX_BOTTLE=${crossoverBottle}` : ''
     const isProton = gameSettings.wineVersion.type === 'proton'
-    const { defaultSteamPath } = await GlobalConfig.get().getSettings()
+    const { defaultSteamPath } = GlobalConfig.get().getSettings()
     const prefix = isProton
       ? `STEAM_COMPAT_CLIENT_INSTALL_PATH="${defaultSteamPath}" STEAM_COMPAT_DATA_PATH='${gameSettings.winePrefix
           .replaceAll("'", '')

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -55,7 +55,7 @@ async function prepareLaunch(
   gameInfo: GameInfo,
   isNative: boolean
 ): Promise<LaunchPreperationResult> {
-  const globalSettings = await GlobalConfig.get().getSettings()
+  const globalSettings = GlobalConfig.get().getSettings()
 
   const offlineMode =
     gameSettings.offlineMode || !isOnline() || (await isEpicServiceOffline())
@@ -500,7 +500,7 @@ async function runWineCommand({
 }: WineCommandArgs): Promise<{ stderr: string; stdout: string }> {
   const settings = gameSettings
     ? gameSettings
-    : await GlobalConfig.get().getSettings()
+    : GlobalConfig.get().getSettings()
   const { wineVersion, winePrefix } = settings
 
   if (!skipPrefixCheckIKnowWhatImDoing && wineVersion.type !== 'crossover') {

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -448,8 +448,7 @@ class LegendaryGame extends Game {
       runner: 'legendary',
       status: 'updating'
     })
-    const { maxWorkers, downloadNoHttps } =
-      await GlobalConfig.get().getSettings()
+    const { maxWorkers, downloadNoHttps } = GlobalConfig.get().getSettings()
     const installPlatform = this.getGameInfo().install.platform!
     const info = await this.getInstallInfo(installPlatform)
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
@@ -534,8 +533,7 @@ class LegendaryGame extends Game {
     status: 'done' | 'error' | 'abort'
     error?: string
   }> {
-    const { maxWorkers, downloadNoHttps } =
-      await GlobalConfig.get().getSettings()
+    const { maxWorkers, downloadNoHttps } = GlobalConfig.get().getSettings()
     const info = await this.getInstallInfo(platformToInstall)
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
     const noHttps = downloadNoHttps ? ['--no-https'] : []
@@ -654,8 +652,7 @@ class LegendaryGame extends Game {
    */
   public async repair(): Promise<ExecResult> {
     // this.state.status = 'repairing'
-    const { maxWorkers, downloadNoHttps } =
-      await GlobalConfig.get().getSettings()
+    const { maxWorkers, downloadNoHttps } = GlobalConfig.get().getSettings()
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
     const noHttps = downloadNoHttps ? ['--no-https'] : []
 

--- a/src/backend/legendary/user.ts
+++ b/src/backend/legendary/user.ts
@@ -86,7 +86,7 @@ export class LegendaryUser {
     return existsSync(userInfo)
   }
 
-  public static async getUserInfo(): Promise<UserInfo | undefined> {
+  public static getUserInfo(): UserInfo | undefined {
     if (!LegendaryUser.isLoggedIn()) {
       configStore.delete('userInfo')
       return

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -276,7 +276,7 @@ if (!gotTheLock) {
     // We can't use .config since apparently its not loaded fast enough.
     // TODO: Remove this after a couple of stable releases
     // Affects only current users, not new installs
-    const settings = await GlobalConfig.get().getSettings()
+    const settings = GlobalConfig.get().getSettings()
     const { language } = settings
     const currentConfigStore = configStore.get('settings', {}) as AppSettings
     if (!currentConfigStore.defaultInstallPath) {
@@ -369,7 +369,7 @@ if (!gotTheLock) {
       logWarning('Protocol already registered.', { prefix: LogPrefix.Backend })
     }
 
-    const { startInTray } = await GlobalConfig.get().getSettings()
+    const { startInTray } = GlobalConfig.get().getSettings()
     const headless = isCLINoGui || startInTray
     if (!headless) {
       ipcMain.once('loadingScreenReady', () => mainWindow.show())
@@ -542,7 +542,7 @@ ipcMain.on('showConfigFileInFolder', async (event, appName) => {
 
 ipcMain.on('removeFolder', async (e, [path, folderName]) => {
   if (path === 'default') {
-    const { defaultInstallPath } = await GlobalConfig.get().getSettings()
+    const { defaultInstallPath } = GlobalConfig.get().getSettings()
     const path = defaultInstallPath.replaceAll("'", '')
     const folderToDelete = `${path}/${folderName}`
     if (existsSync(folderToDelete)) {
@@ -755,7 +755,9 @@ ipcMain.handle(
   }
 )
 
-ipcMain.handle('getUserInfo', LegendaryUser.getUserInfo)
+ipcMain.handle('getUserInfo', async () => {
+  return LegendaryUser.getUserInfo()
+})
 
 // Checks if the user have logged in with Legendary already
 ipcMain.handle('isLoggedIn', LegendaryUser.isLoggedIn)
@@ -908,7 +910,7 @@ ipcMain.handle(
     const game = isSideloaded ? getAppInfo(appName) : extGame.getGameInfo()
     const { title } = game
 
-    const { minimizeOnLaunch } = await GlobalConfig.get().getSettings()
+    const { minimizeOnLaunch } = GlobalConfig.get().getSettings()
 
     const startPlayingDate = new Date()
 
@@ -1467,7 +1469,7 @@ ipcMain.handle('clipboardReadText', () => clipboard.readText())
 ipcMain.on('clipboardWriteText', (e, text) => clipboard.writeText(text))
 
 ipcMain.handle('getCustomThemes', async () => {
-  const { customThemesPath } = await GlobalConfig.get().getSettings()
+  const { customThemesPath } = GlobalConfig.get().getSettings()
 
   if (!existsSync(customThemesPath)) {
     return []
@@ -1479,7 +1481,7 @@ ipcMain.handle('getCustomThemes', async () => {
 })
 
 ipcMain.handle('getThemeCSS', async (event, theme) => {
-  const { customThemesPath } = await GlobalConfig.get().getSettings()
+  const { customThemesPath } = GlobalConfig.get().getSettings()
 
   const cssPath = path.join(customThemesPath, theme)
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -273,7 +273,7 @@ if (!gotTheLock) {
     logInfo(['GOGDL location:', join(...Object.values(getGOGdlBin()))], {
       prefix: LogPrefix.Gog
     })
-    // We can't use .config since apparently its not loaded fast enough.
+
     // TODO: Remove this after a couple of stable releases
     // Affects only current users, not new installs
     const settings = GlobalConfig.get().getSettings()
@@ -824,7 +824,7 @@ ipcMain.handle('requestSettings', async (event, appName) => {
   if (appName === 'default') {
     return mapOtherSettings(GlobalConfig.get().getSettings())
   }
-  // We can't use .config since apparently its not loaded fast enough.
+
   const config = await GameConfig.get(appName).getSettings()
   return mapOtherSettings(config)
 })

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -850,7 +850,7 @@ ipcMain.handle('writeConfig', (event, { appName, config }) => {
   logChangedSetting(config, oldConfig)
 
   if (appName === 'default') {
-    GlobalConfig.get().config = config as AppSettings
+    GlobalConfig.get().set(config as AppSettings)
     GlobalConfig.get().flush()
     const currentConfigStore = configStore.get('settings', {}) as AppSettings
     configStore.set('settings', { ...currentConfigStore, ...config })

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -182,7 +182,7 @@ async function initializeWindow(): Promise<BrowserWindow> {
       configStore.set('window-props', mainWindow.getBounds())
     }
 
-    const { exitToTray } = GlobalConfig.get().config
+    const { exitToTray } = GlobalConfig.get().getSettings()
 
     if (exitToTray) {
       logInfo('Exitting to tray instead of quitting', {
@@ -630,7 +630,7 @@ ipcMain.handle('getNumOfGpus', async (): Promise<number> => {
 })
 
 ipcMain.handle('getLatestReleases', async () => {
-  const { checkForUpdatesOnStartup } = GlobalConfig.get().config
+  const { checkForUpdatesOnStartup } = GlobalConfig.get().getSettings()
   if (checkForUpdatesOnStartup) {
     return getLatestReleases()
   } else {
@@ -822,7 +822,7 @@ ipcMain.handle('requestSettings', async (event, appName) => {
   }
 
   if (appName === 'default') {
-    return mapOtherSettings(GlobalConfig.get().config)
+    return mapOtherSettings(GlobalConfig.get().getSettings())
   }
   // We can't use .config since apparently its not loaded fast enough.
   const config = await GameConfig.get(appName).getSettings()
@@ -843,7 +843,7 @@ ipcMain.handle('writeConfig', (event, { appName, config }) => {
   })
   const oldConfig =
     appName === 'default'
-      ? GlobalConfig.get().config
+      ? GlobalConfig.get().getSettings()
       : GameConfig.get(appName).config
 
   // log only the changed setting

--- a/src/backend/recent_games/recent_games.ts
+++ b/src/backend/recent_games/recent_games.ts
@@ -5,7 +5,7 @@ import { GlobalConfig } from '../config'
 import { configStore } from '../constants'
 
 const maxRecentGames = async () => {
-  const { maxRecentGames } = await GlobalConfig.get().getSettings()
+  const { maxRecentGames } = GlobalConfig.get().getSettings()
   return maxRecentGames || 5
 }
 

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -27,7 +27,7 @@ import { GlobalConfig } from '../../config'
 import { getMainWindow } from '../../main_window'
 
 const getSteamUserdataDir = async () => {
-  const { defaultSteamPath } = await GlobalConfig.get().getSettings()
+  const { defaultSteamPath } = GlobalConfig.get().getSettings()
   return join(defaultSteamPath.replaceAll("'", ''), 'userdata')
 }
 

--- a/src/backend/shortcuts/shortcuts/shortcuts.ts
+++ b/src/backend/shortcuts/shortcuts/shortcuts.ts
@@ -33,7 +33,7 @@ async function addShortcuts(gameInfo: GameInfo, fromMenu?: boolean) {
     prefix: LogPrefix.Backend
   })
   const { addDesktopShortcuts, addStartMenuShortcuts, addSteamShortcuts } =
-    await GlobalConfig.get().getSettings()
+    GlobalConfig.get().getSettings()
 
   if (addSteamShortcuts) {
     addNonSteamGame({ gameInfo })

--- a/src/backend/tray_icon/__tests__/tray_icon.test.ts
+++ b/src/backend/tray_icon/__tests__/tray_icon.test.ts
@@ -190,23 +190,23 @@ describe('TrayIcon', () => {
 
   describe('icon', () => {
     // the mock returns the icon path, the width, and the height
-    it('shows different size per platform', async () => {
-      let icon = await getIcon('linux')
+    it('shows different size per platform', () => {
+      let icon = getIcon('linux')
       expect(icon).toMatch(/.*icon-light.png width=32 height=32/)
 
-      icon = await getIcon('darwin')
+      icon = getIcon('darwin')
       expect(icon).toMatch(/.*icon-light.png width=20 height=20/)
     })
 
-    it('can show dark or light icon', async () => {
+    it('can show dark or light icon', () => {
       GlobalConfig['setConfigValue']('darkTrayIcon', true)
 
-      let icon = await getIcon()
+      let icon = getIcon()
       expect(icon).toMatch(/.*icon-dark.png/)
 
       GlobalConfig['setConfigValue']('darkTrayIcon', false)
 
-      icon = await getIcon()
+      icon = getIcon()
       expect(icon).toMatch(/.*icon-light.png/)
     })
   })

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -11,7 +11,7 @@ import { backendEvents } from '../backend_events'
 
 export const initTrayIcon = async (mainWindow: BrowserWindow) => {
   // create icon
-  const appIcon = new Tray(await getIcon(process.platform))
+  const appIcon = new Tray(getIcon(process.platform))
 
   // helper function to set/update the context menu
   const loadContextMenu = async (recentGames?: RecentGame[]) => {
@@ -37,7 +37,7 @@ export const initTrayIcon = async (mainWindow: BrowserWindow) => {
   ipcMain.on('changeTrayColor', () => {
     logInfo('Changing Tray icon Color...', { prefix: LogPrefix.Backend })
     setTimeout(async () => {
-      appIcon.setImage(await getIcon(process.platform))
+      appIcon.setImage(getIcon(process.platform))
       await loadContextMenu()
     }, 500)
   })
@@ -69,8 +69,8 @@ const iconSizesByPlatform = {
 }
 
 // get the icon path based on platform and settings
-export const getIcon = async (platform = process.platform) => {
-  const settings = await GlobalConfig.get().getSettings()
+export const getIcon = (platform = process.platform) => {
+  const settings = GlobalConfig.get().getSettings()
   const { darkTrayIcon } = settings
 
   return nativeImage


### PR DESCRIPTION
This PR is a refactor on the way we load the application settings to make it synchronous.

There are a few benefits of this:
- usually, sync code is easier to manage than async code (it's easy to miss awaits)
- because of the load being async, we were actually loading the config multiple times because promises were running in parallel until one of the promises finished and it was stored in memory, now we only read the files once and store the settings in memory, I noticed this problem while debugging this issue https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/2262
- I was able to convert other functions that were async into sync too
- I was able to remove a magic ignore ts linter comment, handling config being undefined properly by making it protected

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
