### PR TITLE
[Gamepad] Match sony devices by vendor id

### DIFF
--- a/src/frontend/components/UI/ControllerHints/index.tsx
+++ b/src/frontend/components/UI/ControllerHints/index.tsx
@@ -121,7 +121,7 @@ export default function ControllerHints() {
 
   useEffect(() => {
     // set the brand for the images to use
-    if (activeController.match(/sony|0ce6|PS3|PLAYSTATION|0268|'2563.*0523/i)) {
+    if (activeController.match(/sony|054c|PS3|PLAYSTATION|0268|'2563.*0523/i)) {
       setLayout('ps')
     } else if (activeController.match(/28de.*11ff/)) {
       setLayout('steam-deck')


### PR DESCRIPTION
This changes a regex to match for vendor id for Sony controllers, that way all their devices will have Sony prompts

This fixes the issue with DS4 having Xbox prompts

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
