### PR TITLE
[Shortcuts] Use icon from api for gog shortcuts

### DIFF
--- a/src/backend/shortcuts/utils.ts
+++ b/src/backend/shortcuts/utils.ts
@@ -58,18 +58,17 @@ async function getIcon(appName: string, gameInfo: GameInfo | SideloadGame) {
     mkdirSync(heroicIconFolder)
   }
 
-  let image = gameInfo.art_square.replaceAll(' ', '%20').replace('{ext}', 'png')
+  // By default use vertical image - art_square in jpg format
+  let image = gameInfo.art_square.replaceAll(' ', '%20').replace('{ext}', 'jpg')
+  let icon = `${heroicIconFolder}/${appName}.jpg`
 
   if (gameInfo.runner === 'gog') {
     const productApiData = await GOGLibrary.getProductApi(appName)
-    if (productApiData) {
-      if (productApiData.data.images?.icon) {
-        image = 'https:' + productApiData.data.images?.icon
-      }
+    if (productApiData && productApiData.data.images?.icon) {
+      image = 'https:' + productApiData.data.images?.icon
+      icon = `${heroicIconFolder}/${appName}.png` // Allow transparency
     }
   }
-
-  const icon = `${heroicIconFolder}/${appName}.png` // Use png's since we need support for transparency
 
   if (!checkImageExistsAlready(icon)) {
     downloadImage(image, icon)


### PR DESCRIPTION
This is simple addition that will load icon from API instead of using squashed cover:

Before:  
![obraz](https://user-images.githubusercontent.com/62100117/224111278-156d9902-5250-4b5c-becf-92624dee49e9.png)

After:  
![obraz](https://user-images.githubusercontent.com/62100117/224111297-b2384acb-dd1c-4301-bcb3-957d6b9ce11f.png)

It may be necessary to manually delete icon from icons directory so new ones can be pulled.

**Note** squashed covers will still be used as fallback if for some reason API call fails

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
