### PR TITLE
[Sideload] Only check extGame if not sideloaded app

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1002,7 +1002,7 @@ ipcMain.handle(
     )
 
     // check if isNative, if not, check if wine is valid
-    if (!extGame.isNative() || (isSideloaded && !isNativeApp(appName))) {
+    if ((isSideloaded && !isNativeApp(appName)) || !extGame.isNative()) {
       const isWineOkToLaunch = await checkWineBeforeLaunch(
         appName,
         gameSettings,


### PR DESCRIPTION
This PR fixes a regression, sideloaded apps are not launching, failing with an error in the backend:

```
(22:43:44) ERROR:   [Gog]:              Could not get game info for vNj6P8g9LTCQskZ8bzPkip, returning empty object. Something is probably gonna go wrong soon
Error occurred in handler for 'launch': TypeError: Cannot read properties of undefined (reading 'platform')
    at _GOGGame.isNative (/home/ariel/dev/oss/HeroicGamesLauncher/build/electron/main.53e831e0.js:4068:37)
    at /home/ariel/dev/oss/HeroicGamesLauncher/build/electron/main.53e831e0.js:13651:18
    at process.processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async node:electron/js2c/browser_init:193:551
```

This changes the order to first check if it's a sideloaded app, and, if not, then it will check if it's a store game, because the current order makes heroic check if a gog game that does not exist is native and it fails.


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
