### PR TITLE
[Fix] Linux native games failing to add to launcher

### DIFF
--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -410,6 +410,7 @@ export async function getInstallInfo(
     return
   }
 
+  // We can't calculate install sizes for Linux-native games, so call gogdl info with "windows"
   const commandParts = [
     'info',
     appName,
@@ -417,7 +418,7 @@ export async function getInstallInfo(
     `"${credentials.access_token}"`,
     `--lang=${lang}`,
     '--os',
-    installPlatform
+    installPlatform === 'linux' ? 'windows' : installPlatform
   ]
 
   const res = await runRunnerCommand(


### PR DESCRIPTION
Due to the error in obtaining the installation info for them, Linux-native (GOG) games were being installed on the system but not added to the Launcher as reported in #2678 . This workaround gets the Windows install info instead, proceeding with successful installation.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
