### PR TITLE
[UI] Remove double scrollbar in game page for small screens

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.scss
+++ b/src/frontend/screens/Game/GamePage/index.scss
@@ -2,7 +2,8 @@
   background: var(--background-darker);
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   display: flex;
-  height: 100vh;
+  height: 100%;
+  overflow: hidden;
   justify-content: stretch;
   position: relative;
 


### PR DESCRIPTION
For small screens (like the steam deck), when the controller hints appear there's a double scrollbar and you can see the store logo is outside the space. This PR fixes that.

Before:

![image](https://user-images.githubusercontent.com/188464/212560344-d53c7d29-78ef-4b5b-8ee4-d90fd27b8711.png)

After:

![image](https://user-images.githubusercontent.com/188464/212560341-df48521c-411d-489b-9289-f3457273879b.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
