### PR TITLE
[Feat] Enable Wine Manager on macOS

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -167,13 +167,13 @@ abstract class GlobalConfig {
       return wineSet
     }
 
-    const winePaths: string[] = []
+    const winePaths = new Set<string>()
 
     // search for wine installed on $HOME/Library/Application Support/heroic/tools/wine
     const wineToolsPath = `${heroicToolsPath}/wine/`
     if (existsSync(wineToolsPath)) {
       readdirSync(wineToolsPath).forEach((path) => {
-        winePaths.push(join(wineToolsPath, path))
+        winePaths.add(join(wineToolsPath, path))
       })
     }
 
@@ -181,7 +181,7 @@ abstract class GlobalConfig {
     await execAsync('mdfind kMDItemCFBundleIdentifier = "*.wine"').then(
       async ({ stdout }) => {
         stdout.split('\n').forEach((winePath) => {
-          winePaths.push(winePath)
+          winePaths.add(winePath)
         })
       }
     )

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -166,35 +166,49 @@ abstract class GlobalConfig {
     if (!isMac) {
       return wineSet
     }
+
+    const winePaths: string[] = []
+
+    // search for wine installed on $HOME/Library/Application Support/heroic/tools/wine
+    const wineToolsPath = `${heroicToolsPath}/wine/`
+    if (existsSync(wineToolsPath)) {
+      readdirSync(wineToolsPath).forEach((path) => {
+        winePaths.push(join(wineToolsPath, path))
+      })
+    }
+
+    // search for wine installed around the system
     await execAsync('mdfind kMDItemCFBundleIdentifier = "*.wine"').then(
       async ({ stdout }) => {
         stdout.split('\n').forEach((winePath) => {
-          const infoFilePath = join(winePath, 'Contents/Info.plist')
-          if (winePath && existsSync(infoFilePath)) {
-            const info = plistParse(
-              readFileSync(infoFilePath, 'utf-8')
-            ) as PlistObject
-            const version = info['CFBundleShortVersionString'] || ''
-            const name = info['CFBundleName'] || ''
-            const wineBin = join(
-              winePath,
-              '/Contents/Resources/wine/bin/wine64'
-            )
-            if (existsSync(wineBin)) {
-              wineSet.add({
-                ...this.getWineExecs(wineBin),
-                lib: `${winePath}/Contents/Resources/wine/lib`,
-                lib32: `${winePath}/Contents/Resources/wine/lib`,
-                bin: wineBin,
-                name: `${name} - ${version}`,
-                type: 'wine',
-                ...this.getWineExecs(wineBin)
-              })
-            }
-          }
+          winePaths.push(winePath)
         })
       }
     )
+
+    winePaths.forEach((winePath) => {
+      const infoFilePath = join(winePath, 'Contents/Info.plist')
+      if (winePath && existsSync(infoFilePath)) {
+        const info = plistParse(
+          readFileSync(infoFilePath, 'utf-8')
+        ) as PlistObject
+        const version = info['CFBundleShortVersionString'] || ''
+        const name = info['CFBundleName'] || ''
+        const wineBin = join(winePath, '/Contents/Resources/wine/bin/wine64')
+        if (existsSync(wineBin)) {
+          wineSet.add({
+            ...this.getWineExecs(wineBin),
+            lib: `${winePath}/Contents/Resources/wine/lib`,
+            lib32: `${winePath}/Contents/Resources/wine/lib`,
+            bin: wineBin,
+            name: `${name} - ${version}`,
+            type: 'wine',
+            ...this.getWineExecs(wineBin)
+          })
+        }
+      }
+    })
+
     return wineSet
   }
 

--- a/src/backend/wine/manager/downloader/constants.ts
+++ b/src/backend/wine/manager/downloader/constants.ts
@@ -13,3 +13,7 @@ export const PROTON_URL =
 /// Url to Wine Lutris github release page
 export const WINELUTRIS_URL =
   'https://api.github.com/repos/lutris/wine/releases'
+
+/// Url to Wine Crossover github release page
+export const WINECROSSOVER_URL =
+  'https://api.github.com/repos/Gcenx/winecx/releases'

--- a/src/backend/wine/manager/downloader/constants.ts
+++ b/src/backend/wine/manager/downloader/constants.ts
@@ -17,3 +17,7 @@ export const WINELUTRIS_URL =
 /// Url to Wine Crossover github release page
 export const WINECROSSOVER_URL =
   'https://api.github.com/repos/Gcenx/winecx/releases'
+
+/// Url to Wine Staging for macOS github release page
+export const WINESTAGINGMACOS_URL =
+  'https://api.github.com/repos/Gcenx/macOS_Wine_builds/releases'

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -13,7 +13,8 @@ import {
   PROTONGE_URL,
   PROTON_URL,
   WINELUTRIS_URL,
-  WINECROSSOVER_URL
+  WINECROSSOVER_URL,
+  WINESTAGINGMACOS_URL
 } from './constants'
 import {
   VersionInfo,
@@ -111,6 +112,20 @@ async function getAvailableVersions({
         await fetchReleases({
           url: WINECROSSOVER_URL,
           type: 'Wine-Crossover',
+          count: count
+        })
+          .then((fetchedReleases: VersionInfo[]) => {
+            releases.push(...fetchedReleases)
+          })
+          .catch((error: Error) => {
+            throw error
+          })
+        break
+      }
+      case Repositorys.WINESTAGINGMACOS: {
+        await fetchReleases({
+          url: WINESTAGINGMACOS_URL,
+          type: 'Wine-Staging-macOS',
           count: count
         })
           .then((fetchedReleases: VersionInfo[]) => {

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -12,7 +12,8 @@ import {
   WINEGE_URL,
   PROTONGE_URL,
   PROTON_URL,
-  WINELUTRIS_URL
+  WINELUTRIS_URL,
+  WINECROSSOVER_URL
 } from './constants'
 import {
   VersionInfo,
@@ -44,12 +45,7 @@ interface getVersionsProps {
  *          * rejects with an {@link Error}
  */
 async function getAvailableVersions({
-  repositorys = [
-    Repositorys.WINEGE,
-    Repositorys.PROTONGE,
-    Repositorys.PROTON,
-    Repositorys.WINELUTRIS
-  ],
+  repositorys = [Repositorys.WINEGE, Repositorys.PROTONGE],
   count = 100
 }: getVersionsProps): Promise<VersionInfo[]> {
   const releases: Array<VersionInfo> = []
@@ -101,6 +97,20 @@ async function getAvailableVersions({
         await fetchReleases({
           url: WINELUTRIS_URL,
           type: 'Wine-Lutris',
+          count: count
+        })
+          .then((fetchedReleases: VersionInfo[]) => {
+            releases.push(...fetchedReleases)
+          })
+          .catch((error: Error) => {
+            throw error
+          })
+        break
+      }
+      case Repositorys.WINECROSSOVER: {
+        await fetchReleases({
+          url: WINECROSSOVER_URL,
+          type: 'Wine-Crossover',
           count: count
         })
           .then((fetchedReleases: VersionInfo[]) => {

--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -1,4 +1,4 @@
-import { isMac } from 'backend/constants'
+import { isMac } from '../../../constants'
 import * as axios from 'axios'
 import { existsSync, statSync, unlinkSync } from 'graceful-fs'
 import { spawnSync, spawn } from 'child_process'
@@ -251,7 +251,7 @@ async function unzipFile({
       filePath
     ]
 
-    if (overwrite) {
+    if (overwrite && !isMac) {
       args.push('--overwrite')
     }
 

--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -231,9 +231,9 @@ async function unzipFile({
 
     let extension_options = ''
     if (filePath.endsWith('tar.gz')) {
-      extension_options = '-vzxf'
+      extension_options = '-zxf'
     } else if (filePath.endsWith('tar.xz')) {
-      extension_options = '-vJxf'
+      extension_options = '-Jxf'
     } else {
       reject(`Archive type ${filePath.split('.').pop()} not supported!`)
     }

--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -1,3 +1,4 @@
+import { isMac } from 'backend/constants'
 import * as axios from 'axios'
 import { existsSync, statSync, unlinkSync } from 'graceful-fs'
 import { spawnSync, spawn } from 'child_process'
@@ -86,8 +87,12 @@ function unlinkFile(filePath: string) {
  * @returns size of folder in bytes
  */
 function getFolderSize(folder: string): number {
-  const { stdout } = spawnSync('du', ['-sb', folder])
-  return parseInt(stdout.toString())
+  const param = isMac ? '-sk' : '-sb'
+  const { stdout } = spawnSync('du', [param, folder])
+  const value = parseInt(stdout.toString())
+
+  // on mac we get the size in kilobytes so we need to convert it to bytes
+  return isMac ? value * 1024 : value
 }
 
 interface downloadProps {

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -33,7 +33,7 @@ async function updateWineVersionInfos(
   if (fetch) {
     logInfo('Fetching upstream information...', LogPrefix.WineDownloader)
     const repositorys = isMac
-      ? [Repositorys.WINECROSSOVER]
+      ? [Repositorys.WINECROSSOVER, Repositorys.WINESTAGINGMACOS]
       : [Repositorys.WINEGE, Repositorys.PROTONGE]
     await getAvailableVersions({
       repositorys,

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -15,7 +15,7 @@ import {
 } from 'common/types'
 
 import { getAvailableVersions, installVersion } from './downloader/main'
-import { heroicToolsPath } from '../../constants'
+import { heroicToolsPath, isMac } from '../../constants'
 import { sendFrontendMessage } from '../../main_window'
 
 const wineDownloaderInfoStore = new Store({
@@ -32,12 +32,11 @@ async function updateWineVersionInfos(
   logInfo('Updating wine versions info', LogPrefix.WineDownloader)
   if (fetch) {
     logInfo('Fetching upstream information...', LogPrefix.WineDownloader)
+    const repositorys = isMac
+      ? [Repositorys.WINECROSSOVER]
+      : [Repositorys.WINEGE, Repositorys.PROTONGE]
     await getAvailableVersions({
-      repositorys: [
-        Repositorys.WINEGE,
-        Repositorys.PROTONGE,
-        Repositorys.WINELUTRIS
-      ],
+      repositorys,
       count
     })
       .then((response) => (releases = response as WineVersionInfo[]))

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -650,6 +650,7 @@ export type Type =
   | 'Wine-Lutris'
   | 'Wine-Kron4ek'
   | 'Wine-Crossover'
+  | 'Wine-Staging-macOS'
 
 /**
  * Interface contains information about a version
@@ -678,7 +679,8 @@ export enum Repositorys {
   PROTONGE,
   PROTON,
   WINELUTRIS,
-  WINECROSSOVER
+  WINECROSSOVER,
+  WINESTAGINGMACOS
 }
 
 /**

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -649,6 +649,7 @@ export type Type =
   | 'Proton'
   | 'Wine-Lutris'
   | 'Wine-Kron4ek'
+  | 'Wine-Crossover'
 
 /**
  * Interface contains information about a version
@@ -676,7 +677,8 @@ export enum Repositorys {
   WINEGE,
   PROTONGE,
   PROTON,
-  WINELUTRIS
+  WINELUTRIS,
+  WINECROSSOVER
 }
 
 /**

--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -44,7 +44,7 @@ export default function SidebarLinks() {
 
   const isStore = location.pathname.includes('store')
   const isSettings = location.pathname.includes('settings')
-  const isLinux = platform === 'linux'
+  const isWin = platform === 'win32'
 
   const settingsPath = '/settings/app/default/general'
 
@@ -230,7 +230,7 @@ export default function SidebarLinks() {
           <span>{t('download-manager.link', 'Downloads')}</span>
         </>
       </NavLink>
-      {isLinux && (
+      {!isWin && (
         <NavLink
           className={({ isActive }) =>
             classNames('Sidebar__item', { active: isActive })

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -23,23 +23,38 @@ const configStore = new StoreIpc('wineManagerConfigStore', {
 })
 
 interface WineManagerUISettings {
-  showWineGe: boolean
-  showWineLutris: boolean
-  showProtonGe: boolean
+  value: string
+  type: Type
+  enabled: boolean
 }
 
 export default React.memo(function WineManager(): JSX.Element | null {
   const { t } = useTranslation()
-  const { refreshWineVersionInfo, refreshing } = useContext(ContextProvider)
-  const winege: Type = 'Wine-GE'
-  const protonge: Type = 'Proton-GE'
-  const [repository, setRepository] = useState<Type>(winege)
-  const [wineManagerSettings, setWineManagerSettings] =
-    useState<WineManagerUISettings>({
-      showWineGe: true,
-      showWineLutris: true,
-      showProtonGe: true
-    })
+  const { refreshWineVersionInfo, refreshing, platform } =
+    useContext(ContextProvider)
+  const isLinux = platform === 'linux'
+
+  const winege: WineManagerUISettings = {
+    type: 'Wine-GE',
+    value: 'winege',
+    enabled: isLinux
+  }
+  const winecrossover: WineManagerUISettings = {
+    type: 'Wine-Crossover',
+    value: 'winecrossover',
+    enabled: !isLinux
+  }
+
+  const [repository, setRepository] = useState<WineManagerUISettings>(
+    isLinux ? winege : winecrossover
+  )
+  const [wineManagerSettings, setWineManagerSettings] = useState<
+    WineManagerUISettings[]
+  >([
+    { type: 'Wine-GE', value: 'winege', enabled: isLinux },
+    { type: 'Proton-GE', value: 'protonge', enabled: isLinux },
+    { type: 'Wine-Crossover', value: 'winecrossover', enabled: !isLinux }
+  ])
 
   const getWineVersions = (repo: Type) => {
     const versions = wineDownloaderInfoStore.get(
@@ -50,12 +65,15 @@ export default React.memo(function WineManager(): JSX.Element | null {
   }
 
   const [wineVersions, setWineVersions] = useState<WineVersionInfo[]>(
-    getWineVersions(repository)
+    getWineVersions(repository.type)
   )
 
-  const handleChangeTab = (e: React.SyntheticEvent, repo: Type) => {
+  const handleChangeTab = (
+    e: React.SyntheticEvent,
+    repo: WineManagerUISettings
+  ) => {
     setRepository(repo)
-    setWineVersions(getWineVersions(repo))
+    setWineVersions(getWineVersions(repo.type))
   }
 
   useEffect(() => {
@@ -63,7 +81,7 @@ export default React.memo(function WineManager(): JSX.Element | null {
     if (hasSettings) {
       const oldWineManagerSettings = configStore.get(
         'wine-manager-settings'
-      ) as WineManagerUISettings
+      ) as WineManagerUISettings[]
       if (wineManagerSettings) {
         setWineManagerSettings(oldWineManagerSettings)
       }
@@ -72,7 +90,7 @@ export default React.memo(function WineManager(): JSX.Element | null {
 
   useEffect(() => {
     const removeListener = window.api.handleWineVersionsUpdated(() => {
-      setWineVersions(getWineVersions(repository))
+      setWineVersions(getWineVersions(repository.type))
     })
     return () => {
       removeListener()
@@ -88,16 +106,16 @@ export default React.memo(function WineManager(): JSX.Element | null {
         <span className="tabsWrapper">
           <Tabs
             className="tabs"
-            value={repository}
+            value={repository.value}
             onChange={handleChangeTab}
             centered={true}
           >
-            {wineManagerSettings.showWineGe && (
-              <Tab value={winege} label={winege} />
-            )}
-            {wineManagerSettings.showProtonGe && (
-              <Tab value={protonge} label={protonge} />
-            )}
+            {wineManagerSettings.map(({ type, value, enabled }) => {
+              if (enabled) {
+                return <Tab value={value} label={type} key={value} />
+              }
+              return null
+            })}
           </Tabs>
           <button
             className={'FormControl__button'}

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -53,7 +53,8 @@ export default React.memo(function WineManager(): JSX.Element | null {
   >([
     { type: 'Wine-GE', value: 'winege', enabled: isLinux },
     { type: 'Proton-GE', value: 'protonge', enabled: isLinux },
-    { type: 'Wine-Crossover', value: 'winecrossover', enabled: !isLinux }
+    { type: 'Wine-Crossover', value: 'winecrossover', enabled: !isLinux },
+    { type: 'Wine-Staging-macOS', value: 'winestagingmacos', enabled: !isLinux }
   ])
 
   const getWineVersions = (repo: Type) => {
@@ -107,7 +108,14 @@ export default React.memo(function WineManager(): JSX.Element | null {
           <Tabs
             className="tabs"
             value={repository.value}
-            onChange={handleChangeTab}
+            onChange={(e, value) => {
+              const repo = wineManagerSettings.find(
+                (setting) => setting.value === value
+              )
+              if (repo) {
+                handleChangeTab(e, repo)
+              }
+            }}
             centered={true}
           >
             {wineManagerSettings.map(({ type, value, enabled }) => {

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -490,7 +490,7 @@ export class GlobalState extends PureComponent<Props> {
   }
 
   refreshWineVersionInfo = async (fetch: boolean): Promise<void> => {
-    if (this.state.platform !== 'linux') {
+    if (this.state.platform === 'win32') {
       return
     }
     window.api.logInfo('Refreshing wine downloader releases')


### PR DESCRIPTION
This PR adds the ability to install Wine-crossover and Wine-Staging versions for macOS, making it even more simple for macOS user to play Windows games.

![image](https://user-images.githubusercontent.com/26871415/213207144-ee0db01a-abd9-42c8-a5a0-ed7b3aa7ddc6.png)

![image](https://user-images.githubusercontent.com/26871415/213207220-9cc15563-40de-4719-8f7e-3e699eb58e89.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
