### PR TITLE
[EPIC] Login with preload script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroic",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "private": true,
   "main": "build/electron/main.js",
   "homepage": "./",
@@ -28,7 +28,8 @@
       "build/icon.icns",
       "build/win_icon.ico",
       "build/icon-dark.png",
-      "build/icon-light.png"
+      "build/icon-light.png",
+      "build/webviewPreload.js"
     ],
     "protocols": [
       {

--- a/public/webviewPreload.js
+++ b/public/webviewPreload.js
@@ -1,0 +1,9 @@
+const { ipcRenderer } = require('electron')
+
+window.onload = () => {
+  const content = document.body.innerText
+  if (content.match(/"authorizationCode":/)) {
+    const json = JSON.parse(document.querySelector('pre').innerText)
+    ipcRenderer.sendToHost('processEpicLoginCode', json.authorizationCode)
+  }
+}

--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -72,6 +72,8 @@ export const getGOGLinuxInstallersLangs = async (appName: string) =>
   ipcRenderer.invoke('getGOGLinuxInstallersLangs', appName)
 export const getAlternativeWine = async () =>
   ipcRenderer.invoke('getAlternativeWine')
+export const getLocalPeloadPath = async () =>
+  ipcRenderer.invoke('getLocalPeloadPath')
 export const getShellPath = async (saveLocation: string) =>
   ipcRenderer.invoke('getShellPath', saveLocation)
 export const callTool = async (toolArgs: Tools) =>

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -100,7 +100,8 @@ import {
   publicDir,
   wineprefixFAQ,
   customThemesWikiLink,
-  createNecessaryFolders
+  createNecessaryFolders,
+  fixAsarPath
 } from './constants'
 import { handleProtocol } from './protocol'
 import {
@@ -816,6 +817,11 @@ ipcMain.handle('login', async (event, sid) => LegendaryUser.login(sid))
 ipcMain.handle('authGOG', async (event, code) => GOGUser.login(code))
 ipcMain.handle('logoutLegendary', LegendaryUser.logout)
 ipcMain.on('logoutGOG', GOGUser.logout)
+ipcMain.handle('getLocalPeloadPath', async () => {
+  return `file://${fixAsarPath(
+    join(__dirname, '..', 'public', 'webviewPreload.js')
+  )}`
+})
 
 ipcMain.handle('getAlternativeWine', async () =>
   GlobalConfig.get().getAlternativeWine()

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -819,7 +819,7 @@ ipcMain.handle('logoutLegendary', LegendaryUser.logout)
 ipcMain.on('logoutGOG', GOGUser.logout)
 ipcMain.handle('getLocalPeloadPath', async () => {
   return `file://${fixAsarPath(
-    join(__dirname, '..', 'public', 'webviewPreload.js')
+    join(__dirname, '..', '..', 'public', 'webviewPreload.js')
   )}`
 })
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -818,9 +818,7 @@ ipcMain.handle('authGOG', async (event, code) => GOGUser.login(code))
 ipcMain.handle('logoutLegendary', LegendaryUser.logout)
 ipcMain.on('logoutGOG', GOGUser.logout)
 ipcMain.handle('getLocalPeloadPath', async () => {
-  return `file://${fixAsarPath(
-    join(__dirname, '..', '..', 'public', 'webviewPreload.js')
-  )}`
+  return fixAsarPath(join(publicDir, 'webviewPreload.js'))
 })
 
 ipcMain.handle('getAlternativeWine', async () =>

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -140,6 +140,7 @@ interface AsyncIPCFunctions {
   }>
   logoutLegendary: () => Promise<void>
   getAlternativeWine: () => Promise<WineInstallation[]>
+  getLocalPeloadPath: () => Promise<string>
   readConfig: (config_class: 'library' | 'user') => Promise<GameInfo[] | string>
   requestSettings: (appName: string) => Promise<AppSettings | GameSettings>
   writeConfig: (args: { appName: string; config: Partial<AppSettings> }) => void

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -88,23 +88,6 @@ export default function WebView() {
     }
   }, [])
 
-  // useEffect(() => {
-  //   if (isEpicLogin) {
-  //     ipcRenderer.addListener('epicLoginResponse', async (event, response) => {
-  //       const status = await epic.login(response)
-  //       if (status === 'done') {
-  //         handleSuccessfulLogin()
-  //       }
-  //     })
-
-  //     return () => {
-  //       ipcRenderer.removeListener('epicLoginResponse', epic.login)
-  //     }
-  //   } else {
-  //     return
-  //   }
-  // }, [epic.login])
-
   const handleSuccessfulLogin = () => {
     navigate('/login')
   }
@@ -197,8 +180,6 @@ export default function WebView() {
   if (!preloadPath && isEpicLogin) {
     return <></>
   }
-
-  console.log({ preloadPath })
 
   return (
     <div className="WebView">


### PR DESCRIPTION
This PR is a replacement of https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/1762

I think I found a simpler approach. Instead of overriding the epic functions, the injected JS just adds an `onload` function that, when the expected json response is present, will send a message to the host (the react app) with the code.

It is similar to the current login method but we don't rely on `find-in-page` and we don't mess with the user's clipboard.

The only thing I'm not sure about is that I was not able to make the `contextBridge.exposeInMainWorld` code work so I can't seem to hide the ipcRenderer under a function, but I'm only using it in a callback so I think it's still isolated?

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
