### PR TITLE
[Fix] Library refresh issues

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -685,6 +685,8 @@ interface RunnerProps {
   dir: string
 }
 
+const commandsRunning = {}
+
 async function callRunner(
   commandParts: string[],
   runner: RunnerProps,
@@ -738,7 +740,16 @@ async function callRunner(
     bin = runner.bin
   }
 
-  return new Promise<ExecResult>((res, rej) => {
+  // check if the same command is currently running
+  // if so, return the same promise instead of running it again
+  const key = [runner.name, commandParts].join(' ')
+  const currentPromise = commandsRunning[key]
+
+  if (currentPromise) {
+    return currentPromise
+  }
+
+  const promise = new Promise<ExecResult>((res, rej) => {
     const child = spawn(bin, commandParts, {
       cwd: runner.dir,
       env: { ...process.env, ...options?.env },
@@ -808,6 +819,11 @@ async function callRunner(
       rej(error)
     })
   })
+
+  // keep track of which commands are running
+  commandsRunning[key] = promise
+
+  promise
     .then(({ stdout, stderr }) => {
       return { stdout, stderr, fullCommand: safeCommand }
     })
@@ -841,6 +857,12 @@ async function callRunner(
 
       return { stdout: '', stderr: `${error}`, fullCommand: safeCommand, error }
     })
+    .finally(() => {
+      // remove from list when done
+      delete commandsRunning[key]
+    })
+
+  return promise
 }
 
 /**

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -143,6 +143,11 @@ export function refreshInstalled() {
   }
 }
 
+const defaultExecResult = {
+  stderr: '',
+  stdout: ''
+}
+
 /**
  * Get the game info of all games in the library
  *
@@ -150,12 +155,8 @@ export function refreshInstalled() {
  */
 export async function refresh(): Promise<ExecResult | null> {
   logInfo('Refreshing library...', LogPrefix.Legendary)
-  const isLoggedIn = LegendaryUser.isLoggedIn()
-  if (!isLoggedIn) {
-    return {
-      stderr: 'You must be logged into Epic Games to refresh this library!',
-      stdout: ''
-    }
+  if (!LegendaryUser.isLoggedIn()) {
+    return defaultExecResult
   }
 
   refreshLegendary()
@@ -173,10 +174,7 @@ export async function refresh(): Promise<ExecResult | null> {
     ['Game list updated, got', `${arr.length}`, 'games & DLCs'],
     LogPrefix.Legendary
   )
-  return {
-    stderr: '',
-    stdout: ''
-  }
+  return defaultExecResult
 }
 
 export function getListOfGames() {

--- a/src/backend/storeManagers/nile/library.ts
+++ b/src/backend/storeManagers/nile/library.ts
@@ -150,6 +150,9 @@ export function fetchFuelJSON(
  * @returns App names of updateable games.
  */
 export async function listUpdateableGames(): Promise<string[]> {
+  if (!NileUser.isLoggedIn()) {
+    return []
+  }
   logInfo('Looking for updates...', LogPrefix.Nile)
 
   const abortID = 'nile-list-updates'
@@ -232,12 +235,20 @@ export function refreshInstalled() {
   }
 }
 
+const defaultExecResult = {
+  stderr: '',
+  stdout: ''
+}
+
 /**
  * Get the game info of all games in the library
  *
  * @returns Array of objects.
  */
 export async function refresh(): Promise<ExecResult | null> {
+  if (!NileUser.isLoggedIn()) {
+    return defaultExecResult
+  }
   logInfo('Refreshing library...', LogPrefix.Nile)
 
   refreshNile()
@@ -248,10 +259,7 @@ export async function refresh(): Promise<ExecResult | null> {
   libraryStore.set('library', arr)
   logInfo(['Game list updated, got', `${arr.length}`, 'games'], LogPrefix.Nile)
 
-  return {
-    stderr: '',
-    stdout: ''
-  }
+  return defaultExecResult
 }
 
 /**

--- a/src/backend/storeManagers/nile/user.ts
+++ b/src/backend/storeManagers/nile/user.ts
@@ -115,4 +115,8 @@ export class NileUser {
 
     return user.extensions.customer_info
   }
+
+  public static isLoggedIn() {
+    return configStore.get_nodefault('userData') || false
+  }
 }

--- a/src/frontend/components/UI/UninstallModal/index.tsx
+++ b/src/frontend/components/UI/UninstallModal/index.tsx
@@ -9,7 +9,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { Runner } from 'common/types'
 import ToggleSwitch from '../ToggleSwitch'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 
 interface UninstallModalProps {
   appName: string
@@ -32,6 +32,7 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
   const { t } = useTranslation('gamepage')
   const [showUninstallModal, setShowUninstallModal] = useState(false)
   const navigate = useNavigate()
+  const location = useLocation()
 
   const checkIfIsNative = async () => {
     // This assumes native games are installed should be changed in the future
@@ -85,8 +86,8 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
       deletePrefixChecked,
       deleteSettingsChecked
     )
-    if (runner === 'sideload') {
-      navigate('/')
+    if (runner === 'sideload' && location.pathname.match(/gamepage/)) {
+      navigate('/#library')
     }
     storage.removeItem(appName)
   }

--- a/src/frontend/components/UI/UninstallModal/index.tsx
+++ b/src/frontend/components/UI/UninstallModal/index.tsx
@@ -1,12 +1,11 @@
 import './index.scss'
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   Dialog,
   DialogContent,
   DialogFooter,
   DialogHeader
 } from 'frontend/components/UI/Dialog'
-import ContextProvider from 'frontend/state/ContextProvider'
 import { useTranslation } from 'react-i18next'
 import { Runner } from 'common/types'
 import ToggleSwitch from '../ToggleSwitch'
@@ -25,7 +24,6 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
   onClose,
   isDlc
 }) {
-  const { refreshLibrary } = useContext(ContextProvider)
   const [isNative, setIsNative] = useState(true)
   const [winePrefix, setWinePrefix] = useState('')
   const [deletePrefixChecked, setDeletePrefixChecked] = useState(false)
@@ -91,7 +89,6 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
       navigate('/')
     }
     storage.removeItem(appName)
-    refreshLibrary({ fullRefresh: true, checkForUpdates: false })
   }
 
   const showWineCheckbox = !isNative && !isDlc

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -543,10 +543,7 @@ class GlobalState extends PureComponent<Props> {
     })
     window.api.logInfo(`Refreshing ${library} Library`)
     try {
-      if (!checkForUpdates || library === 'gog' || library === 'nile') {
-        await window.api.refreshLibrary(library)
-      }
-
+      await window.api.refreshLibrary(library)
       return await this.refresh(library, checkForUpdates)
     } catch (error) {
       window.api.logError(`${error}`)


### PR DESCRIPTION
This PR includes 3 fixes:

- a different fix for the issue where people got logged out from legendary (because the `list --third-party` command ran twice in parallel). The previous fix introduced a problem (the refresh library button was not working correctly for epic games). This PR reverts the previous change and, instead, it adds a new measure: when running a `runner` command, if the command is currently running we return the same promise instead of running the command twice in parallel.

This will also prevent an issue we have during development because of react's double rendering of components in strict mode: if a component runs a command to (for example) get the game install info, it was running twice before, with this the command is running and the second call would pick the previous command's promise.

- the other change of this PR is it first checks if we are logged into Nile before trying to refresh its library

- it also fixes an issue where the page was reloaded when uninstalling a sideloaded app from the library, not it only redirects to the library if uninstalling from the game page

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
