### PR TITLE
[Fix] Await for GOG uninstaller to finish

### DIFF
--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -733,7 +733,7 @@ export async function uninstall({ appName }: RemoveArgs): Promise<ExecResult> {
     logInfo(['Executing uninstall command', command.join(' ')], LogPrefix.Gog)
 
     if (!isWindows) {
-      runWineCommandUtil({
+      await runWineCommandUtil({
         gameSettings,
         commandParts: command,
         wait: true,


### PR DESCRIPTION
This prevents an issue when uninstalling a GOG game while at the same time deleting the game prefix.

The uninstaller and the prefix folder deleting was happening in parallel, freezing the uninstaller execution.

Now we first wait until it's done.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
