### PR TITLE
[Fix] `AppSettings` type mismatches

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -5,7 +5,7 @@ import {
   readdirSync,
   writeFileSync
 } from 'graceful-fs'
-import { homedir, userInfo as user } from 'os'
+import { homedir } from 'os'
 import { parse as plistParse, PlistObject } from 'plist'
 
 import {
@@ -13,7 +13,6 @@ import {
   GlobalConfigVersion,
   WineInstallation
 } from 'common/types'
-import { LegendaryUser } from 'backend/storeManagers/legendary/user'
 import {
   currentGlobalConfigVersion,
   configPath,
@@ -579,12 +578,10 @@ class GlobalConfigV0 extends GlobalConfig {
   }
 
   public getFactoryDefaults(): AppSettings {
-    const account_id = LegendaryUser.getUserInfo()?.account_id
-    const userName = user().username
-    const defaultWine = isWindows ? {} : this.getDefaultWine()
+    // @ts-expect-error FIXME: Settings values don't work like this in other parts of the codebase
+    const defaultWine: WineInstallation = isWindows ? {} : this.getDefaultWine()
 
-    // @ts-expect-error TODO: We need to settle on *one* place to define settings defaults
-    return {
+    const settings: Partial<AppSettings> = {
       checkUpdatesInterval: 10,
       enableUpdates: false,
       addDesktopShortcuts: false,
@@ -595,7 +592,7 @@ class GlobalConfigV0 extends GlobalConfig {
       preferSystemLibs: false,
       checkForUpdatesOnStartup: !isFlatpak,
       autoUpdateGames: false,
-      customWinePaths: isWindows ? null : [],
+      customWinePaths: [],
       defaultInstallPath: heroicInstallPath,
       libraryTopSection: 'disabled',
       defaultSteamPath: getSteamCompatFolder(),
@@ -609,14 +606,12 @@ class GlobalConfigV0 extends GlobalConfig {
       wrapperOptions: [],
       showFps: false,
       useGameMode: false,
-      userInfo: {
-        epicId: account_id,
-        name: userName
-      },
       wineCrossoverBottle: 'Heroic',
       winePrefix: isWindows ? '' : defaultWinePrefix,
       wineVersion: defaultWine
-    } as AppSettings
+    }
+    // @ts-expect-error TODO: We need to settle on *one* place to define settings defaults
+    return settings
   }
 
   public setSetting(key: string, value: unknown) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -69,7 +69,6 @@ export interface AppSettings extends GameSettings {
   maxWorkers: number
   minimizeOnLaunch: boolean
   startInTray: boolean
-  userInfo: UserInfo
 }
 
 export type LibraryTopSectionOptions =


### PR DESCRIPTION
- `userInfo`'s structure was completely different to how it should be like, and it seems like it wasn't used anywhere, so removing it felt like the best option
- The `@ts-expect-error` around the object was moved, this way it won't hide errors like this in the future
- Some other smaller issues were corrected

This is also one of the many steps we'll have to take to untangle our circular dependency issues, as this `LegendaryUser` import currently leads to this import chain:
```
src/backend/constants.ts
-> src/backend/config.ts
-> src/backend/storeManagers/legendary/user.ts
-> src/backend/utils.ts
-> src/backend/storeManagers/legendary/library.ts
-> src/backend/launcher.ts
-> src/backend/tools.ts
...
```

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
