### PR TITLE
[Bug] Fix popover inside settings dialog

### DIFF
--- a/src/frontend/components/UI/PopoverComponent/index.scss
+++ b/src/frontend/components/UI/PopoverComponent/index.scss
@@ -1,12 +1,17 @@
-.MuiPaper-root.MuiPopover-paper.popover-paper {
-  background-color: var(--background);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  box-shadow: 0 0 0 1px var(--border-color);
-  padding: 16px;
-  width: fit-content;
-  max-width: 500px;
-  overflow-y: auto;
-  overflow-x: hidden;
+.popover-wrapper {
+  position: relative;
+  .popover {
+    background-color: var(--background);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    box-shadow: 0 0 0 1px var(--border-color);
+    padding: 16px;
+    width: fit-content;
+    max-width: 500px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    position: absolute;
+    z-index: 2;
+  }
 }

--- a/src/frontend/components/UI/PopoverComponent/index.tsx
+++ b/src/frontend/components/UI/PopoverComponent/index.tsx
@@ -1,5 +1,4 @@
-import Popover from '@mui/material/Popover/Popover'
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import './index.scss'
 
 interface PopoverComponentProps {
@@ -11,46 +10,45 @@ const PopoverComponent: React.FC<PopoverComponentProps> = ({
   item,
   children
 }) => {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
-  const open = Boolean(anchorEl)
+  const [open, setOpen] = useState(false)
+  const wrapper = useRef<HTMLDivElement>(null)
 
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    // if already open, close it
+  const handleClick = () => {
+    setOpen(!open)
+  }
+
+  useEffect(() => {
     if (open) {
-      setAnchorEl(null)
-      return
+      // add a click listener to close the popover when clicking outside
+      const callback = (event: MouseEvent) => {
+        if (!wrapper.current!.contains(event.target as HTMLElement)) {
+          setOpen(false)
+        }
+      }
+
+      document.addEventListener('click', callback)
+
+      return () => {
+        // remove the listener when the popover is closed
+        document.removeEventListener('click', callback)
+      }
+    } else {
+      return () => ''
     }
-
-    setAnchorEl(event.currentTarget)
-  }
-
-  const handleClose = () => {
-    setAnchorEl(null)
-  }
+  }, [open])
 
   return (
-    <>
+    <div className="popover-wrapper" ref={wrapper}>
       {React.cloneElement(item, {
         onClick: handleClick,
         style: { cursor: 'pointer' }
       })}
-      <Popover
-        id={item.props.id}
-        open={open}
-        anchorEl={anchorEl}
-        onClick={handleClick}
-        onClose={handleClose}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left'
-        }}
-        classes={{
-          paper: 'popover-paper'
-        }}
-      >
-        {children}
-      </Popover>
-    </>
+      {open && (
+        <div id={item.props.id} className="popover">
+          {children}
+        </div>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
This PR fixes an issue where the popover component was not visible when used inside a modal.

Because of how the MaterialUI `Popover` component works, it was added to the document body, and it was always behind the `dialog` element and it was impossible to bring it to the front.

I tried many options of the Popover component to put it inside the dialog which partially fixed this but then the positioning was broken.

At the end I decided to go with a simpler solution implementing a similar functionality to have more control and to avoid all the weird things the MUI component was doing (adding styles, extra elements, scrolling the container, etc).

I tried this in:
- the settings as a normal page
- in game settings in a dialog
- in the `installation information` `time information` etc links in the game page
- the accessibility page

I think I covered all the places but please let me know if something looks wrong.

An example of this working where it was not working before:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/725d8b55-f98a-408e-8483-53491ecfb189)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
