### PR TITLE
[Fix]: Permission error on updating Proton/Wine-Ge-latest

### DIFF
--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -223,7 +223,6 @@ interface unzipProps {
  *
  * @param filePath url of the file
  * @param unzipDir absolute path to the unzip directory
- * @param overwrite allow overwriting existing unpacked files
  * @defaultValue false
  * @param onProgress callback to get unzip progress
  * @returns resolves or rejects with a message
@@ -231,7 +230,6 @@ interface unzipProps {
 async function unzipFile({
   filePath,
   unzipDir,
-  overwrite = false,
   onProgress,
   abortSignal
 }: unzipProps): Promise<string> {
@@ -266,10 +264,6 @@ async function unzipFile({
       extension_options,
       filePath
     ]
-
-    if (overwrite && !isMac) {
-      args.push('--overwrite')
-    }
 
     const unzip = spawn('tar', args, { signal: abortSignal })
 


### PR DESCRIPTION
This PR removes the `overwrite` flag for unzipping new proton/wine-ge versions and instead backup the old folder.
This should avoid the permission error reported in #3067.

The backup folder is restored if unzipping of the new version fails or deleted if it succeed.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
