### PR TITLE
[UI] Display/allow user to copy alternate Epic login URL

### DIFF
--- a/public/locales/en/login.json
+++ b/public/locales/en/login.json
@@ -1,6 +1,9 @@
 {
     "button": {
-        "login": "Log in"
+        "login": "Log in",
+        "open":"Open Link",
+        "copy":"Copy",
+        "copied":"Copied!"
     },
     "message": {
         "part1": "In order to log in and install your games, you first need to follow the steps below:",

--- a/src/frontend/components/UI/LanguageSelector/index.tsx
+++ b/src/frontend/components/UI/LanguageSelector/index.tsx
@@ -56,7 +56,7 @@ const languageLabels: { [key: string]: string } = {
   uk: 'украї́нська мо́ва',
   vi: 'tiếng Việt',
   zh_Hans: '简化字',
-  zh_Hant: '漢語'
+  zh_Hant: '正體字'
 }
 
 const languageFlags: { [key: string]: string } = {
@@ -98,7 +98,7 @@ const languageFlags: { [key: string]: string } = {
   uk: '🇺🇦',
   vi: '🇻🇳',
   zh_Hans: '🇨🇳',
-  zh_Hant: '🇨🇳'
+  zh_Hant: '🇹🇼'
 }
 
 export default function LanguageSelector({

--- a/src/frontend/screens/Login/components/SIDLogin/index.css
+++ b/src/frontend/screens/Login/components/SIDLogin/index.css
@@ -57,13 +57,33 @@
 .loginInstructions .login-link {
   display: flex;
   background-color: var(--background-darker);
-  border-color: var(--input-background);
-  color: var(--text-secondary);
+  border-color: var(--accent);
+  color: var(--text-default);
   padding: var(--space-2xs);
   margin: var(--space-lg);
   width: inherit;
   justify-content: space-between;
   user-select: text;
+}
+
+.loginInstructions .icon-button {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.loginInstructions .icon-button:hover {
+  color: var(--accent-overlay);
+  border-color: var(--accent-overlay);
+}
+
+.loginInstructions .icon-button-success {
+  color: var(--success);
+  border-color: var(--success);
+}
+
+.loginInstructions .icon-button-success:hover {
+  color: var(--success-hover);
+  border-color: var(--success-hover);
 }
 
 .loginInstructions li {

--- a/src/frontend/screens/Login/components/SIDLogin/index.css
+++ b/src/frontend/screens/Login/components/SIDLogin/index.css
@@ -54,6 +54,18 @@
   color: var(--link-highlight);
 }
 
+.loginInstructions .login-link {
+  display: flex;
+  background-color: var(--background-darker);
+  border-color: var(--input-background);
+  color: var(--text-secondary);
+  padding: var(--space-2xs);
+  margin: var(--space-lg);
+  width: inherit;
+  justify-content: space-between;
+  user-select: text;
+}
+
 .loginInstructions li {
   text-align: left;
 }

--- a/src/frontend/screens/Login/components/SIDLogin/index.tsx
+++ b/src/frontend/screens/Login/components/SIDLogin/index.tsx
@@ -84,7 +84,9 @@ export default function SIDLogin({ backdropClick }: Props) {
                 </Typography>
                 <Stack direction="row" spacing={1}>
                   <Button
-                    color={linkCopied ? 'success' : 'info'}
+                    className={
+                      linkCopied ? 'icon-button-success' : 'icon-button'
+                    }
                     onClick={handleCopyLink}
                     endIcon={<LinkIcon fontSize="small" />}
                     variant="outlined"
@@ -93,6 +95,7 @@ export default function SIDLogin({ backdropClick }: Props) {
                     {linkCopied ? t('button.copied') : t('button.copy')}
                   </Button>
                   <Button
+                    className="icon-button"
                     endIcon={<PublicIcon fontSize="small" />}
                     onClick={() => loginPage()}
                     size="small"

--- a/src/frontend/screens/Login/components/SIDLogin/index.tsx
+++ b/src/frontend/screens/Login/components/SIDLogin/index.tsx
@@ -1,5 +1,8 @@
 import React, { useContext, useState } from 'react'
 import Info from '@mui/icons-material/Info'
+import LinkIcon from '@mui/icons-material/Link'
+import PublicIcon from '@mui/icons-material/Public'
+import { Button, Paper, Stack, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { loginPage, sidInfoPage } from 'frontend/helpers'
 import './index.css'
@@ -11,6 +14,8 @@ interface Props {
 }
 
 export default function SIDLogin({ backdropClick }: Props) {
+  const epicLoginUrl = 'https://legendary.gl/epiclogin'
+
   const { epic } = useContext(ContextProvider)
   const { t } = useTranslation('login')
   const [input, setInput] = useState('')
@@ -18,8 +23,14 @@ export default function SIDLogin({ backdropClick }: Props) {
     loading: false,
     message: ''
   })
+  const [linkCopied, setLinkCopied] = useState(false)
 
   const { loading, message } = status
+
+  const handleCopyLink = () => {
+    window.api.clipboardWriteText(epicLoginUrl)
+    setLinkCopied(true)
+  }
 
   const handleLogin = async (sid: string) => {
     await epic.login(sid).then(async (res) => {
@@ -67,6 +78,30 @@ export default function SIDLogin({ backdropClick }: Props) {
                   className="material-icons"
                 />
               </span>
+              <Paper variant="outlined" className="login-link">
+                <Typography variant="subtitle1" paddingLeft={2}>
+                  {epicLoginUrl}
+                </Typography>
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    color={linkCopied ? 'success' : 'info'}
+                    onClick={handleCopyLink}
+                    endIcon={<LinkIcon fontSize="small" />}
+                    variant="outlined"
+                    size="small"
+                  >
+                    {linkCopied ? t('button.copied') : t('button.copy')}
+                  </Button>
+                  <Button
+                    endIcon={<PublicIcon fontSize="small" />}
+                    onClick={() => loginPage()}
+                    size="small"
+                    variant="outlined"
+                  >
+                    {t('button.open')}
+                  </Button>
+                </Stack>
+              </Paper>
             </li>
             <li>
               {`${t('message.part6')} `}


### PR DESCRIPTION
Added Features:
- Displays login URL
- Button to Copy the URL to the clipboard
- Button to Open Link in the Browser

Related Issue: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2245

Before: 
![image](https://user-images.githubusercontent.com/20613798/221803818-f651d1ad-9c70-49a2-9abb-0c494c55f9a3.png)

After: 
![image](https://user-images.githubusercontent.com/20613798/223017732-a875a192-ee56-4b0a-8cfe-cda39878594d.png)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
