### PR TITLE
[UI] Limit width of elements in game page

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.scss
+++ b/src/frontend/screens/Game/GamePage/index.scss
@@ -199,10 +199,16 @@
     max-width: 420px;
   }
 
+  & > *:not(:first-child) {
+    max-width: 560px;
+  }
+
   .infoWrapper {
     color: var(--text-default);
     flex-grow: 1;
     line-height: 22px;
+    display: flex;
+    flex-direction: column;
 
     .iconWithText {
       transition: color 300ms;
@@ -213,6 +219,11 @@
         margin-right: var(--space-3xs);
       }
     }
+  }
+
+  .timeContainerLabel,
+  .iconWithText {
+    align-self: flex-start;
   }
 
   .developer {


### PR DESCRIPTION
Some elements in the game page are too wide and it's confusing that clicking on the right side of the screen can actually toggle on the popups for info/scores/etc.

This PR makes those elements only use the size they need and also limits the width of the `launch options` dropdown.

Before:

![image](https://user-images.githubusercontent.com/188464/227753402-60ea3fef-992d-4fcb-97ab-6e34e0dd4fbf.png)

You can see the `Click to open` title floating on the right side, you can't tell what it will open

After:

![image](https://user-images.githubusercontent.com/188464/227753425-81d63039-2c4e-4a3f-9658-73a30438f477.png)

In the after you can see the dropdown now matches the width of the button and also the outline of the element is just the space needed for the element.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
