### PR TITLE
[Bug] Disable esync and fsync for windows

### DIFF
--- a/src/frontend/screens/Settings/components/EnableEsync.tsx
+++ b/src/frontend/screens/Settings/components/EnableEsync.tsx
@@ -4,11 +4,16 @@ import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import { isWindows } from 'backend/constants'
 
 const EnableEsync = () => {
   const { t } = useTranslation()
 
   const [enableEsync, setEnableEsync] = useSetting('enableEsync', false)
+
+  if (isWindows) {
+    return <></>
+  }
 
   return (
     <div className="toggleRow">

--- a/src/frontend/screens/Settings/components/EnableEsync.tsx
+++ b/src/frontend/screens/Settings/components/EnableEsync.tsx
@@ -1,17 +1,19 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
-import { isWindows } from 'backend/constants'
+import { isLinux } from 'backend/constants'
+import SettingsContext from '../SettingsContext'
 
 const EnableEsync = () => {
   const { t } = useTranslation()
+  const { isLinuxNative } = useContext(SettingsContext)
 
   const [enableEsync, setEnableEsync] = useSetting('enableEsync', false)
 
-  if (isWindows) {
+  if (!isLinux || isLinuxNative) {
     return <></>
   }
 

--- a/src/frontend/screens/Settings/components/EnableFsync.tsx
+++ b/src/frontend/screens/Settings/components/EnableFsync.tsx
@@ -6,7 +6,6 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import SettingsContext from '../SettingsContext'
-import { isWindows } from 'backend/constants'
 
 const EnableFsync = () => {
   const { t } = useTranslation()
@@ -15,7 +14,7 @@ const EnableFsync = () => {
   const isLinux = platform === 'linux'
   const [enableFsync, setEnableFsync] = useSetting('enableFsync', false)
 
-  if (!isLinux || isLinuxNative || isWindows) {
+  if (!isLinux || isLinuxNative) {
     return <></>
   }
 

--- a/src/frontend/screens/Settings/components/EnableFsync.tsx
+++ b/src/frontend/screens/Settings/components/EnableFsync.tsx
@@ -6,6 +6,7 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import SettingsContext from '../SettingsContext'
+import { isWindows } from 'backend/constants'
 
 const EnableFsync = () => {
   const { t } = useTranslation()
@@ -14,7 +15,7 @@ const EnableFsync = () => {
   const isLinux = platform === 'linux'
   const [enableFsync, setEnableFsync] = useSetting('enableFsync', false)
 
-  if (!isLinux || isLinuxNative) {
+  if (!isLinux || isLinuxNative || isWindows) {
     return <></>
   }
 


### PR DESCRIPTION
Not sure if this is true but it seems fsync and esync is not available for windows. Prove me wrong.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
