### PR TITLE
[UI] Improve contrast of back button in game page

### DIFF
--- a/src/frontend/screens/Game/GamePicture/index.css
+++ b/src/frontend/screens/Game/GamePicture/index.css
@@ -14,10 +14,11 @@
   height: 100%;
   width: 100%;
   background: linear-gradient(
-    90deg,
-    rgba(0, 0, 0, 0),
-    var(--background-darker) 100%
-  );
+      90deg,
+      rgba(0, 0, 0, 0),
+      var(--background-darker) 100%
+    ),
+    linear-gradient(375deg, rgba(0, 0, 0, 0), var(--background-darker) 172%);
 }
 
 .gamePicture > .gameImg {

--- a/src/frontend/screens/Game/GamePicture/index.css
+++ b/src/frontend/screens/Game/GamePicture/index.css
@@ -18,7 +18,7 @@
       rgba(0, 0, 0, 0),
       var(--background-darker) 100%
     ),
-    linear-gradient(375deg, rgba(0, 0, 0, 0), var(--background-darker) 172%);
+    linear-gradient(0deg, rgba(0, 0, 0, 0) 89%, var(--background-darker) 100%);
 }
 
 .gamePicture > .gameImg {


### PR DESCRIPTION
In some combinations of theme and game cover, the `back` button is kinda hard to see. This PR adds a small faded shadow behind that button. For example:

Before:

![image](https://user-images.githubusercontent.com/188464/212561357-c7745b6d-569a-4e08-8b56-8a722b101d5f.png)
![image](https://user-images.githubusercontent.com/188464/212561363-3e5cef10-5e99-4e39-8c89-ddc2a1e07fd8.png)

After:

![image](https://user-images.githubusercontent.com/188464/212561670-9eae23e3-f28f-40f1-9c1b-1680428f2018.png)
![image](https://user-images.githubusercontent.com/188464/212561675-eb5fa59b-736e-4a46-a3ca-d716d3c8f128.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
