### PR TITLE
[Fix]: Inaccuracy of disk and down speed

### DIFF
--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -219,7 +219,7 @@ class GOGGame extends Game {
     const bytesMatch = data.match(/Downloaded: (\S+) MiB/m)
     const bytes =
       bytesMatch && bytesMatch?.length >= 2
-        ? bytesMatch[1]
+        ? `${bytesMatch[1]}MiB`
         : this.lastProgress.bytes
 
     // parse log for download speed
@@ -246,7 +246,7 @@ class GOGGame extends Game {
     const newProgress = {
       eta: eta,
       percent,
-      bytes: `${bytes}MiB`,
+      bytes: bytes,
       downSpeed,
       diskSpeed
     }

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -245,7 +245,11 @@ class GOGGame extends Game {
     }
 
     // only send to frontend if all values are updated
-    if (Object.values(this.tmpProgress).every(Boolean)) {
+    if (
+      Object.values(this.tmpProgress).every(
+        (value) => !(value === undefined || value === '')
+      )
+    ) {
       logInfo(
         [
           `Progress for ${this.getGameInfo().title}:`,

--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -225,7 +225,7 @@ class GOGGame extends Game {
     if (this.tmpProgress.bytes === '') {
       const bytesMatch = data.match(/Downloaded: (\S+) MiB/m)
       this.tmpProgress.bytes =
-        bytesMatch && bytesMatch?.length >= 2 ? `${bytesMatch[1]}MiB` : ''
+        bytesMatch && bytesMatch?.length >= 2 ? `${bytesMatch[1]}MB` : ''
     }
 
     // parse log for download speed

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -396,7 +396,7 @@ class LegendaryGame extends Game {
     const bytesMatch = data.match(/Downloaded: (\S+.) MiB/m)
     const bytes =
       bytesMatch && bytesMatch?.length >= 2
-        ? bytesMatch[1]
+        ? `${bytesMatch[1]}MiB`
         : this.lastProgress.bytes
 
     // parse log for download speed
@@ -435,7 +435,7 @@ class LegendaryGame extends Game {
     const newProgress = {
       eta: eta,
       percent,
-      bytes: `${bytes}MiB`,
+      bytes: bytes,
       downSpeed,
       diskSpeed
     }

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -399,7 +399,7 @@ class LegendaryGame extends Game {
     if (this.tmpProgress.bytes === '') {
       const bytesMatch = data.match(/Downloaded: (\S+.) MiB/m)
       this.tmpProgress.bytes =
-        bytesMatch && bytesMatch?.length >= 2 ? `${bytesMatch[1]}MiB` : ''
+        bytesMatch && bytesMatch?.length >= 2 ? `${bytesMatch[1]}MB` : ''
     }
 
     // parse log for download speed
@@ -442,7 +442,7 @@ class LegendaryGame extends Game {
         [
           `Progress for ${this.getGameInfo().title}:`,
           `${this.tmpProgress.percent}%/${this.tmpProgress.bytes}/${this.tmpProgress.eta}`.trim(),
-          `Down: ${this.tmpProgress.downSpeed}MiB/s / Disk: ${this.tmpProgress.diskSpeed}MiB/s`
+          `Down: ${this.tmpProgress.downSpeed}MB/s / Disk: ${this.tmpProgress.diskSpeed}MB/s`
         ],
         LogPrefix.Legendary
       )

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -11,6 +11,7 @@ import {
   GameInfo,
   InstallArgs,
   InstallPlatform,
+  InstallProgress,
   WineCommandArgs
 } from 'common/types'
 import { Game } from '../games'
@@ -366,12 +367,12 @@ class LegendaryGame extends Game {
 
   // used when downloading games, store the download size read from Legendary's output
   currentDownloadSize = 0
-  lastProgress = {
-    eta: '99:99:99',
-    percent: 0,
-    bytes: '0.00MiB',
-    downSpeed: 0,
-    diskSpeed: 0
+  tmpProgress: InstallProgress = {
+    bytes: '',
+    eta: '',
+    percent: undefined,
+    diskSpeed: undefined,
+    downSpeed: undefined
   }
 
   public onInstallOrUpdateOutput(
@@ -388,66 +389,76 @@ class LegendaryGame extends Game {
     }
 
     // parse log for eta
-    const etaMatch = data.match(/ETA: (\d\d:\d\d:\d\d)/m)
-    const eta =
-      etaMatch && etaMatch?.length >= 2 ? etaMatch[1] : this.lastProgress.eta
+    if (this.tmpProgress.eta === '') {
+      const etaMatch = data.match(/ETA: (\d\d:\d\d:\d\d)/m)
+      this.tmpProgress.eta =
+        etaMatch && etaMatch?.length >= 2 ? etaMatch[1] : ''
+    }
 
     // parse log for game download progress
-    const bytesMatch = data.match(/Downloaded: (\S+.) MiB/m)
-    const bytes =
-      bytesMatch && bytesMatch?.length >= 2
-        ? `${bytesMatch[1]}MiB`
-        : this.lastProgress.bytes
+    if (this.tmpProgress.bytes === '') {
+      const bytesMatch = data.match(/Downloaded: (\S+.) MiB/m)
+      this.tmpProgress.bytes =
+        bytesMatch && bytesMatch?.length >= 2 ? `${bytesMatch[1]}MiB` : ''
+    }
 
     // parse log for download speed
-    const downSpeedMBytes = data.match(/Download\t- (\S+.) MiB/m)
-    const downSpeed = !Number.isNaN(Number(downSpeedMBytes?.at(1)))
-      ? Number(downSpeedMBytes?.at(1))
-      : this.lastProgress.downSpeed
+    if (!this.tmpProgress.downSpeed) {
+      const downSpeedMBytes = data.match(/Download\t- (\S+.) MiB/m)
+      this.tmpProgress.downSpeed = !Number.isNaN(Number(downSpeedMBytes?.at(1)))
+        ? Number(downSpeedMBytes?.at(1))
+        : undefined
+    }
 
     // parse disk write speed
-    const diskSpeedMBytes = data.match(/Disk\t- (\S+.) MiB/m)
-    const diskSpeed = !Number.isNaN(Number(diskSpeedMBytes?.at(1)))
-      ? Number(diskSpeedMBytes?.at(1))
-      : this.lastProgress.diskSpeed
+    if (!this.tmpProgress.diskSpeed) {
+      const diskSpeedMBytes = data.match(/Disk\t- (\S+.) MiB/m)
+      this.tmpProgress.diskSpeed = !Number.isNaN(Number(diskSpeedMBytes?.at(1)))
+        ? Number(diskSpeedMBytes?.at(1))
+        : undefined
+    }
 
     // original is in bytes, convert to MiB with 2 decimals
     totalDownloadSize =
       Math.round((totalDownloadSize / 1024 / 1024) * 100) / 100
 
     // calculate percentage
-    const downloaded = parseFloat(bytes)
-    const downloadCache = totalDownloadSize - this.currentDownloadSize
-    const totalDownloaded = downloaded + downloadCache
-    let percent =
-      Math.round((totalDownloaded / totalDownloadSize) * 10000) / 100
-    if (percent < 0) percent = 0
-
-    logInfo(
-      [
-        `Progress for ${this.getGameInfo().title}:`,
-        `${percent}%/${bytes}MiB/${eta}`.trim(),
-        `Down: ${downSpeed}MiB/s / Disk: ${diskSpeed}MiB/s`
-      ],
-      LogPrefix.Legendary
-    )
-
-    const newProgress = {
-      eta: eta,
-      percent,
-      bytes: bytes,
-      downSpeed,
-      diskSpeed
+    if (this.tmpProgress.bytes !== '') {
+      const downloaded = parseFloat(this.tmpProgress.bytes)
+      const downloadCache = totalDownloadSize - this.currentDownloadSize
+      const totalDownloaded = downloaded + downloadCache
+      const newPercent =
+        Math.round((totalDownloaded / totalDownloadSize) * 10000) / 100
+      this.tmpProgress.percent = newPercent >= 0 ? newPercent : undefined
     }
 
-    this.lastProgress = newProgress
+    // only send to frontend if all values are updated
+    if (Object.values(this.tmpProgress).every(Boolean)) {
+      logInfo(
+        [
+          `Progress for ${this.getGameInfo().title}:`,
+          `${this.tmpProgress.percent}%/${this.tmpProgress.bytes}/${this.tmpProgress.eta}`.trim(),
+          `Down: ${this.tmpProgress.downSpeed}MiB/s / Disk: ${this.tmpProgress.diskSpeed}MiB/s`
+        ],
+        LogPrefix.Legendary
+      )
 
-    sendFrontendMessage(`progressUpdate-${this.appName}`, {
-      appName: this.appName,
-      runner: 'legendary',
-      status: action,
-      progress: newProgress
-    })
+      sendFrontendMessage(`progressUpdate-${this.appName}`, {
+        appName: this.appName,
+        runner: 'legendary',
+        status: action,
+        progress: this.tmpProgress
+      })
+
+      // reset
+      this.tmpProgress = {
+        bytes: '',
+        eta: '',
+        percent: undefined,
+        diskSpeed: undefined,
+        downSpeed: undefined
+      }
+    }
   }
 
   /**

--- a/src/backend/legendary/games.ts
+++ b/src/backend/legendary/games.ts
@@ -433,7 +433,11 @@ class LegendaryGame extends Game {
     }
 
     // only send to frontend if all values are updated
-    if (Object.values(this.tmpProgress).every(Boolean)) {
+    if (
+      Object.values(this.tmpProgress).every(
+        (value) => !(value === undefined || value === '')
+      )
+    ) {
       logInfo(
         [
           `Progress for ${this.getGameInfo().title}:`,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -179,7 +179,7 @@ export interface InstallProgress {
   bytes: string
   eta: string
   folder?: string
-  percent: number
+  percent?: number
   downSpeed?: number
   diskSpeed?: number
   file?: string

--- a/src/frontend/components/UI/Sidebar/components/CurrentDownload/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/CurrentDownload/index.tsx
@@ -42,7 +42,7 @@ export default React.memo(function CurrentDownload({ appName, runner }: Props) {
   }, [appName])
 
   function getStatus() {
-    return progress.percent > 98
+    return progress.percent && progress.percent > 98
       ? t('status.processing', 'Processing files, please wait')
       : t('status.installing', 'Installing')
   }

--- a/src/frontend/hooks/hasProgress.ts
+++ b/src/frontend/hooks/hasProgress.ts
@@ -18,7 +18,7 @@ export const hasProgress = (appName: string) => {
 
   const calculatePercent = (currentProgress: InstallProgress) => {
     // current/100 * (100-heroic_stored) + heroic_stored
-    if (previousProgress.percent) {
+    if (currentProgress.percent && previousProgress.percent) {
       const currentPercent = currentProgress.percent
       const storedPercent = previousProgress.percent
       const newPercent: number = Math.round(

--- a/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
@@ -22,15 +22,15 @@ export default function ProgressHeader(props: {
   const { t } = useTranslation()
   const [progress] = hasProgress(props.appName)
   const [avgSpeed, setAvgDownloadSpeed] = useState<Point[]>(
-    Array<Point>(10).fill({ download: 0, disk: 0 })
+    Array<Point>(20).fill({ download: 0, disk: 0 })
   )
 
   useEffect(() => {
     if (!props.downloading) {
-      setAvgDownloadSpeed(Array<Point>(10).fill({ download: 0, disk: 0 }))
+      setAvgDownloadSpeed(Array<Point>(20).fill({ download: 0, disk: 0 }))
       return
     }
-    if (avgSpeed.length > 9) {
+    if (avgSpeed.length > 19) {
       avgSpeed.shift()
     }
 


### PR DESCRIPTION
This fixes the problem with the inaccuracy of the download and disk speed.
The problem was that either legendary or child_process does not write/read stdout at the same time. Means we get actually two calls to `onInstallOrUpdateOutput` with one time the `eta` and `bytes` and the other time with the `disk` and `down` speed. We did not handled it and just returned earlier if `eta` or `bytes` is empty. The fix just stores the last values of the progress and send the progress if all values are fetched.

Applied the same strategy to gog aswell.
Here a video which shows that the change should fixed it:

https://user-images.githubusercontent.com/61798668/221420102-3c0265b2-1bf5-45dd-8c39-a4bb58e9765d.mp4



---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
