### PR TITLE
[Fix] Fix "Run Game Offline" not working on windows and mac

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -92,7 +92,7 @@ async function prepareLaunch(
 
   // If we're not on Linux, we can return here
   if (!isLinux) {
-    return { success: true, rpcClient }
+    return { success: true, rpcClient, offlineMode }
   }
 
   // Figure out where MangoHud/GameMode are located, if they're enabled


### PR DESCRIPTION
In the prepareLaunch function we have an early return if not linux and it was only returning the discord presence flag but not the offline flag, so even with the setting the launch commands were not created with this argument. It only worked on Linux since it didn't do that early return.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
