### PR TITLE
[GOG]: avoid removing folder_name between library refresh

### DIFF
--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -328,7 +328,7 @@ export async function install(
     ? await getLinuxInstallerInfo(appName)
     : null
 
-  if (gameInfo.folder_name === undefined) {
+  if (gameInfo.folder_name === undefined || gameInfo.folder_name.length === 0) {
     logError('game info folder is undefined in GOG install', LogPrefix.Gog)
     return { status: 'error' }
   }

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -194,6 +194,10 @@ export async function refresh(): Promise<ExecResult> {
       }
       const unifiedObject = await gogToUnifiedInfo(data, product?.data)
       if (unifiedObject.app_name) {
+        const oldData = library.get(unifiedObject.app_name)
+        if (oldData) {
+          unifiedObject.folder_name = oldData.folder_name
+        }
         gamesObjects.push(unifiedObject)
       }
       const installedInfo = installedGames.get(String(game.external_id))


### PR DESCRIPTION
This caused issues like install path being root folder of all installed games. Upon uninstalling it removed all of them

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
