### PR TITLE
[FIX] Sideloaded Games Logs

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -705,7 +705,6 @@ async function runWineCommand({
       }
 
       if (options?.logFile && existsSync(options.logFile)) {
-        writeFileSync(options.logFile, '')
         appendFileSync(
           options.logFile,
           `Wine Command: ${bin} ${commandParts.join(' ')}\n\nGame Log:\n`

--- a/src/frontend/screens/Game/GamePage/components/ReportIssue.tsx
+++ b/src/frontend/screens/Game/GamePage/components/ReportIssue.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react'
-import GameContext from '../../GameContext'
 import { GameInfo } from 'common/types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons'
@@ -13,14 +12,9 @@ interface Props {
 const ReportIssue = ({ gameInfo }: Props) => {
   const { t } = useTranslation('gamepage')
   const { setIsSettingsModalOpen } = useContext(ContextProvider)
-  const { runner } = useContext(GameContext)
 
   const showReportIssue =
     gameInfo.is_installed && gameInfo.install.platform !== 'Browser'
-
-  if (runner === 'sideload') {
-    return null
-  }
 
   if (!showReportIssue) {
     return null


### PR DESCRIPTION
This fixes Sideloaded games logs not showing the system info and game settings.
It also re-adds the 'Report a Problem' Link on the game page to see the logs.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
