### PR TITLE
fix killing wine on non native games

### DIFF
--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -848,7 +848,7 @@ export async function stop(appName: string, stopWine = true): Promise<void> {
   const pattern = isLinux ? appName : 'gogdl'
   killPattern(pattern)
 
-  if (stopWine && !isNative(appName) && isLinux) {
+  if (stopWine && !isNative(appName)) {
     const gameSettings = await getSettings(appName)
     await shutdownWine(gameSettings)
   }

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -973,7 +973,7 @@ export async function stop(appName: string, stopWine = true) {
   const pattern = process.platform === 'linux' ? appName : 'legendary'
   killPattern(pattern)
 
-  if (stopWine && isNative(appName)) {
+  if (stopWine && !isNative(appName)) {
     const gameSettings = await getSettings(appName)
     await shutdownWine(gameSettings)
   }

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -9,7 +9,7 @@ import {
 import { libraryStore } from './electronStores'
 import { GameConfig } from '../../game_config'
 import { isWindows, isMac, isLinux, icon } from '../../constants'
-import { killPattern } from '../../utils'
+import { killPattern, shutdownWine } from '../../utils'
 import { logInfo, LogPrefix, logWarning } from '../../logger/logger'
 import path, { dirname, resolve } from 'path'
 import { existsSync, rmSync } from 'graceful-fs'
@@ -129,6 +129,11 @@ export async function stop(appName: string): Promise<void> {
     const split = executable.split('/')
     const exe = split[split.length - 1]
     killPattern(exe)
+
+    if (!isNative(appName)) {
+      const gameSettings = await getSettings(appName)
+      shutdownWine(gameSettings)
+    }
   }
 }
 


### PR DESCRIPTION
also was broken by the refactor, and seems to have broken sideloaded apps, legendary, and gog on macOS, which is quite a lot lol.

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
