### PR TITLE
Fix missing game settings info in logs

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -955,7 +955,7 @@ ipcMain.handle(
 
     systemInfo.then((systemInfo) => {
       if (systemInfo === '') return
-      writeFileSync(
+      appendFileSync(
         logFileLocation,
         'System Info:\n' + `${systemInfo}\n` + '\n'
       )


### PR DESCRIPTION
This PR https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/2563/files introduced a regression. Because we are calling `writeFileSync` in the 2 places, the second call (system info) replaces the content of the file that had the content of the first call (the game settings).

Now it uses writeFileSync for the game settings and then appendFileSync for the system info to not override the content.

The game settings are now the first part of the file, before the 2.7 release the system info was first. This is not that easy to avoid since the system info fetch is async on purpose cause it can get stuck, so we can't wait for it to be the beginning of the file.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
