### PR TITLE
Add --filesystem only if it install_path has a value

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -128,9 +128,9 @@ async function prepareLaunch(
 
     steamRuntime = [
       path,
-      isNative || !('install_path' in gameInfo.install)
+      isNative || !gameInfo.install['install_path']
         ? ''
-        : `--filesystem=${gameInfo.install.install_path}`,
+        : `--filesystem=${gameInfo.install['install_path']}`,
       ...args
     ]
   }


### PR DESCRIPTION
We are adding the `--filesystem=install_path` argument even if the value is undefined because we only check if the property exists in the object.

This PR changes that to check the actual value instead.

I had to use the `['install_path']` syntax because `install_path` does not exist for sideloaded games and typescript complains if I use the `.install_path` syntax.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
