### PR TITLE
fix build-process when using widevine-capable electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,10 @@
         ],
         "repo": "heroic"
       }
-    }
+    },
+     "electronDownload": {
+    "mirror": "https://github.com/castlabs/electron-releases/releases/download/v"
+  }
   },
   "dependencies": {
     "@emotion/react": "^11.10.6",
@@ -242,7 +245,7 @@
     "@typescript-eslint/parser": "^5.47.1",
     "@vitejs/plugin-react-swc": "^3.2.0",
     "cross-env": "^7.0.3",
-    "electron": "^23.1.3",
+    "electron": "https://github.com/castlabs/electron-releases#v22.3.11+wvcus",
     "electron-builder": "^23.6.0",
     "electron-devtools-installer": "^3.2.0",
     "electron-playwright-helpers": "^1.5.4",


### PR DESCRIPTION
Widevine-capable version: repair build-process

add electron download-location for the possibility to include other electron-versions (f.e. widevine-capable); offer widevine-capable electron default as download for the build-process. Fixes broken build-process on linux. 

to have widevine working, also needed:
```
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -19,7 +19,8 @@ import {
   powerSaveBlocker,
   protocol,
   screen,
-  clipboard
+  clipboard,
+  components
 } from 'electron'
 import 'backend/updater'
 import { autoUpdater } from 'electron-updater'
@@ -259,6 +260,7 @@ if (!gotTheLock) {
   app.whenReady().then(async () => {
     initStoreManagers()
     initOnlineMonitor()
+    await components.whenReady()
```

effect: running widevine-capable hgl-builds on linux (tested: deb, appimg, flatpak).
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x ] Tested the feature and it's working on a current and clean install.
- [ x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x ] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
