### PR TITLE
[Tech] Resolve `baseUrl` in tests

### DIFF
--- a/src/backend/api/downloadmanager.ts
+++ b/src/backend/api/downloadmanager.ts
@@ -1,9 +1,5 @@
 import { ipcRenderer } from 'electron'
-import {
-  DMQueueElement,
-  InstallParams,
-  UpdateParams
-} from './../../common/types'
+import { DMQueueElement, InstallParams, UpdateParams } from 'common/types'
 
 export const install = async (args: InstallParams) => {
   const dmQueueElement: DMQueueElement = {

--- a/src/backend/games.ts
+++ b/src/backend/games.ts
@@ -1,4 +1,3 @@
-import { WineCommandArgs } from './../common/types'
 import { GOGCloudSavesLocation, GogInstallInfo } from 'common/types/gog'
 import { LegendaryInstallInfo } from 'common/types/legendary'
 import {
@@ -7,7 +6,8 @@ import {
   GameInfo,
   GameSettings,
   InstallArgs,
-  InstallPlatform
+  InstallPlatform,
+  WineCommandArgs
 } from 'common/types'
 
 import { join } from 'path'

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -1,4 +1,3 @@
-import { WineCommandArgs } from './../../common/types'
 import {
   createAbortController,
   deleteAbortController
@@ -22,7 +21,8 @@ import {
   ExecResult,
   InstallArgs,
   InstalledInfo,
-  InstallPlatform
+  InstallPlatform,
+  WineCommandArgs
 } from 'common/types'
 import { appendFileSync, existsSync, rmSync } from 'graceful-fs'
 import {

--- a/src/backend/jest.config.js
+++ b/src/backend/jest.config.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { compilerOptions } = require('../../tsconfig')
+
 module.exports = {
   displayName: 'Backend',
 
@@ -13,12 +16,12 @@ module.exports = {
   // `<rootDir>` is a token Jest substitutes
   roots: ['<rootDir>/src/backend'],
 
-  // Test spec file resolution pattern
-  // should contain `test` or `spec`.
-  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
+  testMatch: ['**/__tests__/**/*.test.ts'],
   // Jest transformations -- this adds support for TypeScript
   // using ts-jest
   transform: {
     '^.+\\.tsx?$': 'ts-jest'
-  }
+  },
+
+  modulePaths: [compilerOptions.baseUrl]
 }

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -1,4 +1,3 @@
-import { WineCommandArgs } from './../../common/types'
 import {
   createAbortController,
   deleteAbortController
@@ -11,7 +10,8 @@ import {
   ExtraInfo,
   GameInfo,
   InstallArgs,
-  InstallPlatform
+  InstallPlatform,
+  WineCommandArgs
 } from 'common/types'
 import { Game } from '../games'
 import { GameConfig } from '../game_config'

--- a/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
+++ b/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
@@ -1,13 +1,13 @@
 import { readFileSync, copyFileSync, mkdirSync } from 'graceful-fs'
-import { GameInfo } from '../../../../common/types'
+import { GameInfo } from 'common/types'
 import { join } from 'path'
 import { DirResult, dirSync } from 'tmp'
 import { addNonSteamGame, removeNonSteamGame } from '../nonesteamgame'
-import { showDialogBoxModalAuto } from '../../../dialog/dialog'
+import { showDialogBoxModalAuto } from 'backend/dialog/dialog'
 
-jest.mock('../../../logger/logfile')
-jest.mock('../../../dialog/dialog')
-jest.mock('../../../utils')
+jest.mock('backend/logger/logfile')
+jest.mock('backend/dialog/dialog')
+jest.mock('backend/utils')
 
 let tmpDir = {} as DirResult
 let tmpSteamUserConfigDir = '' as string

--- a/src/backend/sideload/games.ts
+++ b/src/backend/sideload/games.ts
@@ -3,7 +3,7 @@ import {
   GameInfo,
   SideloadGame,
   InstalledInfo
-} from '../../common/types'
+} from 'common/types'
 import { libraryStore } from './electronStores'
 import { GameConfig } from '../game_config'
 import {

--- a/src/backend/tray_icon/__tests__/tray_icon.test.ts
+++ b/src/backend/tray_icon/__tests__/tray_icon.test.ts
@@ -2,7 +2,7 @@ import { BrowserWindow } from 'electron'
 import { contextMenu, getIcon, initTrayIcon } from '../tray_icon'
 import { backendEvents } from '../../backend_events'
 import { GlobalConfig } from '../../config'
-import { RecentGame } from '../../../common/types'
+import { RecentGame } from 'common/types'
 import { configStore } from '../../constants'
 import { wait } from '../../utils'
 

--- a/src/backend/wiki_game_info/__tests__/wiki_game_info.test.ts
+++ b/src/backend/wiki_game_info/__tests__/wiki_game_info.test.ts
@@ -1,9 +1,5 @@
 import { HowLongToBeatEntry } from 'howlongtobeat'
-import {
-  AppleGamingWikiInfo,
-  WikiInfo,
-  PCGamingWikiInfo
-} from '../../../common/types'
+import { AppleGamingWikiInfo, WikiInfo, PCGamingWikiInfo } from 'common/types'
 import { wikiGameInfoStore } from '../electronStore'
 import { getWikiGameInfo } from '../wiki_game_info'
 import * as PCGamingWiki from '../pcgamingwiki/utils'

--- a/src/backend/wiki_game_info/applegamingwiki/__tests__/utils.test.ts
+++ b/src/backend/wiki_game_info/applegamingwiki/__tests__/utils.test.ts
@@ -1,10 +1,10 @@
-import { logError } from '../../../logger/logger'
+import { logError } from 'backend/logger/logger'
 import { getInfoFromAppleGamingWiki } from '../utils'
 import axios from 'axios'
-import { AppleGamingWikiInfo } from '../../../../common/types'
+import { AppleGamingWikiInfo } from 'common/types'
 
-jest.mock('../../../logger/logfile')
-jest.mock('../../../logger/logger')
+jest.mock('backend/logger/logfile')
+jest.mock('backend/logger/logger')
 jest.mock('electron-store')
 
 describe('getAppleGamingWikiInfo', () => {

--- a/src/backend/wiki_game_info/howlongtobeat/__tests__/utils.test.ts
+++ b/src/backend/wiki_game_info/howlongtobeat/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 // needs to be here, because jest.mock places itself before import.
 const mockSearch = jest.fn()
 
-import { logError } from '../../../logger/logger'
+import { logError } from 'backend/logger/logger'
 import { getHowLongToBeat } from '../utils'
 import { HowLongToBeatEntry } from 'howlongtobeat'
 

--- a/src/backend/wiki_game_info/howlongtobeat/__tests__/utils.test.ts
+++ b/src/backend/wiki_game_info/howlongtobeat/__tests__/utils.test.ts
@@ -5,8 +5,8 @@ import { logError } from '../../../logger/logger'
 import { getHowLongToBeat } from '../utils'
 import { HowLongToBeatEntry } from 'howlongtobeat'
 
-jest.mock('../../../logger/logfile')
-jest.mock('../../../logger/logger')
+jest.mock('backend/logger/logfile')
+jest.mock('backend/logger/logger')
 jest.mock('electron-store')
 jest.mock('howlongtobeat', () => ({
   __esModule: true,

--- a/src/backend/wiki_game_info/pcgamingwiki/__tests__/utils.test.ts
+++ b/src/backend/wiki_game_info/pcgamingwiki/__tests__/utils.test.ts
@@ -1,10 +1,10 @@
-import { logError } from '../../../logger/logger'
+import { logError } from 'backend/logger/logger'
 import { getInfoFromPCGamingWiki } from '../utils'
 import axios from 'axios'
-import { PCGamingWikiInfo } from '../../../../common/types'
+import { PCGamingWikiInfo } from 'common/types'
 
-jest.mock('../../../logger/logfile')
-jest.mock('../../../logger/logger')
+jest.mock('backend/logger/logfile')
+jest.mock('backend/logger/logger')
 jest.mock('electron-store')
 
 describe('getPCGamingWikiInfo', () => {

--- a/src/backend/wiki_game_info/wiki_game_info.ts
+++ b/src/backend/wiki_game_info/wiki_game_info.ts
@@ -1,6 +1,6 @@
 import { wikiGameInfoStore } from './electronStore'
 import { removeSpecialcharacters } from '../utils'
-import { WikiInfo } from '../../common/types'
+import { WikiInfo } from 'common/types'
 import { logError, logInfo, LogPrefix } from '../logger/logger'
 import { getInfoFromAppleGamingWiki } from './applegamingwiki/utils'
 import { getHowLongToBeat } from './howlongtobeat/utils'

--- a/src/backend/wine/manager/downloader/__test__/main/getter.test.ts
+++ b/src/backend/wine/manager/downloader/__test__/main/getter.test.ts
@@ -1,4 +1,4 @@
-import { Repositorys, VersionInfo } from '../../../../../../common/types'
+import { Repositorys, VersionInfo } from 'common/types'
 import { getAvailableVersions } from '../../main'
 import { test_data_release_list } from '../test_data/github-api-test-data.json'
 import * as axios from 'axios'

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -14,12 +14,7 @@ import {
   PROTON_URL,
   WINELUTRIS_URL
 } from './constants'
-import {
-  VersionInfo,
-  Repositorys,
-  State,
-  ProgressInfo
-} from '../../../../common/types'
+import { VersionInfo, Repositorys, State, ProgressInfo } from 'common/types'
 import {
   downloadFile,
   fetchReleases,

--- a/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
+++ b/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
@@ -8,7 +8,6 @@ import {
   downloadFile,
   extractTarFile
 } from '../../util'
-// @ts-ignore: Don't know why ts complains about it.
 import { test_data } from './test_data/github-api-heroic-test-data.json'
 import { dirSync } from 'tmp'
 import { platform } from 'os'
@@ -25,12 +24,12 @@ afterEach(jest.restoreAllMocks)
 
 const shouldSkip = platform() !== 'linux'
 const skipMessage = 'not on linux so skipping test'
-const emptyTest = it('should do nothing', () => {})
+const emptyTest = () => it('should do nothing', () => {})
 
 describe('getAssetDataFromDownload', () => {
   if (shouldSkip) {
     console.log(skipMessage)
-    emptyTest
+    emptyTest()
     return
   }
   it('Success', async () => {
@@ -88,7 +87,7 @@ describe('getAssetDataFromDownload', () => {
 describe('downloadFile', () => {
   if (shouldSkip) {
     console.log(skipMessage)
-    emptyTest
+    emptyTest()
     return
   }
   it('Success', async () => {
@@ -168,7 +167,7 @@ describe('downloadFile', () => {
 describe('extractTarFile', () => {
   if (shouldSkip) {
     console.log(skipMessage)
-    emptyTest
+    emptyTest()
     return
   }
   it('Success without strip', async () => {


### PR DESCRIPTION
Originally part of #2176

Jest now knows about our `baseUrl`, making imports from `backend/...`/`common/...` possible. Nothing groundbreaking, just a nice-to-have when writing tests

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [X] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
