### PR TITLE
[FIX] Unbreak legendary update command.

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -822,6 +822,7 @@ export function commandToArgsArray(command: LegendaryCommand): string[] {
       if (command.extraArguments)
         commandParts.push(...shlex.split(command.extraArguments))
       break
+    case 'update':
     case 'info':
     case 'sync-saves':
     case 'uninstall':


### PR DESCRIPTION
86e2e11ce6b4639b186da7fdcac3c3ea6482d2f0 completely broke updating, fix that up by also supplying the `appName` for the `update` subcommand.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
