### PR TITLE
[UI] Fix wide card being extra tall

### DIFF
--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -13,12 +13,16 @@
   aspect-ratio: 173/275;
 }
 
+.gameCard.gamepad {
+  aspect-ratio: 3/4;
+}
+
 .gameCard.justPlayed {
   aspect-ratio: 275/205;
 }
 
-.gameCard.gamepad {
-  aspect-ratio: 3/4;
+.gameCard.gamepad.justPlayed {
+  aspect-ratio: 328/205;
 }
 
 .gameCard:focus-within {

--- a/src/frontend/screens/Library/index.css
+++ b/src/frontend/screens/Library/index.css
@@ -11,7 +11,7 @@
   padding: 0 var(--space-md-fixed) var(--space-md-fixed);
 }
 
-.gameList.firstLane > :first-child {
+.gameList.firstLane > div:has(.justPlayed) {
   grid-column: span 2;
 }
 


### PR DESCRIPTION
This PR should fix these issues for good (hopefully)

We had a problem when using a controller:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/6083f131-0742-4143-ae85-50222beae1c1)

And this was reported on Discord:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/3c418696-ad1b-48e1-a222-46cbe9604a78)

To reproduce the first one, just use a gamepad and it looks like that. I couldn't reproduce the second one manually but I could artificially (removing some classes). The fix I added should fix this in any case though since now the size will only be applied if the `justPlayed` class is actually present on that first element.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
