### PR TITLE
[Feat] Add DLCs manager for Epic Games

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -33,6 +33,7 @@
         },
         "uninstall": {
             "checkbox": "Remove prefix: {{prefix}}{{newLine}}Note: This can't be undone and will also remove not backed up save files.",
+            "dlc": "Do you want to Uninstall this DLC?",
             "message": "Do you want to uninstall this game?",
             "prefix_warning": "The Wine prefix for this game is the default prefix. If you really want to delete it, you have to do it manually.",
             "settingcheckbox": "Erase settings and remove log{{newLine}}Note: This can't be undone. Any modified settings will be forgotten and log will be deleted.",
@@ -74,10 +75,14 @@
     "cloud_save_unsupported": "Unsupported",
     "disabled": "Disabled",
     "dlc": {
-        "installDlcs": "Install all DLCs"
+        "cancel": "Cancel",
+        "install": "Install",
+        "installDlcs": "Install all DLCs",
+        "uninstall": "Uninstall"
     },
     "enabled": "Enabled",
     "game": {
+        "dlcs": "DLCs",
         "downloadSize": "Download Size",
         "firstPlayed": "First Played",
         "getting-download-size": "Getting download size",

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -75,10 +75,7 @@
     "cloud_save_unsupported": "Unsupported",
     "disabled": "Disabled",
     "dlc": {
-        "cancel": "Cancel",
-        "install": "Install",
-        "installDlcs": "Install all DLCs",
-        "uninstall": "Uninstall"
+        "installDlcs": "Install all DLCs"
     },
     "enabled": "Enabled",
     "game": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -180,6 +180,7 @@
     },
     "dlc": {
         "actions": "Actions",
+        "installDlcs": "Install all DLCs",
         "noDlcFound": "No DLCs found",
         "size": "Size",
         "title": "Title"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -178,6 +178,11 @@
             "update_game": "Update game"
         }
     },
+    "dlc": {
+        "actions": "Actions",
+        "size": "Size",
+        "title": "Title"
+    },
     "docs": "Documentation",
     "download-manager": {
         "ETA": "Estimated time",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -180,6 +180,7 @@
     },
     "dlc": {
         "actions": "Actions",
+        "noDlcFound": "No DLCs found",
         "size": "Size",
         "title": "Title"
     },

--- a/src/backend/api/downloadmanager.ts
+++ b/src/backend/api/downloadmanager.ts
@@ -10,7 +10,27 @@ export const install = async (args: InstallParams) => {
     endTime: 0,
     startTime: 0
   }
-  ipcRenderer.invoke('addToDMQueue', dmQueueElement)
+
+  await ipcRenderer.invoke('addToDMQueue', dmQueueElement)
+
+  // Add Dlcs to the queue
+  if (Array.isArray(args.installDlcs) && args.installDlcs.length > 0) {
+    args.installDlcs.forEach(async (dlc) => {
+      const dlcArgs: InstallParams = {
+        ...args,
+        appName: dlc,
+        installDlcs: false
+      }
+      const dlcQueueElement: DMQueueElement = {
+        params: dlcArgs,
+        type: 'install',
+        addToQueueTime: Date.now(),
+        endTime: 0,
+        startTime: 0
+      }
+      await ipcRenderer.invoke('addToDMQueue', dlcQueueElement)
+    })
+  }
 }
 
 export const updateGame = (args: UpdateParams) => {

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -393,23 +393,16 @@ abstract class GlobalConfig {
   }
 
   /**
-   * Checks if a Wine version has Wineboot/Wineserver executables and returns the path to those if they're present
+   * Checks if a Wine version has the Wineserver executable and returns the path to it if it's present
    * @param wineBin The unquoted path to the Wine binary ('wine')
-   * @returns The quoted paths to wineboot and wineserver, if present
+   * @returns The quoted path to wineserver, if present
    */
-  public getWineExecs(wineBin: string): {
-    wineboot: string
-    wineserver: string
-  } {
+  public getWineExecs(wineBin: string): { wineserver: string } {
     const wineDir = dirname(wineBin)
-    const ret = { wineserver: '', wineboot: '' }
+    const ret = { wineserver: '' }
     const potWineserverPath = join(wineDir, 'wineserver')
     if (existsSync(potWineserverPath)) {
       ret.wineserver = potWineserverPath
-    }
-    const potWinebootPath = join(wineDir, 'wineboot')
-    if (existsSync(potWinebootPath)) {
-      ret.wineboot = potWinebootPath
     }
     return ret
   }

--- a/src/backend/downloadmanager/downloadqueue.ts
+++ b/src/backend/downloadmanager/downloadqueue.ts
@@ -179,6 +179,12 @@ function getQueueInformation() {
 
 function cancelCurrentDownload({ removeDownloaded = false }) {
   if (currentElement) {
+    if (currentElement.params.installDlcs) {
+      const dlcsToRemove = currentElement.params.installDlcs as string[]
+      for (const dlc of dlcsToRemove) {
+        removeFromQueue(dlc)
+      }
+    }
     if (isRunning()) {
       stopCurrentDownload()
     }

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -428,8 +428,8 @@ export async function validWine(
   )
 
   // verify if necessary binaries exist
-  const { bin, wineboot, wineserver, type } = wineVersion
-  const necessary = type === 'wine' ? [bin, wineboot, wineserver] : [bin]
+  const { bin, wineserver, type } = wineVersion
+  const necessary = type === 'wine' ? [bin, wineserver] : [bin]
   const haveAll = necessary.every((binary) => existsSync(binary as string))
 
   // if wine version does not exist, use the default one

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -330,7 +330,7 @@ export async function install(
     is_dlc: false,
     version: additionalInfo ? additionalInfo.version : installInfo.game.version,
     appName: appName,
-    installedWithDLCs: installDlcs,
+    installedWithDLCs: Boolean(installDlcs),
     language: installLanguage,
     versionEtag: isLinuxNative ? '' : installInfo.manifest.versionEtag,
     buildId: isLinuxNative ? '' : installInfo.game.buildId

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -550,7 +550,7 @@ function getSdlList(sdlList: Array<string>) {
  */
 export async function install(
   appName: string,
-  { path, installDlcs, sdlList, platformToInstall }: InstallArgs
+  { path, sdlList, platformToInstall }: InstallArgs
 ): Promise<{
   status: 'done' | 'error' | 'abort'
   error?: string
@@ -559,7 +559,6 @@ export async function install(
   const info = await getInstallInfo(appName, platformToInstall)
   const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
   const noHttps = downloadNoHttps ? ['--no-https'] : []
-  const withDlcs = installDlcs ? '--with-dlcs' : '--skip-dlcs'
   const installSdl = sdlList?.length ? getSdlList(sdlList) : ['--skip-sdl']
 
   const logPath = join(gamesConfigPath, appName + '.log')
@@ -571,7 +570,7 @@ export async function install(
     platformToInstall,
     '--base-path',
     path,
-    withDlcs,
+    '--skip-dlcs',
     ...installSdl,
     ...workers,
     ...noHttps,

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -566,6 +566,7 @@ function loadFile(fileName: string): boolean {
       reqs: [],
       storeUrl: formatEpicStoreUrl(title)
     },
+    dlcList: dlcItemList,
     folder_name: installFolder,
     install: {
       executable,

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -121,10 +121,7 @@ interface AsyncIPCFunctions {
   showUpdateSetting: () => boolean
   getLatestReleases: () => Promise<Release[]>
   getCurrentChangelog: () => Promise<Release | null>
-  getGameInfo: (
-    appName: string,
-    runner: Runner
-  ) => Promise<GameInfo | SideloadGame | null>
+  getGameInfo: (appName: string, runner: Runner) => Promise<GameInfo | null>
   getExtraInfo: (appName: string, runner: Runner) => Promise<ExtraInfo | null>
   getGameSettings: (
     appName: string,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -228,7 +228,6 @@ export interface WineInstallation {
   type: 'wine' | 'proton' | 'crossover'
   lib?: string
   lib32?: string
-  wineboot?: string
   wineserver?: string
 }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -235,7 +235,7 @@ export interface WineInstallation {
 export interface InstallArgs {
   path: string
   platformToInstall: InstallPlatform
-  installDlcs?: boolean
+  installDlcs?: Array<string> | boolean
   sdlList?: string[]
   installLanguage?: string
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,5 @@
 import { GOGCloudSavesLocation, GogInstallPlatform } from './types/gog'
-import { LegendaryInstallPlatform } from './types/legendary'
+import { LegendaryInstallPlatform, GameMetadataInner } from './types/legendary'
 import { IpcRendererEvent } from 'electron'
 import { ChildProcess } from 'child_process'
 import { HowLongToBeatEntry } from 'howlongtobeat'
@@ -122,6 +122,7 @@ export interface GameInfo {
   description?: string
   //used for store release versions. if remote !== local, then update
   version?: string
+  dlcList?: GameMetadataInner[]
 }
 
 export interface GameSettings {

--- a/src/common/types/legendary.ts
+++ b/src/common/types/legendary.ts
@@ -142,9 +142,10 @@ interface GameInstallInfo {
   version: string
 }
 
-interface DLCInfo {
+export interface DLCInfo {
   app_name: string
   title: string
+  is_installed?: boolean
 }
 
 interface GameManifest {

--- a/src/common/types/legendary.ts
+++ b/src/common/types/legendary.ts
@@ -47,7 +47,7 @@ interface AssetInfo {
   namespace: string
 }
 
-interface GameMetadataInner {
+export interface GameMetadataInner {
   // TODO: So far every age gating has been {}
   ageGatings: Record<string, unknown>
   applicationId: string

--- a/src/frontend/components/UI/DLCList/DLC/index.scss
+++ b/src/frontend/components/UI/DLCList/DLC/index.scss
@@ -1,24 +1,30 @@
 .dlcItem {
-  display: flex;
+  display: grid;
+  grid-template-columns: 3fr 1fr 1fr;
+  grid-template-rows: auto;
+  grid-gap: var(--space-md-fixed);
+  grid-template-areas: 'title size action';
   justify-content: space-between;
   align-items: center;
   padding: 1rem 0;
   border-bottom: 1px solid #ccc;
-  margin: 0 var(--space-md-fixed);
 
   &:last-child {
     border-bottom: none;
   }
   .title {
     grid-area: title;
-    font-size: 1.3rem;
-    font-weight: 600;
-    margin-right: var(--space-xl-fixed);
+    font-weight: 400;
+  }
+  .size {
+    grid-area: size;
+    font-weight: 400;
+    text-align: center;
   }
   .action {
     grid-area: action;
-    font-size: 1.2rem;
     font-weight: 400;
+    text-align: center;
     cursor: pointer;
     color: var(--primary);
     transition: color 0.2s ease-in-out;

--- a/src/frontend/components/UI/DLCList/DLC/index.scss
+++ b/src/frontend/components/UI/DLCList/DLC/index.scss
@@ -1,0 +1,29 @@
+.dlcItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+  border-bottom: 1px solid #ccc;
+  margin: 0 var(--space-md-fixed);
+
+  &:last-child {
+    border-bottom: none;
+  }
+  .title {
+    grid-area: title;
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin-right: var(--space-xl-fixed);
+  }
+  .action {
+    grid-area: action;
+    font-size: 1.2rem;
+    font-weight: 400;
+    cursor: pointer;
+    color: var(--primary);
+    transition: color 0.2s ease-in-out;
+    &:hover {
+      color: var(--secondary);
+    }
+  }
+}

--- a/src/frontend/components/UI/DLCList/DLC/index.tsx
+++ b/src/frontend/components/UI/DLCList/DLC/index.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react'
+import { DLCInfo } from 'common/types/legendary'
+import './index.scss'
+import { useTranslation } from 'react-i18next'
+import { getGameInfo, install } from 'frontend/helpers'
+import { Runner } from 'common/types'
+import UninstallModal from 'frontend/components/UI/UninstallModal'
+
+type Props = {
+  dlc: DLCInfo
+  runner: Runner
+}
+
+const DLC = ({ dlc, runner }: Props) => {
+  const { title, app_name } = dlc
+  const { t } = useTranslation('gamepage')
+  const [isInstalled, setIsInstalled] = useState(false)
+  const [showUninstallModal, setShowUninstallModal] = useState(false)
+
+  useEffect(() => {
+    const checkInstalled = async () => {
+      const dlcInfo = await getGameInfo(app_name, runner)
+      console.table(dlcInfo)
+      const installed = dlcInfo.is_installed
+      setIsInstalled(installed)
+    }
+    checkInstalled()
+  }, [dlc, runner])
+
+  function mainAction() {
+    if (isInstalled) {
+      setShowUninstallModal(true)
+    } else {
+      console.log('installing')
+    }
+  }
+
+  return (
+    <>
+      {showUninstallModal && (
+        <UninstallModal
+          appName={app_name}
+          runner={runner}
+          onClose={() => setShowUninstallModal(false)}
+          isDlc
+        />
+      )}
+      <div className="dlcItem">
+        <span className="title">{title}</span>
+        <span className="action" onClick={() => mainAction()}>
+          {isInstalled
+            ? t('dlc.uninstall', 'Uninstall')
+            : t('dlc.install', 'Install')}
+        </span>
+      </div>
+    </>
+  )
+}
+
+export default React.memo(DLC)

--- a/src/frontend/components/UI/DLCList/DLC/index.tsx
+++ b/src/frontend/components/UI/DLCList/DLC/index.tsx
@@ -129,10 +129,9 @@ const DLC = ({ dlc, runner, mainAppInfo, onClose }: Props) => {
           </span>
         )}
         {refreshing && (
-          <FontAwesomeIcon
-            className={'InstallModal__sizeIcon fa-spin-pulse'}
-            icon={faSpinner}
-          />
+          <span className="action">
+            <FontAwesomeIcon className={'fa-spin-pulse'} icon={faSpinner} />
+          </span>
         )}
       </div>
     </>

--- a/src/frontend/components/UI/DLCList/DLC/index.tsx
+++ b/src/frontend/components/UI/DLCList/DLC/index.tsx
@@ -20,7 +20,9 @@ const DLC = ({ dlc, runner }: Props) => {
   useEffect(() => {
     const checkInstalled = async () => {
       const dlcInfo = await getGameInfo(app_name, runner)
-      console.table(dlcInfo)
+      if (!dlcInfo) {
+        return
+      }
       const installed = dlcInfo.is_installed
       setIsInstalled(installed)
     }

--- a/src/frontend/components/UI/DLCList/DLC/index.tsx
+++ b/src/frontend/components/UI/DLCList/DLC/index.tsx
@@ -5,15 +5,14 @@ import { useTranslation } from 'react-i18next'
 import { getGameInfo, getInstallInfo, install, size } from 'frontend/helpers'
 import { GameInfo, Runner } from 'common/types'
 import UninstallModal from 'frontend/components/UI/UninstallModal'
-import {
-  faCancel,
-  faCloudArrowDown,
-  faSpinner,
-  faTrash
-} from '@fortawesome/free-solid-svg-icons'
+import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { hasProgress } from 'frontend/hooks/hasProgress'
+import { ReactComponent as DownIcon } from 'frontend/assets/down-icon.svg'
+import { ReactComponent as StopIcon } from 'frontend/assets/stop-icon.svg'
+import { ReactComponent as StopIconAlt } from 'frontend/assets/stop-icon-alt.svg'
+import SvgButton from '../../SvgButton'
 
 type Props = {
   dlc: DLCInfo
@@ -108,24 +107,26 @@ const DLC = ({ dlc, runner, mainAppInfo, onClose }: Props) => {
         <span className="title">{title}</span>
         {refreshing ? '...' : <span className="size">{size(dlcSize)}</span>}
         {showInstallButton && (
-          <span className="action" onClick={() => mainAction()}>
-            <FontAwesomeIcon
-              icon={isInstalled ? faTrash : faCloudArrowDown}
-              title={
-                isInstalled
-                  ? t('dlc.uninstall', 'Uninstall')
-                  : t('dlc.install', 'Install')
-              }
-            />
-          </span>
+          <SvgButton
+            className="action"
+            onClick={() => mainAction()}
+            title={`${
+              isInstalled
+                ? t('button.uninstall', 'Uninstall')
+                : t('button.install', 'Install')
+            } (${title})`}
+          >
+            {isInstalled ? <StopIcon /> : <DownIcon />}
+          </SvgButton>
         )}
         {isInstalling && (
-          <span className="action" onClick={() => mainAction()}>
-            <FontAwesomeIcon
-              icon={faCancel}
-              title={t('dlc.cancel', 'Cancel')}
-            />
-          </span>
+          <SvgButton
+            className="action"
+            onClick={() => mainAction()}
+            title={`${t('button.cancel', 'Cancel')} (${title})`}
+          >
+            <StopIconAlt />
+          </SvgButton>
         )}
         {refreshing && (
           <span className="action">

--- a/src/frontend/components/UI/DLCList/DLC/index.tsx
+++ b/src/frontend/components/UI/DLCList/DLC/index.tsx
@@ -26,12 +26,13 @@ const DLC = ({ dlc, runner, mainAppInfo, onClose }: Props) => {
   const { title, app_name } = dlc
   const { libraryStatus, showDialogModal } = useContext(ContextProvider)
   const { t } = useTranslation('gamepage')
-  const [isInstalled, setIsInstalled] = useState(false)
   const [showUninstallModal, setShowUninstallModal] = useState(false)
   const [dlcInfo, setDlcInfo] = useState<GameInfo | null>(null)
   const [dlcSize, setDlcSize] = useState<number>(0)
   const [refreshing, setRefreshing] = useState(true)
   const [progress] = hasProgress(app_name)
+
+  const isInstalled = dlcInfo?.is_installed
 
   useEffect(() => {
     const checkInstalled = async () => {
@@ -40,8 +41,6 @@ const DLC = ({ dlc, runner, mainAppInfo, onClose }: Props) => {
         return
       }
       setDlcInfo(info)
-      const installed = info.is_installed
-      setIsInstalled(installed)
     }
     checkInstalled()
   }, [dlc, runner])

--- a/src/frontend/components/UI/DLCList/DLC/index.tsx
+++ b/src/frontend/components/UI/DLCList/DLC/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { DLCInfo } from 'common/types/legendary'
 import './index.scss'
 import { useTranslation } from 'react-i18next'
-import { getGameInfo, install } from 'frontend/helpers'
+import { getGameInfo } from 'frontend/helpers'
 import { Runner } from 'common/types'
 import UninstallModal from 'frontend/components/UI/UninstallModal'
 

--- a/src/frontend/components/UI/DLCList/index.scss
+++ b/src/frontend/components/UI/DLCList/index.scss
@@ -1,0 +1,10 @@
+.dlcHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 1rem;
+  height: 3rem;
+  border-bottom: 1px solid #e5e5e5;
+  font-size: 1.3rem;
+  font-weight: 600;
+}

--- a/src/frontend/components/UI/DLCList/index.scss
+++ b/src/frontend/components/UI/DLCList/index.scss
@@ -1,10 +1,22 @@
 .dlcHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0 1rem;
-  height: 3rem;
-  border-bottom: 1px solid #e5e5e5;
-  font-size: 1.3rem;
-  font-weight: 600;
+  display: grid;
+  grid-template-columns: 3fr 1fr 1fr;
+  grid-template-rows: auto;
+  grid-gap: 10px;
+  font-weight: 700;
+  color: var(--text-default);
+
+  .title {
+    grid-column: 1 / 2;
+  }
+
+  .size {
+    grid-column: 2 / 3;
+    text-align: center;
+  }
+
+  .actions {
+    grid-column: 3 / 4;
+    text-align: center;
+  }
 }

--- a/src/frontend/components/UI/DLCList/index.tsx
+++ b/src/frontend/components/UI/DLCList/index.tsx
@@ -16,10 +16,11 @@ const DlcList = ({ dlcs, runner, mainAppInfo, onClose }: Props) => {
   const { t } = useTranslation()
 
   return (
-    <div className="wineList">
+    <div className="dlcList">
       <div className="dlcHeader">
-        <span>{t('dlc.title', 'Title')}</span>
-        <span>{t('dlc.actions', 'Actions')}</span>
+        <span className="title">{t('dlc.title', 'Title')}</span>
+        <span className="size">{t('dlc.size', 'Size')}</span>
+        <span className="actions">{t('dlc.actions', 'Actions')}</span>
       </div>
       {dlcs.map((dlc) => {
         return (

--- a/src/frontend/components/UI/DLCList/index.tsx
+++ b/src/frontend/components/UI/DLCList/index.tsx
@@ -22,17 +22,21 @@ const DlcList = ({ dlcs, runner, mainAppInfo, onClose }: Props) => {
         <span className="size">{t('dlc.size', 'Size')}</span>
         <span className="actions">{t('dlc.actions', 'Actions')}</span>
       </div>
-      {dlcs.map((dlc) => {
-        return (
-          <DLC
-            key={dlc.app_name}
-            dlc={dlc}
-            runner={runner}
-            mainAppInfo={mainAppInfo}
-            onClose={onClose}
-          />
-        )
-      })}
+      {dlcs.length > 0 &&
+        dlcs.map((dlc) => {
+          return (
+            <DLC
+              key={dlc.app_name}
+              dlc={dlc}
+              runner={runner}
+              mainAppInfo={mainAppInfo}
+              onClose={onClose}
+            />
+          )
+        })}
+      {dlcs.length === 0 && (
+        <div className="noDlcFound">{t('dlc.noDlcFound', 'No DLCs found')}</div>
+      )}
     </div>
   )
 }

--- a/src/frontend/components/UI/DLCList/index.tsx
+++ b/src/frontend/components/UI/DLCList/index.tsx
@@ -17,11 +17,13 @@ const DlcList = ({ dlcs, runner, mainAppInfo, onClose }: Props) => {
 
   return (
     <div className="dlcList">
-      <div className="dlcHeader">
-        <span className="title">{t('dlc.title', 'Title')}</span>
-        <span className="size">{t('dlc.size', 'Size')}</span>
-        <span className="actions">{t('dlc.actions', 'Actions')}</span>
-      </div>
+      {dlcs.length > 0 && (
+        <div className="dlcHeader">
+          <span className="title">{t('dlc.title', 'Title')}</span>
+          <span className="size">{t('dlc.size', 'Size')}</span>
+          <span className="actions">{t('dlc.actions', 'Actions')}</span>
+        </div>
+      )}
       {dlcs.length > 0 &&
         dlcs.map((dlc) => {
           return (

--- a/src/frontend/components/UI/DLCList/index.tsx
+++ b/src/frontend/components/UI/DLCList/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { DLCInfo } from 'common/types/legendary'
+import DLC from './DLC'
+import './index.scss'
+import { Runner } from 'common/types'
+
+type Props = {
+  dlcs: DLCInfo[]
+  runner: Runner
+}
+
+const DlcList = ({ dlcs, runner }: Props) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="wineList">
+      <div className="dlcHeader">
+        <span>{t('dlc.title', 'Title')}</span>
+        <span>{t('dlc.actions', 'Actions')}</span>
+      </div>
+      {dlcs.map((dlc) => {
+        return <DLC key={dlc.app_name} dlc={dlc} runner={runner} />
+      })}
+    </div>
+  )
+}
+
+export default React.memo(DlcList)

--- a/src/frontend/components/UI/DLCList/index.tsx
+++ b/src/frontend/components/UI/DLCList/index.tsx
@@ -3,14 +3,16 @@ import { useTranslation } from 'react-i18next'
 import { DLCInfo } from 'common/types/legendary'
 import DLC from './DLC'
 import './index.scss'
-import { Runner } from 'common/types'
+import { GameInfo, Runner } from 'common/types'
 
 type Props = {
   dlcs: DLCInfo[]
   runner: Runner
+  mainAppInfo: GameInfo
+  onClose: () => void
 }
 
-const DlcList = ({ dlcs, runner }: Props) => {
+const DlcList = ({ dlcs, runner, mainAppInfo, onClose }: Props) => {
   const { t } = useTranslation()
 
   return (
@@ -20,7 +22,15 @@ const DlcList = ({ dlcs, runner }: Props) => {
         <span>{t('dlc.actions', 'Actions')}</span>
       </div>
       {dlcs.map((dlc) => {
-        return <DLC key={dlc.app_name} dlc={dlc} runner={runner} />
+        return (
+          <DLC
+            key={dlc.app_name}
+            dlc={dlc}
+            runner={runner}
+            mainAppInfo={mainAppInfo}
+            onClose={onClose}
+          />
+        )
       })}
     </div>
   )

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -19,13 +19,13 @@ type InstallArgs = {
   isInstalling: boolean
   previousProgress: InstallProgress | null
   progress: InstallProgress
+  t: TFunction<'gamepage'>
+  showDialogModal: (options: DialogModalOptions) => void
   setInstallPath?: (path: string) => void
   platformToInstall?: InstallPlatform
-  t: TFunction<'gamepage'>
   installDlcs?: boolean
   sdlList?: Array<string>
   installLanguage?: string
-  showDialogModal: (options: DialogModalOptions) => void
 }
 
 async function install({

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -19,11 +19,11 @@ type InstallArgs = {
   isInstalling: boolean
   previousProgress: InstallProgress | null
   progress: InstallProgress
+  installDlcs?: Array<string> | boolean
   t: TFunction<'gamepage'>
   showDialogModal: (options: DialogModalOptions) => void
   setInstallPath?: (path: string) => void
   platformToInstall?: InstallPlatform
-  installDlcs?: boolean
   sdlList?: Array<string>
   installLanguage?: string
 }

--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
@@ -75,7 +75,11 @@ const DownloadManagerItem = ({ element, current, state }: Props) => {
     getNewInfo()
   }, [element])
 
-  const { art_cover, art_square } = gameInfo || {}
+  const {
+    art_cover,
+    art_square,
+    install: { is_dlc }
+  } = gameInfo || {}
 
   const [progress] = hasProgress(appName)
   const { status } = element
@@ -100,6 +104,9 @@ const DownloadManagerItem = ({ element, current, state }: Props) => {
   }
 
   const goToGamePage = () => {
+    if (is_dlc) {
+      return
+    }
     return navigate(`/gamepage/${runner}/${appName}`, {
       state: { fromDM: true, gameInfo: gameInfo }
     })
@@ -127,6 +134,9 @@ const DownloadManagerItem = ({ element, current, state }: Props) => {
 
   const mainActionIcon = () => {
     if (finished) {
+      if (is_dlc) {
+        return <>-</>
+      }
       return <PlayIcon className="playIcon" />
     }
 
@@ -212,7 +222,10 @@ const DownloadManagerItem = ({ element, current, state }: Props) => {
         role="button"
         onClick={() => goToGamePage()}
         className="downloadManagerTitleList"
-        style={{ color: getStatusColor() }}
+        style={{
+          color: getStatusColor(),
+          cursor: is_dlc ? 'default' : 'pointer'
+        }}
       >
         {cover && <CachedImage src={cover} alt={title} />}
         <span className="titleSize">

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -766,6 +766,8 @@ export default React.memo(function GamePage(): JSX.Element | null {
                   <DLCList
                     dlcs={gameInstallInfo?.game.owned_dlc}
                     runner={runner}
+                    mainAppInfo={gameInfo}
+                    onClose={() => setShowDlcs(false)}
                   />
                 </DialogContent>
               </Dialog>

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -76,6 +76,7 @@ import { hasStatus } from 'frontend/hooks/hasStatus'
 import PopoverComponent from 'frontend/components/UI/PopoverComponent'
 import HowLongToBeat from 'frontend/components/UI/WikiGameInfo/components/HowLongToBeat'
 import GameScore from 'frontend/components/UI/WikiGameInfo/components/GameScore'
+import DLCList from 'frontend/components/UI/DLCList'
 
 export default React.memo(function GamePage(): JSX.Element | null {
   const { appName, runner } = useParams() as { appName: string; runner: Runner }
@@ -121,6 +122,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const [winePrefix, setWinePrefix] = useState('')
   const [wineVersion, setWineVersion] = useState<WineInstallation>()
   const [showRequirements, setShowRequirements] = useState(false)
+  const [showDlcs, setShowDlcs] = useState(false)
 
   const isWin = platform === 'win32'
   const isLinux = platform === 'linux'
@@ -295,6 +297,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
     hasRequirements = extraInfo?.reqs ? extraInfo.reqs.length > 0 : false
     hasUpdate = is_installed && gameUpdates?.includes(appName)
+    const hasDlcs = gameInstallInfo?.game?.owned_dlc.length
 
     const { howlongtobeat, pcgamingwiki, applegamingwiki } = wikiGameInfo || {}
     const hasHLTB = Boolean(howlongtobeat?.gameplayMain)
@@ -403,6 +406,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                         ? () => setShowRequirements(true)
                         : undefined
                     }
+                    onShowDlcs={hasDlcs ? () => setShowDlcs(true) : undefined}
                   />
                 </div>
               </div>
@@ -750,6 +754,19 @@ export default React.memo(function GamePage(): JSX.Element | null {
                 </DialogHeader>
                 <DialogContent>
                   <GameRequirements reqs={extraInfo?.reqs} />
+                </DialogContent>
+              </Dialog>
+            )}
+            {hasDlcs && showDlcs && (
+              <Dialog showCloseButton onClose={() => setShowDlcs(false)}>
+                <DialogHeader onClose={() => setShowDlcs(false)}>
+                  <div>{t('game.dlcs', 'DLCs')}</div>
+                </DialogHeader>
+                <DialogContent>
+                  <DLCList
+                    dlcs={gameInstallInfo?.game.owned_dlc}
+                    runner={runner}
+                  />
                 </DialogContent>
               </Dialog>
             )}

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -297,7 +297,6 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
     hasRequirements = extraInfo?.reqs ? extraInfo.reqs.length > 0 : false
     hasUpdate = is_installed && gameUpdates?.includes(appName)
-    const hasDlcs = gameInstallInfo?.game?.owned_dlc.length
 
     const { howlongtobeat, pcgamingwiki, applegamingwiki } = wikiGameInfo || {}
     const hasHLTB = Boolean(howlongtobeat?.gameplayMain)
@@ -406,7 +405,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                         ? () => setShowRequirements(true)
                         : undefined
                     }
-                    onShowDlcs={hasDlcs ? () => setShowDlcs(true) : undefined}
+                    onShowDlcs={() => setShowDlcs(true)}
                   />
                 </div>
               </div>
@@ -757,18 +756,22 @@ export default React.memo(function GamePage(): JSX.Element | null {
                 </DialogContent>
               </Dialog>
             )}
-            {hasDlcs && showDlcs && (
+            {showDlcs && (
               <Dialog showCloseButton onClose={() => setShowDlcs(false)}>
                 <DialogHeader onClose={() => setShowDlcs(false)}>
                   <div>{t('game.dlcs', 'DLCs')}</div>
                 </DialogHeader>
                 <DialogContent>
-                  <DLCList
-                    dlcs={gameInstallInfo?.game.owned_dlc}
-                    runner={runner}
-                    mainAppInfo={gameInfo}
-                    onClose={() => setShowDlcs(false)}
-                  />
+                  {gameInstallInfo ? (
+                    <DLCList
+                      dlcs={gameInstallInfo?.game.owned_dlc}
+                      runner={runner}
+                      mainAppInfo={gameInfo}
+                      onClose={() => setShowDlcs(false)}
+                    />
+                  ) : (
+                    <UpdateComponent inline />
+                  )}
                 </DialogContent>
               </Dialog>
             )}

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -215,7 +215,7 @@ export default function GamesSubmenu({
     return <CircularProgress className="link button is-text is-link" />
   }
 
-  const showDlcsItem = onShowDlcs && runner === 'legendary'
+  const showDlcsItem = onShowDlcs && runner === 'legendary' && isInstalled
 
   return (
     <>

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -22,6 +22,7 @@ interface Props {
   handleUpdate: () => void
   disableUpdate: boolean
   onShowRequirements?: () => void
+  onShowDlcs?: () => void
 }
 
 export default function GamesSubmenu({
@@ -32,7 +33,8 @@ export default function GamesSubmenu({
   runner,
   handleUpdate,
   disableUpdate,
-  onShowRequirements
+  onShowRequirements,
+  onShowDlcs
 }: Props) {
   const { refresh, platform, libraryStatus, showDialogModal } =
     useContext(ContextProvider)
@@ -221,6 +223,7 @@ export default function GamesSubmenu({
             appName={appName}
             runner={runner}
             onClose={() => setShowUninstallModal(false)}
+            isDlc={false}
           />
         )}
         <div className={`submenu`}>
@@ -331,6 +334,14 @@ export default function GamesSubmenu({
               className="link button is-text is-link"
             >
               {t('game.requirements', 'Requirements')}
+            </button>
+          )}
+          {onShowDlcs && (
+            <button
+              onClick={async () => onShowDlcs()}
+              className="link button is-text is-link"
+            >
+              {t('game.dlcs', 'DLCs')}
             </button>
           )}
         </div>

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -215,6 +215,8 @@ export default function GamesSubmenu({
     return <CircularProgress className="link button is-text is-link" />
   }
 
+  const showDlcsItem = onShowDlcs && runner === 'legendary'
+
   return (
     <>
       <div className="gameTools subMenuContainer">
@@ -336,7 +338,7 @@ export default function GamesSubmenu({
               {t('game.requirements', 'Requirements')}
             </button>
           )}
-          {onShowDlcs && (
+          {showDlcsItem && (
             <button
               onClick={async () => onShowDlcs()}
               className="link button is-text is-link"

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -368,6 +368,7 @@ const GameCard = ({
         <UninstallModal
           appName={appName}
           runner={runner}
+          isDlc={Boolean(gameInfo.install.is_dlc)}
           onClose={() => setShowUninstallModal(false)}
         />
       )}

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/DLCDownloadListing.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/DLCDownloadListing.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react'
+import ToggleSwitch from 'frontend/components/UI/ToggleSwitch'
+import { useTranslation } from 'react-i18next'
+import { DLCInfo } from 'common/types/legendary'
+
+interface Props {
+  DLCList: DLCInfo[]
+  dlcsToInstall: string[]
+  setDlcsToInstall: (dlcs: string[]) => void
+}
+
+const DLCDownloadListing: React.FC<Props> = ({
+  DLCList,
+  setDlcsToInstall,
+  dlcsToInstall
+}) => {
+  const { t } = useTranslation()
+  const [installAllDlcs, setInstallAllDlcs] = useState(false)
+
+  if (!DLCList) {
+    return null
+  }
+
+  const handleAllDlcs = () => {
+    setInstallAllDlcs(!installAllDlcs)
+    if (!installAllDlcs) {
+      setDlcsToInstall(DLCList.map(({ app_name }) => app_name))
+    }
+
+    if (installAllDlcs) {
+      setDlcsToInstall([])
+    }
+  }
+
+  const handleDlcToggle = (index: number) => {
+    const { app_name } = DLCList[index]
+    const newDlcsToInstall = [...dlcsToInstall]
+    if (newDlcsToInstall.includes(app_name)) {
+      newDlcsToInstall.splice(newDlcsToInstall.indexOf(app_name), 1)
+    } else {
+      newDlcsToInstall.push(app_name)
+    }
+    setDlcsToInstall(newDlcsToInstall)
+
+    if (newDlcsToInstall.length === DLCList.length) {
+      setInstallAllDlcs(true)
+    }
+
+    if (newDlcsToInstall.length < DLCList.length) {
+      setInstallAllDlcs(false)
+    }
+  }
+
+  return (
+    <div className="InstallModal__dlcs">
+      <label className="InstallModal__toggle toggleWrapper">
+        <ToggleSwitch
+          htmlId="dlcs"
+          value={installAllDlcs}
+          handleChange={() => handleAllDlcs()}
+          title={t('dlc.installDlcs', 'Install all DLCs')}
+        />
+      </label>
+      <div className="InstallModal__dlcsList">
+        {DLCList?.map(({ title, app_name }, index) => (
+          <label
+            key={title}
+            className="InstallModal__toggle toggleWrapper"
+            title={title}
+          >
+            <ToggleSwitch
+              htmlId={`dlc-${index}`}
+              value={dlcsToInstall.includes(app_name)}
+              title={title}
+              handleChange={() => handleDlcToggle(index)}
+            />
+          </label>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default DLCDownloadListing

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/DLCDownloadListing.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/DLCDownloadListing.tsx
@@ -41,14 +41,7 @@ const DLCDownloadListing: React.FC<Props> = ({
       newDlcsToInstall.push(app_name)
     }
     setDlcsToInstall(newDlcsToInstall)
-
-    if (newDlcsToInstall.length === DLCList.length) {
-      setInstallAllDlcs(true)
-    }
-
-    if (newDlcsToInstall.length < DLCList.length) {
-      setInstallAllDlcs(false)
-    }
+    setInstallAllDlcs(newDlcsToInstall.length === DLCList.length)
   }
 
   return (

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -46,6 +46,7 @@ import { useTranslation } from 'react-i18next'
 import { AvailablePlatforms } from '../index'
 import { SDL_GAMES, SelectiveDownload } from '../selective_dl'
 import { configStore } from 'frontend/helpers/electronStores'
+import DLCDownloadListing from './DLCDownloadListing'
 
 interface Props {
   backdropClick: () => void
@@ -133,7 +134,8 @@ export default function DownloadDialog({
     (game: GameStatus) => game.appName === appName
   )[0]
 
-  const [installDlcs, setInstallDlcs] = useState(false)
+  const [dlcsToInstall, setDlcsToInstall] = useState<string[]>([])
+  const [installAllDlcs, setInstallAllDlcs] = useState(false)
   const [selectedSdls, setSelectedSdls] = useState<{ [key: string]: boolean }>(
     {}
   )
@@ -179,7 +181,7 @@ export default function DownloadDialog({
   )
 
   function handleDlcs() {
-    setInstallDlcs(!installDlcs)
+    setInstallAllDlcs(!installAllDlcs)
   }
 
   async function handleInstall(path?: string) {
@@ -210,7 +212,7 @@ export default function DownloadDialog({
       progress: previousProgress,
       t,
       sdlList,
-      installDlcs,
+      installDlcs: runner === 'gog' ? installAllDlcs : dlcsToInstall,
       installLanguage,
       platformToInstall,
       showDialogModal: () => backdropClick()
@@ -301,6 +303,7 @@ export default function DownloadDialog({
   const haveDLCs =
     gameInstallInfo && gameInstallInfo?.game?.owned_dlc?.length > 0
   const DLCList = gameInstallInfo?.game?.owned_dlc
+
   const downloadSize = () => {
     if (gameInstallInfo?.manifest?.download_size) {
       if (previousProgress.folder === installPath) {
@@ -357,6 +360,9 @@ export default function DownloadDialog({
     installPath &&
     gameInstallInfo?.manifest?.download_size &&
     !gettingInstallInfo
+
+  const showDlcSelector =
+    runner === 'legendary' && DLCList && DLCList?.length > 0
 
   return (
     <>
@@ -521,12 +527,19 @@ export default function DownloadDialog({
             ))}
           </div>
         )}
-        {haveDLCs && (
+        {showDlcSelector && (
+          <DLCDownloadListing
+            DLCList={DLCList}
+            dlcsToInstall={dlcsToInstall}
+            setDlcsToInstall={setDlcsToInstall}
+          />
+        )}
+        {haveDLCs && runner === 'gog' && (
           <div className="InstallModal__dlcs">
             <label className={classNames('InstallModal__toggle toggleWrapper')}>
               <ToggleSwitch
                 htmlId="dlcs"
-                value={installDlcs}
+                value={installAllDlcs}
                 handleChange={() => handleDlcs()}
                 title={t('dlc.installDlcs', 'Install all DLCs')}
               />

--- a/src/frontend/screens/Library/components/InstallModal/index.css
+++ b/src/frontend/screens/Library/components/InstallModal/index.css
@@ -82,8 +82,6 @@
 
 .InstallModal__dlcsList {
   max-width: 300px;
-  margin: var(--space-md)
-    calc(var(--space-md) + var(--space-xs) + var(--space-sm));
   color: var(--text-default);
 }
 


### PR DESCRIPTION
This PR adds the ability to:
- Select individual DLCs to be installed for Epic games, instead of installing all or nothing.
- Adds a new item on the Game Page SubMenu to open a DLC manager dialog where is possible to install and uninstall available DLCs.
- Works only for Epic for now, GOG keeps the current behavior until GogDL adds this feature as well.
- When selecting the DLCs on the install dialog, they will be added to the download Queue just after the main game.

<img width="758" alt="image" src="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/26871415/cea44fa0-6ba4-474e-88e6-7fdb1055a106">

<img width="491" alt="image" src="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/26871415/466a3a03-b97f-4096-8e14-300b3dac5d27">

![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/26871415/2c513ee5-adf7-48dc-abfe-dc0a112cb672)

![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/26871415/8c7923c5-229d-413a-8128-572906efa736)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
