### PR TITLE
callRunner: Use PowerShell to run commands on Windows

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1011,7 +1011,7 @@ async function callRunner(
       .join(',')
     commandParts = [
       'Start-Process',
-      `${fullRunnerPath}`,
+      `"\`"${fullRunnerPath}\`""`,
       '-Wait',
       '-ArgumentList',
       argsAsString,

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -946,6 +946,8 @@ interface RunnerProps {
 
 const commandsRunning = {}
 
+let shouldUsePowerShell: boolean | null = null
+
 function appNameFromCommandParts(commandParts: string[], runner: Runner) {
   let appNameIndex = -1
   let idx = -1
@@ -1004,8 +1006,12 @@ async function callRunner(
   let fullRunnerPath = join(runner.dir, bin)
 
   // On Windows: Use PowerShell's `Start-Process` to wait for the process and
-  // its children to exit
-  if (isWindows) {
+  // its children to exit, provided PowerShell is available
+  if (shouldUsePowerShell === null)
+    shouldUsePowerShell =
+      isWindows && !!(await searchForExecutableOnPath('powershell'))
+
+  if (shouldUsePowerShell) {
     const argsAsString = commandParts.map((part) => `"\`"${part}\`""`).join(',')
     commandParts = [
       'Start-Process',

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -26,6 +26,7 @@ import {
   flatPakHome,
   isLinux,
   isMac,
+  isWindows,
   isSteamDeckGameMode,
   runtimePath,
   userHome
@@ -993,12 +994,31 @@ async function callRunner(
   runner: RunnerProps,
   options?: CallRunnerOptions
 ): Promise<ExecResult> {
-  const fullRunnerPath = join(runner.dir, runner.bin)
   const appName = appNameFromCommandParts(commandParts, runner.name)
 
   // Necessary to get rid of possible undefined or null entries, else
   // TypeError is triggered
   commandParts = commandParts.filter(Boolean)
+
+  let bin = runner.bin
+  let fullRunnerPath = join(runner.dir, bin)
+
+  // On Windows: Use PowerShell's `Start-Process` to wait for the process and
+  // its children to exit
+  if (isWindows) {
+    const argsAsString = commandParts
+      .map((part) => (part.includes(' ') ? `"\`"${part}\`""` : `"${part}"`))
+      .join(',')
+    commandParts = [
+      'Start-Process',
+      `${fullRunnerPath}`,
+      '-Wait',
+      '-ArgumentList',
+      argsAsString,
+      '-NoNewWindow'
+    ]
+    bin = fullRunnerPath = 'powershell'
+  }
 
   const safeCommand = getRunnerCallWithoutCredentials(
     [...commandParts],
@@ -1031,8 +1051,6 @@ async function callRunner(
       }
     }
   }
-
-  const bin = runner.bin
 
   // check if the same command is currently running
   // if so, return the same promise instead of running it again
@@ -1198,11 +1216,25 @@ function getRunnerCallWithoutCredentials(
   const modifiedCommand = [...command]
   // Redact sensitive arguments (Authorization Code for Legendary, token for GOGDL)
   for (const sensitiveArg of ['--code', '--token']) {
-    const sensitiveArgIndex = modifiedCommand.indexOf(sensitiveArg)
-    if (sensitiveArgIndex === -1) {
-      continue
+    // PowerShell's argument formatting is quite different, instead of having
+    // arguments as members of `command`, they're all in one specific member
+    // (the one after "-ArgumentList")
+    if (runnerPath === 'powershell') {
+      const argumentListIndex = modifiedCommand.indexOf('-ArgumentList') + 1
+      if (!argumentListIndex) continue
+      modifiedCommand[argumentListIndex] = modifiedCommand[
+        argumentListIndex
+      ].replace(
+        new RegExp(`"${sensitiveArg}","(.*?)"`),
+        `"${sensitiveArg}","<redacted>"`
+      )
+    } else {
+      const sensitiveArgIndex = modifiedCommand.indexOf(sensitiveArg)
+      if (sensitiveArgIndex === -1) {
+        continue
+      }
+      modifiedCommand[sensitiveArgIndex + 1] = '<redacted>'
     }
-    modifiedCommand[sensitiveArgIndex + 1] = '<redacted>'
   }
 
   const formattedEnvVars: string[] = []

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1006,9 +1006,7 @@ async function callRunner(
   // On Windows: Use PowerShell's `Start-Process` to wait for the process and
   // its children to exit
   if (isWindows) {
-    const argsAsString = commandParts
-      .map((part) => (part.includes(' ') ? `"\`"${part}\`""` : `"${part}"`))
-      .join(',')
+    const argsAsString = commandParts.map((part) => `"\`"${part}\`""`).join(',')
     commandParts = [
       'Start-Process',
       `"\`"${fullRunnerPath}\`""`,


### PR DESCRIPTION
PowerShell's `Start-Process` cmdlet & its `-Wait` parameter are used to wait for a process tree to exit. This means we can now accurately track the "Playing" status of games on Windows.

TODO:
- [X] Since we now modify `commandParts`, hiding login tokens in `getRunnerCallWithoutCredentials` no longer works.  
  Adding a check like `if (runnerPath === 'powershell')` should  *work*, although I don't exactly like this solution

Closes #2046 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
