### PR TITLE
[Tech] Lint all TS/TSX files in the project

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,0 @@
-i18next-parser.config.js
-flatpak-build/
-flatpak/.flatpak-builder/
-flatpak/prepareFlatpak.js
-vite.config.ts
-**/__tests__/**
-**/__mocks__/**

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,7 @@
     },
     "ecmaVersion": 12,
     "sourceType": "module",
-    "project": ["./tsconfig.json"]
+    "project": ["./tsconfig.eslint.json"]
   },
   "plugins": ["react", "@typescript-eslint", "import"],
   "settings": {
@@ -55,5 +55,15 @@
       { "avoidEscape": true, "allowTemplateLiterals": true }
     ],
     "import/no-duplicates": ["error"]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/__tests__/**", "**/__mocks__/**"],
+      "rules": {
+        "import/no-duplicates": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-empty-function": "off"
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "dist:mac": "vite build && electron-builder --mac",
     "dist:win": "vite build && electron-builder --win",
     "dist:flatpak": "yarn dist:linux appimage && yarn flatpak:prepare && yarn flatpak:build",
-    "lint": "eslint --cache -c .eslintrc --ext .tsx,ts ./src",
+    "lint": "eslint --cache -c .eslintrc --ext .tsx,ts .",
     "lint-fix": "eslint --fix -c .eslintrc --ext .tsx,ts ./src",
     "flatpak:build": "cd flatpak-build && flatpak-builder build com.heroicgameslauncher.hgl.yml --install --force-clean --user",
     "flatpak:prepare": "node ./flatpak/prepareFlatpak.js",

--- a/src/backend/__mocks__/electron.ts
+++ b/src/backend/__mocks__/electron.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from 'node:events'
 import {
   BrowserWindowConstructorOptions,
-  Display,
   MenuItemConstructorOptions
 } from 'electron'
 import { tmpdir } from 'os'
@@ -81,15 +80,15 @@ const screen = {
 }
 
 class Tray {
-  icon: string = ''
+  icon = ''
   menu: MenuItemConstructorOptions[] = []
-  tooltip: string = ''
+  tooltip = ''
 
   constructor(icon: string) {
     this.icon = icon
   }
 
-  on(event: string) {}
+  on() {}
 
   setContextMenu(menu: MenuItemConstructorOptions[]) {
     this.menu = menu

--- a/src/backend/__tests__/constants.test.ts
+++ b/src/backend/__tests__/constants.test.ts
@@ -28,7 +28,7 @@ describe('Constants - getShell', () => {
 
   async function getShell(): Promise<string> {
     jest.resetModules()
-    return await import('../constants').then((module) => {
+    return import('../constants').then((module) => {
       return module.execOptions.shell
     })
   }

--- a/src/backend/__tests__/main_window.test.ts
+++ b/src/backend/__tests__/main_window.test.ts
@@ -17,7 +17,7 @@ describe('main_window', () => {
     })
 
     describe('if there is a main window', () => {
-      let window = {
+      const window = {
         webContents: {
           send: jest.fn()
         }

--- a/src/backend/__tests__/skip.ts
+++ b/src/backend/__tests__/skip.ts
@@ -1,0 +1,2 @@
+export const describeSkipOnWindows =
+  process.platform === 'win32' ? describe.skip : describe

--- a/src/backend/logger/__tests__/logger.test.ts
+++ b/src/backend/logger/__tests__/logger.test.ts
@@ -1,7 +1,7 @@
 import * as logger from '../logger'
 import { appendMessageToLogFile } from '../logfile'
 import { showDialogBoxModalAuto } from '../../dialog/dialog'
-import { platform } from 'os'
+import { describeSkipOnWindows } from 'backend/__tests__/skip'
 
 jest.mock('../logfile')
 jest.mock('../../dialog/dialog')
@@ -40,16 +40,7 @@ function getStringPassedToLogFile(type: logLevel, skipMessagePrefix = false) {
   ].join('\n')
 }
 
-const shouldSkip = platform() === 'win32'
-const skipMessage = 'on windows so skipping test'
-const emptyTest = it('should do nothing', () => {})
-
-describe('logger/logger.ts', () => {
-  if (shouldSkip) {
-    console.log(skipMessage)
-    emptyTest
-    return
-  }
+describeSkipOnWindows('logger/logger.ts', () => {
   afterEach(jest.restoreAllMocks)
 
   test('log invokes console', () => {
@@ -62,7 +53,7 @@ describe('logger/logger.ts', () => {
       .mockImplementation()
 
     interface TestCaseProps {
-      function: Function
+      function: typeof logger.logError
       spyConsole: jest.SpyInstance
     }
 
@@ -95,7 +86,7 @@ describe('logger/logger.ts', () => {
     jest.spyOn(global.console, 'log').mockImplementation()
     jest.spyOn(global.console, 'warn').mockImplementation()
 
-    const testCases = new Map<logLevel, Function>([
+    const testCases = new Map<logLevel, typeof logger.logError>([
       ['ERROR', logger.logError],
       ['INFO', logger.logInfo],
       ['WARNING', logger.logWarning],
@@ -116,7 +107,7 @@ describe('logger/logger.ts', () => {
     jest.spyOn(global.console, 'log').mockImplementation()
     jest.spyOn(global.console, 'warn').mockImplementation()
 
-    const testCases = new Map<logLevel, Function>([
+    const testCases = new Map<logLevel, typeof logger.logError>([
       ['ERROR', logger.logError],
       ['INFO', logger.logInfo],
       ['WARNING', logger.logWarning],

--- a/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
+++ b/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
@@ -12,7 +12,7 @@ jest.mock('backend/utils')
 let tmpDir = {} as DirResult
 let tmpSteamUserConfigDir = ''
 
-function copyTestFile(file: string, alternativeUserPath: string = '') {
+function copyTestFile(file: string, alternativeUserPath = '') {
   const testFileDir = join(__dirname, 'test_data')
   const userDir = alternativeUserPath
     ? join(alternativeUserPath, 'shortcuts.vdf')
@@ -183,7 +183,7 @@ describe('NonSteamGame', () => {
     expect(console.error).toBeCalledWith(
       expect.stringContaining('ERROR:   [Shortcuts]:'),
       expect.stringContaining(
-        `Can't add \"${game.title}\" to Steam user \"steam_user\". \"${shortcutFilePath}\" is corrupted!`
+        `Can't add "${game.title}" to Steam user "steam_user". "${shortcutFilePath}" is corrupted!`
       )
     )
     expect(console.error).toBeCalledWith(
@@ -218,7 +218,7 @@ describe('NonSteamGame', () => {
     expect(console.error).toBeCalledWith(
       expect.stringContaining('ERROR:   [Shortcuts]:'),
       expect.stringContaining(
-        `Can't add \"${game.title}\" to Steam user \"steam_user\". \"${shortcutFilePath}\" is corrupted!`
+        `Can't add "${game.title}" to Steam user "steam_user". "${shortcutFilePath}" is corrupted!`
       )
     )
     expect(console.error).toBeCalledWith(
@@ -253,7 +253,7 @@ describe('NonSteamGame', () => {
     expect(console.error).toBeCalledWith(
       expect.stringContaining('ERROR:   [Shortcuts]:'),
       expect.stringContaining(
-        `Can't add \"${game.title}\" to Steam user \"steam_user\". \"${shortcutFilePath}\" is corrupted!`
+        `Can't add "${game.title}" to Steam user "steam_user". "${shortcutFilePath}" is corrupted!`
       )
     )
     expect(console.error).toBeCalledWith(
@@ -343,13 +343,13 @@ describe('NonSteamGame', () => {
       expect(console.error).toBeCalledWith(
         expect.stringContaining('ERROR:   [Shortcuts]:'),
         expect.stringContaining(
-          `Can't add \"${game.title}\" to Steam user \"steam_user2\". \"${shortcutFilePath2}\" is corrupted!`
+          `Can't add "${game.title}" to Steam user "steam_user2". "${shortcutFilePath2}" is corrupted!`
         )
       )
       expect(console.error).toBeCalledWith(
         expect.stringContaining('ERROR:   [Shortcuts]:'),
         expect.stringContaining(
-          `Can't remove \"${game.title}\" from Steam user \"steam_user2\". \"${shortcutFilePath2}\" is corrupted!`
+          `Can't remove "${game.title}" from Steam user "steam_user2". "${shortcutFilePath2}" is corrupted!`
         )
       )
       expect(console.error).toBeCalledWith(

--- a/src/backend/wiki_game_info/applegamingwiki/__tests__/utils.test.ts
+++ b/src/backend/wiki_game_info/applegamingwiki/__tests__/utils.test.ts
@@ -31,7 +31,7 @@ describe('getInfoFromAppleGamingWiki', () => {
   })
 
   test('does not find page id', async () => {
-    const mockAxios = jest.spyOn(axios, 'get').mockResolvedValueOnce({
+    jest.spyOn(axios, 'get').mockResolvedValueOnce({
       data: { query: { search: [{ pageid: undefined }] } }
     })
 

--- a/src/backend/wiki_game_info/pcgamingwiki/__tests__/utils.test.ts
+++ b/src/backend/wiki_game_info/pcgamingwiki/__tests__/utils.test.ts
@@ -1,4 +1,3 @@
-import { Search } from '@mui/icons-material'
 import { logError } from 'backend/logger/logger'
 import { getInfoFromPCGamingWiki } from '../utils'
 import axios from 'axios'
@@ -56,7 +55,7 @@ describe('getInfoFromPCGamingWiki', () => {
   })
 
   test('does not find page id', async () => {
-    const mockAxios = jest.spyOn(axios, 'get').mockResolvedValueOnce({
+    jest.spyOn(axios, 'get').mockResolvedValueOnce({
       data: { query: { search: [{ pageid: undefined }] } }
     })
 

--- a/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
+++ b/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../util'
 import { test_data } from './test_data/github-api-heroic-test-data.json'
 import { dirSync } from 'tmp'
-import { platform } from 'os'
+import { describeSkipOnWindows } from 'backend/__tests__/skip'
 
 const testUrl =
   'https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v2.3.9/Heroic-2.3.9.AppImage'
@@ -22,16 +22,7 @@ const testTarFileWithSubfolder = join(
 
 afterEach(jest.restoreAllMocks)
 
-const shouldSkip = platform() !== 'linux'
-const skipMessage = 'not on linux so skipping test'
-const emptyTest = () => it('should do nothing', () => {})
-
-describe('getAssetDataFromDownload', () => {
-  if (shouldSkip) {
-    console.log(skipMessage)
-    emptyTest()
-    return
-  }
+describeSkipOnWindows('getAssetDataFromDownload', () => {
   it('Success', async () => {
     // https://stackoverflow.com/a/43047378
     jest.spyOn(axios, 'get').mockResolvedValue(test_data)
@@ -84,12 +75,7 @@ describe('getAssetDataFromDownload', () => {
   })
 })
 
-describe('downloadFile', () => {
-  if (shouldSkip) {
-    console.log(skipMessage)
-    emptyTest()
-    return
-  }
+describeSkipOnWindows('downloadFile', () => {
   it('Success', async () => {
     const expectedData = readFileSync(testTarFilePath)
 
@@ -164,12 +150,7 @@ describe('downloadFile', () => {
   })
 })
 
-describe('extractTarFile', () => {
-  if (shouldSkip) {
-    console.log(skipMessage)
-    emptyTest()
-    return
-  }
+describeSkipOnWindows('extractTarFile', () => {
   it('Success without strip', async () => {
     const tmpDir = dirSync({ unsafeCleanup: true })
     jest.spyOn(child_process, 'spawn')

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,6 +1,6 @@
 {
   // extend your base config so you don't have to redefine your compilerOptions
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["**/__tests__/**", "**/__mocks__/**"]
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": []
 }


### PR DESCRIPTION
We weren't linting files outside of the "main" code (namely, tests). Now we do!

Note that I've disabled some rules for test files specifically that might be annoying there (you often "stub out" a function or use `any` in a mock, we don't want ESLint yelling at us there)

This has the nice benefit of our IDEs (at least Webstorm) no longer providing false errors on `backend/`, `common/` and `frontend/` imports, as those test files now actually belong to a project, as well as those weird errors around `.replaceAll` disappearing

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [X] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
