### PR TITLE
[Enhancement]: Provide Wine-ge/Proton-ge latest version via wine manager

### DIFF
--- a/src/backend/wiki_game_info/gamesdb/__tests__/utils.test.ts
+++ b/src/backend/wiki_game_info/gamesdb/__tests__/utils.test.ts
@@ -28,12 +28,18 @@ describe('getInfoFromGamesDB', () => {
   })
 
   test('catches axios throws', async () => {
-    jest.spyOn(axios, 'get').mockRejectedValueOnce(new Error('Failed'))
+    jest.spyOn(axios, 'get').mockRejectedValueOnce({
+      response: {
+        data: {
+          error_description: 'Failed'
+        }
+      }
+    })
 
     const result = await getInfoFromGamesDB('Jotun', 'Grouse', 'legendary')
     expect(result).toStrictEqual({ steamID: '' })
     expect(logError).toBeCalledWith(
-      ['Was not able to get GamesDB data for Grouse', Error('Failed')],
+      ['Was not able to get GamesDB data for Grouse', 'Failed'],
       'ExtraGameInfo'
     )
   })

--- a/src/backend/wiki_game_info/gamesdb/utils.ts
+++ b/src/backend/wiki_game_info/gamesdb/utils.ts
@@ -49,7 +49,10 @@ export async function getGamesdbData(
       .get(url, { headers: headers })
       .catch((error) => {
         logError(
-          [`Was not able to get GamesDB data for ${game_id}`, error],
+          [
+            `Was not able to get GamesDB data for ${game_id}`,
+            error.response.data.error_description
+          ],
           LogPrefix.ExtraGameInfo
         )
         return null

--- a/src/backend/wine/manager/downloader/__tests__/main/getter.test.ts
+++ b/src/backend/wine/manager/downloader/__tests__/main/getter.test.ts
@@ -2,26 +2,25 @@ import { Repositorys, VersionInfo } from 'common/types'
 import { getAvailableVersions } from '../../main'
 import { test_data_release_list } from '../test_data/github-api-test-data.json'
 import * as axios from 'axios'
+import { logError, logWarning } from 'backend/logger/logger'
 
 jest.mock('backend/logger/logger')
+jest.mock('backend/logger/logfile')
 
 describe('Main - GetAvailableVersions', () => {
   test('fetch releases succesfully', async () => {
     axios.default.get = jest.fn().mockResolvedValue(test_data_release_list)
 
-    await getAvailableVersions({})
-      .then((releases: VersionInfo[]) => {
-        expect(releases).not.toBe([])
-        expect(releases.length).toBeGreaterThan(0)
-        expect(releases[2].version).toContain('6.16-GE-1')
-      })
-      .catch(() => {
-        throw Error('No error should be thrown!')
-      })
+    await getAvailableVersions({}).then((releases: VersionInfo[]) => {
+      expect(releases).not.toBe([])
+      expect(releases.length).toBeGreaterThan(0)
+      expect(releases[3].version).toContain('6.16-GE-1')
+    })
 
     expect(axios.default.get).toBeCalledWith(
       'https://api.github.com/repos/GloriousEggroll/wine-ge-custom/releases?per_page=100'
     )
+    expect(logError).not.toBeCalled()
   })
 
   test('fetch releases succesfully independent', async () => {
@@ -30,19 +29,16 @@ describe('Main - GetAvailableVersions', () => {
     for (let key = 0; key < Object.keys(Repositorys).length / 2; key++) {
       await getAvailableVersions({
         repositorys: [key]
+      }).then((releases: VersionInfo[]) => {
+        expect(releases).not.toBe([])
+        expect(releases.length).toBeGreaterThan(0)
+        expect(releases[3].version).toContain('6.16-GE-1')
       })
-        .then((releases: VersionInfo[]) => {
-          expect(releases).not.toBe([])
-          expect(releases.length).toBeGreaterThan(0)
-          expect(releases[2].version).toContain('6.16-GE-1')
-        })
-        .catch(() => {
-          throw Error('No error should be thrown!')
-        })
 
       expect(axios.default.get).toBeCalledWith(
         'https://api.github.com/repos/GloriousEggroll/wine-ge-custom/releases?per_page=100'
       )
+      expect(logError).not.toBeCalled()
     }
   })
 
@@ -50,36 +46,34 @@ describe('Main - GetAvailableVersions', () => {
     axios.default.get = jest.fn().mockRejectedValue('Could not fetch tag 404')
 
     for (let key = 0; key < Object.keys(Repositorys).length / 2; key++) {
-      await getAvailableVersions({ repositorys: [key] })
-        .then(() => {
-          throw Error("Function shouldn't success!")
-        })
-        .catch((error: Error) => {
-          expect(error.message).toContain('Could not fetch tag 404')
-        })
+      await expect(
+        getAvailableVersions({ repositorys: [key] })
+      ).resolves.toStrictEqual([])
 
       expect(axios.default.get).toBeCalledWith(
         expect.stringContaining('https://api.github.com/repos/')
+      )
+      expect(logError).toBeCalledWith(
+        Error(
+          'Could not fetch available releases from https://api.github.com/repos/GloriousEggroll/wine-ge-custom/releases with error:\n ' +
+            'Could not fetch tag 404'
+        ),
+        'WineDownloader'
       )
     }
   })
 
   test('Invalid repository key returns nothing', async () => {
     axios.default.get = jest.fn()
-    console.warn = jest.fn()
 
-    await getAvailableVersions({ repositorys: [-1] })
-      .then((releases: VersionInfo[]) => {
-        expect(releases).toStrictEqual([])
-        expect(releases.length).toBe(0)
-      })
-      .catch(() => {
-        throw Error('No error should be thrown!')
-      })
+    await expect(
+      getAvailableVersions({ repositorys: [-1] })
+    ).resolves.toStrictEqual([])
 
     expect(axios.default.get).not.toBeCalled()
-    expect(console.warn).toBeCalledWith(
-      'Unknown and not supported repository key passed! Skip fetch for -1'
+    expect(logWarning).toBeCalledWith(
+      'Unknown and not supported repository key passed! Skip fetch for -1',
+      'WineDownloader'
     )
   })
 })

--- a/src/backend/wine/manager/downloader/__tests__/utilities/download.test.ts
+++ b/src/backend/wine/manager/downloader/__tests__/utilities/download.test.ts
@@ -2,48 +2,40 @@ import { existsSync, mkdirSync, rmSync } from 'graceful-fs'
 import { downloadFile } from '../../utilities'
 
 jest.mock('backend/logger/logger')
+jest.mock('backend/logger/logfile')
 
 const workDir = process.cwd()
 
 describe('Utilities - Download', () => {
   test('download file fails because of invalid installDir', async () => {
     const progress = jest.fn()
-    await downloadFile({
-      url: '',
-      downloadDir: 'invalid',
-      downsize: 100000,
-      onProgress: progress
-    })
-      .then(() => {
-        throw Error('No error should be thrown!')
+    await expect(
+      downloadFile({
+        url: '',
+        downloadDir: 'invalid',
+        downsize: 100000,
+        onProgress: progress
       })
-      .catch((error) => {
-        expect(error).toBe('Download path invalid does not exist!')
-      })
+    ).rejects.toStrictEqual('Download path invalid does not exist!')
   })
 
   test('download file fails because of installDir is a file', async () => {
     const progress = jest.fn()
-    await downloadFile({
-      url: '',
-      downloadDir: __filename,
-      downsize: 100000,
-      onProgress: progress
-    })
-      .then(() => {
-        throw Error('No error should be thrown!')
+    await expect(
+      downloadFile({
+        url: '',
+        downloadDir: __filename,
+        downsize: 100000,
+        onProgress: progress
       })
-      .catch((error) => {
-        expect(error).toBe(
-          `Download path ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/download.test.ts is not a directory!`
-        )
-      })
+    ).rejects.toMatchInlineSnapshot(
+      `"Download path /home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities/download.test.ts is not a directory!"`
+    )
   })
 
   test('download file can be aborted', async () => {
     const progress = jest.fn()
     const installDir = __dirname + '/test_download'
-    let failed = false
 
     if (!existsSync(installDir)) {
       mkdirSync(installDir)
@@ -55,26 +47,18 @@ describe('Utilities - Download', () => {
       abortController.abort()
     }, 10)
 
-    await downloadFile({
-      url: `file:///${__dirname}/../test_data/test.tar.xz`,
-      downloadDir: installDir,
-      downsize: 100000,
-      onProgress: progress,
-      abortSignal: abortController.signal
-    })
-      .then(() => {
-        failed = true
+    await expect(
+      downloadFile({
+        url: `file:///${__dirname}/../test_data/test.tar.xz`,
+        downloadDir: installDir,
+        downsize: 100000,
+        onProgress: progress,
+        abortSignal: abortController.signal
       })
-      .catch((error) => {
-        expect(error).toBe('AbortError')
-      })
+    ).rejects.toStrictEqual('AbortError')
 
     if (existsSync(installDir)) {
       rmSync(installDir, { recursive: true })
-    }
-
-    if (failed) {
-      throw Error('No error should be thrown!')
     }
   })
 
@@ -87,27 +71,19 @@ describe('Utilities - Download', () => {
       mkdirSync(installDir)
     }
 
-    await downloadFile({
-      url: `file:///${__dirname}/../test_data/test.tar.xz`,
-      downloadDir: installDir,
-      downsize: 100000,
-      onProgress: progress
-    })
-      .then((response) => {
-        expect(response).toBe(
-          `Succesfully downloaded file:///${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.xz to ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/test_download/test.tar.xz.`
-        )
+    await expect(
+      downloadFile({
+        url: `file:///${__dirname}/../test_data/test.tar.xz`,
+        downloadDir: installDir,
+        downsize: 100000,
+        onProgress: progress
       })
-      .catch(() => {
-        failed = true
-      })
+    ).resolves.toMatchInlineSnapshot(
+      `"Succesfully downloaded file:////home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.xz to /home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities/test_download/test.tar.xz."`
+    )
 
     if (existsSync(installDir)) {
       rmSync(installDir, { recursive: true })
-    }
-
-    if (failed) {
-      throw Error('No error should be thrown!')
     }
 
     expect(progress).toBeCalledWith('downloading', {

--- a/src/backend/wine/manager/downloader/__tests__/utilities/rest.test.ts
+++ b/src/backend/wine/manager/downloader/__tests__/utilities/rest.test.ts
@@ -21,24 +21,20 @@ describe('Utilities - Rest', () => {
     expect(size).toBeNaN()
   })
 
-  test('unlink of folder fails', () => {
-    try {
+  test('unlink of folder fails', async () => {
+    expect(() => {
       unlinkFile(__dirname)
-      throw Error('No error should be thrown!')
-    } catch (error) {
-      expect(String(error)).toBe(
-        `Error: Couldn't remove ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities!`
-      )
-    }
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Couldn't remove /home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities!"`
+    )
   })
 
   test('unlink files succeeds', () => {
     writeFileSync('newFile.txt', 'Hello new file!')
-    try {
+
+    expect(() => {
       unlinkFile('newFile.txt')
-      expect(existsSync('newFile.txt')).toBeFalsy()
-    } catch {
-      throw Error('No error should be thrown!')
-    }
+    }).not.toThrow()
+    expect(existsSync('newFile.txt')).toBeFalsy()
   })
 })

--- a/src/backend/wine/manager/downloader/__tests__/utilities/unzip.test.ts
+++ b/src/backend/wine/manager/downloader/__tests__/utilities/unzip.test.ts
@@ -2,61 +2,49 @@ import { existsSync, mkdirSync, rmSync } from 'graceful-fs'
 import { unzipFile } from '../../utilities'
 
 jest.mock('backend/logger/logger')
+jest.mock('backend/logger/logfile')
 
 const workDir = process.cwd()
 
 describe('Utilities - Unzip', () => {
   test('unzip file fails because of invalid archive path', async () => {
     const progress = jest.fn()
-    await unzipFile({
-      filePath: 'invalid.tar.xz',
-      unzipDir: __dirname,
-      onProgress: progress
-    })
-      .then(() => {
-        throw Error('No error should be thrown!')
+    await expect(
+      unzipFile({
+        filePath: 'invalid.tar.xz',
+        unzipDir: __dirname,
+        onProgress: progress
       })
-      .catch((error) => {
-        expect(error).toBe('Zip file invalid.tar.xz does not exist!')
-      })
+    ).rejects.toStrictEqual('Zip file invalid.tar.xz does not exist!')
   })
 
   test('unzip file fails because of archive is not a file', async () => {
     const progress = jest.fn()
-    await unzipFile({
-      filePath: __dirname,
-      unzipDir: __dirname,
-      onProgress: progress
-    })
-      .then(() => {
-        throw Error('No error should be thrown!')
+    await expect(
+      unzipFile({
+        filePath: __dirname,
+        unzipDir: __dirname,
+        onProgress: progress
       })
-      .catch((error) => {
-        expect(error).toBe(
-          `Archive path ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities is not a file!`
-        )
-      })
+    ).rejects.toStrictEqual(
+      `Archive path ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities is not a file!`
+    )
   })
 
   test('unzip file fails because of invalid install path', async () => {
     const progress = jest.fn()
-    await unzipFile({
-      filePath: `${__dirname}/../test_data/test.tar.xz`,
-      unzipDir: 'invalid',
-      onProgress: progress
-    })
-      .then(() => {
-        throw Error('No error should be thrown!')
+    await expect(
+      unzipFile({
+        filePath: `${__dirname}/../test_data/test.tar.xz`,
+        unzipDir: 'invalid',
+        onProgress: progress
       })
-      .catch((error) => {
-        expect(error).toBe('Install path invalid does not exist!')
-      })
+    ).rejects.toStrictEqual('Install path invalid does not exist!')
   })
 
   test('unzip file can be aborted', async () => {
     const progress = jest.fn()
     const installDir = __dirname + '/test_unzip'
-    let failed = false
 
     if (!existsSync(installDir)) {
       mkdirSync(installDir)
@@ -68,135 +56,97 @@ describe('Utilities - Unzip', () => {
       abortController.abort()
     }, 10)
 
-    await unzipFile({
-      filePath: `${__dirname}/../test_data/test.tar.xz`,
-      unzipDir: installDir,
-      onProgress: progress,
-      abortSignal: abortController.signal
-    })
-      .then(() => {
-        failed = true
+    await expect(
+      unzipFile({
+        filePath: `${__dirname}/../test_data/test.tar.xz`,
+        unzipDir: installDir,
+        onProgress: progress,
+        abortSignal: abortController.signal
       })
-      .catch((error) => {
-        expect(error).toBe('AbortError')
-      })
+    ).rejects.toStrictEqual('AbortError')
 
     if (existsSync(installDir)) {
       rmSync(installDir, { recursive: true })
-    }
-
-    if (failed) {
-      throw Error('No error should be thrown!')
     }
   })
 
   test('unzip tar.xz file succeesfully', async () => {
     const progress = jest.fn()
     const installDir = __dirname + '/test_unzip'
-    let failed = false
 
     if (!existsSync(installDir)) {
       mkdirSync(installDir)
     }
 
-    await unzipFile({
-      filePath: `${__dirname}/../test_data/test.tar.xz`,
-      unzipDir: installDir,
-      onProgress: progress
-    })
-      .then((response) => {
-        expect(response).toBe(
-          `Succesfully unzip ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.xz to ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip.`
-        )
+    await expect(
+      unzipFile({
+        filePath: `${__dirname}/../test_data/test.tar.xz`,
+        unzipDir: installDir,
+        onProgress: progress
       })
-      .catch(() => {
-        failed = true
-      })
+    ).resolves.toMatchInlineSnapshot(
+      `"Succesfully unzip /home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.xz to /home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip."`
+    )
 
     if (existsSync(installDir)) {
       rmSync(installDir, { recursive: true })
-    }
-
-    if (failed) {
-      throw Error('No error should be thrown!')
     }
   })
 
   test('unzip tar.gz file succeesfully', async () => {
     const progress = jest.fn()
     const installDir = __dirname + '/test_unzip'
-    let failed = false
 
     if (!existsSync(installDir)) {
       mkdirSync(installDir)
     }
 
-    await unzipFile({
-      filePath: `${__dirname}/../test_data/test.tar.gz`,
-      unzipDir: installDir,
-      onProgress: progress
-    })
-      .then((response) => {
-        expect(response).toBe(
-          `Succesfully unzip ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.gz to ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip.`
-        )
+    await expect(
+      unzipFile({
+        filePath: `${__dirname}/../test_data/test.tar.gz`,
+        unzipDir: installDir,
+        onProgress: progress
       })
-      .catch(() => {
-        failed = true
-      })
+    ).resolves.toMatchInlineSnapshot(
+      `"Succesfully unzip /home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.gz to /home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip."`
+    )
+
     if (existsSync(installDir)) {
       rmSync(installDir, { recursive: true })
-    }
-
-    if (failed) {
-      throw Error('No error should be thrown!')
     }
   })
 
   test('unzip tar.gz file twice to the same direction succeesfully', async () => {
     const progress = jest.fn()
     const installDir = __dirname + '/test_unzip'
-    let failed = false
 
     if (!existsSync(installDir)) {
       mkdirSync(installDir)
     }
 
-    await unzipFile({
-      filePath: `${__dirname}/../test_data/test.tar.gz`,
-      unzipDir: installDir,
-      onProgress: progress
-    })
-      .then((response) => {
-        expect(response).toBe(
-          `Succesfully unzip ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.gz to ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip.`
-        )
+    await expect(
+      unzipFile({
+        filePath: `${__dirname}/../test_data/test.tar.gz`,
+        unzipDir: installDir,
+        onProgress: progress
       })
-      .catch(() => {
-        failed = true
-      })
+    ).resolves.toMatchInlineSnapshot(
+      `"Succesfully unzip /home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.gz to /home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip."`
+    )
 
-    await unzipFile({
-      filePath: `${__dirname}/../test_data/test.tar.gz`,
-      unzipDir: installDir,
-      overwrite: true,
-      onProgress: progress
-    })
-      .then((response) => {
-        expect(response).toBe(
-          `Succesfully unzip ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.gz to ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip.`
-        )
+    await expect(
+      unzipFile({
+        filePath: `${__dirname}/../test_data/test.tar.gz`,
+        unzipDir: installDir,
+        overwrite: true,
+        onProgress: progress
       })
-      .catch(() => {
-        failed = true
-      })
+    ).resolves.toMatchInlineSnapshot(
+      `"Succesfully unzip /home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.gz to /home/niklas/Repository/HeroicGamesLauncher/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip."`
+    )
 
     if (existsSync(installDir)) {
       rmSync(installDir, { recursive: true })
-    }
-
-    if (failed) {
-      throw Error('No error should be thrown!')
     }
 
     expect(progress).toBeCalledWith('unzipping')

--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -52,6 +52,21 @@ async function fetchReleases({
 
           releases.push(release_data)
         }
+
+        // add latest to list
+        releases.unshift({
+          version: releases[0].version.replace(
+            /[0-9]+[-|.]+[0-9]+/m,
+            '-latest'
+          ),
+          type: releases[0].type,
+          date: releases[0].date,
+          download: releases[0].download,
+          downsize: releases[0].downsize,
+          disksize: releases[0].disksize,
+          checksum: releases[0].checksum
+        })
+
         resolve(releases)
       })
       .catch((error) => {

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -35,9 +35,11 @@ async function updateWineVersionInfos(
   logInfo('Updating wine versions info', LogPrefix.WineDownloader)
   if (fetch) {
     logInfo('Fetching upstream information...', LogPrefix.WineDownloader)
+
     const repositorys = isMac
       ? [Repositorys.WINECROSSOVER, Repositorys.WINESTAGINGMACOS]
       : [Repositorys.WINEGE, Repositorys.PROTONGE]
+
     await getAvailableVersions({
       repositorys,
       count
@@ -87,6 +89,7 @@ async function installWineVersion(
   abortSignal: AbortSignal
 ) {
   let updatedInfo: WineVersionInfo
+  const variant = release.hasUpdate ? 'update' : 'installation'
 
   if (!existsSync(`${heroicToolsPath}/wine`)) {
     mkdirSync(`${heroicToolsPath}/wine`, { recursive: true })
@@ -97,7 +100,7 @@ async function installWineVersion(
   }
 
   logInfo(
-    `Start installation of wine version ${release.version}`,
+    `Start ${variant} of wine version ${release.version}`,
     LogPrefix.WineDownloader
   )
 
@@ -109,6 +112,7 @@ async function installWineVersion(
     const response = await installVersion({
       versionInfo: release as VersionInfo,
       installDir,
+      overwrite: release.hasUpdate,
       onProgress: onProgress,
       abortSignal: abortSignal
     })
@@ -157,7 +161,7 @@ async function installWineVersion(
   }
 
   logInfo(
-    `Finished installation of wine version ${release.version}`,
+    `Finished ${variant} of wine version ${release.version}`,
     LogPrefix.WineDownloader
   )
 

--- a/src/frontend/screens/WineManager/components/WineItem/index.tsx
+++ b/src/frontend/screens/WineManager/components/WineItem/index.tsx
@@ -5,12 +5,12 @@ import React, { useEffect, useState } from 'react'
 import { WineVersionInfo, ProgressInfo, State } from 'common/types'
 import { ReactComponent as DownIcon } from 'frontend/assets/down-icon.svg'
 import { ReactComponent as StopIcon } from 'frontend/assets/stop-icon.svg'
+import { faRepeat, faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 import { SvgButton } from 'frontend/components/UI'
 import { useTranslation } from 'react-i18next'
 
 import { notify, size } from 'frontend/helpers'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 
 const WineItem = ({
   version,
@@ -117,16 +117,14 @@ const WineItem = ({
 
   const renderStatus = () => {
     let status
-    if (isInstalled) {
+    if (isDownloading) {
+      status = getProgressElement(progress.progress, downsize)
+    } else if (unZipping) {
+      status = t('wine.manager.unzipping', 'Unzipping')
+    } else if (isInstalled) {
       status = size(disksize)
     } else {
-      if (isDownloading) {
-        status = getProgressElement(progress.progress, downsize)
-      } else if (progress.state === 'unzipping') {
-        status = t('wine.manager.unzipping', 'Unzipping')
-      } else {
-        status = size(downsize)
-      }
+      status = size(downsize)
     }
     return status
   }
@@ -134,10 +132,10 @@ const WineItem = ({
   // using one element for the different states so it doesn't
   // lose focus from the button when using a game controller
   const handleMainActionClick = () => {
-    if (isInstalled) {
-      remove()
-    } else if (isDownloading || unZipping) {
+    if (isDownloading || unZipping) {
       window.api.abort(version)
+    } else if (isInstalled) {
+      remove()
     } else {
       install()
     }
@@ -152,10 +150,10 @@ const WineItem = ({
   }
 
   const mainIconTitle = () => {
-    if (isInstalled) {
+    if (isDownloading || unZipping) {
+      return `Cancel ${version} ${hasUpdate ? 'update' : 'installation'}`
+    } else if (isInstalled) {
       return `Uninstall ${version}`
-    } else if (isDownloading || unZipping) {
-      return `Cancel ${version} installation`
     } else {
       return `Install ${version}`
     }
@@ -170,11 +168,24 @@ const WineItem = ({
         {isInstalled && (
           <SvgButton
             className="material-icons settings folder"
-            onClick={() => openInstallDir()}
+            onClick={openInstallDir}
             title={`Open containing folder for ${version}`}
           >
             <FontAwesomeIcon
               icon={faFolderOpen}
+              data-testid="setinstallpathbutton"
+            />
+          </SvgButton>
+        )}
+
+        {hasUpdate && (
+          <SvgButton
+            className="material-icons settings folder"
+            onClick={install}
+            title={`Update ${version}`}
+          >
+            <FontAwesomeIcon
+              icon={faRepeat}
               data-testid="setinstallpathbutton"
             />
           </SvgButton>


### PR DESCRIPTION
This PR adds a Wine-GE and PRoton-Ge latest version which is updateable via the wine-manager.
The PR also cleans up some test and fixes some small issues.

- Fixed issue where a error was thrown if one fetch call of one github repository failed. Now it shows a error, so other fetches can still succeed.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
