### PR TITLE
Trying to set correct env vars to get legendary to run without exception

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -623,13 +623,17 @@ export async function runRunnerCommand(
   options?: CallRunnerOptions
 ): Promise<ExecResult> {
   const { dir, bin } = getLegendaryBin()
+  const env = options?.env ?? ({} as Record<string, string>)
+  env['PYTHONIOENCODING'] = 'utf-8'
+
   return callRunner(
     commandParts,
     { name: 'legendary', logPrefix: LogPrefix.Legendary, bin, dir },
     abortController,
     {
       ...options,
-      verboseLogFile: legendaryLogFile
+      verboseLogFile: legendaryLogFile,
+      env: env
     }
   )
 }


### PR DESCRIPTION
This sets an additional env var to run the legendary python executable as mentioned [here](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2590#issuecomment-1518451449). This should fix #2590 
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)

I tested this on may Max Book Pro with my Epic Games Login. Everything seems to work as expected but without the error message occuring.
