### PR TITLE
[UX] Remove controller hints when using mouse

### DIFF
--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -411,6 +411,15 @@ export const initGamepad = () => {
 
     currentController = controllerIndex
     dispatchControllerEvent(gamepad.id)
+
+    window.addEventListener(
+      'mousemove',
+      () => {
+        currentController = -1
+        dispatchControllerEvent('')
+      },
+      { once: true }
+    )
   }
 
   window.addEventListener('gamepadconnected', connecthandler)


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2284

When using the steam deck, it's really common to switch between mouse/gamepad controller layout, there's an issue that if you prefer to use the mouse layout to controller heroic but, for any reason, you use the gamepad layout (like right after exiting or before starting a game) then you are locked in that heroic interface (without the settings/play buttons).

This PR changes that by detecting when the mouse moves and revering the layout.

Users can move back and forth between layouts by just using the different controller layouts and Heroic adapts.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
