### PR TITLE
[Fix] Installation of EOS Overlay

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -781,7 +781,7 @@ async function callRunner(
     return currentPromise
   }
 
-  const promise = new Promise<ExecResult>((res, rej) => {
+  let promise = new Promise<ExecResult>((res, rej) => {
     const child = spawn(bin, commandParts, {
       cwd: runner.dir,
       env: { ...process.env, ...options?.env },
@@ -852,10 +852,7 @@ async function callRunner(
     })
   })
 
-  // keep track of which commands are running
-  commandsRunning[key] = promise
-
-  promise
+  promise = promise
     .then(({ stdout, stderr }) => {
       return { stdout, stderr, fullCommand: safeCommand }
     })
@@ -893,6 +890,9 @@ async function callRunner(
       // remove from list when done
       delete commandsRunning[key]
     })
+
+  // keep track of which commands are running
+  commandsRunning[key] = promise
 
   return promise
 }


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2916 and fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2905

I added some code to prevent running the same command twice in parallel (to prevent the epic logout issue), but I didn't know that `then` and `catch` on promises does NOT change the current promise but it actually returns a new object, so I was storing/caching the current promise without handling the catch.

Because the first step installing the overlay is to get the size and then abort the command, it was throwing an exception instead of handling it silently.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
