### PR TITLE
Use the exe's dir as the working dir to run exe in prefix

### DIFF
--- a/src/backend/games.ts
+++ b/src/backend/games.ts
@@ -1,3 +1,4 @@
+import { WineCommandArgs } from './../common/types'
 import { GOGCloudSavesLocation, GogInstallInfo } from 'common/types/gog'
 import { LegendaryInstallInfo } from 'common/types/legendary'
 import {
@@ -6,7 +7,6 @@ import {
   GameInfo,
   GameSettings,
   InstallArgs,
-  ProtonVerb,
   InstallPlatform
 } from 'common/types'
 
@@ -43,11 +43,7 @@ abstract class Game {
   abstract uninstall(): Promise<ExecResult>
   abstract update(): Promise<{ status: 'done' | 'error' | 'abort' }>
   abstract isNative(): boolean
-  abstract runWineCommand(
-    commandParts: string[],
-    wait?: boolean,
-    protonVerb?: ProtonVerb
-  ): Promise<ExecResult>
+  abstract runWineCommand(args: WineCommandArgs): Promise<ExecResult>
 }
 
 export { Game }

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -1,3 +1,4 @@
+import { WineCommandArgs } from './../../common/types'
 import {
   createAbortController,
   deleteAbortController
@@ -21,7 +22,6 @@ import {
   ExecResult,
   InstallArgs,
   InstalledInfo,
-  ProtonVerb,
   InstallPlatform
 } from 'common/types'
 import { appendFileSync, existsSync, rmSync } from 'graceful-fs'
@@ -829,11 +829,12 @@ class GOGGame extends Game {
     }
   }
 
-  public async runWineCommand(
-    commandParts: string[],
+  public async runWineCommand({
+    commandParts,
     wait = false,
-    protonVerb?: ProtonVerb
-  ): Promise<ExecResult> {
+    protonVerb,
+    startFolder
+  }: WineCommandArgs): Promise<ExecResult> {
     if (this.isNative()) {
       logError('runWineCommand called on native game!', LogPrefix.Gog)
       return { stdout: '', stderr: '' }
@@ -846,7 +847,8 @@ class GOGGame extends Game {
       installFolderName: folder_name,
       commandParts,
       wait,
-      protonVerb
+      protonVerb,
+      startFolder
     })
   }
 

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -1,3 +1,4 @@
+import { WineCommandArgs } from './../../common/types'
 import {
   createAbortController,
   deleteAbortController
@@ -10,8 +11,7 @@ import {
   ExtraInfo,
   GameInfo,
   InstallArgs,
-  InstallPlatform,
-  ProtonVerb
+  InstallPlatform
 } from 'common/types'
 import { Game } from '../games'
 import { GameConfig } from '../game_config'
@@ -928,11 +928,12 @@ class LegendaryGame extends Game {
     return !error
   }
 
-  public async runWineCommand(
-    commandParts: string[],
+  public async runWineCommand({
+    commandParts,
     wait = false,
-    protonVerb?: ProtonVerb
-  ): Promise<ExecResult> {
+    protonVerb,
+    startFolder
+  }: WineCommandArgs): Promise<ExecResult> {
     if (this.isNative()) {
       logError('runWineCommand called on native game!', LogPrefix.Legendary)
       return { stdout: '', stderr: '' }
@@ -946,7 +947,8 @@ class LegendaryGame extends Game {
       installFolderName: folder_name,
       commandParts,
       wait,
-      protonVerb
+      protonVerb,
+      startFolder
     })
   }
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -589,13 +589,22 @@ ipcMain.handle('callTool', async (event, { tool, exe, appName, runner }) => {
             commandParts: ['winecfg'],
             wait: false
           })
-        : game.runWineCommand(['winecfg'])
+        : game.runWineCommand({ commandParts: ['winecfg'] })
       break
     case 'runExe':
       if (exe) {
+        const workingDir = path.parse(exe).dir
         isSideloaded
-          ? runWineCommand({ gameSettings, commandParts: [exe], wait: false })
-          : game.runWineCommand([exe])
+          ? runWineCommand({
+              gameSettings,
+              commandParts: [exe],
+              wait: false,
+              startFolder: workingDir
+            })
+          : game.runWineCommand({
+              commandParts: [exe],
+              startFolder: workingDir
+            })
       }
       break
   }
@@ -1557,7 +1566,11 @@ ipcMain.handle(
     }
 
     // FIXME: Why are we using `runinprefix` here?
-    return game.runWineCommand(commandParts, false, 'runinprefix')
+    return game.runWineCommand({
+      commandParts,
+      wait: false,
+      protonVerb: 'runinprefix'
+    })
   }
 )
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -542,7 +542,7 @@ export interface DMQueueElement {
 
 export type WineCommandArgs = {
   commandParts: string[]
-  wait: boolean
+  wait?: boolean
   protonVerb?: ProtonVerb
   gameSettings?: GameSettings
   installFolderName?: string


### PR DESCRIPTION
When using the `Run EXE in prefix` option, the file is not executed in the file's directory as the working dir. This is a problem because it can break executables that reference other files relative to the current working dir.

This PR does 2 things:
- update `runWineCommand` for games to have the same signature as the generic `runWineCommand`
- pass the exe's dir as the `startFolder` to run the commands

The way I'm testing this is with Rayman 2 The Great Escape from GOG (I think it was a giveaway). It has a `GXSetup.exe` file in the install folder that needs to run with the correct working dir or it fails.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
