### PR TITLE
[FIX] Image search on Add Game Screen blocking finish button

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -21,6 +21,7 @@ import { AvailablePlatforms } from '..'
 import fallbackImage from 'frontend/assets/heroic_card.jpg'
 import ContextProvider from 'frontend/state/ContextProvider'
 import classNames from 'classnames'
+import axios from 'axios'
 
 type Props = {
   availablePlatforms: AvailablePlatforms
@@ -50,7 +51,7 @@ export default function SideloadDialog({
     t('sideload.field.title', 'Title')
   )
   const [selectedExe, setSelectedExe] = useState('')
-  const [imageUrl, setImageUrl] = useState(fallbackImage)
+  const [imageUrl, setImageUrl] = useState('')
   const [searching, setSearching] = useState(false)
   const [app_name, setApp_name] = useState(appName ?? '')
   const [runningSetup, setRunningSetup] = useState(false)
@@ -115,20 +116,24 @@ export default function SideloadDialog({
     setSearching(true)
 
     try {
-      const res = await fetch(
-        `https://steamgrid.usebottles.com/api/search/${title}`
+      const response = await axios.get(
+        `https://steamgrid.usebottles.com/api/search/${title}`,
+        { timeout: 3500 }
       )
-      if (res.status === 200) {
-        const steamGridImage = (await res.json()) as string
+
+      if (response.status === 200) {
+        const steamGridImage = response.data as string
+
         if (steamGridImage && steamGridImage.startsWith('http')) {
           setImageUrl(steamGridImage)
         }
-        setSearching(false)
+      } else {
+        throw new Error('Fetch failed')
       }
     } catch (error) {
-      console.error('Error when getting image from SteamGridDB')
-      setSearching(false)
       window.api.logError(`${error}`)
+    } finally {
+      setSearching(false)
     }
   }
 


### PR DESCRIPTION
Fixes #2607

Adds a timeout of 3.5 seconds to get the image, otherwise gives up and uses the fallback.
Also keeps the field empty so people can see the placeholder that states that you can paste an URL there since some people were missing it.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
