### PR TITLE
Fix type errors on Jest functions in VS Code

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "noFallthroughCasesInSwitch": true,
     "baseUrl": "./src/",
     "types": ["vite-plugin-svgr/client", "@types/jest"],
-    "typeRoots": ["./node-modules/@types", "src/common/typedefs"]
+    "typeRoots": ["./node_modules", "src/common/typedefs"]
   },
   "include": ["src"],
   "exclude": ["vite.config.ts", "**/__mocks__/**", "sign"]


### PR DESCRIPTION
This fixes a misconfiguration in `tsconfig.json` which leads to Jest functions such as `describe()`, `expect()`, etc. to not be recognized in VS Code. 

### Before 
<img width="405" alt="image" src="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/98132670/bad320d6-17b2-4ea5-9223-a7823b659b9e">

### After
<img width="393" alt="image" src="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/98132670/5c4f0827-d47f-4ac7-a275-163266247b6a">

## Checklist
- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
