### PR TITLE
[FIX]: remember if window is maximized

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -200,7 +200,10 @@ async function initializeWindow(): Promise<BrowserWindow> {
 
     if (!isCLIFullscreen && !isSteamDeckGameMode) {
       // store windows properties
-      configStore.set('window-props', mainWindow.getBounds())
+      configStore.set('window-props', {
+        ...mainWindow.getBounds(),
+        maximized: mainWindow.isMaximized()
+      })
     }
 
     const { exitToTray } = GlobalConfig.get().getSettings()

--- a/src/backend/main_window.ts
+++ b/src/backend/main_window.ts
@@ -1,3 +1,4 @@
+import { WindowProps } from 'common/types'
 import { BrowserWindow, screen } from 'electron'
 import path from 'path'
 import { configStore } from './constants'
@@ -28,11 +29,12 @@ export const sendFrontendMessage = (message: string, ...payload: unknown[]) => {
 
 // creates the mainWindow based on the configuration
 export const createMainWindow = () => {
-  let windowProps: Electron.Rectangle = {
+  let windowProps: WindowProps = {
     height: 690,
     width: 1200,
     x: 0,
-    y: 0
+    y: 0,
+    maximized: false
   }
 
   if (configStore.has('window-props')) {
@@ -49,10 +51,10 @@ export const createMainWindow = () => {
       windowProps.width = screenInfo.workAreaSize.width * 0.8
     }
   }
-
+  const { maximized, ...props } = windowProps
   // Create the browser window.
   mainWindow = new BrowserWindow({
-    ...windowProps,
+    ...props,
     minHeight: 345,
     minWidth: 600,
     show: false,
@@ -65,6 +67,10 @@ export const createMainWindow = () => {
       preload: path.join(__dirname, 'preload.js')
     }
   })
+
+  if (maximized) {
+    mainWindow.maximize()
+  }
 
   return mainWindow
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -689,3 +689,7 @@ export interface WineManagerUISettings {
 }
 
 export type DownloadManagerState = 'idle' | 'running' | 'paused' | 'stopped'
+
+export interface WindowProps extends Electron.Rectangle {
+  maximized: boolean
+}

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -13,7 +13,8 @@ import {
   WineManagerUISettings,
   AppSettings,
   WikiInfo,
-  GameInfo
+  GameInfo,
+  WindowProps
 } from 'common/types'
 import { UserData } from 'common/types/gog'
 import { NileUserData } from './nile'
@@ -40,7 +41,7 @@ export interface StoreStructure {
       gogdlLogFile: string
       nileLogFile: string
     }
-    'window-props': Electron.Rectangle
+    'window-props': WindowProps
     settings: AppSettings
     skipVcRuntime: boolean
   }


### PR DESCRIPTION
Closes #2850

One small thing though, window will not remember it's original size in non-maximized state, as this is behaviour of getBounds 

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
