### PR TITLE
[Settings] Update Alternative binary settings correctly

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -465,9 +465,11 @@ function splitPathAndName(fullPath: string): { dir: string; bin: string } {
 }
 
 function getLegendaryBin(): { dir: string; bin: string } {
-  const settings = configStore.get('settings', {}) as { altLeg: string }
-  if (settings?.altLeg) {
-    return splitPathAndName(settings.altLeg)
+  const settings = configStore.get('settings', {}) as {
+    altLegendaryBin: string
+  }
+  if (settings?.altLegendaryBin) {
+    return splitPathAndName(settings.altLegendaryBin)
   }
   return splitPathAndName(
     fixAsarPath(join(publicDir, 'bin', process.platform, 'legendary'))
@@ -475,9 +477,9 @@ function getLegendaryBin(): { dir: string; bin: string } {
 }
 
 function getGOGdlBin(): { dir: string; bin: string } {
-  const settings = configStore.get('settings', {}) as { altGogdl: string }
-  if (settings?.altGogdl) {
-    return splitPathAndName(settings.altGogdl)
+  const settings = configStore.get('settings', {}) as { altGogdlBin: string }
+  if (settings?.altGogdlBin) {
+    return splitPathAndName(settings.altGogdlBin)
   }
   return splitPathAndName(
     fixAsarPath(join(publicDir, 'bin', process.platform, 'gogdl'))

--- a/src/frontend/screens/Settings/components/AltGOGdlBin.tsx
+++ b/src/frontend/screens/Settings/components/AltGOGdlBin.tsx
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 import { Backspace } from '@mui/icons-material'
 import useSetting from 'frontend/hooks/useSetting'
-import { configStore } from 'frontend/helpers/electronStores'
 import { TextInputWithIconField } from 'frontend/components/UI'
 
 const AltGOGdlBin = () => {
@@ -14,14 +13,6 @@ const AltGOGdlBin = () => {
 
   useEffect(() => {
     const getGogdlVersion = async () => {
-      const settings = configStore.get('settings') as {
-        altLeg: string
-        altGogdl: string
-      }
-      configStore.set('settings', {
-        ...settings,
-        altGogdl: altGogdlBin
-      })
       const gogdlVersion = await window.api.getGogdlVersion()
       if (gogdlVersion === 'invalid') {
         setGogdlVersion('Invalid')

--- a/src/frontend/screens/Settings/components/AltLegendaryBin.tsx
+++ b/src/frontend/screens/Settings/components/AltLegendaryBin.tsx
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 import { Backspace } from '@mui/icons-material'
 import useSetting from 'frontend/hooks/useSetting'
-import { configStore } from 'frontend/helpers/electronStores'
 import { TextInputWithIconField } from 'frontend/components/UI'
 
 const AltLegendaryBin = () => {
@@ -17,15 +16,6 @@ const AltLegendaryBin = () => {
 
   useEffect(() => {
     const getMoreInfo = async () => {
-      const settings = configStore.get('settings') as {
-        altLeg: string
-        altGogdl: string
-      }
-      configStore.set('settings', {
-        ...settings,
-        altLeg: altLegendaryBin
-      })
-
       const legendaryVer = await window.api.getLegendaryVersion()
       if (legendaryVer === 'invalid') {
         setLegendaryVersion('Invalid')


### PR DESCRIPTION
After the refactor of the settings, I introduced by mistake some setting variables changes and in the case of the alternative binaries there was even a problem with the logic (setting was changed with one key using the settings context and with a different key updating the configStore explicitly). The problem was that removing the binary didn't update the values properly.

This PR fixes that by removing that extra code and using the binary we actually display in the settings.

The problem before this PR was easy to reproduce:
- set an alternative binary
- check the logs that it's using the alt binary to check its version
- remove the alternative binary
- check the logs, it still uses the previous alt binary to check the version instead of the built in binary
- set the built in binary as the alt one
- check the logs, it now uses the built in one

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
