### PR TITLE
[Tech] Type-check Legendary commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,8 @@
     "simple-keyboard": "^3.5.33",
     "steam-shortcut-editor": "^3.1.1",
     "systeminformation": "^5.17.12",
-    "tslib": "^2.5.0"
+    "tslib": "^2.5.0",
+    "zod": "^3.21.4"
   },
   "scripts": {
     "start": "vite",

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -63,7 +63,7 @@ import { gameManagerMap } from 'backend/storeManagers'
 import * as VDF from '@node-steam/vdf'
 import { readFileSync } from 'fs'
 import { LegendaryCommand } from './storeManagers/legendary/commands'
-import { Entries } from 'type-fest'
+import { commandToArgsArray } from './storeManagers/legendary/library'
 
 async function prepareLaunch(
   gameSettings: GameSettings,
@@ -977,63 +977,6 @@ async function getWinePath({
   return stdout.trim()
 }
 
-/**
- * Converts a LegendaryCommand to a parameter list passable to Legendary
- * @param command
- */
-function commandToArgsArray(command: LegendaryCommand): string[] {
-  const commandParts: string[] = []
-
-  if (command.subcommand) commandParts.push(command.subcommand)
-
-  // Some commands need special handling
-  switch (command.subcommand) {
-    case 'install':
-      commandParts.push(command.appName)
-      if (command.sdlList) {
-        commandParts.push('--install-tag=')
-        for (const sdlTag of command.sdlList)
-          commandParts.push('--install-tag', sdlTag)
-      }
-      break
-    case 'launch':
-      commandParts.push(command.appName)
-      if (command.extraArguments)
-        commandParts.push(...shlex.split(command.extraArguments))
-      break
-    case 'info':
-    case 'sync-saves':
-    case 'uninstall':
-      commandParts.push(command.appName)
-      break
-    case 'move':
-      commandParts.push(command.appName, command.newBasePath)
-      break
-    case 'eos-overlay':
-      commandParts.push(command.action)
-      break
-    case 'import':
-      commandParts.push(command.appName, command.installationDirectory)
-      break
-  }
-
-  // Append parameters (anything starting with -)
-  for (const [parameter, value] of Object.entries(
-    command
-  ) as Entries<LegendaryCommand>) {
-    if (!parameter.startsWith('-')) continue
-    if (!value) continue
-    // Boolean values (specifically `true`) have to be handled differently
-    // Parameters that have a boolean type are just signified
-    // by the parameter being present, they don't have a value.
-    // Thus, we only add the key (parameter) here, instead of the key & value
-    if (value === true) commandParts.push(parameter)
-    else commandParts.push(parameter, value.toString())
-  }
-
-  return commandParts
-}
-
 export {
   prepareLaunch,
   launchCleanup,
@@ -1044,6 +987,5 @@ export {
   runWineCommand,
   callRunner,
   getRunnerCallWithoutCredentials,
-  getWinePath,
-  commandToArgsArray
+  getWinePath
 }

--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -25,6 +25,7 @@ import {
 import { legendaryConfigPath } from './constants'
 import { join } from 'path'
 import { gameManagerMap, libraryManagerMap } from 'backend/storeManagers'
+import { LegendaryAppName } from './storeManagers/legendary/commands/base'
 
 async function getDefaultSavePath(
   appName: string,
@@ -81,13 +82,13 @@ async function getDefaultLegendarySavePath(appName: string): Promise<string> {
   logInfo(['Computing default save path for', appName], LogPrefix.Legendary)
   const abortControllerName = appName + '-savePath'
   await runLegendaryCommand(
-    [
-      'sync-saves',
-      appName,
-      '--skip-upload',
-      '--skip-download',
-      '--accept-path'
-    ],
+    {
+      subcommand: 'sync-saves',
+      appName: LegendaryAppName.parse(appName),
+      '--skip-upload': true,
+      '--skip-download': true,
+      '--accept-path': true
+    },
     createAbortController(abortControllerName),
     {
       logMessagePrefix: 'Getting default save path',

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -513,7 +513,7 @@ export async function launch(
         ? wineExec.replaceAll("'", '')
         : wineExec
 
-    wineFlag = [...getWineFlags(wineBin, wineType, shlex.join(wrappers))]
+    wineFlag = [...getWineFlags(wineBin, wineType, shlex.join(wrappers), true)]
   }
 
   const commandParts = [

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -82,7 +82,7 @@ import { showDialogBoxModalAuto } from '../../dialog/dialog'
 import { sendFrontendMessage } from '../../main_window'
 import { RemoveArgs } from 'common/types/game_manager'
 import { logFileLocation } from 'backend/storeManagers/storeManagerCommon/games'
-import { getWineFlags } from 'backend/utils/compatibility_layers'
+import { getWineFlagsArray } from 'backend/utils/compatibility_layers'
 import axios, { AxiosError } from 'axios'
 import { isOnline, runOnceWhenOnline } from 'backend/online_monitor'
 
@@ -513,7 +513,7 @@ export async function launch(
         ? wineExec.replaceAll("'", '')
         : wineExec
 
-    wineFlag = [...getWineFlags(wineBin, wineType, shlex.join(wrappers), true)]
+    wineFlag = getWineFlagsArray(wineBin, wineType, shlex.join(wrappers))
   }
 
   const commandParts = [

--- a/src/backend/storeManagers/legendary/__tests__/games.test.ts
+++ b/src/backend/storeManagers/legendary/__tests__/games.test.ts
@@ -25,18 +25,19 @@ describe('syncSaves', () => {
         return { stderr: '', stdout: '' }
       })
 
-    const paths = ['C:\\my\\path', '/home/someone/saves/path']
-    for (const path of paths) {
-      await syncSaves(appName, '', path)
-      expect(spy.mock.lastCall?.[0]).toEqual([
-        'sync-saves',
-        '',
-        '--save-path',
-        path,
-        'SomeAppName',
-        '-y'
-      ])
-    }
+    jest.spyOn(library, 'hasGame').mockReturnValue(true)
+
+    const testPath =
+      process.platform === 'win32' ? 'C:\\my\\path' : '/home/someone/saves/path'
+
+    await syncSaves(appName, '', testPath)
+    expect(spy.mock.lastCall?.[0]).toEqual({
+      subcommand: 'sync-saves',
+      appName: 'SomeAppName',
+      '': true,
+      '--save-path': testPath,
+      '-y': true
+    })
   })
 
   it('Save-sync fails with empty path', async () => {

--- a/src/backend/storeManagers/legendary/commands/auth.ts
+++ b/src/backend/storeManagers/legendary/commands/auth.ts
@@ -1,0 +1,13 @@
+import { NonEmptyString } from './base'
+
+interface AuthCommand {
+  subcommand: 'auth'
+  '--import'?: true
+  '--code'?: NonEmptyString
+  '--token'?: NonEmptyString
+  '--sid'?: NonEmptyString
+  '--delete'?: true
+  '--disable-webview'?: true
+}
+
+export default AuthCommand

--- a/src/backend/storeManagers/legendary/commands/base.ts
+++ b/src/backend/storeManagers/legendary/commands/base.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+import path from 'path'
+import { hasGame } from '../library'
+
+export const LegendaryAppName = z
+  .string()
+  .refine((val) => hasGame(val), {
+    message: 'AppName was not found on account'
+  })
+  .brand('LegendaryAppName')
+export type LegendaryAppName = z.infer<typeof LegendaryAppName>
+
+export const LegendaryPlatform = z.enum(['Win32', 'Windows', 'Mac'] as const)
+export type LegendaryPlatform = z.infer<typeof LegendaryPlatform>
+
+export const NonEmptyString = z.string().min(1).brand('NonEmptyString')
+export type NonEmptyString = z.infer<typeof NonEmptyString>
+
+export const Path = z
+  .string()
+  .refine((val) => path.parse(val).root, 'Path is not valid')
+  .brand('Path')
+export type Path = z.infer<typeof Path>
+
+export const PositiveInteger = z
+  .number()
+  .int()
+  .positive()
+  .brand('PositiveInteger')
+export type PositiveInteger = z.infer<typeof PositiveInteger>
+
+export const URL = z.string().url().brand('URL')
+export type URL = z.infer<typeof URL>
+
+// FIXME: This doesn't feel right
+export const URI = z.union([Path, URL])
+export type URI = z.infer<typeof URI>

--- a/src/backend/storeManagers/legendary/commands/cleanup.ts
+++ b/src/backend/storeManagers/legendary/commands/cleanup.ts
@@ -1,0 +1,6 @@
+interface CleanupCommand {
+  subcommand: 'cleanup'
+  '--keep-manifests'?: true
+}
+
+export default CleanupCommand

--- a/src/backend/storeManagers/legendary/commands/eos_overlay.ts
+++ b/src/backend/storeManagers/legendary/commands/eos_overlay.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+import { LegendaryAppName, NonEmptyString, Path } from './base'
+
+const EosOverlayAction = z.enum([
+  'install',
+  'update',
+  'remove',
+  'enable',
+  'disable',
+  'info'
+] as const)
+type EosOverlayAction = z.infer<typeof EosOverlayAction>
+
+interface EosOverlayCommand {
+  subcommand: 'eos-overlay'
+  action: EosOverlayAction
+  '--path'?: Path
+  '--prefix'?: Path
+  '--app'?: LegendaryAppName
+  '--bottle'?: NonEmptyString
+}
+
+export default EosOverlayCommand

--- a/src/backend/storeManagers/legendary/commands/import.ts
+++ b/src/backend/storeManagers/legendary/commands/import.ts
@@ -1,0 +1,12 @@
+import { LegendaryAppName, LegendaryPlatform, Path } from './base'
+
+interface ImportCommand {
+  subcommand: 'import'
+  appName: LegendaryAppName
+  installationDirectory: Path
+  '--disable-check'?: true
+  '--with-dlcs'?: true
+  '--platform'?: LegendaryPlatform
+}
+
+export default ImportCommand

--- a/src/backend/storeManagers/legendary/commands/index.ts
+++ b/src/backend/storeManagers/legendary/commands/index.ts
@@ -1,0 +1,44 @@
+import { PositiveInteger } from './base'
+
+import InstallCommand from './install'
+import LaunchCommand from './launch'
+import ListCommand from './list'
+import InfoCommand from './info'
+import MoveCommand from './move'
+import SyncSavesCommand from './sync_saves'
+import StatusCommand from './status'
+import EosOverlayCommand from './eos_overlay'
+import UninstallCommand from './uninstall'
+import ImportCommand from './import'
+import CleanupCommand from './cleanup'
+import AuthCommand from './auth'
+
+interface BaseLegendaryCommand {
+  '-v'?: true
+  '--debug'?: true
+  '-y'?: true
+  '--yes'?: true
+  '-V'?: true
+  '--version'?: true
+  '-J'?: true
+  '--pretty-json'?: true
+  '-A'?: PositiveInteger
+  '--api-timeout'?: PositiveInteger
+}
+
+export type LegendaryCommand = BaseLegendaryCommand &
+  (
+    | { subcommand: undefined }
+    | InstallCommand
+    | LaunchCommand
+    | ListCommand
+    | InfoCommand
+    | MoveCommand
+    | SyncSavesCommand
+    | StatusCommand
+    | EosOverlayCommand
+    | UninstallCommand
+    | ImportCommand
+    | CleanupCommand
+    | AuthCommand
+  )

--- a/src/backend/storeManagers/legendary/commands/info.ts
+++ b/src/backend/storeManagers/legendary/commands/info.ts
@@ -1,0 +1,11 @@
+import { LegendaryAppName, LegendaryPlatform } from './base'
+
+interface InfoCommand {
+  subcommand: 'info'
+  appName: LegendaryAppName
+  '--offline'?: true
+  '--json'?: true
+  '--platform'?: LegendaryPlatform
+}
+
+export default InfoCommand

--- a/src/backend/storeManagers/legendary/commands/install.ts
+++ b/src/backend/storeManagers/legendary/commands/install.ts
@@ -1,0 +1,48 @@
+import {
+  PositiveInteger,
+  LegendaryAppName,
+  NonEmptyString,
+  Path,
+  URL,
+  URI,
+  LegendaryPlatform
+} from './base'
+
+interface InstallCommand {
+  subcommand: 'install' | 'download' | 'update' | 'repair'
+  appName: LegendaryAppName
+  sdlList?: NonEmptyString[]
+  '--base-path'?: Path
+  '--game-folder'?: NonEmptyString
+  '--max-shared-memory'?: PositiveInteger
+  '--max-workers'?: PositiveInteger
+  '--manifest'?: URI
+  '--old-manifest'?: URI
+  '--delta-manifest'?: URI
+  '--base-url'?: URL
+  '--force'?: true
+  '--disable-patching'?: true
+  '--download-only'?: true
+  '--no-install'?: true
+  '--update-only'?: true
+  '--dlm-debug'?: true
+  '--platform'?: LegendaryPlatform
+  '--prefix'?: NonEmptyString
+  '--exclude'?: NonEmptyString
+  '--enable-reordering'?: true
+  '--dl-timeout'?: PositiveInteger
+  '--save-path'?: Path
+  '--repair'?: true
+  '--repair-and-update'?: true
+  '--ignore-free-space'?: true
+  '--disable-delta-manifests'?: true
+  '--reset-sdl'?: true
+  '--skip-sdl'?: true
+  '--disable-sdl'?: true
+  '--preferred-cdn'?: NonEmptyString
+  '--no-https'?: true
+  '--with-dlcs'?: true
+  '--skip-dlcs'?: true
+}
+
+export default InstallCommand

--- a/src/backend/storeManagers/legendary/commands/launch.ts
+++ b/src/backend/storeManagers/legendary/commands/launch.ts
@@ -1,0 +1,26 @@
+import { LegendaryAppName, NonEmptyString, Path } from './base'
+
+interface LaunchCommand {
+  subcommand: 'launch'
+  appName: LegendaryAppName
+  extraArguments?: string
+  '--offline'?: true
+  '--skip-version-check'?: true
+  '--override-username'?: NonEmptyString
+  '--dry-run'?: true
+  '--language'?: NonEmptyString
+  '--wrapper'?: NonEmptyString
+  '--set-defaults'?: true
+  '--reset-defaults'?: true
+  '--override-exe'?: Path
+  '--origin'?: true
+  '--json'?: true
+  '--wine'?: Path
+  '--wine-prefix'?: Path
+  '--no-wine'?: true
+  '--crossover'?: true
+  '--crossover-app'?: Path
+  '--crossover-bottle'?: NonEmptyString
+}
+
+export default LaunchCommand

--- a/src/backend/storeManagers/legendary/commands/list.ts
+++ b/src/backend/storeManagers/legendary/commands/list.ts
@@ -1,0 +1,16 @@
+import { LegendaryPlatform } from './base'
+
+interface ListCommand {
+  subcommand: 'list'
+  '--platform'?: LegendaryPlatform
+  '--include-ue'?: true
+  '-T'?: true
+  '--third-party'?: true
+  '--include-non-installable'?: true
+  '--csv'?: true
+  '--tsv'?: true
+  '--json'?: true
+  '--force-refresh'?: true
+}
+
+export default ListCommand

--- a/src/backend/storeManagers/legendary/commands/move.ts
+++ b/src/backend/storeManagers/legendary/commands/move.ts
@@ -1,0 +1,10 @@
+import { LegendaryAppName, Path } from './base'
+
+interface MoveCommand {
+  subcommand: 'move'
+  appName: LegendaryAppName
+  newBasePath: Path
+  '--skip-move'?: true
+}
+
+export default MoveCommand

--- a/src/backend/storeManagers/legendary/commands/status.ts
+++ b/src/backend/storeManagers/legendary/commands/status.ts
@@ -1,0 +1,7 @@
+interface StatusCommand {
+  subcommand: 'status'
+  '--offline'?: true
+  '--json'?: true
+}
+
+export default StatusCommand

--- a/src/backend/storeManagers/legendary/commands/sync_saves.ts
+++ b/src/backend/storeManagers/legendary/commands/sync_saves.ts
@@ -1,0 +1,15 @@
+import { LegendaryAppName, Path } from './base'
+
+interface SyncSavesCommand {
+  subcommand: 'sync-saves'
+  appName: LegendaryAppName
+  '--skip-upload'?: true
+  '--skip-download'?: true
+  '--force-upload'?: true
+  '--force-download'?: true
+  '--save-path'?: Path
+  '--disable-filters'?: true
+  '--accept-path'?: true
+}
+
+export default SyncSavesCommand

--- a/src/backend/storeManagers/legendary/commands/uninstall.ts
+++ b/src/backend/storeManagers/legendary/commands/uninstall.ts
@@ -1,0 +1,9 @@
+import { LegendaryAppName } from './base'
+
+interface UninstallCommand {
+  subcommand: 'uninstall'
+  appName: LegendaryAppName
+  '--keep-files'?: true
+}
+
+export default UninstallCommand

--- a/src/backend/storeManagers/legendary/user.ts
+++ b/src/backend/storeManagers/legendary/user.ts
@@ -11,12 +11,17 @@ import { logError, LogPrefix } from '../../logger/logger'
 import { userInfo as user } from 'os'
 import { session } from 'electron'
 import { runRunnerCommand as runLegendaryCommand } from './library'
+import { LegendaryCommand } from './commands'
+import { NonEmptyString } from './commands/base'
 
 export class LegendaryUser {
   public static async login(
     authorizationCode: string
   ): Promise<{ status: 'done' | 'failed'; data: UserInfo | undefined }> {
-    const commandParts = ['auth', '--code', authorizationCode]
+    const command: LegendaryCommand = {
+      subcommand: 'auth',
+      '--code': NonEmptyString.parse(authorizationCode)
+    }
 
     const abortID = 'legendary-login'
     const errorMessage = (
@@ -29,7 +34,7 @@ export class LegendaryUser {
 
     try {
       const res = await runLegendaryCommand(
-        commandParts,
+        command,
         createAbortController(abortID),
         {
           logMessagePrefix: 'Logging in'
@@ -55,11 +60,11 @@ export class LegendaryUser {
   }
 
   public static async logout() {
-    const commandParts = ['auth', '--delete']
+    const command: LegendaryCommand = { subcommand: 'auth', '--delete': true }
 
     const abortID = 'legendary-logout'
     const res = await runLegendaryCommand(
-      commandParts,
+      command,
       createAbortController(abortID),
       {
         logMessagePrefix: 'Logging out'

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -41,7 +41,7 @@ import { appendFileSync, existsSync } from 'graceful-fs'
 import { logFileLocation } from 'backend/storeManagers/storeManagerCommon/games'
 import { showDialogBoxModalAuto } from 'backend/dialog/dialog'
 import { t } from 'i18next'
-import { getWineFlags } from 'backend/utils/compatibility_layers'
+import { getWineFlagsArray } from 'backend/utils/compatibility_layers'
 import shlex from 'shlex'
 import { join } from 'path'
 import {
@@ -395,7 +395,7 @@ export async function launch(
         : wineExec
 
     wineFlag = [
-      ...getWineFlags(wineBin, wineType, shlex.join(wrappers), true),
+      ...getWineFlagsArray(wineBin, wineType, shlex.join(wrappers)),
       '--wine-prefix',
       gameSettings.winePrefix
     ]

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -395,7 +395,7 @@ export async function launch(
         : wineExec
 
     wineFlag = [
-      ...getWineFlags(wineBin, wineType, shlex.join(wrappers)),
+      ...getWineFlags(wineBin, wineType, shlex.join(wrappers), true),
       '--wine-prefix',
       gameSettings.winePrefix
     ]

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -209,7 +209,7 @@ async function isEpicServiceOffline(
 const getLegendaryVersion = async () => {
   const abortID = 'legendary-version'
   const { stdout, error, abort } = await runLegendaryCommand(
-    ['--version'],
+    { subcommand: undefined, '--version': true },
     createAbortController(abortID)
   )
 
@@ -515,9 +515,10 @@ function clearCache(library?: 'gog' | 'legendary' | 'nile') {
     libraryStore.clear()
     gameInfoStore.clear()
     const abortID = 'legendary-cleanup'
-    runLegendaryCommand(['cleanup'], createAbortController(abortID)).then(() =>
-      deleteAbortController(abortID)
-    )
+    runLegendaryCommand(
+      { subcommand: 'cleanup' },
+      createAbortController(abortID)
+    ).then(() => deleteAbortController(abortID))
   }
   if (library === 'nile' || !library) {
     nileInstallStore.clear()

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -379,24 +379,17 @@ export type AllowedWineFlags = Pick<
   '--wine' | '--wrapper' | '--no-wine'
 >
 
+/**
+ * Returns a LegendaryCommand with the required flags to use a specified Wine version
+ * @param wineBin The full path to the Wine binary (`wine`/`wine64`/`proton`)
+ * @param wineType The type of the Wine version
+ * @param wrapper Any wrappers to be used, may be `''`
+ */
 export function getWineFlags(
   wineBin: string,
   wineType: WineInstallation['type'],
-  wrapper: string,
-  asArray?: false
-): AllowedWineFlags
-export function getWineFlags(
-  wineBin: string,
-  wineType: WineInstallation['type'],
-  wrapper: string,
-  asArray: true
-): string[]
-export function getWineFlags(
-  wineBin: string,
-  wineType: WineInstallation['type'],
-  wrapper: string,
-  asArray?: boolean
-): AllowedWineFlags | string[] {
+  wrapper: string
+): AllowedWineFlags {
   let partialCommand: AllowedWineFlags = {}
   switch (wineType) {
     case 'wine':
@@ -413,7 +406,18 @@ export function getWineFlags(
     default:
       break
   }
-  if (!asArray) return partialCommand
+  return partialCommand
+}
+
+/**
+ * Like {@link getWineFlags}, but returns a `string[]` with the flags instead
+ */
+export function getWineFlagsArray(
+  wineBin: string,
+  wineType: WineInstallation['type'],
+  wrapper: string
+): string[] {
+  const partialCommand = getWineFlags(wineBin, wineType, wrapper)
 
   const commandArray: string[] = []
   for (const [key, value] of Object.entries(partialCommand)) {

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -4,8 +4,7 @@ import {
   InstallPlatform,
   GameSettings,
   ExecResult,
-  InstallArgs,
-  CallRunnerOptions
+  InstallArgs
 } from 'common/types'
 import { GOGCloudSavesLocation, GogInstallInfo } from './gog'
 import { LegendaryInstallInfo } from './legendary'
@@ -73,9 +72,4 @@ export interface LibraryManager {
   listUpdateableGames: () => Promise<string[]>
   changeGameInstallPath: (appName: string, newPath: string) => Promise<void>
   installState: (appName: string, state: boolean) => void
-  runRunnerCommand: (
-    commandParts: string[],
-    abortController: AbortController,
-    options?: CallRunnerOptions
-  ) => Promise<ExecResult>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8686,3 +8686,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
This PR adds strict type checking to Legendary commands using [Zod](https://zod.dev/). Before a command can be ran, the caller of `runLegendaryCommand` has to verify that, for example, strings that should be non-empty are actually non-empty, numbers are integers & positive (if necessary), paths are valid paths, and so on

Details on how this is achieved / what the design decisions behind things were are in the commit messages

~~I've only tested this on Linux, I can test it on Windows in the coming days~~
Seems to be working fine on both Windows & Linux

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [X] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
