### PR TITLE
[Fix]: Build Mac OS dmg workflow on main

### DIFF
--- a/.github/workflows/build-prs-mac.yml
+++ b/.github/workflows/build-prs-mac.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Build artifacts.
         run: yarn dist:mac --x64 --arm64 --publish=never
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
           NOTARIZE: false
       - name: Upload x64.
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,8 @@ jobs:
         run: yarn
       - name: Build artifacts.
         run: yarn dist:mac --x64 --arm64 --publish=never
+        env:
+          NOTARIZE: false
       - name: Upload x64.
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This PR fixes the workflow not building macos dmg on main.
The problem was that `NOTARIZE` was not set to `false` in enviroment variables.
Notarization only is done on draft-release workflow.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
