### PR TITLE
[Fix] Installation fail when sdlList has empty elements

### DIFF
--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -68,7 +68,7 @@ async function installQueueElement(params: InstallParams): Promise<{
     const { status, error } = await gameManagerMap[runner].install(appName, {
       path: path.replaceAll("'", ''),
       installDlcs,
-      sdlList,
+      sdlList: sdlList.filter((el) => el !== ''),
       platformToInstall,
       installLanguage
     })


### PR DESCRIPTION
[Fix] Installation fail when sdlList has empty elements
---

- Filter sdlList in order to remove empty elements to avoid installation failures.

It fixes an install bug on Kerbal Space Program and probably other games (I haven't any game that can select some specific downloads).

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
