### PR TITLE
[Browser]: handle before unload event properly

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -146,6 +146,12 @@
                 "install": "Epic Servers are having major outage right now, the game cannot be installed!",
                 "update": "Epic Servers are having major outage right now, the game cannot be updated!"
             },
+            "sideload": {
+                "confirmExit": {
+                    "message": "Any unsaved progress might be lost",
+                    "title": "Are you sure you want to quit?"
+                }
+            },
             "title": "Warning",
             "wine-change": {
                 "message": "We could not find the selected wine version to launch this title ({{selectedWine}}). {{newline}} We found another one, do you want to continue launching using {{foundWine}} ?",

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -17,7 +17,7 @@ import { access, chmod } from 'fs/promises'
 import shlex from 'shlex'
 import { showDialogBoxModalAuto } from '../../dialog/dialog'
 import { createAbortController } from '../../utils/aborthandler/aborthandler'
-import { BrowserWindow, Menu } from 'electron'
+import { BrowserWindow, dialog, Menu } from 'electron'
 import { gameManagerMap } from '../index'
 
 async function getAppSettings(appName: string): Promise<GameSettings> {
@@ -65,7 +65,22 @@ const openNewBrowserGameWindow = async (
       browserGame.close()
     })
 
-    browserGame.on('close', () => {
+    browserGame.webContents.on('will-prevent-unload', (event) => {
+      const choice = dialog.showMessageBoxSync(browserGame, {
+        type: 'question',
+        buttons: ['Yes', 'No'],
+        title: 'Are you sure you want to quit?',
+        message: 'Any unsaved progress might be lost',
+        defaultId: 0,
+        cancelId: 1
+      })
+      const leave = choice === 0
+      if (leave) {
+        event.preventDefault()
+      }
+    })
+
+    browserGame.on('closed', () => {
       res(true)
     })
   })

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -69,8 +69,14 @@ const openNewBrowserGameWindow = async (
       const choice = dialog.showMessageBoxSync(browserGame, {
         type: 'question',
         buttons: ['Yes', 'No'],
-        title: 'Are you sure you want to quit?',
-        message: 'Any unsaved progress might be lost',
+        title: i18next.t(
+          'box.warning.sideload.confirmExit.title',
+          'Are you sure you want to quit?'
+        ),
+        message: i18next.t(
+          'box.warning.sideload.confirmExit.message',
+          'Any unsaved progress might be lost'
+        ),
         defaultId: 0,
         cancelId: 1
       })


### PR DESCRIPTION
Closes #2938  
Heroic will now confirm if you want to close the window if website prevents the unload

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
