### PR TITLE
[Fix] Fix three-dots menu closing when hovering certain items

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.scss
+++ b/src/frontend/screens/Game/GamePage/index.scss
@@ -14,6 +14,7 @@
     padding-top: 2rem;
     margin-top: 2rem;
     background: var(--background-darker);
+    z-index: 1;
     .title {
       font-weight: var(--medium);
       font-size: var(--text-xl);


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2915

The menu was rendered with z-index: 0 by default and the elements like `Installed Information` `Game Scores` etc had the same z-index value, because they come after in the DOM they had the focus.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
