### PR TITLE
[UI] Some themes fixes

### DIFF
--- a/src/frontend/themes.scss
+++ b/src/frontend/themes.scss
@@ -227,9 +227,14 @@ body.high-contrast {
   --danger: #ff0000;
   --text-title: #00ddff;
   --icons-background: var(--background);
+  --action-icon-hover: var(--accent);
+  --action-icon-active: var(--accent);
   --osk-background: var(--body-background);
   --osk-button-background: var(--input-background);
   --osk-button-border: #ffffffff;
+  .heroicVersion {
+    color: var(--text-default);
+  }
 }
 
 body.dracula,
@@ -260,7 +265,7 @@ body.dracula-classic {
   --primary-hover: #f560b4;
   --danger: #ff5555;
   --text-title: #8be9fd;
-  --text-default: var(--text-title);
+  --text-default: white;
   --icons-background: #17131c;
   --osk-background: var(--body-background);
   --osk-button-background: var(--input-background);
@@ -268,6 +273,10 @@ body.dracula-classic {
   --action-icon: var(--text-default);
   --action-icon-hover: var(--text-hover);
   --action-icon-active: var(--accent);
+  --action-icon-hover: var(--accent);
+  .heroicVersion {
+    color: var(--text-default);
+  }
 }
 
 body.nord-light {
@@ -328,6 +337,14 @@ body.nord-light {
   .currentDownload {
     color: var(--navbar-active);
     --success: #0bd48c;
+  }
+
+  .selectFieldWrapper select > option {
+    background: var(--background);
+  }
+
+  .heroicVersion:hover {
+    color: var(--navbar-active);
   }
 }
 
@@ -395,7 +412,7 @@ body.marine-classic {
   --osk-button-background: var(--input-background);
   --osk-button-border: var(--navbar-background);
   --action-icon: var(--text-default);
-  --action-icon-hover: var(--text-hover);
+  --action-icon-hover: var(--accent);
   --action-icon-active: var(--accent);
   --navbar-accent: var(--accent);
   --primary: #34aaf8;
@@ -427,7 +444,7 @@ body.zombie-classic {
   --osk-button-background: var(--input-background);
   --osk-button-border: #434343;
   --action-icon: var(--text-default);
-  --action-icon-hover: var(--text-hover);
+  --action-icon-hover: var(--accent);
   --action-icon-active: var(--accent);
   --primary-button: #14e8c8;
 }
@@ -457,7 +474,7 @@ body.old-school {
   --osk-button-background: var(--input-background);
   --osk-button-border: #434343;
   --action-icon: var(--text-default);
-  --action-icon-hover: var(--text-hover);
+  --action-icon-hover: var(--accent);
   --action-icon-active: var(--accent);
 }
 body.classic .sid-input,


### PR DESCRIPTION
This PR adds a few small fixes to some themes.

Dracula was showing many elements in light blue instead of white, and the library sort/filter icons didn't have a `hover` color.

In NordLight, options dropdown in the settings had a dark backround with dark text.

In Marine, Zombie, and Old School, the library sort/filter icons didn't have a `hover` color.

In some themes, the `heroic version` badge at the bottom left was showing the light blue text from the default theme and it looked weird with the color schema of the theme so I changed some of those. Also for this badge, the `hover` color on NordLight was too dark on a dark background.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
