### PR TITLE
[UX] Open the game page from the card's context menu

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -48,6 +48,7 @@
         "add_to_favourites": "Add To Favourites",
         "cancel": "Pause/Cancel",
         "continue": "Continue Download",
+        "details": "Details",
         "finish": "Finish",
         "force_update": "Force Update if Available",
         "force-innstall": "Force Install",

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -356,6 +356,13 @@ const GameCard = ({
       show: isInstalling || isUpdating
     },
     {
+      // open the game page
+      label: t('button.details', 'Details'),
+      onclick: () =>
+        navigate(`/gamepage/${runner}/${appName}`, { state: { gameInfo } }),
+      show: true
+    },
+    {
       // hide
       label: t('button.hide_game', 'Hide Game'),
       onclick: () => hiddenGames.add(appName, title),


### PR DESCRIPTION
This PR adds a new item in the game card's context menu with the text `Details` that opens the game page.

This is an attempt to add some discoverability of that page, since many users do not know it exists.

![image](https://user-images.githubusercontent.com/188464/210036021-f451353b-ee33-4c58-95c5-5c3a827255f6.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
