### PR TITLE
[Mac] Disable the login buttons for MacOS older than version 12

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -344,7 +344,7 @@
         "epic": "Epic Games Login",
         "gog": "GOG Login",
         "message": "Login with your platform. You can login to more than one platform at the same time.",
-        "old-mac": "Your MacOS version is {{version}}. MacOS 12 or newer is required to log in the stores."
+        "old-mac": "Your macOS version is {{version}}. macOS 12 or newer is required to log in."
     },
     "message": {
         "sync": "Sync Complete",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -343,7 +343,8 @@
         "amazon": "Amazon Login",
         "epic": "Epic Games Login",
         "gog": "GOG Login",
-        "message": "Login with your platform. You can login to more than one platform at the same time."
+        "message": "Login with your platform. You can login to more than one platform at the same time.",
+        "old-mac": "Your MacOS version is {{version}}. MacOS 12 or newer is required to log in the stores."
     },
     "message": {
         "sync": "Sync Complete",

--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -105,6 +105,8 @@ export const handleGoToScreen = (callback: any) => {
   }
 }
 
+export const getOSInfo = async () => ipcRenderer.invoke('getOSInfo')
+
 export const handleShowDialog = (
   onMessage: (
     e: Electron.IpcRendererEvent,

--- a/src/backend/utils/ipc_handler.ts
+++ b/src/backend/utils/ipc_handler.ts
@@ -1,6 +1,9 @@
+import si from 'systeminformation'
 import { ipcMain } from 'electron'
 import { callAbortController } from './aborthandler/aborthandler'
 
 ipcMain.on('abort', async (event, id) => {
   callAbortController(id)
 })
+
+ipcMain.handle('getOSInfo', async () => si.osInfo())

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -40,6 +40,7 @@ import {
   NileRegisterData,
   NileUserData
 } from 'common/types/nile'
+import { Systeminformation } from 'systeminformation'
 
 /**
  * Some notes here:
@@ -261,6 +262,7 @@ interface AsyncIPCFunctions {
     appName: string
   ) => Promise<number | undefined>
   getAmazonLoginData: () => Promise<NileLoginData>
+  getOSInfo: () => Promise<Systeminformation.OsData>
 }
 
 // This is quite ugly & throws a lot of errors in a regular .ts file

--- a/src/frontend/screens/Login/components/Runner/index.css
+++ b/src/frontend/screens/Login/components/Runner/index.css
@@ -12,6 +12,15 @@
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 }
 
+.runnerLogin {
+  cursor: pointer;
+}
+
+.runnerWrapper.disabled,
+.runnerWrapper.disabled * {
+  cursor: not-allowed;
+}
+
 .runnerWrapper > h1 {
   color: var(--text-default);
 }
@@ -26,15 +35,11 @@
   text-align: center;
 }
 
-.runnerLogin.alternative {
-  cursor: pointer;
-}
-
 .alternative > svg {
   fill: var(--background-lighter) !important;
 }
 
-.runnerLogin:hover {
+.runnerWrapper:not(.disabled) .runnerLogin:hover {
   color: var(--accent);
 }
 

--- a/src/frontend/screens/Login/components/Runner/index.tsx
+++ b/src/frontend/screens/Login/components/Runner/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import './index.css'
 
 interface RunnerProps {
@@ -15,21 +15,15 @@ interface RunnerProps {
   logoutAction: () => any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   alternativeLoginAction?: () => any
+  buttonText: string
+  disabled: boolean
 }
 
 export default function Runner(props: RunnerProps) {
   const maxNameLength = 20
   const { t } = useTranslation()
-  const [isLoggingOut, setIsLoggingOut] = React.useState(false)
-
-  let buttonText = ''
-  if (props.class === 'epic') {
-    buttonText = t('login.epic', 'Epic Games Login')
-  } else if (props.class === 'nile') {
-    buttonText = t('login.amazon', 'Amazon Login')
-  } else {
-    buttonText = t('login.gog', 'GOG Login')
-  }
+  const navigate = useNavigate()
+  const [isLoggingOut, setIsLoggingOut] = useState(false)
 
   async function handleLogout() {
     setIsLoggingOut(true)
@@ -38,9 +32,30 @@ export default function Runner(props: RunnerProps) {
     //window.localStorage.clear()
     setIsLoggingOut(false)
   }
+
+  function handleLogin() {
+    if (props.disabled) {
+      return
+    }
+
+    navigate(props.loginUrl)
+  }
+
+  function handleAltLogin() {
+    if (props.disabled || !props.alternativeLoginAction) {
+      return
+    }
+
+    props.alternativeLoginAction()
+  }
+
   return (
     <>
-      <div className={`runnerWrapper ${props.class}`}>
+      <div
+        className={`runnerWrapper ${props.class} ${
+          props.disabled ? 'disabled' : ''
+        }`}
+      >
         <div className={`runnerIcon ${props.class}`}>{props.icon()}</div>
         {props.isLoggedIn && (
           <div className="userData">
@@ -52,9 +67,9 @@ export default function Runner(props: RunnerProps) {
         )}
         <div className="runnerButtons">
           {!props.isLoggedIn ? (
-            <Link to={props.loginUrl} className="runnerLogin">
-              {buttonText}
-            </Link>
+            <div className="runnerLogin" onClick={() => handleLogin()}>
+              {props.buttonText}
+            </div>
           ) : isLoggingOut ? (
             <div className="runnerLogin logged">
               {t('userselector.logging_out', 'Logging out')}...
@@ -72,11 +87,11 @@ export default function Runner(props: RunnerProps) {
         </div>
       </div>
       {props.alternativeLoginAction && !props.isLoggedIn && (
-        <div className="runnerWrapper">
+        <div className={`runnerWrapper ${props.disabled ? 'disabled' : ''}`}>
           <div className="runnerIcon alternative">{props.icon()}</div>
           <div className="runnerButtons">
             <div
-              onClick={props.alternativeLoginAction}
+              onClick={() => handleAltLogin()}
               className="runnerLogin alternative"
             >
               {`${props.class} ${t(

--- a/src/frontend/screens/Login/index.scss
+++ b/src/frontend/screens/Login/index.scss
@@ -149,6 +149,11 @@
   gap: var(--login-padding);
 }
 
+.runnerList .disabledMessage {
+  border: 2px solid var(--anticheat-denied);
+  padding: 1rem;
+}
+
 @media screen and (min-width: 850px) {
   .loginContentWrapper {
     width: max(500px, 75%);

--- a/src/frontend/screens/Login/index.tsx
+++ b/src/frontend/screens/Login/index.tsx
@@ -47,7 +47,7 @@ export default React.memo(function NewLogin() {
       oldMac = true
       oldMacMessage = t(
         'login.old-mac',
-        'Your MacOS version is {{version}}. MacOS 12 or newer is required to log in the stores.',
+        'Your macOS version is {{version}}. macOS 12 or newer is required to log in.',
         { version: systemInfo.release }
       )
     }

--- a/src/frontend/screens/Login/index.tsx
+++ b/src/frontend/screens/Login/index.tsx
@@ -13,6 +13,7 @@ import { LanguageSelector, UpdateComponent } from '../../components/UI'
 import { FlagPosition } from '../../components/UI/LanguageSelector'
 import SIDLogin from './components/SIDLogin'
 import ContextProvider from '../../state/ContextProvider'
+import { Systeminformation } from 'systeminformation'
 
 export const epicLoginPath = '/loginweb/legendary'
 export const gogLoginPath = '/loginweb/gog'
@@ -29,6 +30,28 @@ export default React.memo(function NewLogin() {
   const [isAmazonLoggedIn, setIsAmazonLoggedIn] = useState(
     Boolean(amazon.user_id)
   )
+
+  const [systemInfo, setSystemInfo] = useState<Systeminformation.OsData | null>(
+    null
+  )
+
+  useEffect(() => {
+    window.api.getOSInfo().then((info) => setSystemInfo(info))
+  }, [])
+
+  let oldMac = false
+  let oldMacMessage = ''
+  if (systemInfo?.platform === 'darwin') {
+    const version = parseInt(systemInfo.release.split('.')[0])
+    if (version < 12) {
+      oldMac = true
+      oldMacMessage = t(
+        'login.old-mac',
+        'Your MacOS version is {{version}}. MacOS 12 or newer is required to log in the stores.',
+        { version: systemInfo.release }
+      )
+    }
+  }
 
   const loginMessage = t(
     'login.message',
@@ -84,10 +107,12 @@ export default React.memo(function NewLogin() {
           </div>
 
           <p className="runnerMessage">{loginMessage}</p>
+          {oldMac && <p className="disabledMessage">{oldMacMessage}</p>}
 
           <div className="runnerGroup">
             <Runner
               class="epic"
+              buttonText={t('login.epic', 'Epic Games Login')}
               loginUrl={epicLoginPath}
               icon={() => <EpicLogo />}
               isLoggedIn={isEpicLoggedIn}
@@ -96,22 +121,27 @@ export default React.memo(function NewLogin() {
               alternativeLoginAction={() => {
                 setShowSidLogin(true)
               }}
+              disabled={oldMac}
             />
             <Runner
               class="gog"
+              buttonText={t('login.gog', 'GOG Login')}
               icon={() => <GOGLogo />}
               loginUrl={gogLoginPath}
               isLoggedIn={isGogLoggedIn}
               user={gog.username}
               logoutAction={gog.logout}
+              disabled={oldMac}
             />
             <Runner
               class="nile"
+              buttonText={t('login.amazon', 'Amazon Login')}
               icon={() => <AmazonLogo />}
               loginUrl={amazonLoginPath}
               isLoggedIn={isAmazonLoggedIn}
               user={amazon.username || 'Unknown'}
               logoutAction={amazon.logout}
+              disabled={oldMac}
             />
           </div>
         </div>


### PR DESCRIPTION
This PR disables the login buttons if we detect the OS is MacOS older than version 12 and shows a message to the user to clarify that.

Even with the readme and the information in the downloads page in the websites, users of MacOS 10/11 still try to run Heroic and ask for support when it doesn't work.

This PR makes it more explicit in the Log In page itself so the users can see the answer there without the need to ask in discord.

This is how it would look:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/38226af3-0483-47d9-b8f9-65aa1be38ed2)

(I don't have that version of MacOS so I faked some values to generate the image, but I know the logic works since I also tested using version 14 as the limit (and I have MacOS 13) and the message was displayed)

This partially fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2071, but not completely since I didn't implement logic for old Windows systems.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
