### PR TITLE
[FIX] Install all DLCs not adding them to the queue

### DIFF
--- a/src/frontend/components/UI/DLCList/DLC/index.tsx
+++ b/src/frontend/components/UI/DLCList/DLC/index.tsx
@@ -58,7 +58,7 @@ const DLC = ({ dlc, runner, mainAppInfo, onClose }: Props) => {
       if (!info) {
         return
       }
-      setDlcSize(info.manifest.download_size)
+      setDlcSize(info?.manifest?.download_size || 0)
       setRefreshing(false)
     }
     getDlcSize()

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/DLCDownloadListing.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/DLCDownloadListing.tsx
@@ -28,7 +28,7 @@ const DLCDownloadListing: React.FC<Props> = ({
     }
 
     if (installAllDlcs) {
-      setDlcsToInstall([])
+      setDlcsToInstall([...DLCList.map(({ app_name }) => app_name)])
     }
   }
 


### PR DESCRIPTION
This fixes an issue that was happening when toggling the 'Install all DLCS' for Epic games. All DLCs were not being added to the Queue, only one of them.

tested with Dying Light Enhanced Edition and Fallout New Vegas.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
