### PR TITLE
Simplify access of main `BrowserWindow` and consume less resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ vite-plugin-electron.log
 #flatpak
 flatpak-build
 .env
+
+# Ignore IDE-generated files
+*~

--- a/src/backend/dialog/dialog.ts
+++ b/src/backend/dialog/dialog.ts
@@ -2,7 +2,7 @@ import { LogPrefix, logWarning } from '../logger/logger'
 import { dialog, Notification } from 'electron'
 import { ButtonOptions, DialogType } from 'common/types'
 import { isSteamDeckGameMode } from '../constants'
-import { getMainWindow, sendFrontendMessage } from '../main_window'
+import { mainWindow, sendFrontendMessage } from '../main_window'
 
 const { showErrorBox, showMessageBox } = dialog
 

--- a/src/backend/dialog/dialog.ts
+++ b/src/backend/dialog/dialog.ts
@@ -33,17 +33,15 @@ function showDialogBoxModalAuto(props: {
     } catch (error) {
       logWarning(['showDialogBoxModalAuto:', error], LogPrefix.Backend)
 
-      const window = getMainWindow()
-
       switch (props.type) {
         case 'ERROR':
           showErrorBox(props.title, props.message)
           break
         default:
-          if (!window) {
+          if (!mainWindow) {
             break
           }
-          showMessageBox(window, {
+          showMessageBox(mainWindow, {
             title: props.title,
             message: props.message,
             buttons: props.buttons?.map((button) => button.text) || []
@@ -61,7 +59,6 @@ type NotifyType = {
 
 function notify({ body, title }: NotifyType) {
   if (Notification.isSupported() && !isSteamDeckGameMode) {
-    const mainWindow = getMainWindow()
     const notify = new Notification({
       body,
       title

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -126,7 +126,7 @@ import si from 'systeminformation'
 import { initTrayIcon } from './tray_icon/tray_icon'
 import {
   createMainWindow,
-  getMainWindow,
+  mainWindow,
   sendFrontendMessage
 } from './main_window'
 
@@ -251,7 +251,6 @@ if (!gotTheLock) {
 } else {
   app.on('second-instance', (event, argv) => {
     // Someone tried to run a second instance, we should focus our window.
-    const mainWindow = getMainWindow()
     mainWindow?.show()
 
     handleProtocol(argv)
@@ -509,7 +508,6 @@ app.on('window-all-closed', () => {
 
 app.on('open-url', (event, url) => {
   event.preventDefault()
-  const mainWindow = getMainWindow()
 
   if (mainWindow) {
     handleProtocol([url])
@@ -937,7 +935,6 @@ ipcMain.handle(
       status: 'launching'
     })
 
-    const mainWindow = getMainWindow()
     const showAfterClose = mainWindow?.isVisible()
     if (minimizeOnLaunch) {
       mainWindow?.hide()
@@ -1078,7 +1075,6 @@ ipcMain.handle(
 )
 
 ipcMain.handle('openDialog', async (e, args) => {
-  const mainWindow = getMainWindow()
   if (!mainWindow) {
     return false
   }
@@ -1435,9 +1431,6 @@ ipcMain.handle(
 
 // Simulate keyboard and mouse actions as if the real input device is used
 ipcMain.handle('gamepadAction', async (event, args) => {
-  // we can only receive gamepad events if the main window exists
-  const mainWindow = getMainWindow()!
-
   const { action, metadata } = args
   const inputEvents: GamepadInputEvent[] = []
 
@@ -1613,8 +1606,6 @@ ipcMain.handle('pathExists', async (e, path: string) => {
 })
 
 ipcMain.on('processShortcut', async (e, combination: string) => {
-  const mainWindow = getMainWindow()
-
   switch (combination) {
     // hotkey to reload the app
     case 'ctrl+r':

--- a/src/backend/main_window.ts
+++ b/src/backend/main_window.ts
@@ -2,11 +2,7 @@ import { BrowserWindow, screen } from 'electron'
 import path from 'path'
 import { configStore } from './constants'
 
-let mainWindow: BrowserWindow | null = null
-
-export const getMainWindow = () => {
-  return mainWindow
-}
+export let mainWindow: BrowserWindow | null = null
 
 // send a message to the main window's webContents if available
 // returns `false` if no mainWindow or no webContents
@@ -59,12 +55,7 @@ export const createMainWindow = () => {
 
     webPreferences: {
       webviewTag: true,
-      contextIsolation: true,
-      nodeIntegration: true,
-      // sandbox: false,
       preload: path.join(__dirname, 'preload.js')
     }
   })
-
-  return mainWindow
 }

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -3,7 +3,7 @@ import { logError, logInfo, LogPrefix } from './logger/logger'
 import i18next from 'i18next'
 import { getInfo } from './utils'
 import { GameInfo, Runner } from 'common/types'
-import { getMainWindow, sendFrontendMessage } from './main_window'
+import { mainWindow, sendFrontendMessage } from './main_window'
 import { icon } from './constants'
 
 type Command = 'ping' | 'launch'
@@ -20,8 +20,6 @@ const RUNNERS = ['legendary', 'gog', 'sideload']
  * // => 'Received launch! Runner: gog, Arg: 123'
  **/
 export async function handleProtocol(args: string[]) {
-  const mainWindow = getMainWindow()
-
   const url = getUrl(args)
   if (!url) {
     return

--- a/src/backend/shortcuts/nonesteamgame/steamhelper.ts
+++ b/src/backend/shortcuts/nonesteamgame/steamhelper.ts
@@ -18,20 +18,18 @@ import {
   steamDBBaseURL
 } from './constants'
 import { nativeImage } from 'electron'
-import { getMainWindow } from 'backend/main_window'
+import { mainWindow } from 'backend/main_window'
 
 const generateImage = async (
   src: string,
   width: number,
   height: number
 ): Promise<string> => {
-  const window = getMainWindow()
-
-  if (!window) {
+  if (!mainWindow) {
     return Promise.resolve('')
   }
 
-  return window.webContents.executeJavaScript(
+  return mainWindow.webContents.executeJavaScript(
     `window.imageData("${src}", ${width}, ${height})`
   )
 }

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -55,7 +55,7 @@ import {
 import * as fileSize from 'filesize'
 import makeClient from 'discord-rich-presence-typescript'
 import { notify, showDialogBoxModalAuto } from './dialog/dialog'
-import { getMainWindow, sendFrontendMessage } from './main_window'
+import { mainWindow, sendFrontendMessage } from './main_window'
 import { GlobalConfig } from './config'
 import { GameConfig } from './game_config'
 import { validWine, runWineCommand } from './launcher'
@@ -247,7 +247,6 @@ const showAboutWindow = () => {
 
 async function handleExit() {
   const isLocked = existsSync(join(gamesConfigPath, 'lock'))
-  const mainWindow = getMainWindow()
 
   if (isLocked && mainWindow) {
     const { response } = await showMessageBox(mainWindow, {


### PR DESCRIPTION
<--- Put the description here --->
This PR replaces `getMainWindow()` with `mainWindow`, which simplifies code and calls to `mainWindow`. It also helps keep just 1 version of it instead of multiple references.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
