### PR TITLE
[GOG] Fix url for horizontal images for GOG downloads

### DIFF
--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -706,7 +706,7 @@ export async function gogToUnifiedInfo(
     store_url: `https://gog.com${info.url}`,
     developer: '',
     app_name: String(info.id),
-    art_cover: info.image,
+    art_cover: `https:${info.image}.jpg`,
     art_square: fallBackImage,
     cloud_save_enabled: cloudSavesEnabledGames.includes(String(info.id)),
     extra: {


### PR DESCRIPTION
This PR fixes a regression, when downloading gog games the image url is missing parts.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
