### PR TITLE
[UI] sidebar link effect

### DIFF
--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.css
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.css
@@ -3,7 +3,8 @@
   font-size: var(--text-lg);
 }
 
-.Sidebar__item.SidebarLinks__subItem, .Sidebar__item.SidebarLinks__subItem:hover  {
+.Sidebar__item.SidebarLinks__subItem,
+.Sidebar__item.SidebarLinks__subItem:hover {
   padding: var(--space-3xs) var(--sidebar-horizontal-padding) var(--space-3xs)
     var(--space-xl);
   font-size: var(--text-sm);
@@ -26,7 +27,8 @@
 }
 
 @media screen and (max-width: 730px) {
-  .Sidebar__item.SidebarLinks__subItem, .Sidebar__item.SidebarLinks__subItem:hover {
+  .Sidebar__item.SidebarLinks__subItem,
+  .Sidebar__item.SidebarLinks__subItem:hover {
     padding: var(--space-3xs) var(--sidebar-horizontal-padding) var(--space-3xs)
       var(--space-lg);
   }

--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.css
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.css
@@ -3,7 +3,7 @@
   font-size: var(--text-lg);
 }
 
-.Sidebar__item.SidebarLinks__subItem {
+.Sidebar__item.SidebarLinks__subItem, .Sidebar__item.SidebarLinks__subItem:hover  {
   padding: var(--space-3xs) var(--sidebar-horizontal-padding) var(--space-3xs)
     var(--space-xl);
   font-size: var(--text-sm);
@@ -17,11 +17,6 @@
   padding-left: 12px;
 }
 
-.Sidebar__item.SidebarLinks__subItem:hover {
-  padding: var(--space-3xs) var(--sidebar-horizontal-padding) var(--space-3xs)
-    var(--space-xl);
-}
-
 .Sidebar__item.SidebarLinks__subItem::before {
   content: '• ';
 }
@@ -31,12 +26,7 @@
 }
 
 @media screen and (max-width: 730px) {
-  .Sidebar__item.SidebarLinks__subItem {
-    padding: var(--space-3xs) var(--sidebar-horizontal-padding) var(--space-3xs)
-      var(--space-lg);
-  }
-
-  .Sidebar__item.SidebarLinks__subItem:hover {
+  .Sidebar__item.SidebarLinks__subItem, .Sidebar__item.SidebarLinks__subItem:hover {
     padding: var(--space-3xs) var(--sidebar-horizontal-padding) var(--space-3xs)
       var(--space-lg);
   }

--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.css
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.css
@@ -11,6 +11,17 @@
   white-space: break-spaces;
 }
 
+.Sidebar__item:hover {
+  background-color: var(--navbar-active-background);
+  transition: 0.1s;
+  padding-left: 12px;
+}
+
+.Sidebar__item.SidebarLinks__subItem:hover {
+  padding: var(--space-3xs) var(--sidebar-horizontal-padding) var(--space-3xs)
+    var(--space-xl);
+}
+
 .Sidebar__item.SidebarLinks__subItem::before {
   content: '• ';
 }
@@ -21,6 +32,11 @@
 
 @media screen and (max-width: 730px) {
   .Sidebar__item.SidebarLinks__subItem {
+    padding: var(--space-3xs) var(--sidebar-horizontal-padding) var(--space-3xs)
+      var(--space-lg);
+  }
+
+  .Sidebar__item.SidebarLinks__subItem:hover {
     padding: var(--space-3xs) var(--sidebar-horizontal-padding) var(--space-3xs)
       var(--space-lg);
   }

--- a/src/frontend/components/UI/Sidebar/index.scss
+++ b/src/frontend/components/UI/Sidebar/index.scss
@@ -70,16 +70,6 @@
   outline-offset: -2px;
 }
 
-.Sidebar__item:hover {
-  background-color: var(--navbar-active-background);
-  transition: 0.2s;
-  scale: 1.02;
-}
-
-.Sidebar__item.SidebarLinks__subItem:hover {
-  scale: 1;
-}
-
 .Sidebar__item.active {
   color: var(--accent);
   color: var(--navbar-active, var(--accent-overlay));


### PR DESCRIPTION
Ever since the scale hover effect was implemented on the Sidebar links (by me), I found it a bit weird over time.

This PR brings in a new and simple hover effect that slides the item to the left on hover.

[SidebarHover.webm](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/74495920/f4d14098-028f-4e06-8f1e-1274669fdfbb)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
