### PR TITLE
[GOG]: ignore pack game type

### DIFF
--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -622,7 +622,12 @@ export async function gogToUnifiedInfo(
   info: GamesDBData | undefined,
   galaxyProductInfo: ProductsEndpointData | undefined
 ): Promise<GameInfo> {
-  if (!info || info.type !== 'game' || !info.game.visible_in_library) {
+  if (
+    !info ||
+    info.type !== 'game' ||
+    !info.game.visible_in_library ||
+    (galaxyProductInfo && galaxyProductInfo.game_type === 'pack')
+  ) {
     // @ts-expect-error TODO: Handle this somehow
     return {}
   }

--- a/src/common/types/gog.ts
+++ b/src/common/types/gog.ts
@@ -361,7 +361,7 @@ export interface ProductsEndpointData {
   }
   is_secret: boolean
   is_installable: boolean
-  game_type: 'game' | 'dlc' | 'spam'
+  game_type: 'game' | 'dlc' | 'pack'
   is_pre_order: boolean
   release_date: string
   images: {


### PR DESCRIPTION
This should prevent packs that are not games itself like  [The Incredible Machine Mega Pack](https://www.gogdb.org/product/1207658799) from displaying in library.

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
