### PR TITLE
[Fix regression] Set correct horizontal image url for GOG games

### DIFF
--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -678,7 +678,7 @@ export class GOGLibrary {
       store_url: `https://gog.com${info.url}`,
       developer: '',
       app_name: String(info.id),
-      art_cover: info.image,
+      art_cover: `https:${info.image}.jpg`,
       art_square: fallBackImage,
       cloud_save_enabled: cloudSavesEnabledGames.includes(String(info.id)),
       extra: {


### PR DESCRIPTION
I noticed a regression caused by my refactor to load GOG images async. The `art_cover` was being set incorrectly, missing the protocol and the extension based on the previous code https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/2480/files#diff-b81a7a1b73f7704fde02ec68ba60851c261a0139471d91fce4893769f9844330L637

This only happens in the main branch.

If you have this issue already in your configuration files you might need to delete the gog_store/library.json and store_cache/gog_library.json files so it gets updated (I guess clearing heroic cache should fix that too)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
