### PR TITLE
Remove prefix from issue template title, remove Beta

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,5 @@
 name: Bug report
 description: "Things aren't working right? Create a bug report to let us know!"
-title: '[Bug]: '
 labels: bug:unconfirmed
 body:
   - type: markdown
@@ -57,7 +56,7 @@ body:
       label: Heroic Version
       options:
         - Latest Stable
-        - Latest Beta
+        - Latest Stable (Flatpak)
         - main branch from GitHub
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,5 @@
 name: Feature request
 description: "Are we missing something? Open a feature request and we'll get it implemented!"
-title: '[Feature Request]: '
 labels: feature-request
 body:
   - type: textarea


### PR DESCRIPTION
This PR updates the issues templates to remove the `[Bug]` and `[Feature Request]` prefixes.

I also removed the option to pick Heroic Beta in the version selector and added Stable Flatpak because I think it's something important in many cases and people is not always clear with that.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
