### PR TITLE
[Fix] Run game update check when Heroic starts

### DIFF
--- a/src/backend/legendary/library.ts
+++ b/src/backend/legendary/library.ts
@@ -299,16 +299,17 @@ export class LegendaryLibrary {
     }
 
     // First go through all our installed games and store their versions...
-    const installedGames: Map<string, { version: string; platform: string }> =
-      new Map()
-    for (const [appName, data] of Object.entries(installedJson)) {
-      installedGames.set(appName, {
-        version: data.version,
-        platform: data.platform
-      })
+    const installedGames: {
+      appName: string
+      version: string
+      platform: string
+    }[] = []
+    for (const [appName, { version, platform }] of Object.entries(
+      installedJson
+    )) {
+      installedGames.push({ appName, version, platform })
     }
     // ...and now go through all games in `assets.json` to get the newest version
-    // HACK: Same as above,                         ↓ this isn't always `string`, but it works for now
     const assetsJsonFile = join(legendaryConfigPath, 'assets.json')
     let assetsJson: Record<string, Record<string, string>[]> = {}
     try {
@@ -323,42 +324,43 @@ export class LegendaryLibrary {
     }
 
     const updateableGames: string[] = []
-    for (const [platform, assets] of Object.entries(assetsJson)) {
-      installedGames.forEach(
-        ({ version: currentVersion, platform: installedPlatform }, appName) => {
-          if (installedPlatform === platform) {
-            const currentAsset = assets.find((asset) => {
-              return asset.app_name === appName
-            })
-            if (!currentAsset) {
-              logWarning(
-                [
-                  'Game with AppName',
-                  appName,
-                  'is installed but was not found on account'
-                ],
-                LogPrefix.Legendary
-              )
-              return
-            }
-            const latestVersion = currentAsset.build_version
-            if (currentVersion !== latestVersion) {
-              logDebug(
-                [
-                  'Update is available for',
-                  `${appName}:`,
-                  currentVersion,
-                  '!=',
-                  latestVersion
-                ],
-                LogPrefix.Legendary
-              )
-              updateableGames.push(appName)
-            }
-          }
-        }
+    installedGames.forEach(({ appName, version: currentVersion, platform }) => {
+      if (!(platform in assetsJson)) {
+        logError(
+          ['Platform', platform, 'was not found in assets.json?'],
+          LogPrefix.Legendary
+        )
+        return
+      }
+      const asset = assetsJson[platform].find(
+        (asset) => asset.app_name === appName
       )
-    }
+      if (!asset) {
+        logWarning(
+          [
+            'Game with AppName',
+            appName,
+            'is installed but was not found on account'
+          ],
+          LogPrefix.Legendary
+        )
+        return
+      }
+      if (currentVersion !== asset.build_version) {
+        logDebug(
+          [
+            'Update is available for',
+            `${appName}:`,
+            currentVersion,
+            '!=',
+            asset.build_version
+          ],
+          LogPrefix.Legendary
+        )
+        updateableGames.push(appName)
+      }
+    })
+
     logInfo(
       [
         'Found',

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -421,7 +421,7 @@ class GlobalState extends PureComponent<Props> {
     }
 
     let updates = this.state.gameUpdates
-    if (checkUpdates && library) {
+    if (checkUpdates) {
       try {
         updates = await window.api.checkGameUpdates()
       } catch (error) {


### PR DESCRIPTION
We weren't checking for game updates when Heroic was launched. Now we are again!
See commit messages for details

I don't feel entirely confident about this fix (after all, the `library` check was *probably* there for a reason), but nothing seemed to explode when removing it

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
