### PR TITLE
[NILE] run PostInstall setup after install only on Windows

### DIFF
--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -280,7 +280,10 @@ export async function install(
   addShortcuts(appName)
   installState(appName, true)
   const metadata = getInstallMetadata(appName)
-  await setup(appName, metadata?.path)
+
+  if (isWindows) {
+    await setup(appName, metadata?.path)
+  }
 
   return { status: 'done' }
 }


### PR DESCRIPTION
This is small PR. Basically we avoid running post install instructions on Linux and Mac, since they will be ran every time prefix gets updated, like changing it's location or wine version.

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
