### PR TITLE
Read GlobalConfig to get alternative binaries

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -470,9 +470,7 @@ function splitPathAndName(fullPath: string): { dir: string; bin: string } {
 }
 
 function getLegendaryBin(): { dir: string; bin: string } {
-  const settings = configStore.get('settings', {}) as {
-    altLegendaryBin: string
-  }
+  const settings = GlobalConfig.get().getSettings()
   if (settings?.altLegendaryBin) {
     return splitPathAndName(settings.altLegendaryBin)
   }
@@ -482,7 +480,7 @@ function getLegendaryBin(): { dir: string; bin: string } {
 }
 
 function getGOGdlBin(): { dir: string; bin: string } {
-  const settings = configStore.get('settings', {}) as { altGogdlBin: string }
+  const settings = GlobalConfig.get().getSettings()
   if (settings?.altGogdlBin) {
     return splitPathAndName(settings.altGogdlBin)
   }

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -29,7 +29,6 @@ import i18next, { t } from 'i18next'
 import si from 'systeminformation'
 
 import {
-  configStore,
   fixAsarPath,
   getSteamLibraries,
   heroicConfigPath,


### PR DESCRIPTION
This was not working, they were read from an electron store but they were updated using GlobalConfig so things were in different files.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
