### PR TITLE
[EPIC] Add file:// to the preload protocol for login

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -831,7 +831,7 @@ ipcMain.handle('authGOG', async (event, code) => GOGUser.login(code))
 ipcMain.handle('logoutLegendary', LegendaryUser.logout)
 ipcMain.on('logoutGOG', GOGUser.logout)
 ipcMain.handle('getLocalPeloadPath', async () => {
-  return fixAsarPath(join(publicDir, 'webviewPreload.js'))
+  return fixAsarPath(join('file://', publicDir, 'webviewPreload.js'))
 })
 
 ipcMain.handle('getAlternativeWine', async () =>


### PR DESCRIPTION
This fixes this issue I get when running the app from source:
![image](https://user-images.githubusercontent.com/188464/224443180-53524669-b145-45ac-a973-95b23cb429a3.png)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
