### PR TITLE
[FIX] Use gameportingtoolkit exectutable rather than wine to launch games

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -597,7 +597,10 @@ async function runWineCommand({
     commandParts.unshift(prefix)
   }
 
-  const wineBin = wineVersion.bin.replaceAll("'", '')
+  const wineBin =
+    isGPTK && wineVersion.gptkBin !== null
+      ? wineVersion.gptkBin!.replaceAll("'", '')
+      : wineVersion.bin.replaceAll("'", '')
 
   logDebug(['Running Wine command:', commandParts.join(' ')], LogPrefix.Backend)
 

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -591,6 +591,12 @@ async function runWineCommand({
     commandParts.unshift(protonVerb)
   }
 
+  const isGPTK = wineVersion.type === 'toolkit'
+  if (isGPTK) {
+    const prefix = settings.winePrefix
+    commandParts.unshift(prefix)
+  }
+
   const wineBin = wineVersion.bin.replaceAll("'", '')
 
   logDebug(['Running Wine command:', commandParts.join(' ')], LogPrefix.Backend)

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -350,7 +350,6 @@ export async function getGamingPortingToolkitWine(): Promise<
     return p.match(/.*\/gameportingtoolkit$/)
   })[0]
 
-
   if (existsSync(wineBin)) {
     logInfo(
       `Found Gaming Porting Toolkit Wine at ${dirname(wineBin)}`,
@@ -387,7 +386,11 @@ export function getWineFlags(
   const wineFlagsObj = {
     proton: ['--no-wine', '--wrapper', `'${wineBin}' run`],
     wine: ['--wine', wineBin],
-    toolkit: ['--wrapper', `${wineBin} "${gameSettings.winePrefix}"`, '--no-wine']
+    toolkit: [
+      '--wrapper',
+      `${wineBin} "${gameSettings.winePrefix}"`,
+      '--no-wine'
+    ]
   }
 
   wineFlags.push(...(wineFlagsObj[wineType as keyof typeof wineFlagsObj] || []))

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -364,7 +364,8 @@ export async function getGamingPortingToolkitWine(): Promise<
         type: 'toolkit',
         lib: `${dirname(wineBin)}/../lib`,
         lib32: `${dirname(wineBin)}/../lib`,
-        bin: gptkBin
+        bin: wineBin,
+        gptkBin: gptkBin
       })
     } catch (error) {
       logError(
@@ -380,7 +381,8 @@ export async function getGamingPortingToolkitWine(): Promise<
 export function getWineFlags(
   wineBin: string,
   gameSettings: GameSettings,
-  wineType: string
+  wineType: string,
+  gptkBin?: string
 ) {
   const wineFlags = []
   const wineFlagsObj = {
@@ -388,7 +390,7 @@ export function getWineFlags(
     wine: ['--wine', wineBin],
     toolkit: [
       '--wrapper',
-      `${wineBin} "${gameSettings.winePrefix}"`,
+      `${gptkBin} "${gameSettings.winePrefix}"`,
       '--no-wine'
     ]
   }

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -340,10 +340,16 @@ export async function getGamingPortingToolkitWine(): Promise<
   }
 
   logInfo('Searching for Gaming Porting Toolkit Wine', LogPrefix.GlobalConfig)
-  const { stdout } = await execAsync('mdfind wine64')
-  const wineBin = stdout.split('\n').filter((p) => {
+  const { stdout: wineStdout } = await execAsync('mdfind wine64')
+  const wineBin = wineStdout.split('\n').filter((p) => {
     return p.match(/game-porting-toolkit.*\/wine64$/)
   })[0]
+
+  const { stdout: gptkStdout } = await execAsync('mdfind gameportingtoolkit')
+  const gptkBin = gptkStdout.split('\n').filter((p) => {
+    return p.match(/.*\/gameportingtoolkit$/)
+  })[0]
+
 
   if (existsSync(wineBin)) {
     logInfo(
@@ -359,7 +365,7 @@ export async function getGamingPortingToolkitWine(): Promise<
         type: 'toolkit',
         lib: `${dirname(wineBin)}/../lib`,
         lib32: `${dirname(wineBin)}/../lib`,
-        bin: wineBin
+        bin: gptkBin
       })
     } catch (error) {
       logError(
@@ -381,7 +387,7 @@ export function getWineFlags(
   const wineFlagsObj = {
     proton: ['--no-wine', '--wrapper', `'${wineBin}' run`],
     wine: ['--wine', wineBin],
-    toolkit: ['--wrapper', `${wineBin} ${gameSettings.winePrefix}`, '--no-wine']
+    toolkit: ['--wrapper', `${wineBin} "${gameSettings.winePrefix}"`, '--no-wine']
   }
 
   wineFlags.push(...(wineFlagsObj[wineType as keyof typeof wineFlagsObj] || []))

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -232,6 +232,7 @@ export interface WineInstallation {
   type: 'wine' | 'proton' | 'crossover' | 'toolkit'
   lib?: string
   lib32?: string
+  gptkBin?: string
   wineserver?: string
 }
 


### PR DESCRIPTION
Previously, when launching games using Apple's new Game Porting Toolkit, Heroic would launch by finding GPTK's copy of wine. This would cause file explorer to open instead of the game (as stated in #2832 and #2858).

With this fix, heroic uses the "gameportingtoolkit" executable to launch games, apps, and all wine commands (except for winetricks).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)

I've been able to run a few games using the Game Porting Toolkit, and have had no issues with running winecfg, winetricks, or installing, moving, verifying, and uninstalling games.

I have however noticed that many games do not work with the Game Porting Toolkit, although this is most likely a compatibility issue between the games and the toolkit (I've had trouble running many UE4/5 games).