### PR TITLE
[Fix] Log file deletion logic

### DIFF
--- a/src/backend/logger/__tests__/logfile.test.ts
+++ b/src/backend/logger/__tests__/logfile.test.ts
@@ -109,7 +109,7 @@ describe('logger/logfile.ts', () => {
   test('createNewLogFileAndClearOldOnes removing old logs successful', () => {
     jest.spyOn(app, 'getPath').mockReturnValue(tmpDir.name)
     const date = new Date()
-    date.setMonth(date.getMonth() > 0 ? date.getMonth() - 1 : 11)
+    date.setMonth(date.getMonth() - 1)
     const monthOutdatedLogFile = join(
       tmpDir.name,
       // @ts-ignore replaceAll error


### PR DESCRIPTION
When generating a 1-month-ago date, we were handling month 0 in a special case (and then not correctly handling it). This is actually not necessary, since JS takes care of this on its own

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
