### PR TITLE
[UX] Do not force focus on main window after closing game

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -958,7 +958,6 @@ ipcMain.handle(
     })
 
     const mainWindow = getMainWindow()
-    const showAfterClose = mainWindow?.isVisible()
     if (minimizeOnLaunch) {
       mainWindow?.hide()
     }
@@ -1089,8 +1088,6 @@ ipcMain.handle(
     // Exit if we've been launched without UI
     if (isCLINoGui) {
       app.exit()
-    } else if (showAfterClose) {
-      mainWindow?.show()
     }
 
     return { status: launchResult ? 'done' : 'error' }


### PR DESCRIPTION
This fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2594

We were forcing the focus on the main window after a game was closed which was not great UX.

The are many scenarios when starting a game:
- game was started with no GUI (in this case the autofocus was already ignored)
- game was started from the try (in this case the autofocus was already ignored)
- game was started from the gui (the windows is back on focus after closing a game anyway since it was the last window with focus, even after removing these lines)
- main window is minimized/close while a game is loading (in this cases the window was forced to gain focus after close, even if the user explicitly move it out of the way, not it's not)
- sometimes a game takes a long time to actually end after exiting, if you move to another window to do something else then heroic would steal the focus after an undefined amount of time

With the current change we don't force the focus, if the window is the first screen after closing a game it still regains focus automatically anyway.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
