### PR TITLE
Fix getGameInfo and prefix when uninstalling

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -57,6 +57,7 @@ const library: Map<string, GameInfo> = new Map()
 
 export async function initLegendaryLibraryManager() {
   loadGamesInAccount()
+  refreshInstalled()
 }
 
 /**

--- a/src/frontend/components/UI/UninstallModal/index.tsx
+++ b/src/frontend/components/UI/UninstallModal/index.tsx
@@ -49,7 +49,7 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
     })
     setIsNative(isNative)
 
-    if (!isNative || isDlc) {
+    if (isDlc) {
       return
     }
 


### PR DESCRIPTION
I started fixing the uninstall dialog but it actually fixes two issues:

- the uninstall dialog was failing to get the correct getGameInfo (the `installedGames` variable was not properly initialized) and then it was also skipping the set of the prefix for non-native games (so it was not showing the prefix to uninstall)
- when fixing the getGameInfo api function, this also fixed that issue when sometimes the GamePage component would show a game as NOT installed when the game is actually installed and displayed just fine in the library

@flavioislima I'm not sure why the `if (!isNative || isDLC)` check there included the native value so it would be great if you can review that, I don't know why that was there in the first place.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
