### PR TITLE
[Fix] Skip DLCs when listing recently played games

### DIFF
--- a/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
+++ b/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
@@ -23,6 +23,7 @@ function getRecentGames(
     const found = libraries.find((game) => game.app_name === recent.appName)
     if (found) {
       if (onlyInstalled && !found.is_installed) continue
+      if (found.install.is_dlc) continue
       games.push(found)
       if (games.length === limit) break
     }


### PR DESCRIPTION
In the new version of Heroic we are properly ignoring DLCs in listings, but in previous versions you can still click `Play` in a DLC and it will fail but the game is still added in the `Recently played` list.

Because we are now hiding DLCs properly, if the element happens to be the first in the list, it's ignored but then the feature to display the first element bigger breaks because the indexes change and the `justPlayed` class is not set, and there's no way to remove the non-visible element from the list to manually fix the issue (apart from editing the config files manually).

This PR fixes that by ignoring DLCs when getting the list of recently played games.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
