### PR TITLE
[GOG] Remove installinfo cache when updating a game

### DIFF
--- a/src/backend/gog/games.ts
+++ b/src/backend/gog/games.ts
@@ -31,7 +31,11 @@ import {
 } from 'common/types'
 import { appendFileSync, existsSync, rmSync } from 'graceful-fs'
 import { heroicGamesConfigPath, isWindows, isMac, isLinux } from '../constants'
-import { installedGamesStore, syncStore } from '../gog/electronStores'
+import {
+  gogInstallInfoStore,
+  installedGamesStore,
+  syncStore
+} from '../gog/electronStores'
 import { logError, logInfo, LogPrefix, logWarning } from '../logger/logger'
 import { GOGUser } from './user'
 import {
@@ -845,6 +849,14 @@ class GOGGame extends Game {
     const gameObject = installedArray[gameIndex]
 
     if (gameData.install.platform !== 'linux') {
+      // Force getting new cache
+      if (
+        gogInstallInfoStore.has(`${this.appName}_${gameData.install.platform}`)
+      ) {
+        gogInstallInfoStore.delete(
+          `${this.appName}_${gameData.install.platform}`
+        )
+      }
       const installInfo = await this.getInstallInfo()
       gameObject.buildId = installInfo.game.buildId
       gameObject.version = installInfo.game.version


### PR DESCRIPTION
This prevents infinite update available cycle.
Closes #2465

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
