### PR TITLE
[Mac] Allow disabling automatic Applications shortcut creation

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -463,6 +463,7 @@
     "search": "Search for Games",
     "setting": {
         "adddesktopshortcuts": "Add desktop shortcuts automatically",
+        "addgamestoapplications": "Add games to Applications automatically",
         "addgamestostartmenu": "Add games to start menu automatically",
         "addgamestosteam": "Add games to Steam automatically",
         "alt-gogdl-bin": "Choose an Alternative GOGDL Binary to use",

--- a/src/backend/shortcuts/shortcuts/shortcuts.ts
+++ b/src/backend/shortcuts/shortcuts/shortcuts.ts
@@ -105,7 +105,9 @@ Categories=Game;
       break
     }
     case 'darwin': {
-      await generateMacOsApp(gameInfo)
+      if (addStartMenuShortcuts || fromMenu) {
+        await generateMacOsApp(gameInfo)
+      }
       break
     }
   }
@@ -121,11 +123,12 @@ async function removeShortcuts(gameInfo: GameInfo) {
 
   const [desktopFile, menuFile] = shortcutFiles(gameInfo.title)
 
-  if (desktopFile) {
+  if (desktopFile && !isMac) {
     unlink(desktopFile, () =>
       logInfo('Desktop shortcut removed', LogPrefix.Backend)
     )
   }
+
   if (menuFile) {
     if (isMac) {
       rm(menuFile, { recursive: true, force: true }, () =>
@@ -160,7 +163,7 @@ function shortcutFiles(gameTitle: string) {
     }
     case 'darwin':
       menuFile = join(userHome, 'Applications', `${gameTitle}.app`)
-      desktopFile = join(userHome, 'Applications', `${gameTitle}.app`)
+      desktopFile = menuFile
       break
   }
 
@@ -172,7 +175,8 @@ async function generateMacOsApp(gameInfo: GameInfo) {
 
   logInfo('Generating macOS shortcut', LogPrefix.Backend)
 
-  const appShortcut = shortcutFiles(gameInfo.title)[0]!
+  // shortcutFiles => [desktop, menu] on mac, we don't add desktop shortcut
+  const appShortcut = shortcutFiles(gameInfo.title)[1]!
   const macOSFolder = `${appShortcut}/Contents/MacOS`
   const resourcesFolder = `${appShortcut}/Contents/Resources`
   const plistFile = `${appShortcut}/Contents/Info.plist`

--- a/src/frontend/screens/Settings/components/Shortcuts.tsx
+++ b/src/frontend/screens/Settings/components/Shortcuts.tsx
@@ -11,7 +11,7 @@ const Shortcuts = () => {
   const { platform } = useContext(ContextProvider)
   const isWin = platform === 'win32'
   const isLinux = platform === 'linux'
-  const supportsShortcuts = isWin || isLinux
+  const supportsDesktopShortcut = isWin || isLinux
 
   const [addDesktopShortcuts, setAddDesktopShortcuts] = useSetting(
     'addDesktopShortcuts',
@@ -30,32 +30,38 @@ const Shortcuts = () => {
     return <></>
   }
 
+  let menuShortcutsLabel = t(
+    'setting.addgamestostartmenu',
+    'Add games to start menu automatically'
+  )
+  if (!isLinux && !isWin) {
+    menuShortcutsLabel = t(
+      'setting.addgamestoapplications',
+      'Add games to Applications automatically'
+    )
+  }
+
   return (
     <>
-      {supportsShortcuts && (
-        <>
-          <ToggleSwitch
-            htmlId="shortcutsToDesktop"
-            value={addDesktopShortcuts}
-            handleChange={() => setAddDesktopShortcuts(!addDesktopShortcuts)}
-            title={t(
-              'setting.adddesktopshortcuts',
-              'Add desktop shortcuts automatically'
-            )}
-          />
-          <ToggleSwitch
-            htmlId="shortcutsToMenu"
-            value={addStartMenuShortcuts}
-            handleChange={() =>
-              setAddStartMenuShortcuts(!addStartMenuShortcuts)
-            }
-            title={t(
-              'setting.addgamestostartmenu',
-              'Add games to start menu automatically'
-            )}
-          />
-        </>
+      {supportsDesktopShortcut && (
+        <ToggleSwitch
+          htmlId="shortcutsToDesktop"
+          value={addDesktopShortcuts}
+          handleChange={() => setAddDesktopShortcuts(!addDesktopShortcuts)}
+          title={t(
+            'setting.adddesktopshortcuts',
+            'Add desktop shortcuts automatically'
+          )}
+        />
       )}
+
+      <ToggleSwitch
+        htmlId="shortcutsToMenu"
+        value={addStartMenuShortcuts}
+        handleChange={() => setAddStartMenuShortcuts(!addStartMenuShortcuts)}
+        title={menuShortcutsLabel}
+      />
+
       <ToggleSwitch
         htmlId="shortcutsToSteam"
         value={addSteamShortcuts}


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2810

With this PR we can configure if shortcuts for games should be added to Launchpad on Mac, so there's better feature parity between OSes.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
