### PR TITLE
[GOG]: Switch to Galaxy way of loading library

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -133,7 +133,7 @@
     },
     "label": {
         "game": {
-            "not-installable-game": "",
+            "not-installable-game": "Game is NOT Installable",
             "third-party-game": "Third-Party Game NOT Supported"
         },
         "launching": "Launching",

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -133,6 +133,7 @@
     },
     "label": {
         "game": {
+            "not-installable-game": "",
             "third-party-game": "Third-Party Game NOT Supported"
         },
         "launching": "Launching",
@@ -187,6 +188,8 @@
         "downloading": "Downloading",
         "extracting": "Extracting",
         "gameNotAvailable": "Game not available",
+        "gog-goodie": "This game doesn't appear to be installable. Check downloadable content on https://gog.com/account",
+        "goodie": "Not installable",
         "hasUpdates": "New Version Available!",
         "installed": "Installed",
         "installing": "Installing",

--- a/src/backend/api/library.ts
+++ b/src/backend/api/library.ts
@@ -81,6 +81,10 @@ export const handleRefreshLibrary = (
   callback: (event: Electron.IpcRendererEvent, runner: Runner) => void
 ) => ipcRenderer.on('refreshLibrary', callback)
 
+export const handleGamePush = (
+  callback: (event: Electron.IpcRendererEvent, game: GameInfo) => void
+) => ipcRenderer.on('pushGameToLibrary', callback)
+
 export const removeRecentGame = async (appName: string) =>
   ipcRenderer.invoke('removeRecent', appName)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/backend/cache.ts
+++ b/src/backend/cache.ts
@@ -2,6 +2,9 @@ import Store from 'electron-store'
 
 export default class CacheStore<ValueType, KeyType extends string = string> {
   private readonly store: Store
+  private in_memory_store: Map<string, ValueType>
+  private using_in_memory: boolean
+  private current_store: Store | Map<string, ValueType>
   private readonly lifespan: number | null
 
   /**
@@ -16,20 +19,34 @@ export default class CacheStore<ValueType, KeyType extends string = string> {
       name: filename,
       clearInvalidConfig: true
     })
+    this.in_memory_store = new Map<string, ValueType>()
+    this.using_in_memory = false
+    this.current_store = this.store
     this.lifespan = max_value_lifespan
+  }
+
+  /**
+   * Allows to switch over to use in memory store (useful for many read and writes)
+   * IMPORTANT! after operations run commit() to update file on drive
+   */
+  public use_in_memory() {
+    // Mirror store to memory map
+    this.using_in_memory = true
+    this.in_memory_store = new Map(this.store) as Map<string, ValueType>
+    this.current_store = this.in_memory_store
   }
 
   public get(key: KeyType): ValueType | undefined
   public get(key: KeyType, fallback: ValueType): ValueType
   public get(key: KeyType, fallback?: ValueType) {
-    if (!this.store.has(key)) {
+    if (!this.current_store.has(key)) {
       return fallback
     }
 
     if (this.lifespan) {
-      const lastUpdateTimestamp = this.store.get(`__timestamp.${key}`) as
-        | string
-        | undefined
+      const lastUpdateTimestamp = this.current_store.get(
+        `__timestamp.${key}`
+      ) as string | undefined
       if (!lastUpdateTimestamp) {
         return fallback
       }
@@ -38,28 +55,36 @@ export default class CacheStore<ValueType, KeyType extends string = string> {
       const msSinceUpdate = Date.now() - updateDate.getTime()
       const minutesSinceUpdate = msSinceUpdate / 1000 / 60
       if (minutesSinceUpdate > this.lifespan) {
-        this.store.delete(key)
-        this.store.delete(`__timestamp.${key}`)
+        this.current_store.delete(key)
+        this.current_store.delete(`__timestamp.${key}`)
         return fallback
       }
     }
 
-    return this.store.get(key) as ValueType
+    return this.current_store.get(key) as ValueType
   }
 
   public set(key: KeyType, value: ValueType) {
-    this.store.set(key, value)
-    this.store.set(`__timestamp.${key}`, Date())
+    this.current_store.set(key, value)
+    this.current_store.set(`__timestamp.${key}`, Date() as ValueType)
   }
 
   public delete(key: KeyType) {
-    this.store.delete(key)
-    this.store.delete(`__timestamp.${key}`)
+    this.current_store.delete(key)
+    this.current_store.delete(`__timestamp.${key}`)
   }
 
-  public clear = () => this.store.clear()
+  public clear = () => this.current_store.clear()
 
   public has(key: string) {
-    return this.store.has(key)
+    return this.current_store.has(key)
+  }
+
+  public commit() {
+    if (this.using_in_memory) {
+      this.store.store = Object.fromEntries(this.in_memory_store)
+      this.using_in_memory = false
+      this.current_store = this.store
+    }
   }
 }

--- a/src/backend/storeManagers/gog/electronStores.ts
+++ b/src/backend/storeManagers/gog/electronStores.ts
@@ -15,10 +15,7 @@ const configStore = new TypeCheckedStoreBackend('gogConfigStore', {
   cwd: 'gog_store'
 })
 
-const apiInfoCache = new CacheStore<{
-  isUpdated: boolean
-  data: GamesDBData
-}>('gog_api_info')
+const apiInfoCache = new CacheStore<GamesDBData>('gog_api_info')
 const libraryStore = new CacheStore<GameInfo[], 'games'>('gog_library', null)
 const syncStore = new TypeCheckedStoreBackend('gogSyncStore', {
   cwd: 'gog_store',

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -78,10 +78,13 @@ export async function getExtraInfo(appName: string): Promise<ExtraInfo> {
     targetPlatform = 'windows'
   }
 
+  const reqs = await createReqsArray(appName, targetPlatform)
+  const storeUrl = (await getGamesData(appName))?._links.store.href
+
   const extra: ExtraInfo = {
     about: gameInfo.extra?.about,
-    reqs: await createReqsArray(appName, targetPlatform),
-    storeUrl: (await getGamesData(appName))?._links.store.href
+    reqs,
+    storeUrl
   }
   return extra
 }

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -11,7 +11,8 @@ import {
   createReqsArray,
   getGameInfo as getGogLibraryGameInfo,
   changeGameInstallPath,
-  getMetaResponse
+  getMetaResponse,
+  getGamesData
 } from './library'
 import { join } from 'path'
 import { GameConfig } from '../../game_config'
@@ -80,7 +81,7 @@ export async function getExtraInfo(appName: string): Promise<ExtraInfo> {
   const extra: ExtraInfo = {
     about: gameInfo.extra?.about,
     reqs: await createReqsArray(appName, targetPlatform),
-    storeUrl: gameInfo.store_url
+    storeUrl: (await getGamesData(appName))?._links.store.href
   }
   return extra
 }

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -2,7 +2,6 @@ import { sendFrontendMessage } from '../../main_window'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import { GOGUser } from './user'
 import {
-  GOGGameInfo,
   GameInfo,
   InstalledInfo,
   GOGImportData,
@@ -18,7 +17,9 @@ import {
   GOGClientsResponse,
   GamesDBData,
   Library,
-  BuildItem
+  BuildItem,
+  GalaxyLibraryEntry,
+  ProductsEndpointData
 } from 'common/types/gog'
 import { basename, join } from 'node:path'
 import { existsSync, readFileSync } from 'graceful-fs'
@@ -26,9 +27,8 @@ import { app } from 'electron'
 
 import { logError, logInfo, LogPrefix, logWarning } from '../../logger/logger'
 import { getGOGdlBin, getFileSize } from '../../utils'
-import { fallBackImage, gogdlLogFile } from '../../constants'
+import { gogdlLogFile } from '../../constants'
 import {
-  apiInfoCache,
   libraryStore,
   installedGamesStore,
   installInfoStore
@@ -39,6 +39,7 @@ import {
   deleteAbortController
 } from '../../utils/aborthandler/aborthandler'
 import { isOnline } from '../../online_monitor'
+import i18next from 'i18next'
 
 const library: Map<string, GameInfo> = new Map()
 const installedGames: Map<string, InstalledInfo> = new Map()
@@ -86,59 +87,6 @@ export async function getSaveSyncLocation(
   const savesInfo = platformInfo.cloudStorage
   return savesInfo.locations
 }
-/**
- * Returns ids of games with requested features ids
- * @param features
- * @returns
- */
-async function getGamesWithFeatures(
-  features: string[] = ['512']
-): Promise<string[]> {
-  const credentials = await GOGUser.getCredentials()
-  if (!credentials) {
-    return []
-  }
-
-  const headers = {
-    Authorization: 'Bearer ' + credentials.access_token,
-    'User-Agent': 'GOGGalaxyClient/2.0.45.61 (GOG Galaxy)'
-  }
-  const gameArray = []
-  const games = await axios
-    .get(
-      `https://embed.gog.com/account/getFilteredProducts?mediaType=1&sortBy=title&feature=${features.join()}`,
-      { headers }
-    )
-    .catch((e: AxiosError) => {
-      logError(
-        [
-          'There was an error getting games with features',
-          `${features}`,
-          `${e.message}`
-        ],
-        LogPrefix.Gog
-      )
-    })
-
-  if (!games) {
-    return []
-  }
-
-  gameArray.push(...games.data.products)
-  const numberOfPages = games?.data.totalPages
-  for (let page = 2; page <= numberOfPages; page++) {
-    logInfo(['Getting data for page', String(page)], LogPrefix.Gog)
-    const pageData = await axios.get(
-      `https://embed.gog.com/account/getFilteredProducts?mediaType=1&sortBy=title&page=${page}&features=${features.join()}`,
-      { headers }
-    )
-    if (pageData.data?.products) {
-      gameArray.push(...pageData.data.products)
-    }
-  }
-
-  return gameArray.map((value) => String(value.id))
-}
 
 const defaultExecResult = {
   stderr: '',
@@ -174,10 +122,10 @@ export async function refresh(): Promise<ExecResult> {
     'User-Agent': 'GOGGalaxyClient/2.0.45.61 (GOG Galaxy)'
   }
   logInfo('Getting GOG library', LogPrefix.Gog)
-  const gameApiArray: GOGGameInfo[] = []
+  const gameApiArray: GalaxyLibraryEntry[] = []
   const games: Library | null = await axios
     .get(
-      'https://embed.gog.com/account/getFilteredProducts?mediaType=1&sortBy=title',
+      `https://galaxy-library.gog.com/users/${credentials.user_id}/releases`,
       { headers }
     )
     .then(({ data }) => data)
@@ -194,153 +142,112 @@ export async function refresh(): Promise<ExecResult> {
     return defaultExecResult
   }
 
-  if (games.products.length) {
-    const numberOfPages = games.totalPages
-    logInfo(['Number of library pages:', numberOfPages], LogPrefix.Gog)
-    gameApiArray.push(...games.products)
-    for (let page = 2; page <= numberOfPages; page++) {
-      logInfo(['Getting data for page', String(page)], LogPrefix.Gog)
-      const pageData: Library | null = await axios
-        .get(
-          `https://embed.gog.com/account/getFilteredProducts?mediaType=1&sortBy=title&page=${page}`,
-          { headers }
-        )
-        .then(({ data }) => data)
-        .catch((e) => {
-          logError(
-            [
-              'There was an error getting games library data for page',
-              page,
-              e.message
-            ],
-            {
-              prefix: LogPrefix.Gog
-            }
-          )
-          return null
-        })
-      if (pageData && pageData.products.length) {
-        gameApiArray.push(...pageData.products)
-      }
-    }
-  }
+  gameApiArray.push(...games.items)
+  const filteredApiArray = gameApiArray.filter(
+    (entry) => entry.platform_id === 'gog'
+  )
+  // if (games.items.length) {
+  //   const numberOfPages = games.total_count
+  //   logInfo(['Number of library pages:', numberOfPages], LogPrefix.Gog)
+  //   for (let page = 2; page <= numberOfPages; page++) {
+  //     logInfo(['Getting data for page', String(page)], LogPrefix.Gog)
+  //     const pageData: Library | null = await axios
+  //       .get(
+  //         `https://embed.gog.com/account/getFilteredProducts?mediaType=1&sortBy=title&page=${page}`,
+  //         { headers }
+  //       )
+  //       .then(({ data }) => data)
+  //       .catch((e) => {
+  //         logError(
+  //           [
+  //             'There was an error getting games library data for page',
+  //             page,
+  //             e.message
+  //           ],
+  //           {
+  //             prefix: LogPrefix.Gog
+  //           }
+  //         )
+  //         return null
+  //       })
+  //     if (pageData && pageData.products.length) {
+  //       gameApiArray.push(...pageData.products)
+  //     }
+  //   }
+  // }
 
   const gamesObjects: GameInfo[] = []
-  const gamesArray = libraryStore.get('games', [])
-  const cloudSavesEnabledGames = await getGamesWithFeatures(['512'])
-  for (const game of gameApiArray) {
-    let unifiedObject = gamesArray
-      ? gamesArray.find((value) => value.app_name === String(game.id))
-      : null
-    if (!unifiedObject) {
-      unifiedObject = await gogToUnifiedInfo(game, cloudSavesEnabledGames)
-    }
-    gamesObjects.push(unifiedObject)
-    const installedInfo = installedGames.get(String(game.id))
-    // If game is installed, verify if installed game supports cloud saves
-    if (
-      !cloudSavesEnabledGames.includes(String(game.id)) &&
-      installedInfo &&
-      installedInfo?.platform !== 'linux'
-    ) {
-      const saveLocations = await getSaveSyncLocation(
-        unifiedObject.app_name,
-        installedInfo
-      )
-
-      if (saveLocations) {
-        unifiedObject.cloud_save_enabled = true
-        unifiedObject.gog_save_location = saveLocations
+  const promises = filteredApiArray.map(async (game): Promise<GameInfo> => {
+    let retries = 5
+    while (retries > 0) {
+      const { data } = await getGamesdbData(
+        'gog',
+        game.external_id,
+        undefined,
+        game.certificate,
+        credentials.access_token
+      ).catch(() => ({
+        data: null
+      }))
+      const product = await getProductApi(game.external_id).catch(() => null)
+      if (!data) {
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+        retries -= 1
+        continue
       }
+      const unifiedObject = await gogToUnifiedInfo(data, product?.data)
+      if (unifiedObject.app_name) {
+        gamesObjects.push(unifiedObject)
+      }
+      const installedInfo = installedGames.get(String(game.external_id))
+      // If game is installed, verify if installed game supports cloud saves
+      if (installedInfo && installedInfo?.platform !== 'linux') {
+        const saveLocations = await getSaveSyncLocation(
+          unifiedObject.app_name,
+          installedInfo
+        )
+
+        if (saveLocations) {
+          unifiedObject.cloud_save_enabled = true
+          unifiedObject.gog_save_location = saveLocations
+        }
+      }
+      // Create new object to not write install data into library store
+      const copyObject = Object.assign({}, unifiedObject)
+      if (installedInfo) {
+        copyObject.is_installed = true
+        copyObject.install = installedInfo
+      }
+      return copyObject
     }
-    // Create new object to not write install data into library store
-    const copyObject = Object.assign({}, unifiedObject)
-    if (installedInfo) {
-      copyObject.is_installed = true
-      copyObject.install = installedInfo
-    }
-    library.set(String(game.id), copyObject)
-  }
-  libraryStore.set('games', gamesObjects)
-  logInfo('Saved games data', LogPrefix.Gog)
+    throw new Error('Exceeeded max number of retries')
+  })
 
-  // fetch images async
-  fetchImages()
-  return defaultExecResult
-}
-
-export async function fetchImages() {
-  if (!GOGUser.isLoggedIn()) {
-    return
-  }
-
-  const lib = libraryStore.get('games', [])
-
-  // only process games with no image
-  const gamesWithNoImage = lib.filter(
-    (game) => game.art_square === fallBackImage
-  )
-  let changed = false // flag to only save and notify the frontend if something changed
-
-  // split games in chunks of 20 to fetch info in parallel
-  const chunks: GameInfo[][] = []
-  while (gamesWithNoImage.length) {
-    chunks.push(gamesWithNoImage.splice(0, 20))
+  // Await in chunks of 10
+  const chunks: Array<Array<Promise<GameInfo>>> = []
+  while (promises.length) {
+    chunks.push(promises.splice(0, 10))
   }
 
   for (const chunk of chunks) {
-    const promises = chunk.map(async (game) => {
-      // try gamesdb.gog.com
-      const { isUpdated, data } = await getGamesdbData(
-        'gog',
-        String(game.app_name)
-      )
+    const settled = await Promise.allSettled(chunk)
+    const fulfilled = settled
+      .filter((promise) => promise.status === 'fulfilled')
+      //@ts-expect-error Typescript is confused about this filter statement, it's correct however
+      .map((promise: PromiseFulfilledResult<GameInfo>) => promise.value)
 
-      if (data) {
-        // if data available, update the game in memory
-        let newImageUrl = data?.game?.vertical_cover?.url_format
-        if (newImageUrl && newImageUrl !== game.art_square) {
-          newImageUrl = newImageUrl
-            .replace('{formatter}', '')
-            .replace('{ext}', 'jpg')
-          apiInfoCache.set(String(game.app_name), { isUpdated, data })
-          game.art_square = newImageUrl
-          game.developer = data.game.developers
-            .map((dev) => dev.name)
-            .join(', ')
-          if (game.extra !== undefined && game.extra.about !== undefined)
-            game.extra.about.description = data.game.summary['*']
-          changed = true
-        }
-      } else {
-        // if no data, try api api.gog.com
-        const apiData = await getGamesData(String(game.app_name))
-        if (apiData?._links?.boxArtImage) {
-          game.art_square = apiData._links.boxArtImage.href
-          changed = true
-        }
-      }
-
-      return game
-    })
-
-    // update lib array with the upated games from the current chunk
-    const results = await Promise.all(promises)
-    results.forEach((game) => {
-      const index = lib.findIndex((g) => g.app_name === game.app_name)
-      if (index !== -1) {
-        lib[index] = game
+    fulfilled.forEach((data: GameInfo) => {
+      if (data?.app_name) {
+        sendFrontendMessage('pushGameToLibrary', data)
+        library.set(data.app_name, data)
       }
     })
   }
 
-  // if any game changed, store the new updated array and notify the frontend
-  // without this it may end up in an infinite loop since the frontend triggers
-  // another refresh
-  if (changed) {
-    libraryStore.set('games', lib)
-    sendFrontendMessage('refreshLibrary')
-  }
+  libraryStore.set('games', gamesObjects)
+  logInfo('Saved games data', LogPrefix.Gog)
+
+  return defaultExecResult
 }
 
 export function getGameInfo(slug: string): GameInfo | undefined {
@@ -663,7 +570,7 @@ export async function checkForLinuxInstallerUpdate(
   const response = await getProductApi(appName, ['downloads'])
   if (!response) return false
 
-  const installers = response.data?.downloads?.installers
+  const installers = response.data?.downloads?.installers ?? []
   for (const installer of installers) {
     if (installer.os === 'linux') {
       return installer.version === version
@@ -710,33 +617,42 @@ export async function checkForGameUpdate(
  * That way it will be easly accessible on frontend
  */
 export async function gogToUnifiedInfo(
-  info: GOGGameInfo,
-  cloudSavesEnabledGames: string[]
+  info: GamesDBData | undefined,
+  galaxyProductInfo: ProductsEndpointData | undefined
 ): Promise<GameInfo> {
+  // @ts-expect-error TODO: Handle this somehow
+  if (!info || info.type !== 'game') return {}
   const object: GameInfo = {
     runner: 'gog',
-    store_url: `https://gog.com${info.url}`,
-    developer: '',
-    app_name: String(info.id),
-    art_cover: `https:${info.image}.jpg`,
-    art_square: fallBackImage,
-    cloud_save_enabled: cloudSavesEnabledGames.includes(String(info.id)),
+    store_url: galaxyProductInfo?.links.product_card,
+    developer: info.game.developers.map((dev) => dev.name).join(', '),
+    app_name: String(info.external_id),
+    art_cover: `https:${galaxyProductInfo?.images.logo2x}`,
+    art_square: info.game.vertical_cover.url_format
+      .replace('{formatter}', '')
+      .replace('{ext}', 'jpg'),
+    cloud_save_enabled: false,
     extra: {
-      about: { description: '', shortDescription: '' },
+      about: { description: info.summary['*'], shortDescription: '' },
       reqs: [],
-      storeUrl: `https://gog.com${info.url}`
+      storeUrl: galaxyProductInfo?.links.product_card
     },
     folder_name: '',
     install: {
       is_dlc: false
     },
     is_installed: false,
-    namespace: info.slug,
+    namespace: galaxyProductInfo?.slug,
     save_folder: '',
-    title: info.title,
+    title: galaxyProductInfo?.title ?? info.game.title['en-US'] ?? '',
+    sorting_title: info.game.sorting_title['*'] ?? '',
     canRunOffline: true,
-    is_mac_native: info.worksOn.Mac,
-    is_linux_native: info.worksOn.Linux,
+    is_mac_native: Boolean(
+      info.supported_operating_systems.find((os) => os.slug === 'osx')
+    ),
+    is_linux_native: Boolean(
+      info.supported_operating_systems.find((os) => os.slug === 'linux')
+    ),
     thirdPartyManagedApp: undefined
   }
 
@@ -750,7 +666,9 @@ export async function gogToUnifiedInfo(
  * @returns plain API response
  */
 export async function getGamesData(appName: string, lang?: string) {
-  const url = `https://api.gog.com/v2/games/${appName}?locale=${lang || 'en'}`
+  const url = `https://api.gog.com/v2/games/${appName}?locale=${
+    lang || 'en-US'
+  }`
 
   const response: AxiosResponse | null = await axios.get(url).catch(() => {
     return null
@@ -914,18 +832,26 @@ export function getExecutable(appName: string): string {
 export async function getGamesdbData(
   store: string,
   game_id: string,
-  etag?: string
+  etag?: string,
+  certificate?: string,
+  access_token?: string
 ): Promise<{ isUpdated: boolean; data?: GamesDBData | undefined }> {
   const url = `https://gamesdb.gog.com/platforms/${store}/external_releases/${game_id}`
-  const headers = etag
-    ? {
-        'If-None-Match': etag
-      }
-    : undefined
+  const headers = {
+    'If-None-Match': etag ?? '',
+    'X-GOG-Library-Cert': certificate ?? '',
+    Authorization: `Bearer ${access_token}`
+  }
 
-  const response = await axios.get(url, { headers: headers }).catch(() => {
-    return null
-  })
+  const response = await axios
+    .get(url, { headers: headers })
+    .catch((error: AxiosError) => {
+      if (error.response?.status === 404) {
+        return null
+      }
+      throw new Error('connection error', { cause: error })
+    })
+
   if (!response) {
     return { isUpdated: false }
   }
@@ -946,11 +872,21 @@ export async function getGamesdbData(
  * @param expand expanded results to be returned
  * @returns raw axios response, or null if there was a error
  */
-export async function getProductApi(appName: string, expand?: string[]) {
+export async function getProductApi(
+  appName: string,
+  expand?: string[]
+): Promise<AxiosResponse<ProductsEndpointData> | null> {
   expand = expand ?? []
-  const expandString = expand.length ? '?expand=' + expand.join(',') : ''
-  const url = `https://api.gog.com/products/${appName}${expandString}`
-  const response = await axios.get(url).catch(() => null)
+  const language = i18next.language
+  const url = new URL(`https://api.gog.com/products/${appName}`)
+  url.searchParams.set('locale', language)
+  if (expand.length > 0) {
+    url.searchParams.set('expand', expand.join(','))
+  }
+  // `https://api.gog.com/products/${appName}?locale=${language}${expandString}`
+  const response = await axios
+    .get<ProductsEndpointData>(url.toString())
+    .catch(() => null)
 
   return response
 }
@@ -962,11 +898,8 @@ export async function getProductApi(appName: string, expand?: string[]) {
 export async function getLinuxInstallersLanguages(appName: string) {
   const response = await getProductApi(appName, ['downloads'])
   if (response) {
-    const installers = response.data?.downloads?.installers
-    const linuxInstallers = installers.filter(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (value: any) => value.os === 'linux'
-    )
+    const installers = response.data?.downloads?.installers ?? []
+    const linuxInstallers = installers.filter((value) => value.os === 'linux')
     const possibleLanguages: string[] = []
 
     for (const installer of linuxInstallers) {
@@ -994,7 +927,7 @@ export async function getLinuxInstallerInfo(appName: string): Promise<
   if (!response) {
     return
   }
-  const installers = response.data?.downloads?.installers
+  const installers = response.data?.downloads?.installers ?? []
 
   for (const installer of installers) {
     if (installer.os === 'linux')

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -85,6 +85,9 @@ export async function getSaveSyncLocation(
   }
   const platformInfo = response.content[syncPlatform]
   const savesInfo = platformInfo.cloudStorage
+  if (!savesInfo.enabled) {
+    return
+  }
   return savesInfo.locations
 }
 
@@ -645,7 +648,6 @@ export async function gogToUnifiedInfo(
     namespace: galaxyProductInfo?.slug,
     save_folder: '',
     title: galaxyProductInfo?.title ?? info.game.title['en-US'] ?? '',
-    sorting_title: info.game.sorting_title['*'] ?? '',
     canRunOffline: true,
     is_mac_native: Boolean(
       info.supported_operating_systems.find((os) => os.slug === 'osx')

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -613,7 +613,7 @@ export async function checkForGameUpdate(
 }
 
 /**
- * Convert GOGGameInfo object to GameInfo
+ * Convert GamesDBData and ProductEndpointData objects to GameInfo
  * That way it will be easly accessible on frontend
  */
 export async function gogToUnifiedInfo(

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -110,7 +110,6 @@ async function getGalaxyLibrary(
   if (page_token) {
     url.searchParams.set('page_token', page_token)
   }
-  console.log(url.toString())
   const objects: GalaxyLibraryEntry[] = []
   const data = await axios
     .get<Library>(url.toString(), { headers })
@@ -619,7 +618,7 @@ export async function gogToUnifiedInfo(
   info: GamesDBData | undefined,
   galaxyProductInfo: ProductsEndpointData | undefined
 ): Promise<GameInfo> {
-  if (!info || info.type !== 'game') {
+  if (!info || info.type !== 'game' || !info.game.visible_in_library) {
     // @ts-expect-error TODO: Handle this somehow
     return {}
   }
@@ -642,6 +641,11 @@ export async function gogToUnifiedInfo(
     install: {
       is_dlc: false
     },
+    installable:
+      (galaxyProductInfo?.content_system_compatibility.osx ||
+        galaxyProductInfo?.content_system_compatibility.windows ||
+        galaxyProductInfo?.content_system_compatibility.linux) ??
+      false,
     is_installed: false,
     namespace: galaxyProductInfo?.slug,
     save_folder: '',

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -839,7 +839,7 @@ export async function getGamesdbData(
   access_token?: string
 ): Promise<{ isUpdated: boolean; data?: GamesDBData | undefined }> {
   const pieceId = `${store}_${game_id}`
-  const cachedData = apiInfoCache.get(pieceId)
+  const cachedData = !forceUpdate ? apiInfoCache.get(pieceId) : null
   if (cachedData && cachedData?.id && !forceUpdate) {
     return { isUpdated: false, data: apiInfoCache.get(pieceId) }
   }
@@ -853,6 +853,13 @@ export async function getGamesdbData(
   const response = await axios
     .get<GamesDBData>(url, { headers: headers })
     .catch((error: AxiosError) => {
+      logError(
+        [
+          `Was not able to get GamesDB data for ${game_id}`,
+          error.response?.data.error_description
+        ],
+        LogPrefix.ExtraGameInfo
+      )
       if (error.response?.status === 404) {
         return null
       }
@@ -862,7 +869,7 @@ export async function getGamesdbData(
   if (!response) {
     return { isUpdated: false }
   }
-  const resEtag = response.headers.etag
+  const resEtag = response.headers?.etag
   const isUpdated = cachedData?.etag === resEtag
   const data = response.data
 

--- a/src/backend/wiki_game_info/gamesdb/utils.ts
+++ b/src/backend/wiki_game_info/gamesdb/utils.ts
@@ -1,7 +1,7 @@
 import { GamesDBInfo, Runner } from 'common/types'
-import { logError, logInfo, LogPrefix } from 'backend/logger/logger'
+import { logInfo, LogPrefix } from 'backend/logger/logger'
 import { GamesDBData } from 'common/types/gog'
-import axios from 'axios'
+import { getGamesdbData } from 'backend/storeManagers/gog/library'
 
 export async function getInfoFromGamesDB(
   title: string,
@@ -10,7 +10,15 @@ export async function getInfoFromGamesDB(
 ): Promise<GamesDBInfo | null> {
   logInfo(`Getting GamesDB data for ${title}`, LogPrefix.ExtraGameInfo)
 
-  const gamesdb: { data?: GamesDBData } = await getGamesdbData(runner, appName)
+  const storeMap = { legendary: 'epic', gog: 'gog', sideloaded: undefined }
+  const storeName = storeMap[runner]
+  if (!storeName) {
+    return { steamID: '' }
+  }
+  const gamesdb: { data?: GamesDBData } = await getGamesdbData(
+    storeName,
+    appName
+  ).catch(() => ({ data: undefined }))
 
   const steamID =
     gamesdb.data?.game.releases.find((entry) => entry.platform_id === 'steam')
@@ -19,59 +27,4 @@ export async function getInfoFromGamesDB(
   return {
     steamID
   }
-}
-
-/**
- * This function can be also used with outher stores
- * This endpoint doesn't require user to be authenticated.
- * @param runner Indicates a store we have game_id from, like: epic, itch, humble, gog, uplay
- * @param game_id ID of a game
- * @param etag (optional) value returned in response, works as checksum so we can check if we have up to date data
- * @returns object {isUpdated, data}, where isUpdated is true when Etags match
- */
-async function getGamesdbData(
-  runner: Runner,
-  game_id: string,
-  etag?: string
-): Promise<{ isUpdated: boolean; data?: GamesDBData | undefined }> {
-  const storeMap = { legendary: 'epic', gog: 'gog', sideloaded: undefined }
-  const storeName = storeMap[runner]
-
-  if (storeName) {
-    const url = `https://gamesdb.gog.com/platforms/${storeName}/external_releases/${game_id}`
-    const headers = etag
-      ? {
-          'If-None-Match': etag
-        }
-      : undefined
-
-    const response = await axios
-      .get(url, { headers: headers })
-      .catch((error) => {
-        logError(
-          [
-            `Was not able to get GamesDB data for ${game_id}`,
-            error.response.data.error_description
-          ],
-          LogPrefix.ExtraGameInfo
-        )
-        return null
-      })
-    if (!response) {
-      return { isUpdated: false }
-    }
-
-    const resEtag = response.headers?.etag
-    const isUpdated = etag === resEtag
-    const data = response.data
-
-    data.etag = resEtag
-
-    return {
-      isUpdated,
-      data
-    }
-  }
-
-  return { isUpdated: false }
 }

--- a/src/backend/wiki_game_info/gamesdb/utils.ts
+++ b/src/backend/wiki_game_info/gamesdb/utils.ts
@@ -17,7 +17,8 @@ export async function getInfoFromGamesDB(
   }
   const gamesdb: { data?: GamesDBData } = await getGamesdbData(
     storeName,
-    appName
+    appName,
+    true
   ).catch(() => ({ data: undefined }))
 
   const steamID =

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -114,7 +114,6 @@ export interface GameInfo {
   save_path?: string
   gog_save_location?: GOGCloudSavesLocation[]
   title: string
-  sorting_title?: string
   canRunOffline: boolean
   thirdPartyManagedApp?: string | undefined
   is_mac_native?: boolean

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -106,6 +106,7 @@ export interface GameInfo {
   extra?: ExtraInfo
   folder_name?: string
   install: Partial<InstalledInfo>
+  installable?: boolean
   is_installed: boolean
   namespace?: string
   // NOTE: This is the save folder without any variables filled in...

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -114,6 +114,7 @@ export interface GameInfo {
   save_path?: string
   gog_save_location?: GOGCloudSavesLocation[]
   title: string
+  sorting_title?: string
   canRunOffline: boolean
   thirdPartyManagedApp?: string | undefined
   is_mac_native?: boolean

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -263,42 +263,6 @@ export interface GOGLoginData {
   error?: boolean
 }
 
-export interface GOGGameInfo {
-  isGalaxyCompatible: true
-  tags: string[]
-  id: number
-  availability: {
-    isAvailable: boolean
-    isAvailableInAccount: true
-  }
-  title: string
-  image: string
-  url: string
-  worksOn: {
-    [key in 'Windows' | 'Mac' | 'Linux']: boolean
-  }
-  category: string
-  rating: number
-  isComingSoon: boolean
-  isMovie: false
-  isGame: true
-  slug: string
-  updates: number
-  isNew: boolean
-  dlcCount: number
-  releaseDate: {
-    date: string
-    timezone_type: number
-    timezone: string
-  }
-  isBaseProductMissing: boolean
-  isHidingDisabled: boolean
-  isInDevelopment: boolean
-  extraInfo: unknown[]
-  isHidden: boolean
-  runner: 'gogdl'
-}
-
 export interface GOGImportData {
   // "appName": "1441974651", "buildId": "55136646198962890", "title": "Prison Architect", "tasks": [{"category": "launcher", "isPrimary": true, "languages": ["en-US"], "name": "Prison Architect", "osBitness": ["64"], "path": "Launcher/dowser.exe", "type": "FileTask"}, {"category": "game", "isHidden": true, "languages": ["en-US"], "name": "Prison Architect - launcher process Prison Architect64_exe", "osBitness": ["64"], "path": "Prison Architect64.exe", "type": "FileTask"}, {"category": "document", "languages": ["en-US"], "link": "http://www.gog.com/support/prison_architect", "name": "Support", "type": "URLTask"}, {"category": "other", "languages": ["en-US"], "link": "http://www.gog.com/forum/prison_architect/prison_break_escape_map_megathread/post1", "name": "Escape Map Megathread", "type": "URLTask"}], "installedLanguage": "en-US"}
   appName: string

--- a/src/common/types/gog.ts
+++ b/src/common/types/gog.ts
@@ -337,7 +337,7 @@ export interface ProductsEndpointData {
   title: string
   purchase_link: string
   slug: string
-  conent_system_compatibility: {
+  content_system_compatibility: {
     windows: boolean
     osx: boolean
     linux: boolean

--- a/src/common/types/gog.ts
+++ b/src/common/types/gog.ts
@@ -276,6 +276,8 @@ interface Release {
 // Data returned from https://galaxy-library.gog.com/users/${credentials.user_id}/releases
 export interface Library {
   total_count: number
+  next_page_token?: string
+  page_token?: string
   limit: number
   items: Array<GalaxyLibraryEntry>
 }

--- a/src/common/types/gog.ts
+++ b/src/common/types/gog.ts
@@ -304,6 +304,32 @@ export interface BuildItem {
   link: string
 }
 
+interface ProductsEndpointFile {
+  id: string
+  size: number
+  downlink: string
+}
+
+interface ProductsEndpointBonusContent {
+  id: number
+  name: string
+  type: string
+  count: number
+  total_size: number
+  files: Array<ProductsEndpointFile>
+}
+
+interface ProductsEndpointInstaller {
+  id: string
+  name: string
+  os: 'windows' | 'osx' | 'linux'
+  language: string
+  language_full: string
+  version: string
+  total_size: number
+  files: Array<ProductsEndpointFile>
+}
+
 export interface ProductsEndpointData {
   id: number
   title: string
@@ -362,30 +388,4 @@ export interface ProductsEndpointData {
     language_packs: Array<ProductsEndpointInstaller>
     bonus_content: Array<ProductsEndpointBonusContent>
   }
-}
-
-export interface ProductsEndpointFile {
-  id: string
-  size: number
-  downlink: string
-}
-
-export interface ProductsEndpointBonusContent {
-  id: number
-  name: string
-  type: string
-  count: number
-  total_size: number
-  files: Array<ProductsEndpointFile>
-}
-
-export interface ProductsEndpointInstaller {
-  id: string
-  name: string
-  os: 'windows' | 'osx' | 'linux'
-  language: string
-  language_full: string
-  version: string
-  total_size: number
-  files: Array<ProductsEndpointFile>
 }

--- a/src/common/types/gog.ts
+++ b/src/common/types/gog.ts
@@ -1,4 +1,4 @@
-import { GOGGameInfo, LaunchOption } from 'common/types'
+import { LaunchOption } from 'common/types'
 
 export type GogInstallPlatform = 'windows' | 'osx' | 'linux'
 
@@ -273,27 +273,21 @@ interface Release {
   release_per_platform_id: string
 }
 
-// Data returned from https://embed.gog.com/account/getFilteredProducts?mediaType=1&sortBy=title
+// Data returned from https://galaxy-library.gog.com/users/${credentials.user_id}/releases
 export interface Library {
-  sortBy: string
-  page: number
-  totalProducts: number
-  totalPages: number
-  productsPerPage: number
-  contentSystemCompatibility: null
-  moviesCount: number
-  tags: {
-    id: string
-    name: string
-    productCount: string
-  }[]
-  products: GOGGameInfo[]
-  updatedProductsCount: number
-  hiddenUpdatedProductsCount: number
-  appliedFilters: {
-    tags: null
-  }
-  hasHiddenProducts: boolean
+  total_count: number
+  limit: number
+  items: Array<GalaxyLibraryEntry>
+}
+
+export interface GalaxyLibraryEntry {
+  platform_id: string
+  external_id: string
+  origin: string
+  owned: boolean
+  date_created: number
+  owned_since: number | null
+  certificate: string
 }
 
 // One item from https://content-system.gog.com/products/GAMEID/os/windows/builds?generation=2 endpoint
@@ -308,4 +302,90 @@ export interface BuildItem {
   date_published: string
   generation: number
   link: string
+}
+
+export interface ProductsEndpointData {
+  id: number
+  title: string
+  purchase_link: string
+  slug: string
+  conent_system_compatibility: {
+    windows: boolean
+    osx: boolean
+    linux: boolean
+  }
+  languages: { [key: string]: string }
+  links: {
+    purchase_link: string
+    product_card: string
+    support: string
+    forum: string
+  }
+  in_development: {
+    active: boolean
+    until: number | null
+  }
+  is_secret: boolean
+  is_installable: boolean
+  game_type: 'game' | 'dlc' | 'spam'
+  is_pre_order: boolean
+  release_date: string
+  images: {
+    background: string
+    logo: string
+    logo2x: string
+    icon: string
+    sidebarIcon: string
+    sidebarIcon2x: string
+    menuNotificationAv: string
+    menuNotificationAv2: string
+  }
+  dlcs: {
+    products: Array<{
+      id: number
+      link: string
+      expanded_link: string
+    }>
+    all_products_url: string
+    expanded_all_products_url: string
+  }
+  // Requires expanded description
+  description?: {
+    lead: string
+    full: string
+    whats_cool_about_it: string
+  }
+  // Requires downloads
+  downloads?: {
+    installers: Array<ProductsEndpointInstaller>
+    patches: Array<ProductsEndpointInstaller>
+    language_packs: Array<ProductsEndpointInstaller>
+    bonus_content: Array<ProductsEndpointBonusContent>
+  }
+}
+
+export interface ProductsEndpointFile {
+  id: string
+  size: number
+  downlink: string
+}
+
+export interface ProductsEndpointBonusContent {
+  id: number
+  name: string
+  type: string
+  count: number
+  total_size: number
+  files: Array<ProductsEndpointFile>
+}
+
+export interface ProductsEndpointInstaller {
+  id: string
+  name: string
+  os: 'windows' | 'osx' | 'linux'
+  language: string
+  language_full: string
+  version: string
+  total_size: number
+  files: Array<ProductsEndpointFile>
 }

--- a/src/frontend/components/UI/ActionIcons/index.tsx
+++ b/src/frontend/components/UI/ActionIcons/index.tsx
@@ -163,7 +163,7 @@ export default React.memo(function ActionIcons({
           onClick={async () =>
             refreshLibrary({
               checkForUpdates: true,
-              runInBackground: false,
+              runInBackground: library === 'gog',
               library
             })
           }

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -104,6 +104,9 @@ const GameCard = ({
     install: gameInstallInfo
   } = { ...gameInfoFromProps }
 
+  const isInstallable =
+    gameInfo.installable === undefined || gameInfo.installable // If it's undefined we assume it's installable
+
   const [progress, previousProgress] = hasProgress(appName)
   const { install_size: size = '0' } = {
     ...gameInstallInfo
@@ -149,6 +152,18 @@ const GameCard = ({
   }
 
   const renderIcon = () => {
+    if (!isInstallable) {
+      return (
+        <FontAwesomeIcon
+          title={
+            (t('label.game.not-installable-game'), 'Game is NOT Installable')
+          }
+          className="downIcon"
+          icon={faBan}
+        />
+      )
+    }
+
     if (notSupportedGame) {
       return (
         <FontAwesomeIcon
@@ -273,7 +288,7 @@ const GameCard = ({
       // install
       label: t('button.install'),
       onclick: () => buttonClick(),
-      show: !isInstalled && !isQueued
+      show: !isInstalled && !isQueued && isInstallable
     },
     {
       // cancel installation/update

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -155,9 +155,10 @@ const GameCard = ({
     if (!isInstallable) {
       return (
         <FontAwesomeIcon
-          title={
-            (t('label.game.not-installable-game'), 'Game is NOT Installable')
-          }
+          title={t(
+            'label.game.not-installable-game',
+            'Game is NOT Installable'
+          )}
           className="downIcon"
           icon={faBan}
         />

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -282,10 +282,8 @@ export default React.memo(function Library(): JSX.Element {
 
     // sort
     library = library.sort((a, b) => {
-      const titleA = a.sorting_title ?? a.title
-      const titleB = b.sorting_title ?? b.title
-      const gameA = titleA.toUpperCase().replace('THE ', '')
-      const gameB = titleB.toUpperCase().replace('THE ', '')
+      const gameA = a.title.toUpperCase().replace('THE ', '')
+      const gameB = b.title.toUpperCase().replace('THE ', '')
       return sortDescending
         ? -gameA.localeCompare(gameB)
         : gameA.localeCompare(gameB)

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -281,10 +281,14 @@ export default React.memo(function Library(): JSX.Element {
     }
 
     // sort
-    library = library.sort((a: { title: string }, b: { title: string }) => {
-      const gameA = a.title.toUpperCase().replace('THE ', '')
-      const gameB = b.title.toUpperCase().replace('THE ', '')
-      return sortDescending ? (gameA > gameB ? -1 : 1) : gameA < gameB ? -1 : 1
+    library = library.sort((a, b) => {
+      const titleA = a.sorting_title ?? a.title
+      const titleB = b.sorting_title ?? b.title
+      const gameA = titleA.toUpperCase().replace('THE ', '')
+      const gameB = titleB.toUpperCase().replace('THE ', '')
+      return sortDescending
+        ? -gameA.localeCompare(gameB)
+        : gameA.localeCompare(gameB)
     })
     const installed = library.filter((game) => game?.is_installed)
     const notInstalled = library.filter(

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -651,6 +651,25 @@ class GlobalState extends PureComponent<Props> {
       }
     })
 
+    window.api.handleGamePush((e: Event, args: GameInfo) => {
+      if (!args.app_name) return
+      if (args.runner === 'gog') {
+        const library = [...this.state.gog.library]
+        const index = library.findIndex(
+          (game) => game.app_name === args.app_name
+        )
+        if (index !== -1) {
+          library.splice(index, 1)
+        }
+        this.setState({
+          gog: {
+            library: [...library, args],
+            username: this.state.gog.username
+          }
+        })
+      }
+    })
+
     window.api.handleGameStatus(async (e: Event, args: GameStatus) => {
       return this.handleGameStatus({ ...args })
     })


### PR DESCRIPTION
This is a test of trying to replicate how GOG Galaxy loads the library.  

We achieve this using galaxy-library endpoint which contains games from all connected integrations (updated by client), and GOG (updated internally). We filter out all the gog games and use those.  
If we decided to go hardcore we could maybe support those integrations in the future in some way.   


Of course this can be further extended in terms of caching and deciding whether to fetch new data for games.

One proposition is to verify if we have up to date data when opening the game page.  
~~For now I'm marking it as wip (library pagination is still to be done)~~

Additionally the galaxy-library endpoint provides us with certificates that somehow in pair with GOG access token allow us to get data from gamesdb that would return 404 otherwise.  
Additionally I reduced IO traffic when pulling the library thanks to allowing to temporarily offload the CacheStore to memory, and then sync it to drive after all operations.  

This PR also adds new field `installable` to GameInfo. Preventing Cannot get game info errors for goodie packs.



Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
