### PR TITLE
Download and disk click toggle for megabyte and megabit.

### DIFF
--- a/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
@@ -11,9 +11,14 @@ interface Point {
   disk: number
 }
 
-const roundToNearestHundredth = function (val: number | undefined) {
+const roundToNearestHundredthByte = function (val: number | undefined) {
   if (!val) return 0
   return Math.round(val * 100) / 100
+}
+
+const roundToNearestHundredthBit = function (val: number | undefined) {
+  if (!val) return 0
+  return Math.round(val * 100) / 100 * 8
 }
 
 export default function ProgressHeader(props: {
@@ -25,6 +30,7 @@ export default function ProgressHeader(props: {
   const [avgSpeed, setAvgDownloadSpeed] = useState<Point[]>(
     Array<Point>(20).fill({ download: 0, disk: 0 })
   )
+  const [speedType, setSpeedType] = useState<'megabit' | 'megabyte'>('megabyte')
 
   useEffect(() => {
     if (props.state === 'idle') {
@@ -46,6 +52,16 @@ export default function ProgressHeader(props: {
 
     setAvgDownloadSpeed([...avgSpeed])
   }, [progress, props.state])
+
+  const roundSpeed = function (val: number | undefined) {
+    if (speedType === 'megabyte') return roundToNearestHundredthByte(val)
+    return roundToNearestHundredthBit(val)
+  }
+
+  const toggleSpeedType = function () {    
+    if (speedType === 'megabyte') setSpeedType('megabit')
+    else setSpeedType('megabyte')
+  }
 
   return (
     <>
@@ -83,17 +99,17 @@ export default function ProgressHeader(props: {
               </ResponsiveContainer>
             </div>
           </div>
-          <div className="realtimeDownloadStatContainer">
+          <div className="realtimeDownloadStatContainer" onClick={toggleSpeedType}>
             <h5 className="realtimeDownloadStat">
-              {roundToNearestHundredth(avgSpeed.at(-1)?.download)} MB/s
+              {roundSpeed(avgSpeed.at(-1)?.download)} {speedType === 'megabyte' ? 'MB/s' : 'Mb/s'}
             </h5>
             <div className="realtimeDownloadStatLabel downLabel">
               {t('download-manager.label.speed', 'Download')}{' '}
             </div>
           </div>
-          <div className="realtimeDownloadStatContainer">
+          <div className="realtimeDownloadStatContainer" onClick={toggleSpeedType}>
             <h5 className="realtimeDownloadStat">
-              {roundToNearestHundredth(avgSpeed.at(-1)?.disk)} MB/s
+              {roundSpeed(avgSpeed.at(-1)?.disk)} {speedType === 'megabyte' ? 'MB/s' : 'Mb/s'}
             </h5>
             <div className="realtimeDownloadStatLabel diskLabel">
               {t('download-manager.label.disk', 'Disk')}{' '}
@@ -104,9 +120,8 @@ export default function ProgressHeader(props: {
       {props.state !== 'idle' && props.appName && progress.eta && (
         <div className="downloadBar">
           <div className="downloadProgressStats">
-            <p className="downloadStat" color="var(--text-default)">{`${
-              progress.percent ?? 0
-            }% [${progress.bytes ?? ''}] `}</p>
+            <p className="downloadStat" color="var(--text-default)">{`${progress.percent ?? 0
+              }% [${progress.bytes ?? ''}] `}</p>
           </div>
           <Box sx={{ display: 'flex', alignItems: 'baseline' }}>
             <Box sx={{ width: '100%', mr: 1 }}>


### PR DESCRIPTION
In this issue #2730 a user asked to add the ability to view download and disk speeds as Megabits because of his computer is in Megabits format.
I implemented a click event on the disk speeds and download speeds. Each click will change the values from Megabytes to Megabits.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature, and it's working on a current and clean install.
- [x] Tested the main App features, and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
