### PR TITLE
[Performance] Do not store all the output of commands in memory

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -615,7 +615,7 @@ async function runWineCommand({
         options.onOutput(data, child)
       }
 
-      stdout.add(data.trim())
+      stdout.push(data.trim())
     })
 
     child.stderr.on('data', (data: string) => {
@@ -627,13 +627,13 @@ async function runWineCommand({
         options.onOutput(data, child)
       }
 
-      stderr.add(data.trim())
+      stderr.push(data.trim())
     })
 
     child.on('close', async () => {
       const response = {
-        stderr: stderr.toString(),
-        stdout: stdout.toString()
+        stderr: stderr.join(),
+        stdout: stdout.join()
       }
 
       if (wait && wineVersion.wineserver) {
@@ -740,7 +740,7 @@ async function callRunner(
         options.onOutput(data, child)
       }
 
-      stdout.add(data.trim())
+      stdout.push(data.trim())
     })
 
     child.stderr.setEncoding('utf-8')
@@ -757,12 +757,12 @@ async function callRunner(
         options.onOutput(data, child)
       }
 
-      stderr.add(data.trim())
+      stderr.push(data.trim())
     })
 
     child.on('close', (code, signal) => {
       errorHandler({
-        error: `${stdout.toString().concat(stderr.toString())}`,
+        error: `${stdout.join().concat(stderr.join())}`,
         logPath: options?.logFile,
         runner: runner.name,
         appName
@@ -773,8 +773,8 @@ async function callRunner(
       }
 
       res({
-        stdout: stdout.toString('\n'),
-        stderr: stderr.toString('\n')
+        stdout: stdout.join('\n'),
+        stderr: stderr.join('\n')
       })
     })
 

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -631,10 +631,7 @@ async function runWineCommand({
     })
 
     child.on('close', async () => {
-      const response = {
-        stderr: stderr.join(),
-        stdout: stdout.join()
-      }
+      const response = { stderr: stderr.join(), stdout: stdout.join() }
 
       if (wait && wineVersion.wineserver) {
         await new Promise<void>((res_wait) => {

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -631,7 +631,7 @@ async function runWineCommand({
     })
 
     child.on('close', async () => {
-      const response = { stderr: stderr.join(), stdout: stdout.join() }
+      const response = { stderr: stderr.join(''), stdout: stdout.join('') }
 
       if (wait && wineVersion.wineserver) {
         await new Promise<void>((res_wait) => {

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1153,6 +1153,8 @@ export async function moveOnUnix(
 
 // helper object for an array with a length limit
 // this is used when calling system processes to not store the complete output in memory
+//
+// the `limit` is the number of messages, it doesn't mean it will be exactly `limit` lines since a message can be multi-line
 const memoryLog = (limit = 50) => {
   const lines: string[] = []
 

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -904,15 +904,15 @@ export const spawnAsync = async (
     child.on('error', (error) =>
       reject({
         code: 1,
-        stdout: stdout.join(),
-        stderr: stderr.join().concat(error.message)
+        stdout: stdout.join(''),
+        stderr: stderr.join('').concat(error.message)
       })
     )
     child.on('close', (code) => {
       resolve({
         code,
-        stdout: stdout.join(),
-        stderr: stderr.join()
+        stdout: stdout.join(''),
+        stderr: stderr.join('')
       })
     })
   })

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -887,7 +887,7 @@ export const spawnAsync = async (
       if (onOutput) {
         onOutput(data.toString())
       }
-      stdout.add(data.toString())
+      stdout.push(data.toString())
     })
   }
 
@@ -896,7 +896,7 @@ export const spawnAsync = async (
       if (onOutput) {
         onOutput(data.toString())
       }
-      stderr.add(data.toString())
+      stderr.push(data.toString())
     })
   }
 
@@ -904,15 +904,15 @@ export const spawnAsync = async (
     child.on('error', (error) =>
       reject({
         code: 1,
-        stdout: stdout.toString(),
-        stderr: stderr.toString().concat(error.message)
+        stdout: stdout.join(),
+        stderr: stderr.join().concat(error.message)
       })
     )
     child.on('close', (code) => {
       resolve({
         code,
-        stdout: stdout.toString(),
-        stderr: stderr.toString()
+        stdout: stdout.join(),
+        stderr: stderr.join()
       })
     })
   })
@@ -1159,13 +1159,13 @@ const memoryLog = (limit = 50) => {
   const lines: string[] = []
 
   return {
-    add: (newLine: string) => {
+    push: (newLine: string) => {
       lines.unshift(newLine)
       if (lines.length > limit) {
         lines.length = limit
       }
     },
-    toString: (separator = '') => {
+    join: (separator = '') => {
       return lines.reverse().join(separator)
     }
   }


### PR DESCRIPTION
This PR fixes an issue where we were storing all the output of gogdl/legendary/wine/etc in memory for the duration of those processes. That means that for any process with extensive output we were storing maybe megabytes and megabytes of strings for no real use.

This PR changes that to only store the last 50 message (50 is a kinda arbitrary number thinking that we would care about the last messages of an output if needed (like to detect some error message).

This should have a beneficial impact in memory usage, specially when running games that output a lot of data when running through Wine-GE or for long installations (I've had installations extending for hours and we were storing a lot of text every single second).

In some cases the number of lines was so high that converting them to a string when we called `.join()` would actually result in an error exceeding the valid string length!!


This is a bit too specific to test, but you can change the places I changed in this PR to add a `console.log(stdout.join())` and same for stderr at the end of any of those methods to see how much we were storing in memory before and after.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
