### PR TITLE
[UI] Use cover art for the most recently played game

### DIFF
--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -121,7 +121,7 @@
 }
 
 .gameCard.justPlayed > .icons {
-  justify-content: space-between;
+  justify-content: right;
   grid-template-columns: 0.15fr 0.15fr 0.15fr;
   grid-template-areas: 'update settings play';
 }

--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -118,7 +118,7 @@
 
 .gameCard.justPlayed > .icons {
   justify-content: right;
-  grid-template-columns: 0.3fr 1fr 0.3fr 0.3fr;
+  grid-template-columns: 0.3fr 1fr 0.4fr 0.5fr;
   grid-template-areas: 'update gap settings play';
 }
 

--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -13,6 +13,10 @@
   aspect-ratio: 173/275;
 }
 
+.gameCard.justPlayed{
+  aspect-ratio: 275/205;
+}
+
 .gameCard.gamepad {
   aspect-ratio: 3/4;
 }
@@ -60,6 +64,12 @@
   object-fit: cover;
   aspect-ratio: 3 / 4;
   display: block;
+}
+
+.gameCard.justPlayed .justPlayedImg{
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  width: 100%;
 }
 
 .gameCard .gameLogo {

--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -102,10 +102,6 @@
   transform: translateY(100%);
 }
 
-.gameCard.justPlayed .gameTitle {
-  text-align: center;
-}
-
 .gameCard:hover .gameTitle {
   display: block;
   transform: translateY(0);
@@ -122,8 +118,8 @@
 
 .gameCard.justPlayed > .icons {
   justify-content: right;
-  grid-template-columns: 0.15fr 0.15fr 0.15fr;
-  grid-template-areas: 'update settings play';
+  grid-template-columns: 0.3fr 1fr 0.3fr 0.3fr;
+  grid-template-areas: 'update gap settings play';
 }
 
 .gameCard.gamepad > .icons {
@@ -326,6 +322,19 @@
 .cancelIcon {
   grid-area: play;
   transition: all 300ms;
+}
+
+.playIcon > span {
+  font-family: var(--secondary-font-family);
+  border-radius: 5px;
+  color: #161616;
+  cursor: pointer;
+  padding: var(--space-xs-fixed);
+  background: var(--success);
+  color: var(--text-tertiary);
+  font-weight: 500;
+  font-size: 15px;
+  text-align: center;
 }
 
 .icons path,

--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -13,7 +13,7 @@
   aspect-ratio: 173/275;
 }
 
-.gameCard.justPlayed{
+.gameCard.justPlayed {
   aspect-ratio: 275/205;
 }
 
@@ -66,7 +66,7 @@
   display: block;
 }
 
-.gameCard.justPlayed .justPlayedImg{
+.gameCard.justPlayed .justPlayedImg {
   aspect-ratio: 16 / 10;
   object-fit: cover;
   width: 100%;
@@ -102,6 +102,10 @@
   transform: translateY(100%);
 }
 
+.gameCard.justPlayed .gameTitle {
+  text-align: center;
+}
+
 .gameCard:hover .gameTitle {
   display: block;
   transform: translateY(0);
@@ -114,6 +118,12 @@
   grid-template-columns: 1fr 1fr 1fr;
   grid-template-areas: 'update settings play';
   padding: var(--space-xs-fixed);
+}
+
+.gameCard.justPlayed > .icons {
+  justify-content: space-between;
+  grid-template-columns: 0.15fr 0.15fr 0.15fr;
+  grid-template-areas: 'update settings play';
 }
 
 .gameCard.gamepad > .icons {

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -44,6 +44,7 @@ interface Card {
   buttonClick: () => void
   hasUpdate: boolean
   isRecent: boolean
+  justPlayed: boolean
   gameInfo: GameInfo
   forceCard?: boolean
 }
@@ -55,6 +56,7 @@ const GameCard = ({
   buttonClick,
   forceCard,
   isRecent = false,
+  justPlayed = false,
   gameInfo: gameInfoFromProps
 }: Card) => {
   const [visible, setVisible] = useState(false)
@@ -96,6 +98,7 @@ const GameCard = ({
 
   const {
     title,
+    art_cover,
     art_square: cover,
     art_logo: logo = undefined,
     app_name: appName,
@@ -338,6 +341,7 @@ const GameCard = ({
   const hiddenClass = isHiddenGame ? 'hidden' : ''
   const notAvailableClass = notAvailable ? 'notAvailable' : ''
   const gamepadClass = activeController ? 'gamepad' : ''
+  const justPlayedClass = justPlayed ? 'justPlayed' : ''
   const imgClasses = `gameImg ${isInstalled ? 'installed' : ''} ${
     allTilesInColor ? 'allTilesInColor' : ''
   }`
@@ -347,7 +351,7 @@ const GameCard = ({
 
   const wrapperClasses = `${
     grid ? 'gameCard' : 'gameListItem'
-  }  ${instClass} ${hiddenClass} ${notAvailableClass} ${gamepadClass}`
+  }  ${instClass} ${hiddenClass} ${notAvailableClass} ${gamepadClass} ${justPlayedClass}`
 
   const showUpdateButton =
     hasUpdate && !isUpdating && !isQueued && !notAvailable
@@ -382,11 +386,19 @@ const GameCard = ({
             }
           >
             <StoreLogos runner={runner} />
-            <CachedImage
-              src={getImageFormatting(cover, runner)}
-              className={imgClasses}
-              alt="cover"
-            />
+            {justPlayed ? (
+              <CachedImage 
+                src={art_cover}
+                className="justPlayedImg"
+                alt={title} 
+              />
+            ) : (
+              <CachedImage
+                src={getImageFormatting(cover, runner)}
+                className={imgClasses}
+                alt="cover"
+              />
+            )}
             {logo && (
               <CachedImage
                 alt="logo"

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -387,10 +387,10 @@ const GameCard = ({
           >
             <StoreLogos runner={runner} />
             {justPlayed ? (
-              <CachedImage 
+              <CachedImage
                 src={art_cover}
                 className="justPlayedImg"
-                alt={title} 
+                alt={title}
               />
             ) : (
               <CachedImage

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -215,7 +215,7 @@ const GameCard = ({
           title={`${t('label.playing.start')} (${title})`}
           disabled={disabled}
         >
-          <PlayIcon />
+          {justPlayed ? <span>PLAY</span> : <PlayIcon />}
         </SvgButton>
       )
     } else {

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -92,10 +92,7 @@ const GamesList = ({
       {!!library.length &&
         library.map((gameInfo, index) => {
           const { app_name, is_installed, runner } = gameInfo
-          let isJustPlayed = false
-          if (isRecent && index === 0) {
-            isJustPlayed = true
-          }
+          const isJustPlayed = isRecent && index === 0
           let is_dlc = false
           if (gameInfo.runner !== 'sideload') {
             is_dlc = gameInfo.install.is_dlc ?? false

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -93,7 +93,7 @@ const GamesList = ({
         library.map((gameInfo, index) => {
           const { app_name, is_installed, runner } = gameInfo
           let isJustPlayed = false
-          if (isRecent && index == 0) {
+          if (isRecent && index === 0) {
             isJustPlayed = true
           }
           let is_dlc = false

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -90,9 +90,12 @@ const GamesList = ({
         </div>
       )}
       {!!library.length &&
-        library.map((gameInfo) => {
+        library.map((gameInfo, index) => {
           const { app_name, is_installed, runner } = gameInfo
-
+          let isJustPlayed = false
+          if (isRecent && index == 0) {
+            isJustPlayed = true
+          }
           let is_dlc = false
           if (gameInfo.runner !== 'sideload') {
             is_dlc = gameInfo.install.is_dlc ?? false
@@ -117,6 +120,7 @@ const GamesList = ({
               forceCard={layout === 'grid'}
               isRecent={isRecent}
               gameInfo={gameInfo}
+              justPlayed={isJustPlayed}
             />
           )
         })}

--- a/src/frontend/screens/Library/index.css
+++ b/src/frontend/screens/Library/index.css
@@ -11,7 +11,7 @@
   padding: 0 var(--space-md-fixed) var(--space-md-fixed);
 }
 
-.gameList.firstLane > :first-child{
+.gameList.firstLane > :first-child {
   grid-column-start: 1;
   grid-column-end: 3;
 }

--- a/src/frontend/screens/Library/index.css
+++ b/src/frontend/screens/Library/index.css
@@ -11,6 +11,11 @@
   padding: 0 var(--space-md-fixed) var(--space-md-fixed);
 }
 
+.gameList.firstLane > :first-child{
+  grid-column-start: 1;
+  grid-column-end: 3;
+}
+
 .gameListLayout {
   display: flex;
   flex-direction: column;

--- a/src/frontend/screens/Library/index.css
+++ b/src/frontend/screens/Library/index.css
@@ -12,8 +12,7 @@
 }
 
 .gameList.firstLane > :first-child {
-  grid-column-start: 1;
-  grid-column-end: 3;
+  grid-column: span 2;
 }
 
 .gameListLayout {


### PR DESCRIPTION
Although this is not part of the Figma design, I thought of using the cover art for the just recently played game. Kind of like how several game launchers do.

This PR introduces the `justPlayed` property for the `Card` interface that is set to`true` for the first game under the Recently Played `GamesList`. If `true`, the `GameCard`' uses game's `art_cover` as the `src`.

The covert art box occupies two grids for correctly containing the art.

![Screenshot from 2023-05-31 08-05-06](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/74495920/60ed41cb-42be-4737-ad27-e0631c1b5aec)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
