### PR TITLE
[Tech] Skip empty arguments in sideload and frontend command launcher

### DIFF
--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -151,6 +151,8 @@ export async function launchGame(
 
   const gameSettings = await getAppSettings(appName)
   const { launcherArgs } = gameSettings
+  const extraArgs = shlex.split(launcherArgs ?? '')
+  const extraArgsJoined = extraArgs.join(' ')
 
   if (executable) {
     const isNative = gameManagerMap[runner].isNative(appName)
@@ -196,7 +198,7 @@ export async function launchGame(
     // Native
     if (isNative) {
       logInfo(
-        `launching native sideloaded game: ${executable} ${launcherArgs ?? ''}`,
+        `launching native sideloaded game: ${executable} ${extraArgsJoined}`,
         LogPrefix.Backend
       )
 
@@ -204,7 +206,7 @@ export async function launchGame(
         await access(executable, FS_CONSTANTS.X_OK)
       } catch (error) {
         logWarning(
-          'File not executable, changing permissions temporarilly',
+          'File not executable, changing permissions temporarily',
           LogPrefix.Backend
         )
         // On Mac, it gives an error when changing the permissions of the file inside the app bundle. But we need it for other executables like scripts.
@@ -213,7 +215,6 @@ export async function launchGame(
         }
       }
 
-      const commandParts = shlex.split(launcherArgs ?? '')
       const env = {
         ...process.env,
         ...setupWrapperEnvVars({ appName, appRunner: runner }),
@@ -221,7 +222,7 @@ export async function launchGame(
       }
 
       await callRunner(
-        commandParts,
+        extraArgs,
         {
           name: runner,
           logPrefix: LogPrefix.Backend,
@@ -245,12 +246,12 @@ export async function launchGame(
     }
 
     logInfo(
-      `launching non-native sideloaded: ${executable}}`,
+      `launching non-native sideloaded: ${executable} ${extraArgsJoined}`,
       LogPrefix.Backend
     )
 
     await runWineCommand({
-      commandParts: [executable, launcherArgs ?? ''],
+      commandParts: [executable, ...extraArgs],
       gameSettings,
       wait: true,
       protonVerb: 'waitforexitandrun',


### PR DESCRIPTION
If the additional command line arguments are unset/set to an empty string, the wine command launcher will likewise pass an empty argument to the launched application.

While that is usually harmless, some applications try to parse this argument and (rightfully) complain and usually exit with an error.

Make sure that we only pass additional arguments if they are actually set, fixing that issue.

This has been encountered with Palia's launcher.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
