### PR TITLE
[Backend] Add cloudflare url to ping for connectivity check

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -372,7 +372,7 @@
         }
     },
     "offline-message": {
-        "hint": "We are checking the connectivity against:{{newline}}github.com,{{newline}}gog.com and{{newline}}store.epicgames.com",
+        "hint": "We are checking the connectivity against:{{newline}}github.com,{{newline}}gog.com,{{newline}}store.epicgames.com and{{newline}}cloudflare-dns.com",
         "ignore": "Ignore",
         "offline": "Offline",
         "offline-retry-in": "Offline. Retrying in {{seconds}} seconds.",

--- a/src/backend/online_monitor.ts
+++ b/src/backend/online_monitor.ts
@@ -75,8 +75,9 @@ const pingSites = () => {
   const ping1 = ping('https://github.com', abortController.signal)
   const ping2 = ping('https://store.epicgames.com', abortController.signal)
   const ping3 = ping('https://gog.com', abortController.signal)
+  const ping4 = ping('https://cloudflare-dns.com/', abortController.signal)
 
-  Promise.any([ping1, ping2, ping3])
+  Promise.any([ping1, ping2, ping3, ping4])
     .then(() => {
       setStatus('online')
       abortController.abort() // abort the rest

--- a/src/frontend/components/UI/OfflineMessage/index.tsx
+++ b/src/frontend/components/UI/OfflineMessage/index.tsx
@@ -28,7 +28,7 @@ const OfflineMessage = () => {
 
   const hintHtml = t('offline-message.hint', {
     defaultValue:
-      'We are checking the connectivity against:{{newline}}github.com,{{newline}}gog.com and{{newline}}store.epicgames.com',
+      'We are checking the connectivity against:{{newline}}github.com,{{newline}}gog.com,{{newline}}store.epicgames.com and{{newline}}cloudflare-dns.com',
     newline: '<br />'
   })
 


### PR DESCRIPTION
This fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2389

Users for china may experience slow `online` detection because of the urls we ping to detect connectivity. This PR adds a clourflare url based on feedback by a user from China.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
