### PR TITLE
Proper "playing" status detection

### DIFF
--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -495,6 +495,7 @@ export class GlobalState extends PureComponent<Props> {
   }: GameStatus) => {
     const { libraryStatus, gameUpdates } = this.state
     const currentApp = libraryStatus.find((game) => game.appName === appName)
+
     // add app to libraryStatus if it was not present
     if (!currentApp) {
       return this.setState({
@@ -510,32 +511,21 @@ export class GlobalState extends PureComponent<Props> {
       return
     }
 
-    let newLibraryStatus = libraryStatus
+    // if the app's status did change, remove it from the current list and then handle the new status
+    const newLibraryStatus = libraryStatus.filter(
+      (game) => game.appName !== appName
+    )
 
-    if (status === 'installing') {
-      currentApp.status = 'installing'
-      // remove the item from the library to avoid duplicates then add the new status
-      newLibraryStatus = libraryStatus.filter(
-        (game) => game.appName !== appName
-      )
+    // in these cases we just add the new status
+    if (['installing', 'updating', 'playing'].includes(status)) {
+      currentApp.status = status
       newLibraryStatus.push(currentApp)
+      this.setState({ libraryStatus: newLibraryStatus })
     }
 
-    if (status === 'updating') {
-      currentApp.status = 'updating'
-      // remove the item from the library to avoid duplicates then add the new status
-      newLibraryStatus = libraryStatus.filter(
-        (game) => game.appName !== appName
-      )
-      newLibraryStatus.push(currentApp)
-    }
-
-    // if the app is done installing or errored
-    if (['error', 'done', 'playing'].includes(status)) {
-      // if the app was updating, remove from the available game updates
-      newLibraryStatus = libraryStatus.filter(
-        (game) => game.appName !== appName
-      )
+    // when error or done we remove it from the status info
+    if (['error', 'done'].includes(status)) {
+      // also remove from updates if it was updating
       if (currentApp.status === 'updating') {
         const updatedGamesUpdates = gameUpdates.filter(
           (game) => game !== appName


### PR DESCRIPTION
A few days ago I made this PR https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/2257 fixing some issues with the handling of the game status updates, the fix for the `playing` status was incorrect (it catched some of the problems just by luck)

This PR has a proper fix for that an a small refactor to remove a lot of the duplication.

The main problem is that, when installing multiple games at once and then trying to run them without restarting heroic, in some cases the `playing` status was not handled correctly and it was showing the game as not playing.


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
