### PR TITLE
[UX] Prevent old search to step on new search

### DIFF
--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -61,6 +61,8 @@ const GamesList = ({
   const [gameCards, setGameCards] = useState<JSX.Element[]>([])
 
   useEffect(() => {
+    let mounted = true
+
     const createGameCards = async () => {
       if (!library.length) {
         return
@@ -102,10 +104,16 @@ const GamesList = ({
         resolvedLibrary
       )) as JSX.Element[]
 
-      setGameCards(gameCardElements)
+      if (mounted) {
+        setGameCards(gameCardElements)
+      }
     }
 
     createGameCards()
+
+    return () => {
+      mounted = false
+    }
   }, [
     library,
     onlyInstalled,


### PR DESCRIPTION
I noticed this bug that, if you type in the search field a few characters relatively fast (not really that fast), after a moment the search result was the one from the first character press and not the last. This was because the new letter updated things and a the useEffect of GameList was triggering without cleaning up the previous useEffect.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
