### PR TITLE
Sanitize shortcut names

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "react-markdown": "^8.0.3",
     "react-router-dom": "^6.3.0",
     "recharts": "^2.1.14",
+    "sanitize-filename": "^1.6.3",
     "shlex": "^2.1.2",
     "short-uuid": "^4.2.0",
     "simple-keyboard": "^3.4.136",

--- a/src/backend/shortcuts/shortcuts/shortcuts.ts
+++ b/src/backend/shortcuts/shortcuts/shortcuts.ts
@@ -20,6 +20,7 @@ import { isMac, userHome } from '../../constants'
 import { GOGLibrary } from '../../gog/library'
 import { getIcon } from '../utils'
 import { addNonSteamGame } from '../nonesteamgame/nonesteamgame'
+import sanitize from 'sanitize-filename'
 
 /**
  * Adds a desktop shortcut to $HOME/Desktop and to /usr/share/applications
@@ -139,6 +140,8 @@ function shortcutFiles(gameTitle: string) {
   let desktopFile
   let menuFile
 
+  gameTitle = sanitize(gameTitle)
+
   switch (process.platform) {
     case 'linux': {
       desktopFile = `${app.getPath('desktop')}/${gameTitle}.desktop`
@@ -162,11 +165,11 @@ function shortcutFiles(gameTitle: string) {
 }
 
 async function generateMacOsApp(gameInfo: GameInfo | SideloadGame) {
-  const { title, app_name } = gameInfo
+  const { app_name } = gameInfo
 
   logInfo('Generating macOS shortcut', LogPrefix.Backend)
 
-  const appShortcut = join(userHome, 'Applications', `${title}.app`)
+  const appShortcut = shortcutFiles(gameInfo.title)[0]!
   const macOSFolder = `${appShortcut}/Contents/MacOS`
   const resourcesFolder = `${appShortcut}/Contents/Resources`
   const plistFile = `${appShortcut}/Contents/Info.plist`


### PR DESCRIPTION
Sanitize game title for shortcut creation.

Previously games like `Ruined King: A League of Legends Story` will silently fail and create an invalid shortcut named `Ruined King` in windows, due to not filtering reserved characters.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
