### PR TITLE
[Tech] Refactor Download Dialog + Cache GOG Install Info

### DIFF
--- a/src/backend/gog/electronStores.ts
+++ b/src/backend/gog/electronStores.ts
@@ -28,6 +28,15 @@ const syncStore = new TypeCheckedStoreBackend('gogSyncStore', {
   clearInvalidConfig: true
 })
 
+export const gogInstallInfoStore = new TypeCheckedStoreBackend(
+  'gogInstallInfo',
+  {
+    cwd: 'gog_store',
+    name: 'installInfo',
+    clearInvalidConfig: true
+  }
+)
+
 export {
   configStore,
   installedGamesStore,

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -23,7 +23,8 @@ import {
   ExecResult,
   InstallArgs,
   InstalledInfo,
-  WineCommandArgs
+  WineCommandArgs,
+  InstallPlatform
 } from 'common/types'
 import { appendFileSync, existsSync, rmSync } from 'graceful-fs'
 import { heroicGamesConfigPath, isWindows, isMac, isLinux } from '../constants'
@@ -109,7 +110,7 @@ class GOGGame extends Game {
   }
 
   async getInstallInfo(
-    installPlatform: GogInstallPlatform
+    installPlatform: InstallPlatform = 'windows'
   ): Promise<GogInstallInfo> {
     const info = await GOGLibrary.get().getInstallInfo(
       this.appName,
@@ -776,9 +777,7 @@ class GOGGame extends Game {
     const gameObject = installedArray[gameIndex]
 
     if (gameData.install.platform !== 'linux') {
-      const installInfo = await this.getInstallInfo(
-        gameData.install.platform as GogInstallPlatform
-      )
+      const installInfo = await this.getInstallInfo()
       gameObject.buildId = installInfo.game.buildId
       gameObject.version = installInfo.game.version
       gameObject.versionEtag = installInfo.manifest.versionEtag

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -23,7 +23,6 @@ import {
   ExecResult,
   InstallArgs,
   InstalledInfo,
-  InstallPlatform,
   WineCommandArgs
 } from 'common/types'
 import { appendFileSync, existsSync, rmSync } from 'graceful-fs'
@@ -110,7 +109,7 @@ class GOGGame extends Game {
   }
 
   async getInstallInfo(
-    installPlatform: InstallPlatform = 'windows'
+    installPlatform: GogInstallPlatform
   ): Promise<GogInstallInfo> {
     const info = await GOGLibrary.get().getInstallInfo(
       this.appName,
@@ -777,7 +776,9 @@ class GOGGame extends Game {
     const gameObject = installedArray[gameIndex]
 
     if (gameData.install.platform !== 'linux') {
-      const installInfo = await this.getInstallInfo()
+      const installInfo = await this.getInstallInfo(
+        gameData.install.platform as GogInstallPlatform
+      )
       gameObject.buildId = installInfo.game.buildId
       gameObject.version = installInfo.game.version
       gameObject.versionEtag = installInfo.manifest.versionEtag

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -15,8 +15,7 @@ import {
   GOGGameDotIdFile,
   GOGClientsResponse,
   GamesDBData,
-  Library,
-  GogInstallPlatform
+  Library
 } from 'common/types/gog'
 import { basename, join } from 'node:path'
 import { existsSync, readFileSync } from 'graceful-fs'
@@ -324,7 +323,7 @@ export class GOGLibrary {
    */
   public async getInstallInfo(
     appName: string,
-    installPlatform: GogInstallPlatform = 'windows',
+    installPlatform = 'windows',
     lang = 'en-US'
   ): Promise<GogInstallInfo | undefined> {
     if (gogInstallInfoStore.has(`${appName}_${installPlatform}`)) {

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -330,17 +330,17 @@ export class GOGLibrary {
       const cache = gogInstallInfoStore.get_nodefault(
         `${appName}_${installPlatform}`
       )
-      logInfo(
-        [
-          'Got install info from cache for',
-          appName,
-          'on',
-          installPlatform,
-          'platform'
-        ],
-        LogPrefix.Gog
-      )
       if (cache) {
+        logInfo(
+          [
+            'Got install info from cache for',
+            appName,
+            'on',
+            installPlatform,
+            'platform'
+          ],
+          LogPrefix.Gog
+        )
         return cache
       }
     }

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -341,7 +341,6 @@ export class GOGLibrary {
         ],
         LogPrefix.Gog
       )
-      console.log({ cache, installPlatform })
       if (cache) {
         return cache
       }

--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -1,4 +1,4 @@
-import { Runner } from 'common/types'
+import { InstalledInfo, Runner } from 'common/types'
 import { GOGCloudSavesLocation, SaveFolderVariable } from 'common/types/gog'
 import { getWinePath, setupWineEnvVars, verifyWinePrefix } from './launcher'
 import { runLegendaryCommand, LegendaryLibrary } from './legendary/library'
@@ -108,10 +108,13 @@ async function getDefaultGogSavePaths(
 ): Promise<GOGCloudSavesLocation[]> {
   const game = getGame(appName, 'gog')
   const gameSettings = await game.getSettings()
-  const {
-    gog_save_location,
-    install: { platform: installed_platform, install_path }
-  } = game.getGameInfo()
+  const installInfo = game.getGameInfo().install as InstalledInfo
+  const gog_save_location = await GOGLibrary.get().getSaveSyncLocation(
+    appName,
+    installInfo
+  )
+
+  const { platform: installed_platform, install_path } = installInfo
   if (!gog_save_location || !install_path) {
     logError([
       'gog_save_location/install_path undefined. gog_save_location = ',

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -51,7 +51,7 @@ import {
 } from './legendary/electronStores'
 import {
   apiInfoCache as GOGapiInfoCache,
-  gogInstallInfoStore,
+  gogInstallInfoStore as GOGinstallInfoStore,
   libraryStore as GOGlibraryStore
 } from './gog/electronStores'
 import fileSize from 'filesize'
@@ -420,7 +420,7 @@ async function openUrlOrFile(url: string): Promise<string | void> {
 async function clearCache() {
   GOGapiInfoCache.clear()
   GOGlibraryStore.clear()
-  gogInstallInfoStore.clear()
+  GOGinstallInfoStore.clear()
   installStore.clear()
   libraryStore.clear()
   gameInfoStore.clear()

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -51,6 +51,7 @@ import {
 } from './legendary/electronStores'
 import {
   apiInfoCache as GOGapiInfoCache,
+  gogInstallInfoStore,
   libraryStore as GOGlibraryStore
 } from './gog/electronStores'
 import fileSize from 'filesize'
@@ -419,6 +420,7 @@ async function openUrlOrFile(url: string): Promise<string | void> {
 async function clearCache() {
   GOGapiInfoCache.clear()
   GOGlibraryStore.clear()
+  gogInstallInfoStore.clear()
   installStore.clear()
   libraryStore.clear()
   gameInfoStore.clear()

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -1,3 +1,4 @@
+import { LegendaryInstallPlatform } from './../types/legendary'
 import { EventEmitter } from 'node:events'
 import { IpcMainEvent, OpenDialogOptions } from 'electron'
 
@@ -9,7 +10,6 @@ import {
   Release,
   GameInfo,
   GameSettings,
-  InstallPlatform,
   UserInfo,
   WineInstallation,
   AppSettings,
@@ -126,7 +126,7 @@ interface AsyncIPCFunctions {
   getInstallInfo: (
     appName: string,
     runner: Runner,
-    installPlatform: InstallPlatform
+    installPlatform: LegendaryInstallPlatform | GOGInstallPlatform
   ) => Promise<LegendaryInstallInfo | GogInstallInfo | null>
   getUserInfo: () => Promise<UserInfo | undefined>
   isLoggedIn: () => boolean

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -1,4 +1,3 @@
-import { LegendaryInstallPlatform } from './../types/legendary'
 import { EventEmitter } from 'node:events'
 import { IpcMainEvent, OpenDialogOptions } from 'electron'
 
@@ -10,6 +9,7 @@ import {
   Release,
   GameInfo,
   GameSettings,
+  InstallPlatform,
   UserInfo,
   WineInstallation,
   AppSettings,
@@ -126,7 +126,7 @@ interface AsyncIPCFunctions {
   getInstallInfo: (
     appName: string,
     runner: Runner,
-    installPlatform: LegendaryInstallPlatform | GOGInstallPlatform
+    installPlatform: InstallPlatform
   ) => Promise<LegendaryInstallInfo | GogInstallInfo | null>
   getUserInfo: () => Promise<UserInfo | undefined>
   isLoggedIn: () => boolean

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -1,4 +1,3 @@
-import { GogInstallPlatform } from './gog'
 import Store from 'electron-store'
 import { Get } from 'type-fest'
 
@@ -96,7 +95,7 @@ export interface StoreStructure {
     }
   }
   gogInstallInfo: {
-    [appName: string]: Record<GogInstallPlatform, GogInstallInfo>
+    [appName_platform: string]: GogInstallInfo
   }
   legendaryInstallInfo: {
     [appName: string]: LegendaryInstallInfo

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -1,3 +1,4 @@
+import { GogInstallPlatform } from './gog'
 import Store from 'electron-store'
 import { Get } from 'type-fest'
 
@@ -17,7 +18,7 @@ import {
   AppSettings,
   WikiInfo
 } from 'common/types'
-import { GamesDBData, UserData } from 'common/types/gog'
+import { GamesDBData, GogInstallInfo, UserData } from 'common/types/gog'
 import { LegendaryInstallInfo } from 'common/types/legendary'
 
 export interface StoreStructure {
@@ -93,6 +94,9 @@ export interface StoreStructure {
     [appName: string]: {
       [saveName: string]: string
     }
+  }
+  gogInstallInfo: {
+    [appName: string]: Record<GogInstallPlatform, GogInstallInfo>
   }
   legendaryInstallInfo: {
     [appName: string]: LegendaryInstallInfo

--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -84,7 +84,7 @@ const getInstallInfo = async (
   )
 }
 
-export function handleRunnersPlatforms(
+function handleRunnersPlatforms(
   platform: InstallPlatform,
   runner: Runner
 ): InstallPlatform {

--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -77,7 +77,28 @@ const getInstallInfo = async (
   runner: Runner,
   installPlatform: InstallPlatform
 ): Promise<LegendaryInstallInfo | GogInstallInfo | null> => {
-  return window.api.getInstallInfo(appName, runner, installPlatform)
+  return window.api.getInstallInfo(
+    appName,
+    runner,
+    handleRunnersPlatforms(installPlatform, runner)
+  )
+}
+
+export function handleRunnersPlatforms(
+  platform: InstallPlatform,
+  runner: Runner
+): InstallPlatform {
+  if (runner === 'legendary') {
+    return platform
+  }
+  switch (platform) {
+    case 'Mac':
+      return 'osx'
+    case 'Windows':
+      return 'windows'
+    default:
+      return platform
+  }
 }
 
 const createNewWindow = (url: string) => window.api.createNewWindow(url)

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -99,6 +99,8 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const [gameAvailable, setGameAvailable] = useState(true)
 
   const isWin = platform === 'win32'
+  const isLinux = platform === 'linux'
+  const isMac = platform === 'darwin'
   const isSideloaded = runner === 'sideload'
 
   const isInstalling = status === 'installing'
@@ -144,10 +146,21 @@ export default React.memo(function GamePage(): JSX.Element | null {
   useEffect(() => {
     const updateConfig = async () => {
       if (gameInfo) {
-        const { install } = gameInfo
+        const {
+          install,
+          is_linux_native = undefined,
+          is_mac_native = undefined
+        } = { ...gameInfo }
 
-        if (runner !== 'sideload' && !notSupportedGame && install.platform) {
-          getInstallInfo(appName, runner, install.platform)
+        const installPlatform =
+          install.platform || (is_linux_native && isLinux)
+            ? 'linux'
+            : is_mac_native && isMac
+            ? 'Mac'
+            : 'Windows'
+
+        if (runner !== 'sideload' && !notSupportedGame) {
+          getInstallInfo(appName, runner, installPlatform)
             .then((info) => {
               if (!info) {
                 throw 'Cannot get game info'

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -153,11 +153,12 @@ export default React.memo(function GamePage(): JSX.Element | null {
         } = { ...gameInfo }
 
         const installPlatform =
-          install.platform || (is_linux_native && isLinux)
+          install.platform ||
+          (is_linux_native && isLinux
             ? 'linux'
             : is_mac_native && isMac
             ? 'Mac'
-            : 'Windows'
+            : 'Windows')
 
         if (runner !== 'sideload' && !notSupportedGame) {
           getInstallInfo(appName, runner, installPlatform)

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -28,7 +28,6 @@ import {
   getProgress,
   size,
   getInstallInfo,
-  getGameInfo,
   writeConfig,
   install
 } from 'frontend/helpers'
@@ -52,8 +51,6 @@ interface Props {
   runner: Runner
   platformToInstall: InstallPlatform
   availablePlatforms: AvailablePlatforms
-  setIsLinuxNative: React.Dispatch<React.SetStateAction<boolean>>
-  setIsMacNative: React.Dispatch<React.SetStateAction<boolean>>
   winePrefix: string
   crossoverBottle: string
   wineVersion: WineInstallation | undefined
@@ -103,8 +100,6 @@ export default function DownloadDialog({
   runner,
   platformToInstall,
   availablePlatforms,
-  setIsLinuxNative,
-  setIsMacNative,
   winePrefix,
   wineVersion,
   children,
@@ -117,8 +112,6 @@ export default function DownloadDialog({
   const { libraryStatus, platform, showDialogModal } =
     useContext(ContextProvider)
 
-  const isMac = platform === 'darwin'
-  const isLinux = platform === 'linux'
   const isWin = platform === 'win32'
 
   const [gameInstallInfo, setGameInstallInfo] = useState<
@@ -218,7 +211,7 @@ export default function DownloadDialog({
   }
 
   useEffect(() => {
-    const getIinstallInfo = async () => {
+    const getIinstInfo = async () => {
       try {
         setGettingInstallInfo(true)
         const gameInstallInfo = await getInstallInfo(
@@ -264,23 +257,8 @@ export default function DownloadDialog({
         return
       }
     }
-    getIinstallInfo()
+    getIinstInfo()
   }, [appName, i18n.languages, platformToInstall])
-
-  useEffect(() => {
-    const getCacheInfo = async () => {
-      if (gameInfo) {
-        setIsLinuxNative(gameInfo.is_linux_native && isLinux)
-        setIsMacNative(gameInfo.is_mac_native && isMac)
-      } else {
-        const gameData = await getGameInfo(appName, runner)
-        if (gameData?.runner === 'sideload') return
-        setIsLinuxNative((gameData?.is_linux_native && isLinux) ?? false)
-        setIsMacNative((gameData?.is_mac_native && isMac) ?? false)
-      }
-    }
-    getCacheInfo()
-  }, [appName])
 
   useEffect(() => {
     const getSpace = async () => {
@@ -312,23 +290,6 @@ export default function DownloadDialog({
     }
     getSpace()
   }, [installPath, gameInstallInfo?.manifest?.disk_size])
-
-  useEffect(() => {
-    const getCacheInfo = async () => {
-      if (gameInfo) {
-        setIsLinuxNative(gameInfo.is_linux_native && isLinux)
-        setIsMacNative(gameInfo.is_mac_native && isMac)
-      } else {
-        const gameData = await getGameInfo(appName, runner)
-        if (!gameData || gameData.runner === 'sideload') {
-          return
-        }
-        setIsLinuxNative(gameData.is_linux_native && isLinux)
-        setIsMacNative(gameData.is_mac_native && isMac)
-      }
-    }
-    getCacheInfo()
-  }, [appName])
 
   const haveDLCs =
     gameInstallInfo && gameInstallInfo?.game?.owned_dlc?.length > 0

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -48,10 +48,8 @@ export default React.memo(function InstallModal({
   const [wineVersionList, setWineVersionList] = useState<WineInstallation[]>([])
   const [crossoverBottle, setCrossoverBottle] = useState('')
 
-  const [isLinuxNative, setIsLinuxNative] = useState(false)
-  const [isMacNative, setIsMacNative] = useState(false)
-  const [defaultPlatform, setDefaultPlatform] =
-    useState<InstallPlatform>('Windows')
+  const isLinuxNative = Boolean(gameInfo?.is_linux_native)
+  const isMacNative = Boolean(gameInfo?.is_mac_native)
 
   const isMac = platform === 'darwin'
   const isWin = platform === 'win32'
@@ -83,19 +81,21 @@ export default React.memo(function InstallModal({
     (p) => p.available
   )
 
-  useEffect(() => {
-    const selectedPlatform = isLinuxNative
-      ? 'linux'
-      : isMacNative
-      ? 'Mac'
-      : 'Windows'
+  const getDefaultplatform = () => {
+    if (isLinux && gameInfo?.is_linux_native) {
+      return 'linux'
+    }
 
-    setPlatformToInstall(selectedPlatform)
-    setDefaultPlatform(selectedPlatform)
-  }, [isLinuxNative, isMacNative])
+    if (isMac && gameInfo?.is_mac_native) {
+      return 'Mac'
+    }
 
-  const [platformToInstall, setPlatformToInstall] =
-    useState<InstallPlatform>(defaultPlatform)
+    return 'Windows'
+  }
+
+  const [platformToInstall, setPlatformToInstall] = useState<InstallPlatform>(
+    getDefaultplatform()
+  )
 
   const hasWine = platformToInstall === 'Windows' && !isWin
 
@@ -136,8 +136,8 @@ export default React.memo(function InstallModal({
           setPlatformToInstall(e.target.value as InstallPlatform)
         }
       >
-        {availablePlatforms.map((p) => (
-          <option value={p.value} key={p.value}>
+        {availablePlatforms.map((p, i) => (
+          <option value={p.value} key={i}>
             {p.name}
           </option>
         ))}
@@ -156,8 +156,6 @@ export default React.memo(function InstallModal({
       >
         {showDownloadDialog ? (
           <DownloadDialog
-            setIsLinuxNative={setIsLinuxNative}
-            setIsMacNative={setIsMacNative}
             appName={appName}
             runner={runner}
             winePrefix={winePrefix}


### PR DESCRIPTION
Basically the title.
cache the GOG install info by platform and also simplifies the Download Dialog that was doing some weird stuff to get the `installInfo` and the platform list.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
