### PR TITLE
[GOG] Handle nested keys in setIni action

### DIFF
--- a/src/backend/gog/setup.ts
+++ b/src/backend/gog/setup.ts
@@ -372,7 +372,7 @@ async function setup(
             encoding
           })
           const config = ini.parse(fileData)
-          const section = actionArguments?.section
+          const section: string | undefined = actionArguments?.section
           const keyName = actionArguments?.keyName
           if (!section || !keyName) {
             logError(
@@ -382,10 +382,15 @@ async function setup(
             break
           }
 
-          config[section][keyName] = handlePathVars(
-            actionArguments.keyValue,
-            pathsValues
-          )
+          let leaf = config
+          // section can be in the format `Key.SubKey1.SubKey2.etc`
+          // Alien Breed: Impact is one example of such game
+          section.split('.').forEach((key) => {
+            leaf = leaf[key]
+          })
+
+          leaf[keyName] = handlePathVars(actionArguments.keyValue, pathsValues)
+
           writeFileSync(filePath, ini.stringify(config), { encoding })
           break
         }


### PR DESCRIPTION
This PR fixes a bug I noticed testing the new givewaway `Alien Breed: Impact`.

The script has this step:

```
            "install": {
                "action": "setIni",
                "arguments": {
                    "conditions": [
                        "onLanguageChange"
                    ],
                    "filename": "{app}\\AlienBreedEp1Game\\Config\\DefaultEngine.ini",
                    "keyName": "Language",
                    "keyType": "string",
                    "keyValue": "int",
                    "section": "Engine.Engine",
                    "utf8": false
                }
            },
```

And the section key is `Engine.Engine`.

We use the `ini` module that loads the `DefaultEngine.ini` into  js object and the structure is:

```
{
  ...
  Engine: {
    Engine: {
      Language: ...
      ...
    }
  }
  ...
}
```

Without this change, we were doing `config[section]` which is actually `config["Engine.Engine"]` instead of `config["Engine"]["Engine"]`, causing the game to always fails with a Heroic error the first time (the game fails to start anyway after that, but that's unrelated) because `config["Engine.Engine"]` is undefined.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
