### PR TITLE
Prettier - Move exclamation mark to outside the single quotes of flatpak-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,8 +212,8 @@
     "flatpak:prepare-release": "node ./flatpak/prepareFlatpak.js release",
     "i18n": "i18next --silent",
     "prepare": "husky install",
-    "prettier": "prettier --check . '!flatpak-build'",
-    "prettier-fix": "prettier --write . '!flatpak-build'"
+    "prettier": "prettier --check . !'flatpak-build'",
+    "prettier-fix": "prettier --write . !'flatpak-build'"
   },
   "eslintConfig": {
     "extends": [

--- a/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
@@ -11,9 +11,14 @@ interface Point {
   disk: number
 }
 
-const roundToNearestHundredth = function (val: number | undefined) {
+const roundToNearestHundredthByte = function (val: number | undefined) {
   if (!val) return 0
   return Math.round(val * 100) / 100
+}
+
+const roundToNearestHundredthBit = function (val: number | undefined) {
+  if (!val) return 0
+  return Math.round(val * 100) / 100 * 8
 }
 
 export default function ProgressHeader(props: {
@@ -25,6 +30,7 @@ export default function ProgressHeader(props: {
   const [avgSpeed, setAvgDownloadSpeed] = useState<Point[]>(
     Array<Point>(20).fill({ download: 0, disk: 0 })
   )
+  const [speedType, setSpeedType] = useState<'megabit' | 'megabyte'>('megabyte')
 
   useEffect(() => {
     if (props.state === 'idle') {
@@ -46,6 +52,16 @@ export default function ProgressHeader(props: {
 
     setAvgDownloadSpeed([...avgSpeed])
   }, [progress, props.state])
+
+  const roundSpeed = function (val: number | undefined) {
+    if (speedType === 'megabyte') return roundToNearestHundredthByte(val)
+    return roundToNearestHundredthBit(val)
+  }
+
+  const toggleSpeedType = function () {    
+    if (speedType === 'megabyte') setSpeedType('megabit')
+    else setSpeedType('megabyte')
+  }
 
   return (
     <>
@@ -83,17 +99,17 @@ export default function ProgressHeader(props: {
               </ResponsiveContainer>
             </div>
           </div>
-          <div className="realtimeDownloadStatContainer">
+          <div className="realtimeDownloadStatContainer" onClick={toggleSpeedType}>
             <h5 className="realtimeDownloadStat">
-              {roundToNearestHundredth(avgSpeed.at(-1)?.download)} MB/s
+              {roundSpeed(avgSpeed.at(-1)?.download)} {speedType === 'megabyte' ? 'MB/s' : 'Mb/s'}
             </h5>
             <div className="realtimeDownloadStatLabel downLabel">
               {t('download-manager.label.speed', 'Download')}{' '}
             </div>
           </div>
-          <div className="realtimeDownloadStatContainer">
+          <div className="realtimeDownloadStatContainer" onClick={toggleSpeedType}>
             <h5 className="realtimeDownloadStat">
-              {roundToNearestHundredth(avgSpeed.at(-1)?.disk)} MB/s
+              {roundSpeed(avgSpeed.at(-1)?.disk)} {speedType === 'megabyte' ? 'MB/s' : 'Mb/s'}
             </h5>
             <div className="realtimeDownloadStatLabel diskLabel">
               {t('download-manager.label.disk', 'Disk')}{' '}
@@ -104,9 +120,8 @@ export default function ProgressHeader(props: {
       {props.state !== 'idle' && props.appName && progress.eta && (
         <div className="downloadBar">
           <div className="downloadProgressStats">
-            <p className="downloadStat" color="var(--text-default)">{`${
-              progress.percent ?? 0
-            }% [${progress.bytes ?? ''}] `}</p>
+            <p className="downloadStat" color="var(--text-default)">{`${progress.percent ?? 0
+              }% [${progress.bytes ?? ''}] `}</p>
           </div>
           <Box sx={{ display: 'flex', alignItems: 'baseline' }}>
             <Box sx={{ width: '100%', mr: 1 }}>

--- a/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
@@ -11,14 +11,9 @@ interface Point {
   disk: number
 }
 
-const roundToNearestHundredthByte = function (val: number | undefined) {
+const roundToNearestHundredth = function (val: number | undefined) {
   if (!val) return 0
   return Math.round(val * 100) / 100
-}
-
-const roundToNearestHundredthBit = function (val: number | undefined) {
-  if (!val) return 0
-  return Math.round(val * 100) / 100 * 8
 }
 
 export default function ProgressHeader(props: {
@@ -30,7 +25,6 @@ export default function ProgressHeader(props: {
   const [avgSpeed, setAvgDownloadSpeed] = useState<Point[]>(
     Array<Point>(20).fill({ download: 0, disk: 0 })
   )
-  const [speedType, setSpeedType] = useState<'megabit' | 'megabyte'>('megabyte')
 
   useEffect(() => {
     if (props.state === 'idle') {
@@ -52,16 +46,6 @@ export default function ProgressHeader(props: {
 
     setAvgDownloadSpeed([...avgSpeed])
   }, [progress, props.state])
-
-  const roundSpeed = function (val: number | undefined) {
-    if (speedType === 'megabyte') return roundToNearestHundredthByte(val)
-    return roundToNearestHundredthBit(val)
-  }
-
-  const toggleSpeedType = function () {    
-    if (speedType === 'megabyte') setSpeedType('megabit')
-    else setSpeedType('megabyte')
-  }
 
   return (
     <>
@@ -99,17 +83,17 @@ export default function ProgressHeader(props: {
               </ResponsiveContainer>
             </div>
           </div>
-          <div className="realtimeDownloadStatContainer" onClick={toggleSpeedType}>
+          <div className="realtimeDownloadStatContainer">
             <h5 className="realtimeDownloadStat">
-              {roundSpeed(avgSpeed.at(-1)?.download)} {speedType === 'megabyte' ? 'MB/s' : 'Mb/s'}
+              {roundToNearestHundredth(avgSpeed.at(-1)?.download)} MB/s
             </h5>
             <div className="realtimeDownloadStatLabel downLabel">
               {t('download-manager.label.speed', 'Download')}{' '}
             </div>
           </div>
-          <div className="realtimeDownloadStatContainer" onClick={toggleSpeedType}>
+          <div className="realtimeDownloadStatContainer">
             <h5 className="realtimeDownloadStat">
-              {roundSpeed(avgSpeed.at(-1)?.disk)} {speedType === 'megabyte' ? 'MB/s' : 'Mb/s'}
+              {roundToNearestHundredth(avgSpeed.at(-1)?.disk)} MB/s
             </h5>
             <div className="realtimeDownloadStatLabel diskLabel">
               {t('download-manager.label.disk', 'Disk')}{' '}
@@ -120,8 +104,9 @@ export default function ProgressHeader(props: {
       {props.state !== 'idle' && props.appName && progress.eta && (
         <div className="downloadBar">
           <div className="downloadProgressStats">
-            <p className="downloadStat" color="var(--text-default)">{`${progress.percent ?? 0
-              }% [${progress.bytes ?? ''}] `}</p>
+            <p className="downloadStat" color="var(--text-default)">{`${
+              progress.percent ?? 0
+            }% [${progress.bytes ?? ''}] `}</p>
           </div>
           <Box sx={{ display: 'flex', alignItems: 'baseline' }}>
             <Box sx={{ width: '100%', mr: 1 }}>


### PR DESCRIPTION
This is my first pull request.

In Windows when you try to run `yarn prettier` or `yarn prettier-fix` the commands won't work because the `!` is being inside the single quotes of the "flatpak-build" and there maybe be difference between Windows and Linux where Windows treats the '!flatpak-build' as a folder while we are trying to ignore the folder. 
By moving the exclamation mark to the outside of the single quote you will be able to run prettier and ignore the "flatpak-build" folder.
I have tested this in Windows and WSL Ubuntu and the and it works on both of them.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
