### PR TITLE
[BUG] Don't add shortcut for DLCs. Fix adding sideload app shortcuts

### DIFF
--- a/src/backend/shortcuts/shortcuts/shortcuts.ts
+++ b/src/backend/shortcuts/shortcuts/shortcuts.ts
@@ -30,6 +30,8 @@ import * as GogLibraryManager from '../../storeManagers/gog/library'
  * @public
  */
 async function addShortcuts(gameInfo: GameInfo, fromMenu?: boolean) {
+  if (gameInfo.install.is_dlc) return
+
   const { app_name, runner, title } = gameInfo
 
   logInfo(`Adding shortcuts for ${title}`, LogPrefix.Backend)
@@ -115,6 +117,8 @@ Categories=Game;
  * @public
  */
 async function removeShortcuts(gameInfo: GameInfo) {
+  if (gameInfo.install.is_dlc) return
+
   const [desktopFile, menuFile] = shortcutFiles(gameInfo.title)
 
   if (desktopFile) {

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -104,10 +104,11 @@ export async function uninstall({
   const old = libraryStore.get('games', [])
   const current = old.filter((a: GameInfo) => a.app_name !== appName)
 
+  const gameInfo = getGameInfo(appName)
   const {
     title,
     install: { executable }
-  } = getGameInfo(appName)
+  } = gameInfo
   const { winePrefix } = await getSettings(appName)
 
   if (shouldRemovePrefix) {
@@ -125,7 +126,7 @@ export async function uninstall({
 
   notify({ title, body: i18next.t('notify.uninstalled') })
 
-  removeShortcuts(appName)
+  removeShortcutsUtil(gameInfo)
 
   sendFrontendMessage('gameStatusUpdate', {
     appName,

--- a/src/backend/storeManagers/sideload/library.ts
+++ b/src/backend/storeManagers/sideload/library.ts
@@ -8,8 +8,8 @@ import {
 import { readdirSync } from 'graceful-fs'
 import { dirname, join } from 'path'
 import { libraryStore } from './electronStores'
-import { addShortcuts } from './games'
 import { logWarning } from 'backend/logger/logger'
+import { addShortcuts } from 'backend/shortcuts/shortcuts/shortcuts'
 
 export function addNewApp({
   app_name,
@@ -27,7 +27,8 @@ export function addNewApp({
     title,
     install: {
       executable,
-      platform
+      platform,
+      is_dlc: false
     },
     folder_name: executable !== undefined ? dirname(executable) : undefined,
     art_cover,
@@ -59,7 +60,7 @@ export function addNewApp({
     current[gameIndex] = { ...current[gameIndex], ...game }
   } else {
     current.push(game)
-    addShortcuts(app_name)
+    addShortcuts(game)
   }
 
   libraryStore.set('games', current)


### PR DESCRIPTION
This PR fixes two issues:

- Heroic was adding shortcuts for DLCs, but in general launching a DLC directly wouldn't work.
- Shortcuts creation/deletion failed for sideloaded apps

This fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2756

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
