### PR TITLE
[FIX] Graphics card info can't always be resolved

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -283,6 +283,32 @@ async function handleExit() {
   app.exit()
 }
 
+const getGraphicsInfo = async (): Promise<string> => {
+  try {
+    const { controllers }: si.Systeminformation.GraphicsData =
+      await Promise.race([
+        si.graphics(),
+        new Promise((resolve) => setTimeout(resolve, 5000))
+      ])[0]
+    const graphicsCards = String(
+      controllers
+        .map(
+          ({ name, model, vram, driverVersion }, i: number) =>
+            `GPU${i}: ${name ? name : model} ${vram ? `VRAM: ${vram}MB` : ''} ${
+              driverVersion ? `DRIVER: ${driverVersion}` : ''
+            }\n`
+        )
+        .join('')
+    )
+      .replaceAll(',', '')
+      .replaceAll('\n', '')
+    return graphicsCards
+  } catch (err) {
+    logError('Could not determine Graphics Info', LogPrefix.Backend)
+    return ''
+  }
+}
+
 // This won't change while the app is running
 // Caching significantly increases performance when launching games
 let systemInfoCache = ''
@@ -306,18 +332,7 @@ const getSystemInfo = async () => {
   const { distro, kernel, arch, platform, release, codename } =
     await si.osInfo()
 
-  // get GPU information
-  const { controllers } = await si.graphics()
-  const graphicsCards = String(
-    controllers.map(
-      ({ name, model, vram, driverVersion }, i) =>
-        `GPU${i}: ${name ? name : model} ${vram ? `VRAM: ${vram}MB` : ''} ${
-          driverVersion ? `DRIVER: ${driverVersion}` : ''
-        } \n`
-    )
-  )
-    .replaceAll(',', '')
-    .replaceAll('\n', '')
+  const graphicsCards = await getGraphicsInfo()
 
   const isLinux = platform === 'linux'
   const xEnv = isLinux


### PR DESCRIPTION
When starting a game, or starting the launcher, it tries to resolve the GPU and driver information using the systeminformation library's graphics() call (aswell as cpu(), mem() and osInfo() which work unreasonably, but i do see an issue not checking if they run indefinitely too).

Fixes #2562

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
