### PR TITLE
[Fix] Handle shortcuts from the frontend without depending on menu

### DIFF
--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -88,6 +88,17 @@ export const clipboardWriteText = async (text: string) =>
 export const pathExists = async (path: string) =>
   ipcRenderer.invoke('pathExists', path)
 
+export const processShortcut = async (combination: string) =>
+  ipcRenderer.send('processShortcut', combination)
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const handleGoToScreen = (callback: any) => {
+  ipcRenderer.on('openScreen', callback)
+  return () => {
+    ipcRenderer.removeListener('openScreen', callback)
+  }
+}
+
 export const handleShowDialog = (
   onMessage: (
     e: Electron.IpcRendererEvent,
@@ -155,11 +166,3 @@ export const getWikiGameInfo = async (
   appName: string,
   runner: Runner
 ) => ipcRenderer.invoke('getWikiGameInfo', title, appName, runner)
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const handleGoToScreen = (callback: any) => {
-  ipcRenderer.on('openScreen', callback)
-  return () => {
-    ipcRenderer.removeListener('openScreen', callback)
-  }
-}

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -19,8 +19,7 @@ import {
   powerSaveBlocker,
   protocol,
   screen,
-  clipboard,
-  globalShortcut
+  clipboard
 } from 'electron'
 import 'backend/updater'
 import { autoUpdater } from 'electron-updater'
@@ -397,36 +396,6 @@ if (!gotTheLock) {
     downloadAntiCheatData()
 
     initTrayIcon(mainWindow)
-
-    // hotkey to reload the app
-    globalShortcut.register('CommandOrControl+R', () => {
-      mainWindow.reload()
-    })
-
-    // hotkey to quit the app
-    globalShortcut.register('CommandOrControl+Q', () => {
-      handleExit()
-    })
-
-    // hotkey to open the dev tools
-    globalShortcut.register('CommandOrControl+Shift+I', () => {
-      mainWindow.webContents.openDevTools()
-    })
-
-    // hotkey to open the settings on frontend
-    globalShortcut.register('CommandOrControl+K', () => {
-      sendFrontendMessage('openScreen', '/settings/app/default/general')
-    })
-
-    // hotkey to open the library screen on frontend
-    globalShortcut.register('CommandOrControl+L', () => {
-      sendFrontendMessage('openScreen', '/library')
-    })
-
-    // hotkey to open the downloads screen on frontend
-    globalShortcut.register('CommandOrControl+J', () => {
-      sendFrontendMessage('openScreen', '/download-manager')
-    })
 
     return
   })
@@ -1641,6 +1610,36 @@ ipcMain.handle('isNative', (e, { appName, runner }) => {
 
 ipcMain.handle('pathExists', async (e, path: string) => {
   return existsSync(path)
+})
+
+ipcMain.on('processShortcut', async (e, combination: string) => {
+  const mainWindow = getMainWindow()
+
+  switch (combination) {
+    // hotkey to reload the app
+    case 'ctrl+r':
+      mainWindow?.reload()
+      break
+    // hotkey to quit the app
+    case 'ctrl+q':
+      handleExit()
+      break
+    // hotkey to open the settings on frontend
+    case 'ctrl+k':
+      sendFrontendMessage('openScreen', '/settings/app/default/general')
+      break
+    // hotkey to open the downloads screen on frontend
+    case 'ctrl+j':
+      sendFrontendMessage('openScreen', '/download-manager')
+      break
+    // hotkey to open the library screen on frontend
+    case 'ctrl+l':
+      sendFrontendMessage('openScreen', '/library')
+      break
+    case 'ctrl+shift+i':
+      mainWindow?.webContents?.openDevTools()
+      break
+  }
 })
 
 /*

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -79,6 +79,7 @@ interface SyncIPCFunctions {
   logInfo: (message: unknown) => void
   showItemInFolder: (item: string) => void
   clipboardWriteText: (text: string) => void
+  processShortcut: (combination: string) => void
   addNewApp: (args: SideloadGame) => void
   showLogFileInFolder: (args: {
     appName: string

--- a/src/frontend/helpers/shortcuts.ts
+++ b/src/frontend/helpers/shortcuts.ts
@@ -4,5 +4,21 @@ export const initShortcuts = () => {
     if ((e.ctrlKey || e.metaKey) && e.key.toLocaleLowerCase() === 'f') {
       document.getElementById('search')?.focus()
     }
+
+    if (e.ctrlKey || e.metaKey) {
+      // Ctrl+R or Cmd+R, reload
+      // Ctrl+L or Cmd+L, show library
+      // Ctrl+J or Cmd+J, download manager
+      // Ctrl+K or Cmd+K, settings
+      // Ctrl+Q or Cmd+Q, quit heroic
+      if (['r', 'j', 'k', 'l', 'q'].includes(e.key)) {
+        window.api.processShortcut(`ctrl+${e.key}`)
+      }
+
+      // Ctrl+Shift+I or Cmd+Shift+I, open devtools
+      if (e.key === 'I') {
+        window.api.processShortcut(`ctrl+shift+${e.key.toLocaleLowerCase()}`)
+      }
+    }
   })
 }


### PR DESCRIPTION
This PR is an adaptation of the current globalShortcuts feature, instead of using globalShorcuts that are causing issues, it uses an event listener in the frontend and based on the different combinations it sends a message to the backend to be processed

This fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2676 and fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2671

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
