### PR TITLE
[Download Manager] Some images fixes

### DIFF
--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.css
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.css
@@ -130,3 +130,8 @@
 .downloadManagerListItem span:nth-child(3) {
   text-transform: capitalize;
 }
+
+.downloadManagerTitleList > img {
+  aspect-ratio: 16/9;
+  object-fit: cover;
+}

--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
@@ -60,7 +60,7 @@ const DownloadManagerItem = ({ element, current }: Props) => {
       }
     }
     getNewInfo()
-  }, [])
+  }, [element])
 
   const { art_cover, art_square } = gameInfo || {}
 

--- a/src/frontend/screens/DownloadManager/index.tsx
+++ b/src/frontend/screens/DownloadManager/index.tsx
@@ -119,8 +119,12 @@ export default React.memo(function DownloadManager(): JSX.Element | null {
           <div className="dmItemList">
             <DownloadManagerHeader time="queued" />
             {plannendElements.length > 0 ? (
-              plannendElements.map((el, key) => (
-                <DownloadManagerItem key={key} element={el} current={false} />
+              plannendElements.map((el) => (
+                <DownloadManagerItem
+                  key={el.params.appName}
+                  element={el}
+                  current={false}
+                />
               ))
             ) : (
               <DownloadManagerItem current={false} />


### PR DESCRIPTION
This PR fixes 3 issues I found in the download manager.

- When a game finishes downloading and a new one starts, the new game has the previous game's picture
- When a game finishes downloading, the next elements in the queue have the wrong image from the previous element in the list
- Some images have images with a different aspect ratio (like Far Cry 5)

Issues 1 and 2 only are noticeable if looking at the Downloads screen when a game finishes and there are elements in the queue (re-entering the Downloads page fixes the images)

Before the aspect-ratio fix:
![image](https://user-images.githubusercontent.com/188464/209602887-aa7b071c-3c5c-40e6-ae55-cc992ded8805.png)

After:
![image](https://user-images.githubusercontent.com/188464/209602892-31df98fd-85f0-4e39-9bbf-4255d4b624f9.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
