### PR TITLE
[Fix] Return an empty string when save path calculation fails

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -73,7 +73,6 @@ import {
   getLatestReleases,
   getShellPath,
   getCurrentChangelog,
-  wait,
   checkWineBeforeLaunch
 } from './utils'
 import {
@@ -1515,14 +1514,8 @@ ipcMain.handle(
 
 ipcMain.handle(
   'getDefaultSavePath',
-  async (event, appName, runner, alreadyDefinedGogSaves) => {
-    return Promise.race([
-      getDefaultSavePath(appName, runner, alreadyDefinedGogSaves),
-      wait(15000).then(() => {
-        return runner === 'gog' ? [] : ''
-      })
-    ])
-  }
+  async (event, appName, runner, alreadyDefinedGogSaves) =>
+    getDefaultSavePath(appName, runner, alreadyDefinedGogSaves)
 )
 
 // Simulate keyboard and mouse actions as if the real input device is used

--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -42,7 +42,11 @@ async function getDefaultSavePath(
 
 async function getDefaultLegendarySavePath(appName: string): Promise<string> {
   const game = getGame(appName, 'legendary')
-  const { save_path } = game.getGameInfo()
+  const { save_folder, save_path } = game.getGameInfo()
+  logInfo(
+    ['Computing save path for save folder', save_folder],
+    LogPrefix.Legendary
+  )
   if (save_path) {
     logDebug(
       ['Legendary has a save path stored, discarding it:', save_path],

--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -89,14 +89,16 @@ async function getDefaultLegendarySavePath(appName: string): Promise<string> {
 
   // If the save path was computed successfully, Legendary will have saved
   // this path in `installed.json` (so the GameInfo)
-  const { save_path: new_save_path, save_folder } =
-    LegendaryLibrary.get().getGameInfo(appName, true)!
+  const { save_path: new_save_path } = LegendaryLibrary.get().getGameInfo(
+    appName,
+    true
+  )!
   if (!new_save_path) {
     logError(
       ['Unable to compute default save path for', appName],
       LogPrefix.Legendary
     )
-    return save_folder
+    return ''
   }
   logInfo(['Computed save path:', new_save_path], LogPrefix.Legendary)
   return new_save_path

--- a/src/backend/tray_icon/__tests__/tray_icon.test.ts
+++ b/src/backend/tray_icon/__tests__/tray_icon.test.ts
@@ -4,10 +4,12 @@ import { backendEvents } from '../../backend_events'
 import { GlobalConfig } from '../../config'
 import { RecentGame } from 'common/types'
 import { configStore } from '../../constants'
-import { wait } from '../../utils'
 
 jest.mock('../../logger/logfile')
 jest.mock('../../config')
+
+const wait = async (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms))
 
 describe('TrayIcon', () => {
   const mainWindow = new BrowserWindow()

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -869,9 +869,6 @@ async function shutdownWine(gameSettings: GameSettings) {
 const getShellPath = async (path: string): Promise<string> =>
   normalize((await execAsync(`echo "${path}"`)).stdout.trim())
 
-export const wait = async (ms: number) =>
-  new Promise((resolve) => setTimeout(resolve, ms))
-
 export const spawnAsync = async (
   command: string,
   args: string[],


### PR DESCRIPTION
This PR includes two minor improvements to our save sync code, hopefully reducing the amount of questions we get about it
- As mentioned in the title, instead of returning the save path with variables (`{AppData}/SomeApp`, for example) when the actual path can't be computed, an empty string is returned instead
- The `Promise.race` in the IPC function was removed. Apart from the reason outlined in the commit message, it is also the only way *I* could test the first change (on a somewhat slow laptop, everything takes a little longer)

To test this change:
1. Open your `~/.config/legendary/installed.json` and locate a game with a `save_path` (if you don't have one, "Loop Hero" is quick to install). Delete that property, then mark the file as read-only.
2. Start Heroic, head to the same game; try to compute the save path. You'll get an error message (about Legendary not being able to write to `installed.json`), and you'll see that the save input box is empty.
3. Make sure to reset the permissions on your `installed.json` afterwards!

There is probably also an easier way to test this, although I couldn't find anything consistent

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
