### PR TITLE
Use runRunnerCommand to fix issue with spaces enabling egl-sync

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -30,7 +30,6 @@ import {
   appendFileSync,
   constants,
   existsSync,
-  mkdirSync,
   rmSync,
   unlinkSync,
   watch,
@@ -63,7 +62,6 @@ import {
   resetHeroic,
   showAboutWindow,
   showItemInFolder,
-  getLegendaryBin,
   getFileSize,
   detectVCRedist,
   getFirstExistingParentPath,
@@ -1402,38 +1400,7 @@ ipcMain.handle(
 )
 
 ipcMain.handle('egsSync', async (event, args) => {
-  if (isWindows) {
-    const egl_manifestPath =
-      'C:\\ProgramData\\Epic\\EpicGamesLauncher\\Data\\Manifests'
-
-    if (!existsSync(egl_manifestPath)) {
-      mkdirSync(egl_manifestPath, { recursive: true })
-    }
-  }
-
-  const linkArgs = isWindows
-    ? `--enable-sync`
-    : `--enable-sync --egl-wine-prefix ${args}`
-  const unlinkArgs = `--unlink`
-  const isLink = args !== 'unlink'
-  const command = isLink ? linkArgs : unlinkArgs
-  const { bin, dir } = getLegendaryBin()
-  const legendary = path.join(dir, bin)
-
-  try {
-    const { stderr, stdout } = await execAsync(
-      `${legendary} egl-sync ${command} -y`
-    )
-    logInfo(`${stdout}`, LogPrefix.Legendary)
-    if (stderr.includes('ERROR')) {
-      logError(`${stderr}`, LogPrefix.Legendary)
-      return 'Error'
-    }
-    return `${stdout} - ${stderr}`
-  } catch (error) {
-    logError(error, LogPrefix.Legendary)
-    return 'Error'
-  }
+  return LegendaryLibraryManager.toggleGamesSync(args)
 })
 
 ipcMain.handle('syncGOGSaves', async (event, gogSaves, appName, arg) =>


### PR DESCRIPTION
This PR should fix https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2891

We were still using `execAsync` to execute a legendary command instead of `runRunnerCommand` that handles spaces properly.

I also moved the logic of the function into the legendary/library.ts file, it makes more sense there.

I did test this in Linux sideloading the EGL app, but I don't have spaces in my username and I don't have a windows machine to test there either.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
