### PR TITLE
Disable Winemenubuilder when launching with Wine

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -268,9 +268,24 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
   // Add WINEPREFIX / STEAM_COMPAT_DATA_PATH / CX_BOTTLE
   const steamInstallPath = join(flatPakHome, '.steam', 'steam')
   switch (wineVersion.type) {
-    case 'wine':
+    case 'wine': {
       ret.WINEPREFIX = winePrefix
+
+      // Disable Winemenubuilder to not mess with file associations
+      const wmbDisableString = 'winemenubuilder='
+      // If the user already set WINEDLLOVERRIDES, append to the end
+      const dllOverridesVar = gameSettings.enviromentOptions.find(
+        ({ key }) => key.toLowerCase() === 'winemenubuilder'
+      )
+      if (dllOverridesVar) {
+        ret[dllOverridesVar.key] =
+          dllOverridesVar.value + ',' + wmbDisableString
+      } else {
+        ret.WINEDLLOVERRIDES = wmbDisableString
+      }
+
       break
+    }
     case 'proton':
       ret.STEAM_COMPAT_CLIENT_INSTALL_PATH = steamInstallPath
       ret.STEAM_COMPAT_DATA_PATH = winePrefix


### PR DESCRIPTION
Winemenubuilder is responsible for adding application shortcuts & managing file associations. For most users, it it more known as the reason all their `.ini` files are suddenly opening in Wine's Notepad
Disabling it is, in my opinion, the more sensible option. It is, for example, also done by Lutris (see [their FAQ](https://lutris.net/faq#winemenubuilder))

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
