### PR TITLE
[Fix] Treat GPTK Wine like regular Wine

### DIFF
--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -503,7 +503,7 @@ export async function launch(
         ? wineExec.replaceAll("'", '')
         : wineExec
 
-    wineFlag = [...getWineFlags(wineBin, gameSettings, wineType)]
+    wineFlag = getWineFlags(wineBin, wineType)
   }
 
   const commandParts = [

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -860,7 +860,7 @@ export async function launch(
         ? wineExec.replaceAll("'", '')
         : wineExec
 
-    wineFlag = [...getWineFlags(wineBin, gameSettings, wineType)]
+    wineFlag = getWineFlags(wineBin, wineType)
   }
 
   const commandParts = [

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -382,7 +382,7 @@ export async function launch(
         : wineExec
 
     wineFlag = [
-      ...getWineFlags(wineBin, gameSettings, wineType),
+      ...getWineFlags(wineBin, wineType),
       '--wine-prefix',
       gameSettings.winePrefix
     ]

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -9,7 +9,7 @@ import {
 import { logError, LogPrefix, logInfo } from 'backend/logger/logger'
 import { execAsync } from 'backend/utils'
 import { execSync } from 'child_process'
-import { GameSettings, WineInstallation } from 'common/types'
+import { WineInstallation } from 'common/types'
 import { existsSync, mkdirSync, readFileSync, readdirSync } from 'graceful-fs'
 import { homedir } from 'os'
 import { dirname, join } from 'path'
@@ -374,16 +374,15 @@ export async function getGamingPortingToolkitWine(): Promise<
 
 export function getWineFlags(
   wineBin: string,
-  gameSettings: GameSettings,
-  wineType: string
+  wineType: WineInstallation['type']
 ) {
-  const wineFlags = []
-  const wineFlagsObj = {
-    proton: ['--no-wine', '--wrapper', `'${wineBin}' run`],
-    wine: ['--wine', wineBin],
-    toolkit: ['--wrapper', `${wineBin} ${gameSettings.winePrefix}`, '--no-wine']
+  switch (wineType) {
+    case 'wine':
+    case 'toolkit':
+      return ['--wine', wineBin]
+    case 'proton':
+      return ['--no-wine', '--wrapper', `'${wineBin}' run`]
+    default:
+      return []
   }
-
-  wineFlags.push(...(wineFlagsObj[wineType as keyof typeof wineFlagsObj] || []))
-  return wineFlags
 }


### PR DESCRIPTION
When launching GPTK, Heroic simply uses the underlying `wine64` binary. This binary is a (mostly) normal Wine binary, meaning it's meant to be launched with the WINEPREFIX environment variable set to the desired Wineprefix & a single argument (the executable to run). `gameportingtoolkit` on the other hand is the wrapper around Wine, not taking in a WINEPREFIX & instead requiring two arguments (the prefix, then the executable to run)
We were running `wine64`, but were passing it parameters intended for `gameportingtoolkit`. I'm not sure how this ever worked

While touching the responsible function (getWineFlags) I've also made it a little more type-safe & removed the unused `gameSettings` parameter

Note that I cannot test this myself, as I don't have a device running macOS, however there were plenty of people with this issue on our Discord & here (#2858)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
