### PR TITLE
[FIX] Show correct number of gamecards in recently played.

### DIFF
--- a/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
+++ b/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
@@ -10,7 +10,11 @@ interface Props {
   onlyInstalled: boolean
 }
 
-function getRecentGames(libraries: GameInfo[], limit: number): GameInfo[] {
+function getRecentGames(
+  libraries: GameInfo[],
+  limit: number,
+  onlyInstalled: boolean
+): GameInfo[] {
   const recentGames = configStore.get('games.recent', [])
 
   const games: GameInfo[] = []
@@ -18,6 +22,7 @@ function getRecentGames(libraries: GameInfo[], limit: number): GameInfo[] {
   for (const recent of recentGames) {
     const found = libraries.find((game) => game.app_name === recent.appName)
     if (found) {
+      if (onlyInstalled && !found.is_installed) continue
       games.push(found)
       if (games.length === limit) break
     }
@@ -43,7 +48,8 @@ export default React.memo(function RecentlyPlayed({
         ...sideloadedLibrary,
         ...amazon.library
       ],
-      maxRecentGames
+      maxRecentGames,
+      onlyInstalled
     )
 
     setRecentGames(newRecentGames)


### PR DESCRIPTION
When using the only show installed option, it shows the wrong number of gamecards, this PR fixes that. 

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
