### PR TITLE
[Fix] Flaky wiki_game_info test

### DIFF
--- a/src/backend/wiki_game_info/__tests__/wiki_game_info.test.ts
+++ b/src/backend/wiki_game_info/__tests__/wiki_game_info.test.ts
@@ -15,6 +15,8 @@ jest.mock('../../constants', () => {
     isMac: true
   }
 })
+const currentTime = new Date()
+jest.useFakeTimers().setSystemTime(currentTime)
 
 describe('getWikiGameInfo', () => {
   test('use cached data', async () => {
@@ -121,7 +123,7 @@ const testPCGamingWikiInfo = {
 } as PCGamingWikiInfo
 
 const testExtraGameInfo = {
-  timestampLastFetch: Date(),
+  timestampLastFetch: currentTime.toString(),
   pcgamingwiki: testPCGamingWikiInfo,
   applegamingwiki: testAppleGamingWikiInfo,
   howlongtobeat: testHowLongToBeat


### PR DESCRIPTION
We didn't fixate the Date/Time in this test, causing it to fail if the test is run right before a second passes (so the test expects the "old" second while the tested function returns the new one)
This is now fixed using Jest's Fake Timers

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
