### PR TITLE
Remove debug code leftover

### DIFF
--- a/src/backend/tools.ts
+++ b/src/backend/tools.ts
@@ -288,8 +288,6 @@ export const DXVK = {
       )
     })
 
-    exec(`echo ${globalVersion} > ${currentVersionCheck}`)
-
     writeFile(currentVersionCheck, globalVersion, (err) => {
       if (err) {
         logError(


### PR DESCRIPTION
Either old or debug code was left behind in the tools-installation routine, which blindly wrote data to a file using `exec()` without escaping either the data nor the file name, leading to errant writes when the game title contained one or more spaces.

This patch simply deletes the operation as a correct routine to write the file immediately follows it.

This fixed #2335.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
