### PR TITLE
[Fix] Add an error handler to stdout/stderr

### DIFF
--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -53,6 +53,24 @@ interface LogOptions {
 export let logsDisabled = false
 
 export function initLogger() {
+  // Add a basic error handler to our stdout/stderr. If we don't do this,
+  // the main `process.on('uncaughtException', ...)` handler catches them (and
+  // presents an error message to the user, which is hardly necessary for
+  // "just" failing to write to the streams)
+  for (const channel of ['stdout', 'stderr'] as const) {
+    process[channel].once('error', (error: Error) => {
+      const prefix = `${getTimeStamp()} ${getLogLevelString(
+        'ERROR'
+      )} ${getPrefixString(LogPrefix.Backend)}`
+      appendMessageToLogFile(
+        `${prefix} Error writing to ${channel}: ${error.stack}`
+      )
+      process[channel].on('error', () => {
+        // Silence further write errors
+      })
+    })
+  }
+
   // check `disableLogs` setting
   const { disableLogs } = GlobalConfig.get().getSettings()
 


### PR DESCRIPTION
Closes #2522 

To test:
- Run regular Heroic with `heroic | head`; for every log message pushed, one exception is thrown
- Run this version with the same pipe (to avoid having to install this PR's version globally, you can build & run with `node_modules/.bin/vite build && CI=e2e node_modules/.bin/electron build/electron/main.js | head`); exceptions are no longer thrown

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
