### PR TITLE
[UI] Add user feedback when copying log to clipboard

### DIFF
--- a/src/frontend/screens/Settings/sections/LogSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/LogSettings/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import { Done } from '@mui/icons-material'
 import { UpdateComponent } from 'frontend/components/UI'
 import SettingsContext from '../../SettingsContext'
 import './index.css'
@@ -64,6 +65,7 @@ export default function LogSettings() {
   const [logFileExist, setLogFileExist] = useState<boolean>(false)
   const [defaultLast, setDefaultLast] = useState<boolean>(false)
   const [refreshing, setRefreshing] = useState<boolean>(true)
+  const [copiedLog, setCopiedLog] = useState<boolean>(false)
   const { appName, isDefault } = useContext(SettingsContext)
 
   const getLogContent = () => {
@@ -163,6 +165,10 @@ export default function LogSettings() {
           <a
             onClick={() => {
               navigator.clipboard.writeText(logFileContent)
+              setCopiedLog(true)
+              setTimeout(() => {
+                setCopiedLog(false)
+              }, 3000)
             }}
             title={t(
               'setting.log.copy-to-clipboard',
@@ -172,7 +178,7 @@ export default function LogSettings() {
           >
             <div className="button-icontext-flex">
               <div className="button-icon-flex">
-                <ContentCopyIcon />
+                {copiedLog ? <Done /> : <ContentCopyIcon />}
               </div>
               <span className="button-icon-text">
                 {t(


### PR DESCRIPTION
This PR brings adds a simple visual feedback for the user when the log is copied to the clipboard.

The ContentCopyIcon is replaced by the Done icon for a couple seconds. The user can be sure that the log has been successfully copied.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
