### PR TITLE
Set Legendary's config path to a Heroic-specific location

### DIFF
--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -39,10 +39,8 @@ const currentGlobalConfigVersion: GlobalConfigVersion = 'v0'
 const flatPakHome = env.XDG_DATA_HOME?.replace('/data', '') || homedir()
 const userHome = homedir()
 const configFolder = app.getPath('appData')
-const legendaryConfigPath = isLinux
-  ? join(configFolder, 'legendary')
-  : join(userHome, '.config', 'legendary')
 const appFolder = join(configFolder, 'heroic')
+const legendaryConfigPath = join(appFolder, 'legendaryConfig', 'legendary')
 const configPath = join(appFolder, 'config.json')
 const gamesConfigPath = join(appFolder, 'GamesConfig')
 const toolsPath = join(appFolder, 'tools')

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -858,31 +858,6 @@ export async function launch(
     )
   }
 
-  // Log any launch information configured in Legendary's config.ini
-  const { stdout } = await runLegendaryCommand(
-    ['launch', appName, '--json', '--offline'],
-    createAbortController(appName)
-  )
-
-  appendFileSync(
-    logFileLocation(appName),
-    "Legendary's config from config.ini (before App's settings):\n"
-  )
-
-  try {
-    const json = JSON.parse(stdout)
-    // remove egl auth info
-    delete json['egl_parameters']
-
-    appendFileSync(
-      logFileLocation(appName),
-      JSON.stringify(json, null, 2) + '\n\n'
-    )
-  } catch (error) {
-    // in case legendary's command fails and the output is not json
-    appendFileSync(logFileLocation(appName), error + '\n' + stdout + '\n\n')
-  }
-
   const commandParts = [
     'launch',
     appName,

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -31,7 +31,9 @@ import {
   fallBackImage,
   legendaryConfigPath,
   legendaryLogFile,
-  legendaryMetadata
+  legendaryMetadata,
+  isLinux,
+  userHome
 } from '../../constants'
 import {
   logDebug,
@@ -50,12 +52,24 @@ import { dirname, join } from 'path'
 import { isOnline } from 'backend/online_monitor'
 import { update } from './games'
 import axios from 'axios'
+import { app } from 'electron'
+import { copySync } from 'fs-extra'
 
 const allGames: Set<string> = new Set()
 let installedGames: Map<string, InstalledJsonMetadata> = new Map()
 const library: Map<string, GameInfo> = new Map()
 
 export async function initLegendaryLibraryManager() {
+  // Migrate user data from global Legendary config if necessary
+  const globalLegendaryConfig = isLinux
+    ? join(app.getPath('appData'), 'legendary')
+    : join(userHome, '.config', 'legendary')
+  if (!existsSync(legendaryConfigPath) && existsSync(globalLegendaryConfig)) {
+    copySync(globalLegendaryConfig, legendaryConfigPath, {
+      recursive: true
+    })
+  }
+
   loadGamesInAccount()
 }
 
@@ -631,6 +645,17 @@ export async function runRunnerCommand(
   options?: CallRunnerOptions
 ): Promise<ExecResult> {
   const { dir, bin } = getLegendaryBin()
+
+  // Set XDG_CONFIG_HOME to a custom, Heroic-specific location so user-made
+  // changes to Legendary's main config file don't affect us
+  if (!options) {
+    options = {}
+  }
+  if (!options.env) {
+    options.env = {}
+  }
+  options.env.XDG_CONFIG_HOME = dirname(legendaryConfigPath)
+
   return callRunner(
     commandParts,
     { name: 'legendary', logPrefix: LogPrefix.Legendary, bin, dir },


### PR DESCRIPTION
Legendary's configuration will now be stored in a Heroic-specific location. This avoids issues where users change their `config.ini` and in turn change Heroic's behavior.
Existing configuration data will be migrated automatically, meaning anyone testing this PR *should* not notice anything out of the ordinary.

The original issue I've aimed to solve here was reported on our Discord ([here](https://discord.com/channels/812703221789097985/1093506682673446983)): When launching a game, we used to run `legendary launch <AppName> --json --offline` to get Legendary's original launch configuration for the game. This is problematic on macOS systems without CrossOver installed, as Legendary will crash when trying to auto-detect a version.
With us now controlling the config file, we simply don't have to check for user modifications at all.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
