### PR TITLE
[FIX] Fix windows dotnet applications from improperly working through wine

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -320,6 +320,8 @@ function setupWineEnvVars(
 
   const ret: Record<string, string> = {}
 
+  ret.DOTNET_BUNDLE_EXTRACT_BASE_DIR = ''
+
   // Add WINEPREFIX / STEAM_COMPAT_DATA_PATH / CX_BOTTLE
   const steamInstallPath = join(flatPakHome, '.steam', 'steam')
   switch (wineVersion.type) {


### PR DESCRIPTION
This variable breaks fall guys on systems that have dotnet sdk installed (even through flatpak)

Solution: Set it to a blank path

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
