### PR TITLE
[Test]: Example how to test launch command

### DIFF
--- a/src/backend/__mocks__/game_config.ts
+++ b/src/backend/__mocks__/game_config.ts
@@ -1,0 +1,20 @@
+import { GameSettings } from '../../common/types'
+
+const GameConfig = (() => {
+  let config = {} as GameSettings
+
+  const set = (value: Partial<GameSettings>) => {
+    config = { ...config, ...value }
+  }
+
+  return {
+    set,
+    get: () => {
+      return {
+        getSettings: () => config
+      }
+    }
+  }
+})()
+
+export { GameConfig }

--- a/src/backend/storeManagers/legendary/__tests__/games.test.ts
+++ b/src/backend/storeManagers/legendary/__tests__/games.test.ts
@@ -1,11 +1,22 @@
-import { syncSaves } from '../games'
 import * as library from '../library'
+import * as launcher from '../../../launcher'
+import graceful_fs from 'graceful-fs'
+import { launch, syncSaves } from '../games'
+import { GameConfig } from '../../../game_config'
+import { WineInstallation } from 'common/types'
 
 // Mock functions that the actual implementation depends on
 jest.mock('../../../logger/logger')
 jest.mock('../../../logger/logfile')
+jest.mock('../../../game_config')
+jest.mock('../../../config')
 
 describe('syncSaves', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
   test("returns 'No path provided.' if path parameter is falsy", async () => {
     const appName = 'test'
     const arg = ''
@@ -16,7 +27,7 @@ describe('syncSaves', () => {
     expect(result).toBe('No path provided.')
   })
 
-  it('Save-sync uses correct path', async () => {
+  test('Save-sync uses correct path', async () => {
     const appName = 'SomeAppName'
 
     const spy = jest
@@ -39,8 +50,49 @@ describe('syncSaves', () => {
     }
   })
 
-  it('Save-sync fails with empty path', async () => {
+  test('Save-sync fails with empty path', async () => {
     jest.spyOn(library, 'runRunnerCommand')
     expect(await syncSaves('SomeAppName', '', '')).toBe('No path provided.')
+  })
+})
+
+describe('launch', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  test('check that empty wrapper args are ignored', async () => {
+    jest.spyOn(graceful_fs, 'appendFileSync').mockReturnValue()
+    jest.spyOn(launcher, 'prepareLaunch').mockResolvedValue({
+      success: true,
+      failureReason: '',
+      rpcClient: undefined,
+      mangoHudCommand: undefined,
+      gameModeBin: undefined,
+      steamRuntime: undefined,
+      offlineMode: undefined
+    })
+    jest.spyOn(launcher, 'prepareWineLaunch').mockResolvedValue({
+      success: true
+    })
+
+    GameConfig['set']({
+      wineVersion: {
+        bin: '',
+        name: '',
+        type: 'wine'
+      } as WineInstallation
+    })
+    const command = jest.spyOn(library, 'runRunnerCommand')
+
+    await expect(launch('test')).resolves.toBeTruthy()
+    expect(command).toBeCalledWith(
+      ['launch', 'test', '--wine', '', ''],
+      new AbortController(),
+      expect.objectContaining({
+        wrappers: []
+      })
+    )
   })
 })


### PR DESCRIPTION
This PR shows an example how to test the launch command of a storeManager. By mocking out all stuff and return values you would expect you can test what command was created.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
