### PR TITLE
[Tech] Update electron to version 26.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
     "@typescript-eslint/parser": "^5.47.1",
     "@vitejs/plugin-react-swc": "^3.2.0",
     "cross-env": "^7.0.3",
-    "electron": "castlabs/electron-releases#24.4.1+wvcus",
+    "electron": "castlabs/electron-releases#26.2.1+wvcus",
     "electron-builder": "^23.6.0",
     "electron-devtools-installer": "^3.2.0",
     "electron-playwright-helpers": "^1.5.5",

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -468,7 +468,7 @@ ipcMain.on('unlock', () => {
     unlinkSync(join(gamesConfigPath, 'lock'))
     if (powerId) {
       logInfo('Stopping Power Saver Blocker', LogPrefix.Backend)
-      return powerSaveBlocker.stop(powerId)
+      powerSaveBlocker.stop(powerId)
     }
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,9 +3543,9 @@ electron-updater@^5.0.1:
     semver "^7.3.5"
     typed-emitter "^2.1.0"
 
-electron@castlabs/electron-releases#24.4.1+wvcus:
-  version "24.4.1"
-  resolved "https://codeload.github.com/castlabs/electron-releases/tar.gz/382f71fa5495e1523d6677fa96b3d3c583d79e3a"
+electron@castlabs/electron-releases#26.2.1+wvcus:
+  version "26.2.1"
+  resolved "https://codeload.github.com/castlabs/electron-releases/tar.gz/e5fad1db625a4414ab2000c2f1456586fc33af42"
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
This PR updates Electron to version 26.2.1.

I tested HBO Max as a sideloaded app and it works fine (I think that means the DRM is good?)
I tested logging into Epic and it works fine
I tested navigating stores and it works fine

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
