### PR TITLE
[FIX] Fix sideload statuses

### DIFF
--- a/src/backend/sideload/games.ts
+++ b/src/backend/sideload/games.ts
@@ -179,6 +179,12 @@ export async function launchApp(appName: string): Promise<boolean> {
         }
       }
 
+      sendFrontendMessage('gameStatusUpdate', {
+        appName: appName,
+        runner: 'sideload',
+        status: 'playing'
+      })
+
       const commandParts = shlex.split(launcherArgs ?? '')
       await callRunner(
         commandParts,
@@ -214,6 +220,12 @@ export async function launchApp(appName: string): Promise<boolean> {
       const globalSettings = await GameConfig.get('global').getSettings()
       gameSettings.wineVersion = globalSettings.wineVersion
     }
+
+    sendFrontendMessage('gameStatusUpdate', {
+      appName: appName,
+      runner: 'sideload',
+      status: 'playing'
+    })
 
     await runWineCommand({
       commandParts: [executable, launcherArgs ?? ''],

--- a/src/backend/sideload/games.ts
+++ b/src/backend/sideload/games.ts
@@ -179,12 +179,6 @@ export async function launchApp(appName: string): Promise<boolean> {
         }
       }
 
-      sendFrontendMessage('gameStatusUpdate', {
-        appName: appName,
-        runner: 'sideload',
-        status: 'playing'
-      })
-
       const commandParts = shlex.split(launcherArgs ?? '')
       await callRunner(
         commandParts,
@@ -202,6 +196,12 @@ export async function launchApp(appName: string): Promise<boolean> {
           logMessagePrefix: LogPrefix.Backend
         }
       )
+
+      sendFrontendMessage('gameStatusUpdate', {
+        appName: appName,
+        runner: 'sideload',
+        status: 'playing'
+      })
 
       launchCleanup(rpcClient)
       // TODO: check and revert to previous permissions
@@ -221,12 +221,6 @@ export async function launchApp(appName: string): Promise<boolean> {
       gameSettings.wineVersion = globalSettings.wineVersion
     }
 
-    sendFrontendMessage('gameStatusUpdate', {
-      appName: appName,
-      runner: 'sideload',
-      status: 'playing'
-    })
-
     await runWineCommand({
       commandParts: [executable, launcherArgs ?? ''],
       gameSettings,
@@ -237,6 +231,12 @@ export async function launchApp(appName: string): Promise<boolean> {
         logFile: appLogFileLocation(appName),
         logMessagePrefix: LogPrefix.Backend
       }
+    })
+
+    sendFrontendMessage('gameStatusUpdate', {
+      appName: appName,
+      runner: 'sideload',
+      status: 'playing'
     })
 
     launchCleanup(rpcClient)

--- a/src/backend/sideload/games.ts
+++ b/src/backend/sideload/games.ts
@@ -179,6 +179,12 @@ export async function launchApp(appName: string): Promise<boolean> {
         }
       }
 
+      sendFrontendMessage('gameStatusUpdate', {
+        appName: appName,
+        runner: 'sideload',
+        status: 'playing'
+      })
+
       const commandParts = shlex.split(launcherArgs ?? '')
       await callRunner(
         commandParts,
@@ -196,12 +202,6 @@ export async function launchApp(appName: string): Promise<boolean> {
           logMessagePrefix: LogPrefix.Backend
         }
       )
-
-      sendFrontendMessage('gameStatusUpdate', {
-        appName: appName,
-        runner: 'sideload',
-        status: 'playing'
-      })
 
       launchCleanup(rpcClient)
       // TODO: check and revert to previous permissions
@@ -221,6 +221,12 @@ export async function launchApp(appName: string): Promise<boolean> {
       gameSettings.wineVersion = globalSettings.wineVersion
     }
 
+    sendFrontendMessage('gameStatusUpdate', {
+      appName: appName,
+      runner: 'sideload',
+      status: 'playing'
+    })
+
     await runWineCommand({
       commandParts: [executable, launcherArgs ?? ''],
       gameSettings,
@@ -231,12 +237,6 @@ export async function launchApp(appName: string): Promise<boolean> {
         logFile: appLogFileLocation(appName),
         logMessagePrefix: LogPrefix.Backend
       }
-    })
-
-    sendFrontendMessage('gameStatusUpdate', {
-      appName: appName,
-      runner: 'sideload',
-      status: 'playing'
     })
 
     launchCleanup(rpcClient)


### PR DESCRIPTION
Whenever you started playing a sideloaded game, the status would be stuck on launching, this patch fixes that so that it now says playing!

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
