### PR TITLE
[DRM]: fix update error causing hang

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -284,7 +284,7 @@ if (!gotTheLock) {
       await components.whenReady().catch((e) => {
         logError([
           'Failed to download / update DRM components.',
-          'Make sure you do not block update.googleapis.com domain if you want to use WideVine in Browser siedeloaded apps',
+          'Make sure you do not block update.googleapis.com domain if you want to use WideVine in Browser sideloaded apps',
           e
         ])
       })

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -281,7 +281,13 @@ if (!gotTheLock) {
     initImagesCache()
 
     if (!process.env.CI) {
-      await components.whenReady()
+      await components.whenReady().catch((e) => {
+        logError([
+          'Failed to download / update DRM components.',
+          'Make sure you do not block update.googleapis.com domain if you want to use WideVine in Browser siedeloaded apps',
+          e
+        ])
+      })
       logInfo(['DRM module staus', components.status()])
     }
 


### PR DESCRIPTION
avoids main "thread" hang when downloading of widevine components fails  

Reported on discord by user `Jiibus`  
The issue can be easily reproduced by blocking `update.googleapis.com` 
sample /etc/hosts line
```
0.0.0.0 update.googleapis.com
```


Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
