### PR TITLE
FIX: Fix winemenubuilder not being disabled

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -278,7 +278,7 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
       ret.WINEPREFIX = winePrefix
 
       // Disable Winemenubuilder to not mess with file associations
-      const wmbDisableString = 'winemenubuilder='
+      const wmbDisableString = 'winemenubuilder.exe=d'
       // If the user already set WINEDLLOVERRIDES, append to the end
       const dllOverridesVar = gameSettings.enviromentOptions.find(
         ({ key }) => key.toLowerCase() === 'winedlloverrides'


### PR DESCRIPTION
self explanatory
desktop files were still being created and stuff, hopefully this fixes it
https://wiki.winehq.org/FAQ#How_can_I_prevent_Wine_from_changing_the_filetype_associations_on_my_system_or_adding_unwanted_menu_entries.2Fdesktop_links.3F

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
