### PR TITLE
[Fix] Kill leftover wine processes after stop button is pressed

### DIFF
--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -891,7 +891,7 @@ class GOGGame extends Game {
   public async stop(): Promise<void> {
     const pattern = isLinux ? this.appName : 'gogdl'
     killPattern(pattern)
-    if (!this.isNative()) {
+    if (!this.isNative() && isLinux) {
       const gameSettings = await this.getSettings()
       await shutdownWine(gameSettings)
     }

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -888,8 +888,16 @@ class GOGGame extends Game {
   // Could be removed if gogdl handles SIGKILL and SIGTERM for us
   // which is send via AbortController
   public async stop(): Promise<void> {
+    const gameSettings = await this.getSettings()
     const pattern = isLinux ? this.appName : 'gogdl'
     killPattern(pattern)
+    if (!this.isNative())
+      await runWineCommand({
+        gameSettings,
+        commandParts: ['wineboot', '-k'],
+        wait: true,
+        protonVerb: 'waitforexitandrun'
+      })
   }
 }
 

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -12,6 +12,7 @@ import {
   getFileSize,
   getGOGdlBin,
   killPattern,
+  shutdownWine,
   spawnAsync,
   moveOnUnix,
   moveOnWindows
@@ -888,16 +889,12 @@ class GOGGame extends Game {
   // Could be removed if gogdl handles SIGKILL and SIGTERM for us
   // which is send via AbortController
   public async stop(): Promise<void> {
-    const gameSettings = await this.getSettings()
     const pattern = isLinux ? this.appName : 'gogdl'
     killPattern(pattern)
-    if (!this.isNative())
-      await runWineCommand({
-        gameSettings,
-        commandParts: ['wineboot', '-k'],
-        wait: true,
-        protonVerb: 'waitforexitandrun'
-      })
+    if (!this.isNative()) {
+      const gameSettings = await this.getSettings()
+      await shutdownWine(gameSettings)
+    }
   }
 }
 

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -22,7 +22,8 @@ import {
   getLegendaryBin,
   killPattern,
   moveOnUnix,
-  moveOnWindows
+  moveOnWindows,
+  shutdownWine
 } from '../utils'
 import {
   heroicGamesConfigPath,
@@ -1008,21 +1009,16 @@ class LegendaryGame extends Game {
   // Could be removed if legendary handles SIGKILL and SIGTERM for us
   // which is send via AbortController
   public async stop() {
-    const gameSettings = await this.getSettings()
-
     // until the legendary bug gets fixed, kill legendary on mac
     // not a perfect solution but it's the only choice for now
 
     // @adityaruplaha: this is kinda arbitary and I don't understand it.
     const pattern = process.platform === 'linux' ? this.appName : 'legendary'
     killPattern(pattern)
-    if (!this.isNative())
-      await runWineCommand({
-        gameSettings,
-        commandParts: ['wineboot', '-k'],
-        wait: true,
-        protonVerb: 'waitforexitandrun'
-      })
+    if (!this.isNative()) {
+      const gameSettings = await this.getSettings()
+      await shutdownWine(gameSettings)
+    }
   }
 }
 

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -1008,12 +1008,21 @@ class LegendaryGame extends Game {
   // Could be removed if legendary handles SIGKILL and SIGTERM for us
   // which is send via AbortController
   public async stop() {
+    const gameSettings = await this.getSettings()
+
     // until the legendary bug gets fixed, kill legendary on mac
     // not a perfect solution but it's the only choice for now
 
     // @adityaruplaha: this is kinda arbitary and I don't understand it.
     const pattern = process.platform === 'linux' ? this.appName : 'legendary'
     killPattern(pattern)
+    if (!this.isNative())
+      await runWineCommand({
+        gameSettings,
+        commandParts: ['wineboot', '-k'],
+        wait: true,
+        protonVerb: 'waitforexitandrun'
+      })
   }
 }
 

--- a/src/backend/sideload/games.ts
+++ b/src/backend/sideload/games.ts
@@ -235,6 +235,7 @@ export async function launchApp(appName: string): Promise<boolean> {
 }
 
 export async function stop(appName: string): Promise<void> {
+  const gameSettings = await getAppSettings(appName)
   const {
     install: { executable }
   } = getAppInfo(appName)
@@ -243,6 +244,13 @@ export async function stop(appName: string): Promise<void> {
     const split = executable.split('/')
     const exe = split[split.length - 1]
     killPattern(exe)
+    if (!isNativeApp(appName))
+      await runWineCommand({
+        gameSettings,
+        commandParts: ['wineboot', '-k'],
+        wait: true,
+        protonVerb: 'waitforexitandrun'
+      })
   }
 }
 

--- a/src/backend/sideload/games.ts
+++ b/src/backend/sideload/games.ts
@@ -2,7 +2,7 @@ import { GameSettings, SideloadGame } from 'common/types'
 import { libraryStore } from './electronStores'
 import { GameConfig } from '../game_config'
 import { isWindows, isMac, isLinux, heroicGamesConfigPath } from '../constants'
-import { killPattern } from '../utils'
+import { killPattern, shutdownWine } from '../utils'
 import { logInfo, LogPrefix, logWarning } from '../logger/logger'
 import { dirname, join } from 'path'
 import {
@@ -235,7 +235,6 @@ export async function launchApp(appName: string): Promise<boolean> {
 }
 
 export async function stop(appName: string): Promise<void> {
-  const gameSettings = await getAppSettings(appName)
   const {
     install: { executable }
   } = getAppInfo(appName)
@@ -244,13 +243,12 @@ export async function stop(appName: string): Promise<void> {
     const split = executable.split('/')
     const exe = split[split.length - 1]
     killPattern(exe)
-    if (!isNativeApp(appName))
-      await runWineCommand({
-        gameSettings,
-        commandParts: ['wineboot', '-k'],
-        wait: true,
-        protonVerb: 'waitforexitandrun'
-      })
+    if (!isNativeApp(appName)) {
+      const gameSettings = await getAppSettings(appName)
+      await shutdownWine(gameSettings)
+    }
+    
+    
   }
 }
 

--- a/src/backend/sideload/games.ts
+++ b/src/backend/sideload/games.ts
@@ -247,8 +247,6 @@ export async function stop(appName: string): Promise<void> {
       const gameSettings = await getAppSettings(appName)
       await shutdownWine(gameSettings)
     }
-    
-    
   }
 }
 

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -62,7 +62,7 @@ import { getAppInfo } from './sideload/games'
 import { getMainWindow, sendFrontendMessage } from './main_window'
 import { GlobalConfig } from './config'
 import { GameConfig } from './game_config'
-import { validWine } from './launcher'
+import { runWineCommand, validWine } from './launcher'
 
 const execAsync = promisify(exec)
 
@@ -845,6 +845,15 @@ function killPattern(pattern: string) {
   return ret
 }
 
+async function shutdownWine(gameSettings: GameSettings) {
+  await runWineCommand({
+    gameSettings,
+    commandParts: ['wineboot', '-k'],
+    wait: true,
+    protonVerb: 'waitforexitandrun'
+  })
+}
+
 const getShellPath = async (path: string): Promise<string> =>
   normalize((await execAsync(`echo "${path}"`)).stdout.trim())
 
@@ -1153,6 +1162,7 @@ export {
   detectVCRedist,
   getGame,
   killPattern,
+  shutdownWine,
   getInfo,
   getShellPath,
   getFirstExistingParentPath,


### PR DESCRIPTION
it may be dangerous, but we kill the game process anyways, so I don't think it matters too much if we kill the wineserver too, this would kill leftover wine processes (e.g game launchers) in the prefix when the kill button is pressed, which is crucial when side loading games. 

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
