### PR TITLE
[Improv]: Add environment variables for use by wrappers

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -315,6 +315,7 @@ function setupWrapperEnvVars(wrapperEnv: WrapperEnv) {
   const ret: Record<string, string> = {}
 
   ret.HEROIC_APP_NAME = wrapperEnv.appName
+  ret.HEROIC_APP_RUNNER = wrapperEnv.appRunner
 
   switch (wrapperEnv.appRunner) {
     case 'gog':

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -45,6 +45,7 @@ import {
   GameInfo,
   Runner,
   EnviromentVariable,
+  WrapperEnv,
   WrapperVariable,
   ExecResult,
   GameSettings,
@@ -275,6 +276,7 @@ async function prepareWineLaunch(
 /**
  * Maps general settings to environment variables
  * @param gameSettings The GameSettings to get the environment variables for
+ * @param wrapperEnv The wrapper info to be added into the environment variables
  * @returns A big string of environment variables, structured key=value
  */
 function setupEnvVars(gameSettings: GameSettings) {
@@ -301,6 +303,20 @@ function setupEnvVars(gameSettings: GameSettings) {
   if (!process.env.LD_PRELOAD && !ret.LD_PRELOAD) {
     ret.LD_PRELOAD = ''
   }
+
+  return ret
+}
+
+/**
+ * Maps launcher info to environment variables for consumption by wrappers
+ * @param wrapperEnv The info to be added into the environment variables
+ * @returns Environment variables
+ */
+function setupWrapperEnvVars(wrapperEnv: WrapperEnv) {
+  const ret: Record<string, string> = {}
+
+  ret.HEROIC_APP_NAME = wrapperEnv.appName
+  ret.HEROIC_APP_STORE = wrapperEnv.appStore
 
   return ret
 }
@@ -982,6 +998,7 @@ export {
   launchCleanup,
   prepareWineLaunch,
   setupEnvVars,
+  setupWrapperEnvVars,
   setupWineEnvVars,
   setupWrappers,
   runWineCommand,

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -316,7 +316,21 @@ function setupWrapperEnvVars(wrapperEnv: WrapperEnv) {
   const ret: Record<string, string> = {}
 
   ret.HEROIC_APP_NAME = wrapperEnv.appName
-  ret.HEROIC_APP_STORE = wrapperEnv.appStore
+
+  switch (wrapperEnv.appRunner) {
+    case 'gog':
+      ret.HEROIC_APP_SOURCE = 'gog'
+      break
+    case 'legendary':
+      ret.HEROIC_APP_SOURCE = 'epic'
+      break
+    case 'nile':
+      ret.HEROIC_APP_SOURCE = 'amazon'
+      break
+    case 'sideload':
+      ret.HEROIC_APP_SOURCE = 'sideload'
+      break
+  }
 
   return ret
 }

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -276,7 +276,6 @@ async function prepareWineLaunch(
 /**
  * Maps general settings to environment variables
  * @param gameSettings The GameSettings to get the environment variables for
- * @param wrapperEnv The wrapper info to be added into the environment variables
  * @returns A big string of environment variables, structured key=value
  */
 function setupEnvVars(gameSettings: GameSettings) {

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -467,7 +467,7 @@ export async function launch(
 
   let commandEnv = {
     ...process.env,
-    ...setupWrapperEnvVars({ appName, appStore: 'gog' })
+    ...setupWrapperEnvVars({ appName, appRunner: 'gog' })
   }
   if (!isWindows) {
     commandEnv = { ...commandEnv, ...setupEnvVars(gameSettings) }

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -467,10 +467,8 @@ export async function launch(
 
   let commandEnv = {
     ...process.env,
-    ...setupWrapperEnvVars({ appName, appRunner: 'gog' })
-  }
-  if (!isWindows) {
-    commandEnv = { ...commandEnv, ...setupEnvVars(gameSettings) }
+    ...setupWrapperEnvVars({ appName, appRunner: 'gog' }),
+    ...(isWindows ? {} : setupEnvVars(gameSettings))
   }
 
   const wrappers = setupWrappers(

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -62,6 +62,7 @@ import {
   prepareWineLaunch,
   runWineCommand as runWineCommandUtil,
   setupEnvVars,
+  setupWrapperEnvVars,
   setupWrappers
 } from '../../launcher'
 import {
@@ -464,9 +465,13 @@ export async function launch(
     ? ['--override-exe', gameSettings.targetExe]
     : []
 
-  let commandEnv = isWindows
-    ? process.env
-    : { ...process.env, ...setupEnvVars(gameSettings) }
+  let commandEnv = {
+    ...process.env,
+    ...setupWrapperEnvVars({ appName, appStore: 'gog' })
+  }
+  if (!isWindows) {
+    commandEnv = { ...commandEnv, ...setupEnvVars(gameSettings) }
+  }
 
   const wrappers = setupWrappers(
     gameSettings,

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -825,10 +825,8 @@ export async function launch(
 
   let commandEnv = {
     ...process.env,
-    ...setupWrapperEnvVars({ appName, appRunner: 'legendary' })
-  }
-  if (!isWindows) {
-    commandEnv = { ...commandEnv, ...setupEnvVars(gameSettings) }
+    ...setupWrapperEnvVars({ appName, appRunner: 'legendary' }),
+    ...(isWindows ? {} : setupEnvVars(gameSettings))
   }
 
   const wrappers = setupWrappers(

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -47,6 +47,7 @@ import {
   prepareLaunch,
   prepareWineLaunch,
   setupEnvVars,
+  setupWrapperEnvVars,
   setupWrappers,
   launchCleanup,
   getRunnerCallWithoutCredentials,
@@ -822,9 +823,13 @@ export async function launch(
 
   const languageCode = gameSettings.language || configStore.get('language', '')
 
-  let commandEnv = isWindows
-    ? process.env
-    : { ...process.env, ...setupEnvVars(gameSettings) }
+  let commandEnv = {
+    ...process.env,
+    ...setupWrapperEnvVars({ appName, appStore: 'epic' })
+  }
+  if (!isWindows) {
+    commandEnv = { ...commandEnv, ...setupEnvVars(gameSettings) }
+  }
 
   const wrappers = setupWrappers(
     gameSettings,

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -825,7 +825,7 @@ export async function launch(
 
   let commandEnv = {
     ...process.env,
-    ...setupWrapperEnvVars({ appName, appStore: 'epic' })
+    ...setupWrapperEnvVars({ appName, appRunner: 'legendary' })
   }
   if (!isWindows) {
     commandEnv = { ...commandEnv, ...setupEnvVars(gameSettings) }

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -347,7 +347,7 @@ export async function launch(
 
   let commandEnv = {
     ...process.env,
-    ...setupWrapperEnvVars({ appName, appStore: 'amazon' })
+    ...setupWrapperEnvVars({ appName, appRunner: 'nile' })
   }
   if (!isWindows) {
     commandEnv = { ...commandEnv, ...setupEnvVars(gameSettings) }

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -347,10 +347,8 @@ export async function launch(
 
   let commandEnv = {
     ...process.env,
-    ...setupWrapperEnvVars({ appName, appRunner: 'nile' })
-  }
-  if (!isWindows) {
-    commandEnv = { ...commandEnv, ...setupEnvVars(gameSettings) }
+    ...setupWrapperEnvVars({ appName, appRunner: 'nile' }),
+    ...(isWindows ? {} : setupEnvVars(gameSettings))
   }
 
   const wrappers = setupWrappers(

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -35,6 +35,7 @@ import {
   prepareLaunch,
   prepareWineLaunch,
   setupEnvVars,
+  setupWrapperEnvVars,
   setupWrappers
 } from 'backend/launcher'
 import { appendFileSync, existsSync } from 'graceful-fs'
@@ -344,9 +345,13 @@ export async function launch(
     ? ['--override-exe', gameSettings.targetExe]
     : []
 
-  let commandEnv = isWindows
-    ? process.env
-    : { ...process.env, ...setupEnvVars(gameSettings) }
+  let commandEnv = {
+    ...process.env,
+    ...setupWrapperEnvVars({ appName, appStore: 'amazon' })
+  }
+  if (!isWindows) {
+    commandEnv = { ...commandEnv, ...setupEnvVars(gameSettings) }
+  }
 
   const wrappers = setupWrappers(
     gameSettings,

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -11,6 +11,7 @@ import {
   prepareLaunch,
   runWineCommand,
   setupEnvVars,
+  setupWrapperEnvVars,
   setupWrappers
 } from '../../launcher'
 import { access, chmod } from 'fs/promises'
@@ -131,7 +132,12 @@ export async function launchGame(
       })
       return false
     }
-    const env = { ...process.env, ...setupEnvVars(gameSettings) }
+
+    const env = {
+      ...process.env,
+      ...setupWrapperEnvVars({ appName, appRunner: runner }),
+      ...setupEnvVars(gameSettings)
+    }
 
     // Native
     if (isNative) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -351,6 +351,11 @@ export interface WrapperVariable {
   args: string
 }
 
+export interface WrapperEnv {
+  appName: string
+  appStore: 'amazon' | 'epic' | 'gog'
+}
+
 type AntiCheat =
   | 'Arbiter'
   | 'BattlEye'

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -353,7 +353,7 @@ export interface WrapperVariable {
 
 export interface WrapperEnv {
   appName: string
-  appStore: 'amazon' | 'epic' | 'gog'
+  appRunner: Runner
 }
 
 type AntiCheat =


### PR DESCRIPTION
This adds two environment variables when launching games: `HEROIC_APP_NAME` and `HEROIC_APP_STORE`. Wrapper commands can use these to look up the app info in the Heroic config (e.g., to get the title or Wine prefix for save backup purposes, in my case).

I tested this on Windows 11 with GOG and Epic. I don't have any Amazon games, so I wasn't able to test that.

In order to test on my system, I made the `WrappersTable` display on Windows (which I'd like to submit in a separate PR after some testing), then configured a wrapper as a Python script. Main interesting part of the script:

```python
path = Path("C:/tmp/script.log")

with path.open("a") as f:
    f.write(f"{sys.argv}\n")
    for k, v in os.environ.items():
        if k.startswith("HEROIC_"):
            f.write(f"{k} = {v}\n")
```

I verified that the new environment variables were written out to the log file:

```
['C:/tmp/script.py', 'C:\\Users\\mtken\\Games\\Heroic\\Dead Cells\\deadcells.exe']
HEROIC_APP_NAME = 1237807960
HEROIC_APP_STORE = gog

['C:/tmp/script.py', 'C:\\Users\\mtken\\Games\\Heroic\\CaveStoryPlus\\CaveStory+.exe', '-AUTH_LOGIN=unused', '-AUTH_PASSWORD=<redacted>', '-AUTH_TYPE=exchangecode', '-epicapp=1dea8a6ddb544842a58e4b5c8675ff58', '-epicenv=Prod', '-EpicPortal', '-epicusername=<redacted>', '-epicuserid=<redacted>', '-epiclocale=en', '-epicsandboxid=78473822f724474d8e436f6bde735623']
HEROIC_APP_NAME = 1dea8a6ddb544842a58e4b5c8675ff58
HEROIC_APP_STORE = epic
```

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)

I think these environment variables should be documented, but I'm not sure where that information belongs.