### PR TITLE
[FIX] fix Keyboard shortcuts being activated globally rather than within heroic

### DIFF
--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -155,11 +155,3 @@ export const getWikiGameInfo = async (
   appName: string,
   runner: Runner
 ) => ipcRenderer.invoke('getWikiGameInfo', title, appName, runner)
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const handleGoToScreen = (callback: any) => {
-  ipcRenderer.on('openScreen', callback)
-  return () => {
-    ipcRenderer.removeListener('openScreen', callback)
-  }
-}

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -19,8 +19,7 @@ import {
   powerSaveBlocker,
   protocol,
   screen,
-  clipboard,
-  globalShortcut
+  clipboard
 } from 'electron'
 import 'backend/updater'
 import { autoUpdater } from 'electron-updater'
@@ -397,36 +396,6 @@ if (!gotTheLock) {
     downloadAntiCheatData()
 
     initTrayIcon(mainWindow)
-
-    // hotkey to reload the app
-    globalShortcut.register('CommandOrControl+R', () => {
-      mainWindow.reload()
-    })
-
-    // hotkey to quit the app
-    globalShortcut.register('CommandOrControl+Q', () => {
-      handleExit()
-    })
-
-    // hotkey to open the dev tools
-    globalShortcut.register('CommandOrControl+Shift+I', () => {
-      mainWindow.webContents.openDevTools()
-    })
-
-    // hotkey to open the settings on frontend
-    globalShortcut.register('CommandOrControl+K', () => {
-      sendFrontendMessage('openScreen', '/settings/app/default/general')
-    })
-
-    // hotkey to open the library screen on frontend
-    globalShortcut.register('CommandOrControl+L', () => {
-      sendFrontendMessage('openScreen', '/library')
-    })
-
-    // hotkey to open the downloads screen on frontend
-    globalShortcut.register('CommandOrControl+J', () => {
-      sendFrontendMessage('openScreen', '/download-manager')
-    })
 
     return
   })

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -12,7 +12,6 @@ import {
 import * as path from 'path'
 import {
   BrowserWindow,
-  Menu,
   app,
   dialog,
   ipcMain,
@@ -210,7 +209,7 @@ async function initializeWindow(): Promise<BrowserWindow> {
     // Open the DevTools.
     mainWindow.webContents.openDevTools()
   } else {
-    Menu.setApplicationMenu(null)
+    mainWindow.setMenuBarVisibility(false)
     mainWindow.loadURL(`file://${path.join(publicDir, '../build/index.html')}`)
     autoUpdater.checkForUpdates()
   }

--- a/src/frontend/components/UI/Sidebar/index.tsx
+++ b/src/frontend/components/UI/Sidebar/index.tsx
@@ -7,7 +7,6 @@ import HeroicVersion from './components/HeroicVersion'
 import { DMQueueElement } from 'common/types'
 
 import { ReactComponent as HeroicIcon } from 'frontend/assets/heroic-icon.svg'
-import { useNavigate } from 'react-router-dom'
 
 let sidebarSize = localStorage.getItem('sidebar-width') || 240
 const minWidth = 60
@@ -17,8 +16,6 @@ const collapsedWidth = 120
 export default React.memo(function Sidebar() {
   const sidebarEl = useRef<HTMLDivElement | null>(null)
   const [currentDMElement, setCurrentDMElement] = useState<DMQueueElement>()
-
-  const navigate = useNavigate()
 
   useEffect(() => {
     window.api.getDMQueueInformation().then(({ elements }) => {
@@ -39,7 +36,7 @@ export default React.memo(function Sidebar() {
   useEffect(() => {
     if (!sidebarEl.current) return
 
-    if (Number(sidebarSize) < collapsedWidth) {
+    if (sidebarSize < collapsedWidth) {
       sidebarEl.current.classList.add('collapsed')
     } else {
       sidebarEl.current.classList.remove('collapsed')
@@ -47,13 +44,6 @@ export default React.memo(function Sidebar() {
 
     sidebarEl.current.style.setProperty('--sidebar-width', `${sidebarSize}px`)
   }, [sidebarEl])
-
-  useEffect(() => {
-    window.api.handleGoToScreen((e: Event, screen: string) => {
-      // handle navigate to screen
-      navigate(screen, { state: { fromGameCard: false } })
-    })
-  }, [])
 
   const handleDragStart = (e: React.MouseEvent<HTMLDivElement>) => {
     let mouseDragX = e.clientX

--- a/src/frontend/components/UI/Sidebar/index.tsx
+++ b/src/frontend/components/UI/Sidebar/index.tsx
@@ -36,7 +36,7 @@ export default React.memo(function Sidebar() {
   useEffect(() => {
     if (!sidebarEl.current) return
 
-    if (sidebarSize < collapsedWidth) {
+    if (Number(sidebarSize) < collapsedWidth) {
       sidebarEl.current.classList.add('collapsed')
     } else {
       sidebarEl.current.classList.remove('collapsed')


### PR DESCRIPTION
Unfortunately, we lose the custom shortcuts we created (but we retain the default ones, like reload, dev tools, quit, etc), but at least I don't have heroic stealing focus every time I press control-r

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
