### PR TITLE
[UX] Add Keyboard global shortcuts

### DIFF
--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -155,3 +155,11 @@ export const getWikiGameInfo = async (
   appName: string,
   runner: Runner
 ) => ipcRenderer.invoke('getWikiGameInfo', title, appName, runner)
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const handleGoToScreen = (callback: any) => {
+  ipcRenderer.on('openScreen', callback)
+  return () => {
+    ipcRenderer.removeListener('openScreen', callback)
+  }
+}

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -19,7 +19,8 @@ import {
   powerSaveBlocker,
   protocol,
   screen,
-  clipboard
+  clipboard,
+  globalShortcut
 } from 'electron'
 import 'backend/updater'
 import { autoUpdater } from 'electron-updater'
@@ -396,6 +397,36 @@ if (!gotTheLock) {
     downloadAntiCheatData()
 
     initTrayIcon(mainWindow)
+
+    // hotkey to reload the app
+    globalShortcut.register('CommandOrControl+R', () => {
+      mainWindow.reload()
+    })
+
+    // hotkey to quit the app
+    globalShortcut.register('CommandOrControl+Q', () => {
+      handleExit()
+    })
+
+    // hotkey to open the dev tools
+    globalShortcut.register('CommandOrControl+Shift+I', () => {
+      mainWindow.webContents.openDevTools()
+    })
+
+    // hotkey to open the settings on frontend
+    globalShortcut.register('CommandOrControl+K', () => {
+      sendFrontendMessage('openScreen', '/settings/app/default/general')
+    })
+
+    // hotkey to open the library screen on frontend
+    globalShortcut.register('CommandOrControl+L', () => {
+      sendFrontendMessage('openScreen', '/library')
+    })
+
+    // hotkey to open the downloads screen on frontend
+    globalShortcut.register('CommandOrControl+J', () => {
+      sendFrontendMessage('openScreen', '/download-manager')
+    })
 
     return
   })

--- a/src/frontend/components/UI/Sidebar/index.tsx
+++ b/src/frontend/components/UI/Sidebar/index.tsx
@@ -7,6 +7,7 @@ import HeroicVersion from './components/HeroicVersion'
 import { DMQueueElement } from 'common/types'
 
 import { ReactComponent as HeroicIcon } from 'frontend/assets/heroic-icon.svg'
+import { useNavigate } from 'react-router-dom'
 
 let sidebarSize = localStorage.getItem('sidebar-width') || 240
 const minWidth = 60
@@ -16,6 +17,8 @@ const collapsedWidth = 120
 export default React.memo(function Sidebar() {
   const sidebarEl = useRef<HTMLDivElement | null>(null)
   const [currentDMElement, setCurrentDMElement] = useState<DMQueueElement>()
+
+  const navigate = useNavigate()
 
   useEffect(() => {
     window.api.getDMQueueInformation().then(({ elements }) => {
@@ -36,7 +39,7 @@ export default React.memo(function Sidebar() {
   useEffect(() => {
     if (!sidebarEl.current) return
 
-    if (sidebarSize < collapsedWidth) {
+    if (Number(sidebarSize) < collapsedWidth) {
       sidebarEl.current.classList.add('collapsed')
     } else {
       sidebarEl.current.classList.remove('collapsed')
@@ -44,6 +47,13 @@ export default React.memo(function Sidebar() {
 
     sidebarEl.current.style.setProperty('--sidebar-width', `${sidebarSize}px`)
   }, [sidebarEl])
+
+  useEffect(() => {
+    window.api.handleGoToScreen((e: Event, screen: string) => {
+      // handle navigate to screen
+      navigate(screen, { state: { fromGameCard: false } })
+    })
+  }, [])
 
   const handleDragStart = (e: React.MouseEvent<HTMLDivElement>) => {
     let mouseDragX = e.clientX


### PR DESCRIPTION
This pull request adds several hotkeys to improve the user experience of our application. The new hotkeys are as follows:

CommandOrControl+R: Reloads the app
CommandOrControl+Q: Quits the app
CommandOrControl+Shift+I: Opens the dev tools
CommandOrControl+K: Opens the Heroic settings screen on the frontend
CommandOrControl+L: Opens the library screen
CommandOrControl+J: Opens the downloads screen

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
