### PR TITLE
[Fix] Actually search for WINEDLLOVERRIDES when disabling WineMenuBuilder

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -275,7 +275,7 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
       const wmbDisableString = 'winemenubuilder='
       // If the user already set WINEDLLOVERRIDES, append to the end
       const dllOverridesVar = gameSettings.enviromentOptions.find(
-        ({ key }) => key.toLowerCase() === 'winemenubuilder'
+        ({ key }) => key.toLowerCase() === 'winedlloverrides'
       )
       if (dllOverridesVar) {
         ret[dllOverridesVar.key] =


### PR DESCRIPTION
In #2298, I had *intended* to append the WineMenuBuilder override to an already-set `WINEDLLOVERRIDES` variable if one is present. While doing that however, I was accidentally searching for a variable with the name "WINEMENUBUILDER" instead
That's now fixed

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
