### PR TITLE
[UX]: request install info only when online

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -103,7 +103,8 @@ export default React.memo(function GamePage(): JSX.Element | null {
     platform,
     showDialogModal,
     setIsSettingsModalOpen,
-    isSettingsModalOpen
+    isSettingsModalOpen,
+    connectivity
   } = useContext(ContextProvider)
 
   const [gameInfo, setGameInfo] = useState(locationGameInfo)
@@ -149,6 +150,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
     gameInfo.installable !== undefined && !gameInfo.installable
   const notSupportedGame =
     gameInfo.runner !== 'sideload' && gameInfo.thirdPartyManagedApp === 'Origin'
+  const isOffline = connectivity.status !== 'online'
 
   const backRoute = location.state?.fromDM ? '/download-manager' : '/library'
 
@@ -182,7 +184,12 @@ export default React.memo(function GamePage(): JSX.Element | null {
             ? 'Mac'
             : 'Windows')
 
-        if (runner !== 'sideload' && !notSupportedGame && !notInstallable) {
+        if (
+          runner !== 'sideload' &&
+          !notSupportedGame &&
+          !notInstallable &&
+          !isOffline
+        ) {
           getInstallInfo(appName, runner, installPlatform)
             .then((info) => {
               if (!info) {
@@ -246,7 +253,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       }
     }
     updateConfig()
-  }, [status, epic.library, gog.library, gameInfo, isSettingsModalOpen])
+  }, [status, epic.library, gog.library, gameInfo, isSettingsModalOpen, isOffline])
 
   useEffect(() => {
     window.api
@@ -491,7 +498,8 @@ export default React.memo(function GamePage(): JSX.Element | null {
                 {!is_installed &&
                   !isSideloaded &&
                   !notSupportedGame &&
-                  !notInstallable && (
+                  !notInstallable &&
+                  !isOffline && (
                     <>
                       <div className="iconWithText">
                         <CloudDownload />


### PR DESCRIPTION
GamePage will request and show install info only when online 

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
