### PR TITLE
Call `legendary list` only once when refreshing the library

### DIFF
--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -600,6 +600,7 @@ export class GOGLibrary {
     if (!isOnline()) {
       return []
     }
+    this.sync()
     const installed = Array.from(this.installedGames.values())
     const updateable: Array<string> = []
     for (const game of installed) {

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -467,7 +467,9 @@ class GlobalState extends PureComponent<Props> {
     window.api.logInfo('Refreshing Library')
     try {
       await window.api.refreshLibrary(fullRefresh, library)
-      return await this.refresh(library, checkForUpdates)
+      setTimeout(() => {
+        this.refresh(library, checkForUpdates)
+      }, 10000)
     } catch (error) {
       window.api.logError(`${error}`)
     }

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -410,6 +410,15 @@ class GlobalState extends PureComponent<Props> {
   ): Promise<void> => {
     console.log('refreshing')
 
+    let updates = this.state.gameUpdates
+    if (checkUpdates) {
+      try {
+        updates = await window.api.checkGameUpdates()
+      } catch (error) {
+        window.api.logError(`${error}`)
+      }
+    }
+
     const currentLibraryLength = this.state.epic.library?.length
     let epicLibrary = libraryStore.get('library', [])
 
@@ -418,15 +427,6 @@ class GlobalState extends PureComponent<Props> {
       window.api.logInfo('No cache found, getting data from legendary...')
       const { library: legendaryLibrary } = await getLegendaryConfig()
       epicLibrary = legendaryLibrary
-    }
-
-    let updates = this.state.gameUpdates
-    if (checkUpdates) {
-      try {
-        updates = await window.api.checkGameUpdates()
-      } catch (error) {
-        window.api.logError(`${error}`)
-      }
     }
 
     const updatedSideload = sideloadLibrary.get('games', [])
@@ -466,10 +466,11 @@ class GlobalState extends PureComponent<Props> {
     })
     window.api.logInfo('Refreshing Library')
     try {
-      await window.api.refreshLibrary(fullRefresh, library)
-      setTimeout(() => {
-        this.refresh(library, checkForUpdates)
-      }, 10000)
+      if (!checkForUpdates) {
+        await window.api.refreshLibrary(fullRefresh, library)
+      }
+
+      return await this.refresh(library, checkForUpdates)
     } catch (error) {
       window.api.logError(`${error}`)
     }


### PR DESCRIPTION
This might fix the login issues that seems to be caused by 2 calls to `legendary list` happening at the same time.

We were doing 2 calls: one to refresh the library and, if checking updated, one to process the updates.

With this change we only do 1: if we are checking updates we don't do the first one (since checking updates now calls the same method), if we are NOT checking updates then we only do the first one.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
