### PR TITLE
[UI] Fix Incorrect Sideload settings and Refactor nativeGame

### DIFF
--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -47,8 +47,7 @@ type Props = {
 export default function GamesSettings({ useDetails = true }: Props) {
   const { t } = useTranslation()
   const { platform } = useContext(ContextProvider)
-  const { isDefault, gameInfo, isMacNative, isLinuxNative } =
-    useContext(SettingsContext)
+  const { isDefault, gameInfo } = useContext(SettingsContext)
   const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
   const isLinux = platform === 'linux'
   const isCrossover = wineVersion?.type === 'crossover'
@@ -57,11 +56,13 @@ export default function GamesSettings({ useDetails = true }: Props) {
   const [nativeGame, checkNativeGame] = useState(false)
 
   useEffect(() => {
-    window.api
-      .isNative({ appName: gameInfo?.app_name!, runner: gameInfo?.runner! })
-      .then((nativeGame) => {
-        checkNativeGame(nativeGame)
-      })
+    if (gameInfo) {
+      window.api
+        .isNative({ appName: gameInfo?.app_name, runner: gameInfo?.runner })
+        .then((nativeGame) => {
+          checkNativeGame(nativeGame)
+        })
+    }
   }, [])
 
   return (

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -66,7 +66,7 @@ export default function GamesSettings({ useDetails = true }: Props) {
       }
       getIsNative()
     }
-  })
+  }, [])
 
   return (
     <>

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -47,7 +47,7 @@ type Props = {
 export default function GamesSettings({ useDetails = true }: Props) {
   const { t } = useTranslation()
   const { platform } = useContext(ContextProvider)
-  const { isDefault, gameInfo } = useContext(SettingsContext)
+  const { isDefault, gameInfo, isLinuxNative } = useContext(SettingsContext)
   const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
   const isLinux = platform === 'linux'
   const isCrossover = wineVersion?.type === 'crossover'

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -53,17 +53,20 @@ export default function GamesSettings({ useDetails = true }: Props) {
   const isCrossover = wineVersion?.type === 'crossover'
   const hasCloudSaves = gameInfo?.cloud_save_enabled
 
-  const [nativeGame, checkNativeGame] = useState(false)
+  const [nativeGame, setNativeGame] = useState(false)
 
   useEffect(() => {
     if (gameInfo) {
-      window.api
-        .isNative({ appName: gameInfo?.app_name, runner: gameInfo?.runner })
-        .then((nativeGame) => {
-          checkNativeGame(nativeGame)
+      const getIsNative = async () => {
+        const isNative = await window.api.isNative({
+          appName: gameInfo?.app_name,
+          runner: gameInfo?.runner
         })
+        setNativeGame(isNative)
+      }
+      getIsNative()
     }
-  }, [])
+  })
 
   return (
     <>

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -1,6 +1,6 @@
 import './index.scss'
 
-import React, { useContext } from 'react'
+import React, { useContext, useState, useEffect } from 'react'
 
 import { useTranslation } from 'react-i18next'
 import {
@@ -51,14 +51,18 @@ export default function GamesSettings({ useDetails = true }: Props) {
     useContext(SettingsContext)
   const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
   const isLinux = platform === 'linux'
-  const isWin = platform === 'win32'
   const isCrossover = wineVersion?.type === 'crossover'
   const hasCloudSaves = gameInfo?.cloud_save_enabled
 
-  const nativeGame =
-    isWin ||
-    (isMacNative && gameInfo?.install.platform === 'Mac') ||
-    (isLinuxNative && gameInfo?.install.platform === 'linux')
+  const [nativeGame, checkNativeGame] = useState(false)
+
+  useEffect(() => {
+    window.api
+      .isNative({ appName: gameInfo?.app_name!, runner: gameInfo?.runner! })
+      .then((nativeGame) => {
+        checkNativeGame(nativeGame)
+      })
+  }, [])
 
   return (
     <>


### PR DESCRIPTION
This PR fixes the wrong Settings options displayed for sideloaded games with the install platform as native (Linux/macOS).
It also refactors the way how games are identified as native using `window.api.isNative()`

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
