### PR TITLE
[FIX] mark paths starting with XDG_RUNTIME_DIR as invalid

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -410,7 +410,11 @@ export default function DownloadDialog({
   const readyToInstall =
     installPath &&
     gameInstallInfo?.manifest?.download_size &&
-    !gettingInstallInfo
+    !gettingInstallInfo &&
+    !(
+      !!process.env.FLATPAK_ID &&
+      installPath.startsWith(process.env.XDG_RUNTIME_DIR || '/run/user/')
+    )
 
   const showDlcSelector =
     runner === 'legendary' && DLCList && DLCList?.length > 0


### PR DESCRIPTION
All it needs is a popup message box to inform the user and some testing :)

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
