### PR TITLE
[Fix/Tech] Run Prettier on pre-push action

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,2 @@
 #!/bin/bash
-yarn codecheck && yarn lint && yarn i18n
+yarn codecheck && yarn lint && yarn prettier && yarn i18n


### PR DESCRIPTION
We run `yarn prettier` as part of our GH Workflows, but weren't running it when you actually tried to push. Thus, you might forget to run it locally, only for the workflow to then fail & you having to make a "lint commit" / force-push.
Most of us have our editors/IDEs configured to lint on save, but I'd say this is still a good safety net in case something goes wrong there.

The original reason to not do this ([here](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/2010#discussion_r1017058383)) was that `prettier-fix` changes file permissions, but just running Prettier without writing changes shouldn't touch those (please correct me if I'm wrong there, I cannot test this on Windows).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
