### PR TITLE
[FIX] Unbreak updating games list if user is logged in to Amazon account, but has no games installed.

### DIFF
--- a/src/backend/storeManagers/nile/library.ts
+++ b/src/backend/storeManagers/nile/library.ts
@@ -166,6 +166,14 @@ export async function listUpdateableGames(): Promise<string[]> {
   )
   deleteAbortController(abortID)
 
+  if (!output) {
+    /*
+     * Nothing installed: nothing to update, output will be empty and JSON.parse can't
+     * handle empty strings (they aren't proper JSON).
+     */
+    return []
+  }
+
   const updates: string[] = JSON.parse(output)
   if (updates.length) {
     logInfo(['Found', `${updates.length}`, 'games to update'], LogPrefix.Nile)


### PR DESCRIPTION
If no game is installed, `nile list-updates` will return an empty string. Unfortunately, this is not valid JSON and `JSON.parse()` later bails out with an error.

We're good to go if no game is installed either way, so break out early and don't try to parse an empty string.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
