### PR TITLE
[Improv]: Confirm installing broken anticheat games

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -125,6 +125,12 @@
         "version": "Version"
     },
     "install": {
+        "anticheat-warning": {
+            "cancel": "No",
+            "install": "Yes (I understand it will not work)",
+            "message": "The anticheat support is broken or denied. The game will not work. Do you want to install it anyway?",
+            "title": "Anticheat Broken or Denied"
+        },
         "disk-space-left": "Space Available",
         "not-enough-disk-space": "Not enough disk space",
         "path": "Select Install Path",

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -129,7 +129,7 @@
             "cancel": "No",
             "install": "Yes (I understand it will not work)",
             "message": "The anticheat support is broken or denied. The game will not work. Do you want to install it anyway?",
-            "title": "Anticheat Broken or Denied"
+            "title": "Anticheat Broken/Denied"
         },
         "disk-space-left": "Space Available",
         "not-enough-disk-space": "Not enough disk space",

--- a/src/frontend/components/UI/Anticheat/index.tsx
+++ b/src/frontend/components/UI/Anticheat/index.tsx
@@ -1,5 +1,5 @@
-import React, { MouseEvent, useEffect, useState } from 'react'
-import { AntiCheatInfo, GameInfo } from 'common/types'
+import React, { MouseEvent } from 'react'
+import { AntiCheatInfo } from 'common/types'
 import { createNewWindow } from 'frontend/helpers'
 
 import { ReactComponent as InfoIcon } from 'frontend/assets/info_icon.svg'
@@ -10,29 +10,13 @@ import './index.scss'
 import { useTranslation } from 'react-i18next'
 
 type Props = {
-  gameInfo: GameInfo
+  anticheatInfo: AntiCheatInfo | null
 }
 
 const awacyUrl = 'https://areweanticheatyet.com/'
 
-export default function Anticheat({ gameInfo }: Props) {
+export default function Anticheat({ anticheatInfo }: Props) {
   const { t } = useTranslation()
-
-  const [anticheatInfo, setAnticheatInfo] = useState<AntiCheatInfo | null>(null)
-
-  useEffect(() => {
-    if (
-      gameInfo.runner !== 'sideload' &&
-      gameInfo.title &&
-      gameInfo.namespace !== undefined
-    ) {
-      window.api
-        .getAnticheatInfo(gameInfo.namespace)
-        .then((anticheatInfo: AntiCheatInfo | null) => {
-          setAnticheatInfo(anticheatInfo)
-        })
-    }
-  }, [gameInfo])
 
   if (!anticheatInfo) {
     return null

--- a/src/frontend/hooks/hasAnticheatInfo.ts
+++ b/src/frontend/hooks/hasAnticheatInfo.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+import { AntiCheatInfo, GameInfo } from 'common/types'
+
+export const hasAnticheatInfo = (gameInfo: GameInfo) => {
+  const [anticheatInfo, setAnticheatInfo] = useState<AntiCheatInfo | null>(null)
+
+  useEffect(() => {
+    if (
+      gameInfo.runner !== 'sideload' &&
+      gameInfo.title &&
+      gameInfo.namespace !== undefined
+    ) {
+      window.api
+        .getAnticheatInfo(gameInfo.namespace)
+        .then((anticheatInfo: AntiCheatInfo | null) => {
+          setAnticheatInfo(anticheatInfo)
+        })
+    }
+  }, [gameInfo])
+
+  return anticheatInfo
+}

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -82,6 +82,7 @@ import HowLongToBeat from 'frontend/components/UI/WikiGameInfo/components/HowLon
 import GameScore from 'frontend/components/UI/WikiGameInfo/components/GameScore'
 import DLCList from 'frontend/components/UI/DLCList'
 import { NileInstallInfo } from 'common/types/nile'
+import { hasAnticheatInfo } from 'frontend/hooks/hasAnticheatInfo'
 
 export default React.memo(function GamePage(): JSX.Element | null {
   const { appName, runner } = useParams() as { appName: string; runner: Runner }
@@ -129,6 +130,8 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const [wineVersion, setWineVersion] = useState<WineInstallation>()
   const [showRequirements, setShowRequirements] = useState(false)
   const [showDlcs, setShowDlcs] = useState(false)
+
+  const anticheatInfo = hasAnticheatInfo(gameInfo)
 
   const isWin = platform === 'win32'
   const isLinux = platform === 'linux'
@@ -760,7 +763,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                   ))}
                 </SelectField>
               )}
-              <Anticheat gameInfo={gameInfo} />
+              <Anticheat anticheatInfo={anticheatInfo} />
               {is_installed && !isQueued && (
                 <button
                   disabled={

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -7,7 +7,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import classNames from 'classnames'
 import {
-  AntiCheatInfo,
   GameInfo,
   GameStatus,
   InstallPlatform,
@@ -48,6 +47,7 @@ import { AvailablePlatforms } from '../index'
 import { configStore } from 'frontend/helpers/electronStores'
 import DLCDownloadListing from './DLCDownloadListing'
 import { NileInstallInfo } from 'common/types/nile'
+import { hasAnticheatInfo } from 'frontend/hooks/hasAnticheatInfo'
 
 interface Props {
   backdropClick: () => void
@@ -155,21 +155,7 @@ export default function DownloadDialog({
     spaceLeftAfter: ''
   })
 
-  const [anticheatInfo, setAnticheatInfo] = useState<AntiCheatInfo | null>(null)
-
-  useEffect(() => {
-    if (
-      gameInfo.runner !== 'sideload' &&
-      gameInfo.title &&
-      gameInfo.namespace !== undefined
-    ) {
-      window.api
-        .getAnticheatInfo(gameInfo.namespace)
-        .then((anticheatInfo: AntiCheatInfo | null) => {
-          setAnticheatInfo(anticheatInfo)
-        })
-    }
-  }, [gameInfo])
+  const anticheatInfo = hasAnticheatInfo(gameInfo)
 
   const { i18n, t } = useTranslation('gamepage')
   const { t: tr } = useTranslation()
@@ -206,7 +192,7 @@ export default function DownloadDialog({
 
   function confirmInstallBrokenAnticheat(path?: string) {
     showDialogModal({
-      title: t('install.anticheat-warning.title', 'Anticheat Broken or Denied'),
+      title: t('install.anticheat-warning.title', 'Anticheat Broken/Denied'),
       message: t(
         'install.anticheat-warning.message',
         'The anticheat support is broken or denied. The game will not work. Do you want to install it anyway?'

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import classNames from 'classnames'
 import {
+  AntiCheatInfo,
   GameInfo,
   GameStatus,
   InstallPlatform,
@@ -154,6 +155,22 @@ export default function DownloadDialog({
     spaceLeftAfter: ''
   })
 
+  const [anticheatInfo, setAnticheatInfo] = useState<AntiCheatInfo | null>(null)
+
+  useEffect(() => {
+    if (
+      gameInfo.runner !== 'sideload' &&
+      gameInfo.title &&
+      gameInfo.namespace !== undefined
+    ) {
+      window.api
+        .getAnticheatInfo(gameInfo.namespace)
+        .then((anticheatInfo: AntiCheatInfo | null) => {
+          setAnticheatInfo(anticheatInfo)
+        })
+    }
+  }, [gameInfo])
+
   const { i18n, t } = useTranslation('gamepage')
   const { t: tr } = useTranslation()
 
@@ -187,7 +204,37 @@ export default function DownloadDialog({
     setInstallAllDlcs(!installAllDlcs)
   }
 
-  async function handleInstall(path?: string) {
+  function confirmInstallBrokenAnticheat(path?: string) {
+    showDialogModal({
+      title: t('install.anticheat-warning.title', 'Anticheat Broken or Denied'),
+      message: t(
+        'install.anticheat-warning.message',
+        'The anticheat support is broken or denied. The game will not work. Do you want to install it anyway?'
+      ),
+      buttons: [
+        {
+          text: t(
+            'install.anticheat-warning.install',
+            'Yes (I understand it will not work)'
+          ),
+          onClick: async () => handleInstall(path, true)
+        },
+        {
+          text: t('install.anticheat-warning.cancel', 'No'),
+          onClick: () => null
+        }
+      ]
+    })
+  }
+
+  async function handleInstall(path?: string, ignoreAnticheat = false) {
+    if (anticheatInfo && ['Denied', 'Broken'].includes(anticheatInfo.status)) {
+      if (!ignoreAnticheat) {
+        confirmInstallBrokenAnticheat(path)
+        return
+      }
+    }
+
     backdropClick()
 
     // Write Default game config with prefix on linux
@@ -394,7 +441,7 @@ export default function DownloadDialog({
           />
         ))}
       </DialogHeader>
-      {gameInfo && <Anticheat gameInfo={gameInfo} />}
+      <Anticheat anticheatInfo={anticheatInfo} />
       <DialogContent>
         <div className="InstallModal__sizes">
           <div className="InstallModal__size">


### PR DESCRIPTION
This PR adds an extra confirmation dialog when trying to install a game that we have data about its anticheat support being broken/denied.

We keep getting users asking about Fortnite for example even with the message in both the game page and the install dialog.

This will add another barrier for users to understand these games will not work, and they have to click a button that says `I UNDERSTAND THIS WILL NOT WORK` to even install the game.

This has no impact on games where the anticheat works so it only adds one barrier to prevent extra support tickets.

You can see it working in this video:

https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/b3ae8035-2bb7-493e-8d52-be649acc54ff

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
