### PR TITLE
Fix non-available status for games just installed

### DIFF
--- a/src/frontend/hooks/hasStatus.ts
+++ b/src/frontend/hooks/hasStatus.ts
@@ -31,7 +31,7 @@ export function hasStatus(
       const { status, folder } =
         libraryStatus.find((game: GameStatus) => game.appName === appName) || {}
 
-      if (status) {
+      if (status && status !== 'done') {
         const label = getStatusLabel({
           status,
           t,


### PR DESCRIPTION
This PR fixes a bug in a maybe uncommon use case: if you install a game and, without restarting heroic, remove its folder, after refreshing the library the game does NOT show up as not available.

The issue was that, when a game is installed, the status in the frontend's state is set to `done` and that was preventing the `notAvailable` status to be considered.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
