### PR TITLE
README: Remove the instruction for removing attribute to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,6 @@ The Setup will create shortcuts to Heroic on your Desktop and in your Start Menu
 If you use Homebrew, you can run `brew install --cask --no-quarantine heroic` to install Heroic.  
 Otherwise, download the file ending in .dmg from the [latest release](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/latest), double-click it to mount it, and drag the "Heroic" application into the "Applications" folder.
 
-Afterwards open terminal and run this command : `xattr -d com.apple.quarantine /Applications/Heroic.app` this will fix the app is damaged error.
-
 ## Development environment
 
 This part will walk you through setting up a development environment so you can build Heroic binaries yourself or make changes to the code.


### PR DESCRIPTION
This is no longer needed since 2.7 as it is now properly signed with an apple developer certificate

<--- Put the description here --->
adjusted readme to reflect new changes
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ x] Tested the feature and it's working on a current and clean install.
- [ x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ x] Created / Updated Tests (If necessary)
- [ x] Created / Updated documentation (If necessary)
