### PR TITLE
[UX] Close install dialog with B when select is focused

### DIFF
--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -132,14 +132,14 @@ export const initGamepad = () => {
             // closes the keyboard if present
             VirtualKeyboardController.destroy()
             return
+          } else if (insideInstallDialog()) {
+            closeInstallDialog()
           } else if (isSelect()) {
             // closes the select dropdown and re-focus element
             const el = currentElement()
             el?.blur()
             el?.focus()
             return
-          } else if (insideInstallDialog()) {
-            closeInstallDialog()
           } else if (isContextMenu()) {
             action = 'rightClick'
           }


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1975

We were checking the `isSelect` before the `insideInstallDialog` so the B button was getting captured by that element's behavior. Now being inside the install dialog has priority.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
