### PR TITLE
[UX] Do not restore the window visibility if hidden when launch a game

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1014,6 +1014,7 @@ ipcMain.handle(
     })
 
     const mainWindow = getMainWindow()
+    const showAfterClose = mainWindow?.isVisible()
     if (minimizeOnLaunch) {
       mainWindow?.hide()
     }
@@ -1133,7 +1134,7 @@ ipcMain.handle(
     // Exit if we've been launched without UI
     if (isCLINoGui) {
       app.exit()
-    } else {
+    } else if (showAfterClose) {
       mainWindow?.show()
     }
 


### PR DESCRIPTION
This PR closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2478

When launching a game, we have to remember if the window was visible and only show the main window when the game closes in that case.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
