### PR TITLE
[Legendary] Refresh legendary only once at boot

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -57,7 +57,6 @@ const library: Map<string, GameInfo> = new Map()
 
 export async function initLegendaryLibraryManager() {
   loadGamesInAccount()
-  await refresh()
 }
 
 /**


### PR DESCRIPTION
The issue with `legendary list --third-party` running twice at boot causing a race condition and invalidating the auth token has been back for a while.

This PR removes the extra call to `.refresh` so it will now run that only once (the frontend is triggering the refresh too)

Should fix https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2753

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
