### PR TITLE
[UX] Show game logs from card's context menu

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -200,6 +200,7 @@
         "disableEosOverlay": "Disable EOS Overlay",
         "enableEosOverlay": "Enable EOS Overlay",
         "extraInfo": "Extra Info",
+        "logs": "Logs",
         "move": "Move Game",
         "protondb": "Check Compatibility",
         "removeFromSteam": "Remove from Steam",

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -275,6 +275,17 @@ const GameCard = ({
       show: true
     },
     {
+      // settings
+      label: t('submenu.settings', 'Settings'),
+      onclick: () => setIsSettingsModalOpen(true, 'settings', gameInfo),
+      show: isInstalled && !isUninstalling
+    },
+    {
+      label: t('submenu.logs', 'Logs'),
+      onclick: () => setIsSettingsModalOpen(true, 'log', gameInfo),
+      show: isInstalled && !isUninstalling
+    },
+    {
       // hide
       label: t('button.hide_game', 'Hide Game'),
       onclick: () => hiddenGames.add(appName, title),
@@ -300,12 +311,6 @@ const GameCard = ({
       label: t('button.remove_from_recent', 'Remove From Recent'),
       onclick: async () => window.api.removeRecentGame(appName),
       show: isRecent
-    },
-    {
-      // settings
-      label: t('submenu.settings'),
-      onclick: () => setIsSettingsModalOpen(true, 'settings', gameInfo),
-      show: isInstalled && !isUninstalling
     },
     {
       // uninstall


### PR DESCRIPTION
This PR adds a `Logs` item in the game card's context menu:
![image](https://user-images.githubusercontent.com/188464/217425026-b7e61ef0-a7a8-4ec6-b0b2-01d24d5fa160.png)

We've had many users mentioning that they couldn't find the logs so this menu item should help with the UX of that.

I also moved the `Settings` up in the list, I think it makes more sense to have it next to the `Details` item.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
