### PR TITLE
[FIX] Improve Wine not available / not found handler

### DIFF
--- a/public/locales/be/translation.json
+++ b/public/locales/be/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
         "change-target-exe": "Select an alternative EXE to run",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Custom Wine/Proton Paths",
         "darktray": "Use Dark Tray Icon (needs restart)",

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Автоматично инсталиране/обновяване на VKD3D в префикса",
         "change-target-exe": "Изберете алтернативен файл EXE за изпълнение",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Персонализирани пътища за Wine/Proton",
         "darktray": "Използване на тъмна иконка за системната област за уведомления",

--- a/public/locales/da/translation.json
+++ b/public/locales/da/translation.json
@@ -350,7 +350,7 @@
             "updating": "Opdaterer..."
         },
         "wineprefix": "WinePrefix mappe",
-        "crossover-version": "Crossover version",
+        "crossover-version": "Crossover/Wine Version",
         "darktray": "Brug mørkt bakkeikon",
         "default-install-path": "Standard installationssti",
         "default-steam-path": "Standard Steam-sti",

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Αυτόματη Εγκατάσταση/Ενημέρωση VKD3D με Πρόθημα",
         "change-target-exe": "Επιλέξτε ένα εναλλακτικό αρχείο EXE προς εκτέλεση",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Ειδικές διαδρομές Wine/Proton",
         "darktray": "Χρήση σκοτεινού εικονιδίου",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -69,11 +69,6 @@
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"
             },
-            "wine-not-found": {
-                "invalid": "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
-                "message": "No Wine Version Selected. Check Game Settings!",
-                "title": "Wine Not Found"
-            },
             "winetricks": {
                 "message": "Winetricks returned the following error during execution:{{newLine}}{{error}}",
                 "title": "Winetricks error"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -453,7 +453,7 @@
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
         "change-target-exe": "Select an alternative EXE to run",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Custom Wine/Proton Paths",
         "darktray": "Use Dark Tray Icon",

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "VKD3D:n automaattinen asennus/päivitys prefixille",
         "change-target-exe": "Valitse vaihtoehtoinen EXE suoritettavaksi",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Mukautetut Wine/Proton sijainnit",
         "darktray": "Käytä tummaa ilmaisinalueen kuvaketta",

--- a/public/locales/gl/translation.json
+++ b/public/locales/gl/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
         "change-target-exe": "Seleccionar un EXE alternativo a executar",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Rutas personalizadas de Wine e Proton",
         "darktray": "Usar icona escura na bandexa do sistema",

--- a/public/locales/hr/translation.json
+++ b/public/locales/hr/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
         "change-target-exe": "Select an alternative EXE to run",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Custom Wine/Proton Paths",
         "darktray": "Use Dark Tray Icon",

--- a/public/locales/hu/translation.json
+++ b/public/locales/hu/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "A VKD3D automatikus telepítése/frissítése a prefixen",
         "change-target-exe": "Válassz egy alternatív EXE fájlt a futtatáshoz",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Egyéni Wine/Proton útvonalak",
         "darktray": "Sötét tálcaikon használata",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
         "change-target-exe": "Seleziona un eseguibile alternativo da avviare",
         "checkForUpdatesOnStartup": "Controlla aggiornamenti di Heroic all'avvio",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Percorso Temi Personalizzati",
         "customWineProton": "Percorsi di Wine/Proton personalizzati",
         "darktray": "Usa l'icona scura della barra delle applicazioni",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
         "change-target-exe": "実行する代替EXEを選択します",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "カスタムWine/Protonパス",
         "darktray": "ダークトレイアイコンを使用する",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "접두사에서 VKD3D 자동 설치/업데이트",
         "change-target-exe": "대체하여 실행할 EXE 선택",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "커스텀 Wine/Proton 경로",
         "darktray": "다크 트레이 아이콘 사용",

--- a/public/locales/ml/translation.json
+++ b/public/locales/ml/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
         "change-target-exe": "ഓടിക്കുവാനായി പകരംവയ്ക്കാവുന്ന ഒരു EXE തിരഞ്ഞെടുക്കൂ",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "ഇഷ്ടാനുസൃതം ചേര്ത്ത വൈന്/പ്രോട്ടോണ് അറകള്",
         "darktray": "താലത്തില്(ട്രേയില്) ഇരുണ്ട ചിത്രം ഉപയോഗിക്കുക",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
         "change-target-exe": "Selecteer een alternatieve EXE om uit te voeren",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Aangepaste wijn- of protonpaden",
         "darktray": "Gebruik donker tray icoon",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
         "change-target-exe": "Selecio-ne  um EXE alternativo\nSelect an alternative EXE to run",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Wine e Proton Customizados",
         "darktray": "Usar ícone escuro",

--- a/public/locales/sk/translation.json
+++ b/public/locales/sk/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
         "change-target-exe": "Select an alternative EXE to run",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Custom Wine/Proton Paths",
         "darktray": "Use Dark Tray Icon (needs restart)",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Installera/uppdatera VKD3D i prefix automatiskt",
         "change-target-exe": "Ange alternativ EXE-fil att köra",
         "checkForUpdatesOnStartup": "Sök efter Heroic-uppdateringar vid uppstart",
-        "crossover-version": "Crossover version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Sökväg till anpassade teman",
         "customWineProton": "Anpassad Wine/Proton sökväg",
         "darktray": "Använd mörk ikon i systemfältet",

--- a/public/locales/ta/translation.json
+++ b/public/locales/ta/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
         "change-target-exe": "Select an alternative EXE to run",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "தனிப்பயன் Wine/Proton பாதைகள்",
         "darktray": "கணினி தட்டில் இருண்ட சின்னத்தை பயன்படுத்து",

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Prefix'te VKD3D'yi Otomatik Kur/Güncelle",
         "change-target-exe": "Çalıştırmak için alternatif bir EXE seçin",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Özel Wine/Proton Yolları",
         "darktray": "Koyu Tepsi Simgesi Kullan",

--- a/public/locales/uk/translation.json
+++ b/public/locales/uk/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Автоматично встановлювати/оновлювати VKD3D на префіксі",
         "change-target-exe": "Обрати для запуску альтернативний EXE файл",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Інші шляхи до Wine/Proton",
         "darktray": "Використовувати темну піктограму на панелі",

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "Tự động cài đặt/cập nhật DXVK trên prefix",
         "change-target-exe": "Chọn một EXE thay thế để chạy",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "Đường dẫn Wine/Proton tùy chọn",
         "darktray": "Sử dụng icon tối",

--- a/public/locales/zh_Hant/translation.json
+++ b/public/locales/zh_Hant/translation.json
@@ -448,7 +448,7 @@
         "autovkd3d": "自動在 Prefix 中安裝/更新 VKD3D",
         "change-target-exe": "選擇要執行的替代 EXE",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",
-        "crossover-version": "Crossover Version",
+        "crossover-version": "Crossover/Wine Version",
         "custom_themes_path": "Custom Themes Path",
         "customWineProton": "自定義Wine/Proton路徑",
         "darktray": "使用暗色系統列圖示",

--- a/src/backend/api/helpers.ts
+++ b/src/backend/api/helpers.ts
@@ -85,12 +85,6 @@ export const runWineCommand = async (args: WineCommandArgs) =>
 export const runWineCommandForGame = async (args: RunWineCommandArgs) =>
   ipcRenderer.invoke('runWineCommandForGame', args)
 
-export const requestAppSettings = async () =>
-  ipcRenderer.invoke('requestSettings', 'default') as Promise<AppSettings>
-
-export const requestGameSettings = async (appName: string) =>
-  ipcRenderer.invoke('requestSettings', appName) as Promise<GameSettings>
-
 export const onConnectivityChanged = async (
   callback: ConnectivityChangedCallback
 ) => ipcRenderer.on('connectivity-changed', callback)

--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -85,6 +85,9 @@ export const clipboardReadText = async () =>
 export const clipboardWriteText = async (text: string) =>
   ipcRenderer.send('clipboardWriteText', text)
 
+export const pathExists = async (path: string) =>
+  ipcRenderer.invoke('pathExists', path)
+
 export const handleShowDialog = (
   onMessage: (
     e: Electron.IpcRendererEvent,

--- a/src/backend/api/settings.ts
+++ b/src/backend/api/settings.ts
@@ -1,4 +1,17 @@
+import { AppSettings, GameSettings } from 'common/types'
 import { ipcRenderer } from 'electron'
+
+export const requestAppSettings = async () =>
+  ipcRenderer.invoke('requestSettings', 'default') as Promise<AppSettings>
+
+export const requestGameSettings = async (appName: string) =>
+  ipcRenderer.invoke('requestSettings', appName) as Promise<GameSettings>
+
+export const setSetting = (args: {
+  appName: string
+  key: string
+  value: unknown
+}) => ipcRenderer.send('setSetting', args)
 
 export const getLegendaryVersion = async () =>
   ipcRenderer.invoke('getLegendaryVersion')

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -472,6 +472,9 @@ abstract class GlobalConfig {
    */
   public abstract flush(): void
 
+  /** change a specific setting */
+  public abstract setSetting(key: string, value: unknown): void
+
   /**
    * Load the config file, upgrade if needed.
    */
@@ -608,12 +611,19 @@ class GlobalConfigV0 extends GlobalConfig {
     } as AppSettings
   }
 
-  public async resetToDefaults() {
+  public setSetting(key: string, value: unknown) {
+    const config = this.getSettings()
+    config[key] = value
+    this.config = config
+    return this.flush()
+  }
+
+  public resetToDefaults() {
     this.config = this.getFactoryDefaults()
     return this.flush()
   }
 
-  public async flush() {
+  public flush() {
     return this.writeToFile({
       defaultSettings: this.config,
       version: 'v0'

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -615,6 +615,7 @@ class GlobalConfigV0 extends GlobalConfig {
     const config = this.getSettings()
     config[key] = value
     this.config = config
+    logInfo(`Heroic: Setting ${key} to ${JSON.stringify(value)}`)
     return this.flush()
   }
 

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -291,7 +291,10 @@ abstract class GlobalConfig {
   public async getAlternativeWine(
     scanCustom = true
   ): Promise<WineInstallation[]> {
-    const macOsWineSet = await this.getMacOsWineSet()
+    if (isMac) {
+      const macOsWineSet = await this.getMacOsWineSet()
+      return [...macOsWineSet]
+    }
 
     if (!existsSync(`${heroicToolsPath}/wine`)) {
       mkdirSync(`${heroicToolsPath}/wine`, { recursive: true })
@@ -372,13 +375,7 @@ abstract class GlobalConfig {
       customWineSet = this.getCustomWinePaths()
     }
 
-    return [
-      ...defaultWineSet,
-      ...altWine,
-      ...proton,
-      ...customWineSet,
-      ...macOsWineSet
-    ]
+    return [...defaultWineSet, ...altWine, ...proton, ...customWineSet]
   }
 
   /**

--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -291,6 +291,7 @@ class GameConfigV0 extends GameConfig {
 
   public setSetting(key: string, value: unknown) {
     this.config[key] = value
+    logInfo(`${this.appName}: Setting ${key} to ${JSON.stringify(value)}`)
     return this.flush()
   }
 

--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -125,6 +125,9 @@ abstract class GameConfig {
    */
   public abstract getSettings(): Promise<GameSettings>
 
+  /** Change a specific setting */
+  public abstract setSetting(key: string, value: unknown): void
+
   /**
    * Updates this.config, this.version to upgrade the current config file.
    *
@@ -286,12 +289,17 @@ class GameConfigV0 extends GameConfig {
     }
   }
 
-  public async resetToDefaults() {
+  public setSetting(key: string, value: unknown) {
+    this.config[key] = value
+    return this.flush()
+  }
+
+  public resetToDefaults() {
     this.config = {} as GameSettings
     return this.flush()
   }
 
-  public async flush() {
+  public flush() {
     const config = new Map(Object.entries({ ...this.config }))
     if (this.isExplicit) {
       // Explicit mode on. Config is taken as is, missing values are not substituted for defaults.

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -426,34 +426,18 @@ export async function validWine(
     LogPrefix.Backend
   )
 
-  // if wine version does not exist, use the default one and update the game settings
-  if (!existsSync(wineVersion.bin)) {
-    const { wineVersion: defaultWineVersion } = GlobalConfig.get().getSettings()
-    logWarning(
-      `Wine version not found: ${wineVersion.name}, using the default one ${defaultWineVersion.name} `,
-      LogPrefix.Backend
-    )
-    wineVersion = defaultWineVersion
-  }
-
   // verify if necessary binaries exist
   const { bin, wineboot, wineserver, type } = wineVersion
   const necessary = type === 'proton' ? [bin] : [bin, wineboot, wineserver]
   const haveAll = necessary.every((binary) => existsSync(binary as string))
 
+  // if wine version does not exist, use the default one
   if (!haveAll) {
-    showDialogBoxModalAuto({
-      title: i18next.t('box.error.wine-not-found.title', 'Wine Not Found'),
-      message: i18next.t('box.error.wine-not-found.invalid', {
-        defaultValue:
-          "The selected wine version was not found. Install it or select a different version in the game's settings{{newline}}Version: {{version}}{{newline}}Path: {{path}}",
-        version: wineVersion.name,
-        path: bin,
-        newline: '\n',
-        interpolation: { escapeValue: false }
-      }),
-      type: 'ERROR'
-    })
+    const { wineVersion: defaultWineVersion } = GlobalConfig.get().getSettings()
+    logWarning(
+      `Wine version not found: ${wineVersion.name}, using the default one ${defaultWineVersion.name} `,
+      LogPrefix.Backend
+    )
     return false
   }
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -864,6 +864,14 @@ ipcMain.handle('writeConfig', (event, { appName, config }) => {
   }
 })
 
+ipcMain.on('setSetting', (event, { appName, key, value }) => {
+  if (appName === 'default') {
+    GlobalConfig.get().setSetting(key, value)
+  } else {
+    GameConfig.get(appName).setSetting(key, value)
+  }
+})
+
 // Watch the installed games file and trigger a refresh on the installed games if something changes
 if (existsSync(installed)) {
   let watchTimeout: NodeJS.Timeout | undefined

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1535,6 +1535,10 @@ ipcMain.handle('isNative', (e, { appName, runner }) => {
   return game.isNative()
 })
 
+ipcMain.handle('pathExists', async (e, path: string) => {
+  return existsSync(path)
+})
+
 /*
   Other Keys that should go into translation files:
   t('box.error.generic.title')
@@ -1542,7 +1546,7 @@ ipcMain.handle('isNative', (e, { appName, runner }) => {
  */
 
 /*
- * INSERT OTHER IPC HANLDER HERE
+ * INSERT OTHER IPC HANDLERS HERE
  */
 import './logger/ipc_handler'
 import './wine/manager/ipc_handler'

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -92,6 +92,7 @@ interface SyncIPCFunctions {
   'connectivity-changed': (newStatus: ConnectivityStatus) => void
   'set-connectivity-online': () => void
   changeTrayColor: () => void
+  setSetting: (args: { appName: string; key: string; value: unknown }) => void
 }
 
 interface AsyncIPCFunctions {

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -233,6 +233,7 @@ interface AsyncIPCFunctions {
     runner: Runner
   }) => Promise<boolean>
   toggleDXVK: (args: ToolArgs) => Promise<boolean>
+  pathExists: (path: string) => Promise<boolean>
 }
 
 // This is quite ugly & throws a lot of errors in a regular .ts file

--- a/src/frontend/hooks/useSettingsContext.ts
+++ b/src/frontend/hooks/useSettingsContext.ts
@@ -1,5 +1,4 @@
 import { AppSettings, GameInfo, Runner } from 'common/types'
-import { writeConfig } from 'frontend/helpers'
 import { SettingsContextType } from 'frontend/types'
 import { useTranslation } from 'react-i18next'
 import { useState, useEffect, useContext } from 'react'
@@ -42,7 +41,7 @@ const useSettingsContext = ({ appName, gameInfo, runner }: Props) => {
         if (noChange) return
       }
       setCurrentConfig({ ...currentConfig, [key]: value })
-      writeConfig({ appName, config: { ...currentConfig, [key]: value } })
+      window.api.setSetting({ appName, key, value })
     },
     config: currentConfig,
     isDefault,

--- a/src/frontend/screens/Settings/components/WineVersionSelector.tsx
+++ b/src/frontend/screens/Settings/components/WineVersionSelector.tsx
@@ -29,12 +29,25 @@ export default function WineVersionSelector() {
     getAltWine()
   }, [])
 
+  useEffect(() => {
+    // Fix setting in case wine path does not exists anymore
+    const updateWine = async () => {
+      const winePathExists = await window.api.pathExists(wineVersion.bin)
+      if (!winePathExists) {
+        const { wineVersion: defaultWine } =
+          await window.api.requestAppSettings()
+        setWineVersion(defaultWine)
+      }
+    }
+    updateWine()
+  }, [wineVersion, altWine])
+
   return (
     <SelectField
       label={
         isLinux
           ? t('setting.wineversion')
-          : t('setting.crossover-version', 'Crossover Version')
+          : t('setting.crossover-version', 'Crossover/Wine Version')
       }
       htmlId="setWineVersion"
       onChange={(event) =>
@@ -62,7 +75,6 @@ export default function WineVersionSelector() {
                   <li>~/.local/share/lutris/runners/wine</li>
                   <li>~/.var/app/com.valvesoftware.Steam (Steam Flatpak)</li>
                   <li>/usr/share/steam</li>
-                  <li>Everywhere on the system (CrossOver Mac)</li>
                 </i>
               </ul>
               <span>{t('help.wine.part2')}</span>
@@ -71,8 +83,8 @@ export default function WineVersionSelector() {
         </>
       }
     >
-      {altWine.map(({ name }) => (
-        <option key={name}>{name}</option>
+      {altWine.map(({ name }, i) => (
+        <option key={i}>{name}</option>
       ))}
     </SelectField>
   )

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -78,8 +78,8 @@ export default function GamesSettings({ useDetails = true }: Props) {
             isCollapsible={useDetails}
             summary={isLinux ? 'Wine' : 'Wine/Crossover'}
           >
-            <WinePrefix />
             <WineVersionSelector />
+            <WinePrefix />
             <CrossoverBottle />
 
             {!isCrossover && (


### PR DESCRIPTION
I am trying to find a solution to this issue people complain sometimes when wine was not found or maybe it was deleted somehow, the game fails to launch and you need to go to the settings and change it back and forth, etc.
So my solution is pretty simple:
- On launch, if the game is not native, check if the wine is valid. if not, try the default one on the config. 
- If the one set as default is not valid somehow, query the list of wine, proton, crossover, etc. And get the first one.
- if none was found, then it will fail and show a message to the user.

Besides that, I added a few QOL improvements on the settings part.
I mean, we have a WHOLE class to deal with the settings and there is no way to SET a Single setting, everytime we change a setting in Heroic it rewrites the whole file again. So if we need to change a setting on the backend we need to query the whole list, then change the key inside that object, and then rewrite the settings again. That is not practical.

So I added the `setSetting` method to the class on the backend and also added the ipc call on the frontend. so we can now set one single setting on backend and frontend, making our life easier if we need to handle something on runtime.

Another small method I added was `pathExists`, so we can query on the frontend if a path exists and use it to update the UI or show some message to the user, etc.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
