### PR TITLE
[IMPROV]: avoid caching same images in the same time

### DIFF
--- a/src/backend/images_cache.ts
+++ b/src/backend/images_cache.ts
@@ -17,17 +17,32 @@ export const initImagesCache = () => {
   })
 }
 
+const pending = new Map<string, Promise<void>>()
+
 const getImageFromCache = (url: string) => {
   const realUrl = url.replace('imagecache://', '')
   // digest of the image url for the file name
   const digest = createHash('sha256').update(realUrl).digest('hex')
   const cachePath = join(imagesCachePath, digest)
 
-  if (!existsSync(cachePath) && realUrl.startsWith('http')) {
+  if (
+    !existsSync(cachePath) &&
+    realUrl.startsWith('http') &&
+    !pending.has(digest)
+  ) {
     // if not found, download in the background
-    axios
-      .get(realUrl, { responseType: 'stream' })
-      .then((response) => response.data.pipe(createWriteStream(cachePath)))
+    pending.set(
+      digest,
+      new Promise((res) => {
+        axios
+          .get(realUrl, { responseType: 'stream' })
+          .then((response) => response.data.pipe(createWriteStream(cachePath)))
+          .finally(() => {
+            pending.delete(digest)
+            res()
+          })
+      })
+    )
   }
 
   return join(cachePath)


### PR DESCRIPTION
This PR optimizes how image cache works and prevents same images to be loaded at the same time. This speeds up loading library and future game page redesign


Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
