### PR TITLE
[UI] Match Zoom slider look to theme

### DIFF
--- a/src/frontend/screens/Accessibility/index.css
+++ b/src/frontend/screens/Accessibility/index.css
@@ -13,14 +13,13 @@ input[type='range']::-webkit-slider-runnable-track {
 }
 
 input[type='range']::-webkit-slider-thumb {
-  height: 20px;
-  width: 20px;
+  height: 30px;
+  width: 8px;
   border-radius: 10px;
-  border-width: 3px;
-  background: var(--accent-overlay);
+  background: var(--text-default);
   cursor: pointer;
   appearance: none;
-  margin-top: -5px;
+  margin-top: -10px;
 }
 
 .zoomHint {

--- a/src/frontend/screens/Accessibility/index.css
+++ b/src/frontend/screens/Accessibility/index.css
@@ -1,6 +1,26 @@
 input[type='range'] {
   width: 100%;
   max-width: 513px;
+  appearance: none;
+  background: transparent;
+}
+
+input[type='range']::-webkit-slider-runnable-track {
+  height: 10px;
+  cursor: pointer;
+  background: var(--accent);
+  border-radius: 5px;
+}
+
+input[type='range']::-webkit-slider-thumb {
+  height: 20px;
+  width: 20px;
+  border-radius: 10px;
+  border-width: 3px;
+  background: var(--accent-overlay);
+  cursor: pointer;
+  appearance: none;
+  margin-top: -5px;
 }
 
 .zoomHint {


### PR DESCRIPTION
Makes the zoom slider's appearance match the selected theme.

_Nord Dark_

![Zoom-slider-theme](https://user-images.githubusercontent.com/74495920/213183292-67fe1ccd-7b29-4d14-bfce-b97bed7ed6ef.png)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
