### PR TITLE
Try to solve Download/Disk speed not getting picked up consistently

### DIFF
--- a/src/frontend/hooks/hasProgress.ts
+++ b/src/frontend/hooks/hasProgress.ts
@@ -4,44 +4,35 @@ import { GameStatus, InstallProgress } from 'common/types'
 const storage: Storage = window.localStorage
 
 export const hasProgress = (appName: string) => {
-  const previousProgress = JSON.parse(
-    storage.getItem(appName) || '{}'
-  ) as InstallProgress
+  const previousProgressItem = storage.getItem(appName)
+  const previousProgress = previousProgressItem
+    ? (JSON.parse(previousProgressItem) as InstallProgress)
+    : null
 
-  const [progress, setProgress] = useState(
-    previousProgress ??
-      ({
-        bytes: '0.00MB',
-        eta: '00:00:00',
-        percent: 0
-      } as InstallProgress)
+  const [progress, setProgress] = useState<InstallProgress>(
+    previousProgress ?? {
+      bytes: '0.00MB',
+      eta: '00:00:00',
+      percent: 0
+    }
   )
 
-  const calculatePercent = (currentProgress: InstallProgress) => {
-    // current/100 * (100-heroic_stored) + heroic_stored
-    if (previousProgress.percent) {
-      const currentPercent = currentProgress.percent
-      const storedPercent = previousProgress.percent
-      const newPercent: number = Math.round(
-        (currentPercent / 100) * (100 - storedPercent) + storedPercent
+  const handleProgressUpdate = async (
+    _e: Electron.IpcRendererEvent,
+    { appName: appWithProgress, progress: currentProgress }: GameStatus
+  ) => {
+    if (appName === appWithProgress && currentProgress) {
+      console.log(
+        'Current progress:\n',
+        progress,
+        '\nNew progress:\n',
+        currentProgress
       )
-      return newPercent
+      setProgress({ ...progress, ...currentProgress })
     }
-    return currentProgress.percent
   }
 
   useEffect(() => {
-    const handleProgressUpdate = async (
-      _e: Electron.IpcRendererEvent,
-      { appName: appWithProgress, progress: currentProgress }: GameStatus
-    ) => {
-      if (appName === appWithProgress && currentProgress) {
-        setProgress({
-          ...currentProgress,
-          percent: calculatePercent(currentProgress)
-        })
-      }
-    }
     const setGameStatusRemoveListener = window.api.onProgressUpdate(
       appName,
       handleProgressUpdate
@@ -52,5 +43,5 @@ export const hasProgress = (appName: string) => {
     }
   }, [appName])
 
-  return [progress, previousProgress]
+  return [progress, previousProgress] as const
 }


### PR DESCRIPTION
As discussed on Discord:
When reading out install/update progress from the output of Legendary (and I assume GOGDL as well), we were sometimes not getting the Download/Disk write speed. This is caused by Python buffering the output to stdout, and us only sending progress updates if everything (ETA, download percent, as mentioned download/disk speed, etc.) is in *one* message. This is often not the case
I've attempted to fix this issue by sending `Partial<InstallProgress>` messages to the frontend instead. It *should* be able to handle those just fine (updating the properties that were included, and leaving those that weren't alone), however this does not work. It seems like the `hasProgress` hook's `progress` state variable is not actually getting saved (?), returning to its default value whenever a re-render happens

Maybe someone else can tell me what's going wrong here

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
