### PR TITLE
[UI] title on ETA

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -181,6 +181,7 @@
     },
     "docs": "Documentation",
     "download-manager": {
+        "ETA": "Estimated time",
         "install-type": {
             "install": "Install",
             "update": "Update"
@@ -196,8 +197,7 @@
             "start-time": "Started at",
             "type": "Type"
         },
-        "title": "Downloads",
-        "ETA": "Estimated time"
+        "title": "Downloads"
     },
     "epic": {
         "offline-notification-body": "Online services may not work fully as Epic Games servers are offline!",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -196,7 +196,8 @@
             "start-time": "Started at",
             "type": "Type"
         },
-        "title": "Downloads"
+        "title": "Downloads",
+        "ETA": "Estimated time"
     },
     "epic": {
         "offline-notification-body": "Online services may not work fully as Epic Games servers are offline!",

--- a/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
@@ -116,7 +116,10 @@ export default function ProgressHeader(props: {
               />
             </Box>
             <Box sx={{ minWidth: 35 }}>
-              <Typography variant="subtitle1" title={t('download-manager.ETA', 'Estimated Time')}>
+              <Typography
+                variant="subtitle1"
+                title={t('download-manager.ETA', 'Estimated Time')}
+              >
                 {progress.eta ?? '00.00.00'}
               </Typography>
             </Box>

--- a/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
@@ -116,7 +116,7 @@ export default function ProgressHeader(props: {
               />
             </Box>
             <Box sx={{ minWidth: 35 }}>
-              <Typography variant="subtitle1">
+              <Typography variant="subtitle1" title={t('download-manager.ETA', 'Estimated Time')}>
                 {progress.eta ?? '00.00.00'}
               </Typography>
             </Box>


### PR DESCRIPTION
Just added a title on the estimated time on the downloading page. Without a title, it's hard to understand what this time means.

---

- [x] Tested the feature and it's working on a current and clean install.
