### PR TITLE
[Bug] Fix "no https" toggle not working

### DIFF
--- a/src/frontend/screens/Settings/components/DownloadNoHTTPS.tsx
+++ b/src/frontend/screens/Settings/components/DownloadNoHTTPS.tsx
@@ -14,7 +14,7 @@ const DownloadNoHTTPS = () => {
     <ToggleSwitch
       htmlId="downloadNoHttps"
       value={downloadNoHttps}
-      handleChange={() => setDownloadNoHttps(!setDownloadNoHttps)}
+      handleChange={() => setDownloadNoHttps(!downloadNoHttps)}
       title={t(
         'setting.download-no-https',
         'Download games without HTTPS (useful for CDNs e.g. LanCache)'


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2721

The onClick handler was always setting this to `false`

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
