### PR TITLE
[GOG] Prevent obtaining auth and game info when app is offline

### DIFF
--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -401,6 +401,10 @@ export class GOGLibrary {
       return cache
     }
 
+    if (!isOnline) {
+      logWarning('App offline, unable to get install info')
+      return
+    }
     const credentials = await GOGUser.getCredentials()
     if (!credentials) {
       logError('No credentials, cannot get install info')

--- a/src/backend/gog/user.ts
+++ b/src/backend/gog/user.ts
@@ -85,6 +85,12 @@ export class GOGUser {
    * @returns user credentials
    */
   public static async getCredentials() {
+    if (!isOnline()) {
+      logWarning('Unable to get credentials - app is offline', {
+        prefix: LogPrefix.Gog
+      })
+      return
+    }
     const { stdout } = await runGogdlCommand(
       ['auth'],
       createAbortController('gogdl-get-credentials')


### PR DESCRIPTION
This fixes edge cases where install info is no longer available and heroic tries to obtain it while offline

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
