### PR TITLE
[UI] Fix position of submenus of collapsed sidebar

### DIFF
--- a/src/frontend/components/UI/Sidebar/index.scss
+++ b/src/frontend/components/UI/Sidebar/index.scss
@@ -181,6 +181,11 @@
   display: none;
 }
 
+.Sidebar.collapsed .SidebarItemWithSubmenu:has(.SidebarSubmenu) {
+  position: relative;
+  z-index: 2;
+}
+
 .Sidebar.collapsed .SidebarItemWithSubmenu .SidebarSubmenu {
   display: none;
 }
@@ -194,7 +199,7 @@
 .Sidebar.collapsed .SidebarItemWithSubmenu:focus-within .SidebarSubmenu {
   display: block;
   position: fixed;
-  left: 62px;
+  left: var(--sidebar-width);
   top: 66px;
   background-color: var(--navbar-background);
   padding: var(--space-2xs) 0;


### PR DESCRIPTION
The submenus for Stores and Settings when the sidebar was collapsed where not positioned correctly.

<img width="230" alt="Screenshot 2023-09-30 at 7 55 12 PM" src="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/6200d178-92c9-4898-9ac4-1771e8a50eb1">

The `left` was fixed to 62px with variable width of the sidebar.

There was another related issue: because of the `drag` area of the sidebar, moving the mouse from the Settings or Store buttons to the submenu was not possible for the smallest widths of the sidebar (the mouse was not `hovering` the button anymore for a moment). This PR fixes that too by making the element be on top of the drag area.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
