### PR TITLE
Fix GOG download size in download manager

### DIFF
--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -16,7 +16,6 @@ import {
   GogInstallInfo,
   GOGGameDotIdFile,
   GOGClientsResponse,
-  GogInstallPlatform,
   GamesDBData,
   Library,
   BuildItem
@@ -375,10 +374,10 @@ export function getInstallAndGameInfo(slug: string): GameInfo | undefined {
  */
 export async function getInstallInfo(
   appName: string,
-  installPlatform: GogInstallPlatform = 'windows',
+  installPlatform = 'windows',
   lang = 'en-US'
 ): Promise<GogInstallInfo | undefined> {
-  installPlatform = installPlatform.toLowerCase() as GogInstallPlatform
+  installPlatform = installPlatform.toLowerCase()
 
   if (installInfoStore.has(`${appName}_${installPlatform}`)) {
     const cache = installInfoStore.get(`${appName}_${installPlatform}`)

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -16,6 +16,7 @@ import {
   GogInstallInfo,
   GOGGameDotIdFile,
   GOGClientsResponse,
+  GogInstallPlatform,
   GamesDBData,
   Library,
   BuildItem
@@ -374,9 +375,11 @@ export function getInstallAndGameInfo(slug: string): GameInfo | undefined {
  */
 export async function getInstallInfo(
   appName: string,
-  installPlatform = 'windows',
+  installPlatform: GogInstallPlatform = 'windows',
   lang = 'en-US'
 ): Promise<GogInstallInfo | undefined> {
+  installPlatform = installPlatform.toLowerCase() as GogInstallPlatform
+
   if (installInfoStore.has(`${appName}_${installPlatform}`)) {
     const cache = installInfoStore.get(`${appName}_${installPlatform}`)
     if (cache) {


### PR DESCRIPTION
When adding GOG games to the download queue, the game size shows up as `??`.

The issue is that we were passing `Windows` instead of `windows` as the platform.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
