### PR TITLE
[FIX]: gamepage play button not working

### DIFF
--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -16,7 +16,7 @@ import { GameInfo } from 'common/types'
 
 interface Props {
   gameInfo: GameInfo
-  handlePlay: (gameInfo: GameInfo) => () => Promise<void>
+  handlePlay: (gameInfo: GameInfo) => Promise<void>
   handleInstall: (
     is_installed: boolean
   ) => Promise<void | { status: 'done' | 'error' | 'abort' }>

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -355,21 +355,19 @@ export default React.memo(function GamePage(): JSX.Element | null {
   }
   return <UpdateComponent />
 
-  function handlePlay(gameInfo: GameInfo) {
-    return async () => {
-      if (isPlaying || isUpdating) {
-        return sendKill(appName, gameInfo.runner)
-      }
-
-      await launch({
-        appName,
-        t,
-        launchArguments,
-        runner: gameInfo.runner,
-        hasUpdate,
-        showDialogModal
-      })
+  async function handlePlay(gameInfo: GameInfo) {
+    if (isPlaying || isUpdating) {
+      return sendKill(appName, gameInfo.runner)
     }
+
+    await launch({
+      appName,
+      t,
+      launchArguments,
+      runner: gameInfo.runner,
+      hasUpdate,
+      showDialogModal
+    })
   }
 
   async function handleInstall(is_installed: boolean) {


### PR DESCRIPTION
Issue introduced in gamepage refactor, we somehow missed this.  
`handlePlay` function returned another function... 

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
