### PR TITLE
[UX] Prevent spawning separate window of heroic ui

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -218,12 +218,7 @@ async function initializeWindow(): Promise<BrowserWindow> {
   }
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
-    let pattern
-    if (!app.isPackaged) {
-      pattern = 'localhost:5173'
-    } else {
-      pattern = publicDir
-    }
+    const pattern = app.isPackaged ? publicDir : 'localhost:5173'
     return { action: !details.url.match(pattern) ? 'allow' : 'deny' }
   })
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -217,6 +217,16 @@ async function initializeWindow(): Promise<BrowserWindow> {
     }
   }
 
+  mainWindow.webContents.setWindowOpenHandler((details) => {
+    let pattern
+    if (!app.isPackaged) {
+      pattern = 'localhost:5173'
+    } else {
+      pattern = publicDir
+    }
+    return { action: !details.url.match(pattern) ? 'allow' : 'deny' }
+  })
+
   ipcMain.on('setZoomFactor', async (event, zoomFactor) => {
     mainWindow.webContents.setZoomFactor(
       processZoomForScreen(parseFloat(zoomFactor))


### PR DESCRIPTION
I found this by accident, apparently when using middle click some ui parts were able to launch new window, which was obviously broken.

![obraz](https://user-images.githubusercontent.com/62100117/210632509-0694f2ef-00f4-486a-8a05-889e01ca20d2.png)


So I added the open handler which prevents mainWindow.webContents of using `window.open()` for spawning new windows for internal links.

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
