### PR TITLE
[FIX] Unset DOTNET_ROOT for wine

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -354,6 +354,7 @@ function setupWineEnvVars(
   const ret: Record<string, string> = {}
 
   ret.DOTNET_BUNDLE_EXTRACT_BASE_DIR = ''
+  ret.DOTNET_ROOT = ''
 
   // Add WINEPREFIX / STEAM_COMPAT_DATA_PATH / CX_BOTTLE
   const steamInstallPath = join(flatPakHome, '.steam', 'steam')


### PR DESCRIPTION
URGENT:
Fixes games/launchers that require DOTNET 6.0 and higher with linux dotnet sdk installed on the host

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
