### PR TITLE
[FIX] GOG Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroic",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "private": true,
   "main": "build/electron/main.js",
   "homepage": "./",

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -565,10 +565,15 @@ export class GOGLibrary {
       (value) => value.appName === appName
     )
 
+    if (cachedGameData.install.platform === 'osx') {
+      newInstallPath = join(newInstallPath, cachedGameData.folder_name)
+    }
+
     installedArray[gameIndex].install_path = newInstallPath
     cachedGameData.install.install_path = newInstallPath
     installedGamesStore.set('installed', installedArray)
   }
+
   public async importGame(data: GOGImportData, path: string) {
     const gameInfo = await this.getInstallInfo(data.appName)
 

--- a/src/backend/gog/library.ts
+++ b/src/backend/gog/library.ts
@@ -653,7 +653,7 @@ export class GOGLibrary {
     return false
   }
 
-  public async checkForGameUpdate(
+  public static async getMetaResponse(
     appName: string,
     platform: string,
     etag?: string
@@ -661,17 +661,29 @@ export class GOGLibrary {
     const buildData = await axios.get(
       `https://content-system.gog.com/products/${appName}/os/${platform}/builds?generation=2`
     )
-    const metaUrl = buildData.data?.items[0]?.link
     const headers = etag
       ? {
           'If-None-Match': etag
         }
       : undefined
+    const metaUrl = buildData.data?.items[0]?.link
     const metaResponse = await axios.get(metaUrl, {
       headers,
       validateStatus: (status) => status === 200 || status === 304
     })
+    return { status: metaResponse.status, etag: metaResponse.headers.etag }
+  }
 
+  public async checkForGameUpdate(
+    appName: string,
+    platform: string,
+    etag?: string
+  ) {
+    const metaResponse = await GOGLibrary.getMetaResponse(
+      appName,
+      platform,
+      etag
+    )
     return metaResponse.status === 200
   }
 

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -229,7 +229,7 @@ const getGogdlVersion = async () => {
 const getHeroicVersion = () => {
   const VERSION_NUMBER = app.getVersion()
   const BETA_VERSION_NAME = 'Caesar Clown'
-  const STABLE_VERSION_NAME = 'Trafalgar Law'
+  const STABLE_VERSION_NAME = 'Eustass Kid'
   const isBetaorAlpha =
     VERSION_NUMBER.includes('alpha') || VERSION_NUMBER.includes('beta')
   const VERSION_NAME = isBetaorAlpha ? BETA_VERSION_NAME : STABLE_VERSION_NAME

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -70,7 +70,8 @@ async function install({
       await window.api.requestAppSettings()
     const args: Electron.OpenDialogOptions = {
       buttonLabel: t('gamepage:box.choose'),
-      properties: ['openDirectory'],
+      properties:
+        platformToInstall === 'Mac' ? ['openFile'] : ['openDirectory'],
       title: t('gamepage:box.importpath'),
       defaultPath: defaultInstallPath
     }

--- a/src/frontend/screens/Game/GamePage/index.scss
+++ b/src/frontend/screens/Game/GamePage/index.scss
@@ -194,9 +194,8 @@
     cursor: text;
   }
 
-  & > .settingSelect {
-    margin-bottom: 12px;
-    max-width: 420px;
+  & > .selectFieldWrapper.Field {
+    margin-bottom: var(--space-md);
   }
 
   & > *:not(:first-child) {

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -582,6 +582,7 @@ class GlobalState extends PureComponent<Props> {
           library: runner
         })
 
+        storage.setItem('updates', JSON.stringify(updatedGamesUpdates))
         return this.setState({
           gameUpdates: updatedGamesUpdates,
           libraryStatus: newLibraryStatus


### PR DESCRIPTION
- Fix an issue with GOG games keep asking for an update after an update since the ETAG was not being updated on installed.json file.
- Fix an issue where when changing a GOG game path on macOS games, it was not adding the .app folder to the path.
- Fix an issue with importing native GOG macOS games, where we could not select the .app file, only the folder.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
