### PR TITLE
[Enhancement] Add logic to Stores feature

### DIFF
--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -116,7 +116,8 @@ export default function SidebarLinks() {
               active: isActive || location.pathname.includes('store')
             })
           }
-          to="/epicstore"
+          //open gog store if only gog account logged in, otherwise by default open epic store
+          to={gog.username && !epic.username ? '/gogstore' : '/epicstore'}
         >
           <>
             <div className="Sidebar__itemIcon">


### PR DESCRIPTION
This PR makes the store feature by adding a simple logic:
- Open epic store by default
- Open gog store only if gog account logged in

Solves #2620 

Tested with both epic and gog logged in, only epic logged in and only gog logged in.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
