### PR TITLE
[Fix] Steam Shortcuts with missing runner

### DIFF
--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -290,7 +290,10 @@ async function addNonSteamGame(props: {
     if (!isWindows) {
       args.push('--no-sandbox')
     }
-    args.push(`"heroic://launch/${props.gameInfo.app_name}"`)
+
+    const { runner, app_name } = props.gameInfo
+
+    args.push(`"heroic://launch/${runner}/${app_name}"`)
     newEntry.LaunchOptions = args.join(' ')
     if (isFlatpak) {
       newEntry.LaunchOptions = `run com.heroicgameslauncher.hgl ${newEntry.LaunchOptions}`


### PR DESCRIPTION
Small Fix to add the runner to the launch command on steam shortcuts.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
