### PR TITLE
[GOG] Allow uninstalling gog games when not available

### DIFF
--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -729,7 +729,7 @@ class GOGGame extends Game {
         ])
       }
     } else {
-      rmSync(object.install_path, { recursive: true })
+      rmSync(object.install_path, { recursive: true, force: true })
     }
     installedGamesStore.set('installed', array)
     GOGLibrary.get().refreshInstalled()


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2303

using the `force: true` option, if the directory doesn't exist it won't throw an exception, allow the uninstall process to complete.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
