### PR TITLE
[FIX] Second try to fix Epic login

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -259,6 +259,8 @@ if (!gotTheLock) {
   app.whenReady().then(async () => {
     initStoreManagers()
     initOnlineMonitor()
+    app.userAgentFallback =
+      'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:70.0) Gecko/20100101 Firefox/70.0'
 
     getSystemInfo().then((systemInfo) => {
       if (systemInfo === '') return

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -70,17 +70,6 @@ export default function WebView() {
   const isEpicLogin = runner === 'legendary' && startUrl === epicLoginUrl
   const [preloadPath, setPreloadPath] = useState('')
 
-  // Small hack here to use the user agent of firefox on linux for the epic login screen
-  // and firefox on windows for the rest of the pages
-  // this is to test if the epic login improves
-  let userAgent =
-    'Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/85.0'
-  if (isEpicLogin) {
-    // firefox on linux for login screen
-    userAgent =
-      'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/113.0'
-  }
-
   useEffect(() => {
     let mounted = true
     const fetchLocalPreloadPath = async () => {
@@ -208,7 +197,6 @@ export default function WebView() {
         partition="persist:epicstore"
         src={startUrl}
         allowpopups={trueAsStr}
-        useragent={userAgent}
         {...(preloadPath ? { preload: preloadPath } : {})}
       />
       {showLoginWarningFor && (

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -70,6 +70,17 @@ export default function WebView() {
   const isEpicLogin = runner === 'legendary' && startUrl === epicLoginUrl
   const [preloadPath, setPreloadPath] = useState('')
 
+  // Small hack here to use the user agent of firefox on linux for the epic login screen
+  // and firefox on windows for the rest of the pages
+  // this is to test if the epic login improves
+  let userAgent =
+    'Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/85.0'
+  if (isEpicLogin) {
+    // firefox on linux for login screen
+    userAgent =
+      'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:85.0) Gecko/20100101 Firefox/85.0'
+  }
+
   useEffect(() => {
     let mounted = true
     const fetchLocalPreloadPath = async () => {
@@ -197,7 +208,7 @@ export default function WebView() {
         partition="persist:epicstore"
         src={startUrl}
         allowpopups={trueAsStr}
-        useragent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/200.0"
+        useragent={userAgent}
         {...(preloadPath ? { preload: preloadPath } : {})}
       />
       {showLoginWarningFor && (

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -78,7 +78,7 @@ export default function WebView() {
   if (isEpicLogin) {
     // firefox on linux for login screen
     userAgent =
-      'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:85.0) Gecko/20100101 Firefox/85.0'
+      'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/113.0'
   }
 
   useEffect(() => {

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -197,6 +197,7 @@ export default function WebView() {
         partition="persist:epicstore"
         src={startUrl}
         allowpopups={trueAsStr}
+        useragent="Mozilla/5.0 (Windows NT 10.0; WOW64; rv:70.0) Gecko/20100101 Firefox/70.0"
         {...(preloadPath ? { preload: preloadPath } : {})}
       />
       {showLoginWarningFor && (


### PR DESCRIPTION
Since some people said that Firefox on Linux was working fine, I changed the user agent to use it on the Login Screen only.
Tested on macOS:
- With default user agents: always fail
- With Firefox on Linux user agent: Captcha fail once and pass the second time. No reponse error message.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
