### PR TITLE
Render an empty div for game cards until they inter the viewport

### DIFF
--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -10,6 +10,7 @@
   flex-direction: column;
   border-radius: var(--space-3xs);
   animation: fade-in 0.2s ease-in;
+  aspect-ratio: 173/275;
 }
 
 .gameCard:focus-within {

--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -13,6 +13,10 @@
   aspect-ratio: 173/275;
 }
 
+.gameCard.gamepad {
+  aspect-ratio: 3/4;
+}
+
 .gameCard:focus-within {
   outline: -webkit-focus-ring-color auto 1px;
 }
@@ -102,7 +106,7 @@
   padding: var(--space-xs-fixed);
 }
 
-.gameCard > .icons.gamepad {
+.gameCard.gamepad > .icons {
   display: none;
 }
 

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -98,7 +98,8 @@ const GameCard = ({
     favouriteGames,
     allTilesInColor,
     showDialogModal,
-    setIsSettingsModalOpen
+    setIsSettingsModalOpen,
+    activeController
   } = useContext(ContextProvider)
 
   const {
@@ -336,6 +337,7 @@ const GameCard = ({
   const instClass = isInstalled ? 'installed' : ''
   const hiddenClass = isHiddenGame ? 'hidden' : ''
   const notAvailableClass = notAvailable ? 'notAvailable' : ''
+  const gamepadClass = activeController ? 'gamepad' : ''
   const imgClasses = `gameImg ${isInstalled ? 'installed' : ''} ${
     allTilesInColor ? 'allTilesInColor' : ''
   }`
@@ -345,9 +347,7 @@ const GameCard = ({
 
   const wrapperClasses = `${
     grid ? 'gameCard' : 'gameListItem'
-  }  ${instClass} ${hiddenClass} ${notAvailableClass}`
-
-  const { activeController } = useContext(ContextProvider)
+  }  ${instClass} ${hiddenClass} ${notAvailableClass} ${gamepadClass}`
 
   const showUpdateButton =
     hasUpdate && !isUpdating && !isQueued && !notAvailable
@@ -422,11 +422,7 @@ const GameCard = ({
             </span>
           </Link>
           <>
-            <span
-              className={classNames('icons', {
-                gamepad: activeController
-              })}
-            >
+            <span className="icons">
               {showUpdateButton && (
                 <SvgButton
                   className="updateIcon"

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -63,6 +63,24 @@ const GameCard = ({
   isRecent = false,
   gameInfo: gameInfoFromProps
 }: Card) => {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    // render an empty div until the card enters the viewport
+    // check GameList for the other side of this detection
+    const callback = (e: CustomEvent<{ appNames: string[] }>) => {
+      if (e.detail.appNames.includes(gameInfoFromProps.app_name)) {
+        setVisible(true)
+      }
+    }
+
+    window.addEventListener('visible-cards', callback)
+
+    return () => {
+      window.removeEventListener('visible-cards', callback)
+    }
+  }, [])
+
   const [gameInfo, setGameInfo] = useState<GameInfo | SideloadGame>(
     gameInfoFromProps
   )
@@ -334,6 +352,16 @@ const GameCard = ({
   const showUpdateButton =
     hasUpdate && !isUpdating && !isQueued && !notAvailable
 
+  if (!visible) {
+    return (
+      <div
+        className={wrapperClasses}
+        data-app-name={appName}
+        data-invisible={true}
+      ></div>
+    )
+  }
+
   return (
     <div>
       {showUninstallModal && (
@@ -344,7 +372,7 @@ const GameCard = ({
         />
       )}
       <ContextMenu items={items}>
-        <div className={wrapperClasses}>
+        <div className={wrapperClasses} data-app-name={appName}>
           {haveStatus && <span className="gameCardStatus">{label}</span>}
           <Link
             to={`/gamepage/${runner}/${appName}`}

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect } from 'react'
 import { GameInfo, Runner, SideloadGame } from 'common/types'
 import cx from 'classnames'
 import GameCard from '../GameCard'
@@ -26,62 +26,51 @@ const GamesList = ({
   onlyInstalled = false,
   isRecent = false
 }: Props): JSX.Element => {
-  const { gameUpdates, showNonAvailable } = useContext(ContextProvider)
+  const { gameUpdates } = useContext(ContextProvider)
   const { t } = useTranslation()
-  const [gameCards, setGameCards] = useState<JSX.Element[]>([])
 
   useEffect(() => {
-    let mounted = true
-
-    const createGameCards = async () => {
-      if (!library.length) {
-        return
+    if (library.length) {
+      const options = {
+        root: document.querySelector('.listing'),
+        rootMargin: '500px',
+        threshold: 0
       }
-      const resolvedLibrary = library.map(async (gameInfo) => {
-        const { app_name, is_installed, runner } = gameInfo
 
-        let is_dlc = false
-        if (gameInfo.runner !== 'sideload') {
-          is_dlc = gameInfo.install.is_dlc ?? false
-        }
+      const callback: IntersectionObserverCallback = (entries, observer) => {
+        const entered: string[] = []
+        entries.forEach((entry) => {
+          if (entry.intersectionRatio > 0) {
+            // when a card is intersecting the viewport
+            const appName = (entry.target as HTMLDivElement).dataset
+              .appName as string
 
-        if (is_dlc) {
-          return null
-        }
-        if (!is_installed && onlyInstalled) {
-          return null
-        }
+            // store this appName for later
+            entered.push(appName)
+            // stop observing this element
+            observer.unobserve(entry.target)
+          }
+        })
 
-        const hasUpdate = is_installed && gameUpdates?.includes(app_name)
-        return (
-          <GameCard
-            key={app_name}
-            hasUpdate={hasUpdate}
-            buttonClick={() => {
-              if (gameInfo.runner !== 'sideload')
-                handleGameCardClick(app_name, runner, gameInfo)
-            }}
-            forceCard={layout === 'grid'}
-            isRecent={isRecent}
-            gameInfo={gameInfo}
-          />
+        // dispatch an event with the newley visible cards
+        // check GameCard for the other side of this detection
+        window.dispatchEvent(
+          new CustomEvent('visible-cards', { detail: { appNames: entered } })
         )
-      })
-      const gameCardElements = (await Promise.all(
-        resolvedLibrary
-      )) as JSX.Element[]
+      }
 
-      if (mounted) {
-        setGameCards(gameCardElements)
+      const observer = new IntersectionObserver(callback, options)
+
+      document.querySelectorAll('[data-invisible]').forEach((card) => {
+        observer.observe(card)
+      })
+
+      return () => {
+        observer.disconnect()
       }
     }
-
-    createGameCards()
-
-    return () => {
-      mounted = false
-    }
-  }, [library, onlyInstalled, layout, gameUpdates, isRecent, showNonAvailable])
+    return () => ({})
+  }, [library])
 
   return (
     <div
@@ -100,7 +89,37 @@ const GamesList = ({
           <span>{t('wine.actions', 'Action')}</span>
         </div>
       )}
-      {!!library.length && gameCards}
+      {!!library.length &&
+        library.map((gameInfo) => {
+          const { app_name, is_installed, runner } = gameInfo
+
+          let is_dlc = false
+          if (gameInfo.runner !== 'sideload') {
+            is_dlc = gameInfo.install.is_dlc ?? false
+          }
+
+          if (is_dlc) {
+            return null
+          }
+          if (!is_installed && onlyInstalled) {
+            return null
+          }
+
+          const hasUpdate = is_installed && gameUpdates?.includes(app_name)
+          return (
+            <GameCard
+              key={app_name}
+              hasUpdate={hasUpdate}
+              buttonClick={() => {
+                if (gameInfo.runner !== 'sideload')
+                  handleGameCardClick(app_name, runner, gameInfo)
+              }}
+              forceCard={layout === 'grid'}
+              isRecent={isRecent}
+              gameInfo={gameInfo}
+            />
+          )
+        })}
     </div>
   )
 }

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect } from 'react'
 import { GameInfo, Runner, SideloadGame } from 'common/types'
 import cx from 'classnames'
 import GameCard from '../GameCard'
@@ -16,7 +16,6 @@ interface Props {
   ) => void
   onlyInstalled?: boolean
   isRecent?: boolean
-  showNonAvailable?: boolean
 }
 
 const GamesList = ({
@@ -25,8 +24,7 @@ const GamesList = ({
   handleGameCardClick,
   isFirstLane = false,
   onlyInstalled = false,
-  isRecent = false,
-  showNonAvailable = true
+  isRecent = false
 }: Props): JSX.Element => {
   const { gameUpdates } = useContext(ContextProvider)
   const { t } = useTranslation()

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { GameInfo, Runner, SideloadGame } from 'common/types'
 import cx from 'classnames'
 import GameCard from '../GameCard'
@@ -16,6 +16,7 @@ interface Props {
   ) => void
   onlyInstalled?: boolean
   isRecent?: boolean
+  showNonAvailable?: boolean
 }
 
 const GamesList = ({
@@ -24,7 +25,8 @@ const GamesList = ({
   handleGameCardClick,
   isFirstLane = false,
   onlyInstalled = false,
-  isRecent = false
+  isRecent = false,
+  showNonAvailable = true
 }: Props): JSX.Element => {
   const { gameUpdates } = useContext(ContextProvider)
   const { t } = useTranslation()

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -337,6 +337,7 @@ export default React.memo(function Library(): JSX.Element {
               library={favourites}
               handleGameCardClick={handleModal}
               isFirstLane
+              showNonAvailable={showNonAvailable}
             />
           </>
         )}
@@ -357,6 +358,7 @@ export default React.memo(function Library(): JSX.Element {
             library={libraryToShow}
             layout={layout}
             handleGameCardClick={handleModal}
+            showNonAvailable={showNonAvailable}
           />
         )}
       </div>

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -337,7 +337,6 @@ export default React.memo(function Library(): JSX.Element {
               library={favourites}
               handleGameCardClick={handleModal}
               isFirstLane
-              showNonAvailable={showNonAvailable}
             />
           </>
         )}
@@ -358,7 +357,6 @@ export default React.memo(function Library(): JSX.Element {
             library={libraryToShow}
             layout={layout}
             handleGameCardClick={handleModal}
-            showNonAvailable={showNonAvailable}
           />
         )}
       </div>

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -143,6 +143,7 @@ declare global {
   }
 
   interface WindowEventMap {
+    'visible-cards': CustomEvent<{ appNames: string[] }>
     'controller-changed': CustomEvent<{ controllerId: string }>
   }
 }


### PR DESCRIPTION
This is an alternative to https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/2447

Instead of pagination, it renders all the library elements but for the ones that are outside of the viewport it renders an empty div until the element has to be displayed. Then it uses the IntersectionObserver to actually render the real content.

I'll add some comments in the PR.

There are still improvements that can be made (because of how react works, all hooks has to be defined before rendering the empty div, so there's extra unnecessary work there, also cards are re-rendered multiple times) but I'll leave those things for another PR.

You can see the empty divs using devtools and how they are updated when scrolling:
![image](https://user-images.githubusercontent.com/188464/219547779-90fe8421-baeb-41b8-9ec7-3070521629d1.png)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
