### PR TITLE
[Fix] Pause/cancel becoming unresponsive in some cases / re-add the progress bar in game page

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -447,14 +447,13 @@ export default React.memo(function GamePage(): JSX.Element | null {
               </div>
               <TimeContainer game={appName} />
               <div className="gameStatus">
-                {isInstalling ||
-                  (isUpdating && (
-                    <progress
-                      className="installProgress"
-                      max={100}
-                      value={getProgress(progress)}
-                    />
-                  ))}
+                {(isInstalling || isUpdating) && (
+                  <progress
+                    className="installProgress"
+                    max={100}
+                    value={getProgress(progress)}
+                  />
+                )}
                 <p
                   style={{
                     color: isInstalling

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -540,12 +540,16 @@ class GlobalState extends PureComponent<Props> {
 
     // in these cases we just add the new status
     if (
-      ['installing', 'updating', 'playing', 'launching', 'ubisoft'].includes(
-        status
-      )
+      [
+        'installing',
+        'updating',
+        'playing',
+        'launching',
+        'ubisoft',
+        'queued'
+      ].includes(status)
     ) {
-      currentApp.status = status
-      newLibraryStatus.push(currentApp)
+      newLibraryStatus.push({ appName, status, folder, progress, runner })
       this.setState({ libraryStatus: newLibraryStatus })
     }
 


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2412 and also fixes a bug I've found while debugging this, we had an incorrect logic and the progress bar was not showing up in the game page.

The way to reproduce the original issue is:
- start installing a game
- pause/cancel the installation
- start installing the same game again
- now the pause/cancel button does nothing

The issue was the status not being updated properly.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
