### PR TITLE
Allow 'null' as lifespan so cachestore does not expire

### DIFF
--- a/src/backend/__tests__/cache.test.ts
+++ b/src/backend/__tests__/cache.test.ts
@@ -49,4 +49,13 @@ describe('backend/cache.ts', () => {
     jest.setSystemTime(now)
     expect(testStore2.get('foo')).toBe(undefined)
   })
+
+  test('Allows having no expiration time', () => {
+    const testStore2 = new CacheStore<string>('test_store_2', null)
+    const three_hours_ago = new Date(now).setHours(now.getHours() - 3)
+    jest.setSystemTime(three_hours_ago)
+    testStore2.set('foo', 'bar')
+    jest.setSystemTime(now)
+    expect(testStore2.get('foo')).toBe('bar')
+  })
 })

--- a/src/backend/cache.ts
+++ b/src/backend/cache.ts
@@ -2,7 +2,7 @@ import Store from 'electron-store'
 
 export default class CacheStore<ValueType, KeyType extends string = string> {
   private readonly store: Store
-  private readonly lifespan: number
+  private readonly lifespan: number | null
 
   /**
    * Creates a new cache store
@@ -10,7 +10,7 @@ export default class CacheStore<ValueType, KeyType extends string = string> {
    * @param max_value_lifespan How long an individual entry in the store will
    *                           be cached (in minutes)
    */
-  constructor(filename: string, max_value_lifespan = 60 * 6) {
+  constructor(filename: string, max_value_lifespan: number | null = 60 * 6) {
     this.store = new Store({
       cwd: 'store_cache',
       name: filename,
@@ -35,7 +35,7 @@ export default class CacheStore<ValueType, KeyType extends string = string> {
     const updateDate = new Date(lastUpdateTimestamp)
     const msSinceUpdate = Date.now() - updateDate.getTime()
     const minutesSinceUpdate = msSinceUpdate / 1000 / 60
-    if (minutesSinceUpdate > this.lifespan) {
+    if (this.lifespan && minutesSinceUpdate > this.lifespan) {
       this.store.delete(key)
       this.store.delete(`__timestamp.${key}`)
       return fallback

--- a/src/backend/cache.ts
+++ b/src/backend/cache.ts
@@ -26,19 +26,22 @@ export default class CacheStore<ValueType, KeyType extends string = string> {
       return fallback
     }
 
-    const lastUpdateTimestamp = this.store.get(`__timestamp.${key}`) as
-      | string
-      | undefined
-    if (!lastUpdateTimestamp) {
-      return fallback
-    }
-    const updateDate = new Date(lastUpdateTimestamp)
-    const msSinceUpdate = Date.now() - updateDate.getTime()
-    const minutesSinceUpdate = msSinceUpdate / 1000 / 60
-    if (this.lifespan && minutesSinceUpdate > this.lifespan) {
-      this.store.delete(key)
-      this.store.delete(`__timestamp.${key}`)
-      return fallback
+    if (this.lifespan) {
+      const lastUpdateTimestamp = this.store.get(`__timestamp.${key}`) as
+        | string
+        | undefined
+      if (!lastUpdateTimestamp) {
+        return fallback
+      }
+
+      const updateDate = new Date(lastUpdateTimestamp)
+      const msSinceUpdate = Date.now() - updateDate.getTime()
+      const minutesSinceUpdate = msSinceUpdate / 1000 / 60
+      if (minutesSinceUpdate > this.lifespan) {
+        this.store.delete(key)
+        this.store.delete(`__timestamp.${key}`)
+        return fallback
+      }
     }
 
     return this.store.get(key) as ValueType

--- a/src/backend/storeManagers/gog/electronStores.ts
+++ b/src/backend/storeManagers/gog/electronStores.ts
@@ -19,7 +19,7 @@ const apiInfoCache = new CacheStore<{
   isUpdated: boolean
   data: GamesDBData
 }>('gog_api_info')
-const libraryStore = new CacheStore<GameInfo[], 'games'>('gog_library')
+const libraryStore = new CacheStore<GameInfo[], 'games'>('gog_library', null)
 const syncStore = new TypeCheckedStoreBackend('gogSyncStore', {
   cwd: 'gog_store',
   name: 'saveTimestamps',

--- a/src/backend/storeManagers/legendary/electronStores.ts
+++ b/src/backend/storeManagers/legendary/electronStores.ts
@@ -5,7 +5,10 @@ import { LegendaryInstallInfo } from 'common/types/legendary'
 const installStore = new CacheStore<LegendaryInstallInfo>(
   'legendary_install_info'
 )
-const libraryStore = new CacheStore<GameInfo[], 'library'>('legendary_library')
+const libraryStore = new CacheStore<GameInfo[], 'library'>(
+  'legendary_library',
+  null
+)
 
 const gameInfoStore = new CacheStore<ExtraInfo>('legendary_gameinfo')
 

--- a/src/frontend/helpers/electronStores.ts
+++ b/src/frontend/helpers/electronStores.ts
@@ -61,7 +61,7 @@ export class TypeCheckedStoreFrontend<
 
 class CacheStore<ValueType, KeyType extends string = string> {
   private readonly storeName: string
-  private readonly lifespan: number
+  private readonly lifespan: number | null
 
   /**
    * Creates a new cache store
@@ -69,7 +69,7 @@ class CacheStore<ValueType, KeyType extends string = string> {
    * @param max_value_lifespan How long an individual entry in the store will
    *                           be cached (in minutes)
    */
-  constructor(filename: string, max_value_lifespan = 60 * 6) {
+  constructor(filename: string, max_value_lifespan: number | null = 60 * 6) {
     this.storeName = filename
     window.api.storeNew(filename, {
       cwd: 'store_cache',
@@ -96,7 +96,7 @@ class CacheStore<ValueType, KeyType extends string = string> {
     const updateDate = new Date(lastUpdateTimestamp)
     const msSinceUpdate = Date.now() - updateDate.getTime()
     const minutesSinceUpdate = msSinceUpdate / 1000 / 60
-    if (minutesSinceUpdate > this.lifespan) {
+    if (this.lifespan && minutesSinceUpdate > this.lifespan) {
       window.api.storeDelete(this.storeName, key)
       window.api.storeDelete(this.storeName, `__timestamp.${key}`)
       return
@@ -115,7 +115,10 @@ const configStore = new TypeCheckedStoreFrontend('configStore', {
   cwd: 'store'
 })
 
-const libraryStore = new CacheStore<GameInfo[], 'library'>('legendary_library')
+const libraryStore = new CacheStore<GameInfo[], 'library'>(
+  'legendary_library',
+  null
+)
 
 const wineDownloaderInfoStore = new TypeCheckedStoreFrontend(
   'wineDownloaderInfoStore',
@@ -125,7 +128,7 @@ const wineDownloaderInfoStore = new TypeCheckedStoreFrontend(
   }
 )
 
-const gogLibraryStore = new CacheStore<GameInfo[], 'games'>('gog_library')
+const gogLibraryStore = new CacheStore<GameInfo[], 'games'>('gog_library', null)
 const gogInstalledGamesStore = new TypeCheckedStoreFrontend(
   'gogInstalledGamesStore',
   {


### PR DESCRIPTION
This PR adds a tweak to the CacheStore class to allow `null` as the lifespan for the cache values. With that added I configured the libraries to not expire.

Another option is to move these back to a normal ElectronStore but I think this change is simpler.

This should fix some issues users have reported opening heroic for the first time in a given day:
- library going blank when offline for a day
- library getting re-fetched completely after a day

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
