### PR TITLE
[Refactor] Introduce Recoil to start migrating to a more efficient state management

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "react-markdown": "^8.0.5",
     "react-router-dom": "^6.9.0",
     "recharts": "^2.4.3",
+    "recoil": "^0.7.7",
     "sanitize-filename": "^1.6.3",
     "semver": "^7.5.2",
     "shlex": "^2.1.2",

--- a/src/frontend/components/UI/SearchBar/index.tsx
+++ b/src/frontend/components/UI/SearchBar/index.tsx
@@ -13,6 +13,8 @@ import './index.scss'
 import { faXmark } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { GameInfo } from '../../../../common/types'
+import { epicState } from 'frontend/state/epic_state'
+import { useRecoilValue } from 'recoil'
 
 function fixFilter(text: string) {
   const regex = new RegExp(/([?\\|*|+|(|)|[|]|])+/, 'g')
@@ -26,7 +28,8 @@ const RUNNER_TO_STORE = {
 }
 
 export default React.memo(function SearchBar() {
-  const { handleSearch, filterText, epic, gog, sideloadedLibrary, amazon } =
+  const epic = useRecoilValue(epicState)
+  const { handleSearch, filterText, gog, sideloadedLibrary, amazon } =
     useContext(ContextProvider)
   const { t } = useTranslation()
   const navigate = useNavigate()

--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -24,6 +24,8 @@ import './index.css'
 import QuitButton from '../QuitButton'
 import { LocationState } from 'frontend/types'
 import { SHOW_EXTERNAL_LINK_DIALOG_STORAGE_KEY } from 'frontend/components/UI/ExternalLinkDialog'
+import { epicState } from 'frontend/state/epic_state'
+import { useRecoilValue } from 'recoil'
 
 type PathSplit = [
   a: undefined,
@@ -39,14 +41,10 @@ export default function SidebarLinks() {
   const location = useLocation() as { pathname: string }
   const [, , runner, appName, type] = location.pathname.split('/') as PathSplit
 
-  const {
-    amazon,
-    epic,
-    gog,
-    platform,
-    refreshLibrary,
-    handleExternalLinkDialog
-  } = useContext(ContextProvider)
+  const epic = useRecoilValue(epicState)
+
+  const { amazon, gog, platform, refreshLibrary, handleExternalLinkDialog } =
+    useContext(ContextProvider)
 
   const isStore = location.pathname.includes('store')
   const isSettings = location.pathname.includes('settings')

--- a/src/frontend/components/UI/StoreFilter/index.tsx
+++ b/src/frontend/components/UI/StoreFilter/index.tsx
@@ -3,10 +3,12 @@ import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import FormControl from 'frontend/components/UI/FormControl'
 import ContextProvider from 'frontend/state/ContextProvider'
+import { epicState } from 'frontend/state/epic_state'
+import { useRecoilValue } from 'recoil'
 
 export default React.memo(function StoreFilter() {
-  const { category, handleCategory, gog, epic, amazon } =
-    useContext(ContextProvider)
+  const epic = useRecoilValue(epicState)
+  const { category, handleCategory, gog, amazon } = useContext(ContextProvider)
   const { t } = useTranslation()
 
   const isGOGLoggedin = gog.username

--- a/src/frontend/hooks/hasStatus.ts
+++ b/src/frontend/hooks/hasStatus.ts
@@ -1,16 +1,19 @@
+import { useRecoilValue } from 'recoil'
 import React from 'react'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { GameInfo, GameStatus, Status } from 'common/types'
 import { hasProgress } from './hasProgress'
 import { useTranslation } from 'react-i18next'
 import { getStatusLabel, handleNonAvailableGames } from './constants'
+import { epicState } from 'frontend/state/epic_state'
 
 export function hasStatus(
   appName: string,
   gameInfo: GameInfo,
   gameSize?: string
 ) {
-  const { libraryStatus, epic, gog } = React.useContext(ContextProvider)
+  const epic = useRecoilValue(epicState)
+  const { libraryStatus, gog } = React.useContext(ContextProvider)
   const [progress] = hasProgress(appName)
   const { t } = useTranslation('gamepage')
 

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -4,10 +4,11 @@ import React, { lazy, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import i18next from 'i18next'
 import { initGamepad } from './helpers/gamepad'
+import { RecoilRoot } from 'recoil'
 
 import './index.scss'
 import './themes.scss'
-import GlobalState from './state/GlobalState'
+import { GlobalStateFunctional } from './state/GlobalStateFunctional'
 import { initShortcuts } from './helpers/shortcuts'
 import { configStore } from './helpers/electronStores'
 import { initOnlineMonitor } from './helpers/onlineMonitor'
@@ -104,15 +105,17 @@ const root = createRoot(container!) // createRoot(container!) if you use TypeScr
 const App = lazy(async () => import('./App'))
 
 root.render(
-  // <React.StrictMode>
-  <GlobalState>
-    <I18nextProvider i18n={i18next}>
-      <Suspense fallback={<Loading />}>
-        <App />
-      </Suspense>
-    </I18nextProvider>
-  </GlobalState>
-  // </React.StrictMode>
+  <React.StrictMode>
+    <RecoilRoot>
+      <GlobalStateFunctional>
+        <I18nextProvider i18n={i18next}>
+          <Suspense fallback={<Loading />}>
+            <App />
+          </Suspense>
+        </I18nextProvider>
+      </GlobalStateFunctional>
+    </RecoilRoot>
+  </React.StrictMode>
 )
 
 // helper function to set the theme class and load custom css if needed

--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
@@ -14,6 +14,8 @@ import { useNavigate } from 'react-router-dom'
 import { ReactComponent as PlayIcon } from 'frontend/assets/play-icon.svg'
 import { ReactComponent as DownIcon } from 'frontend/assets/down-icon.svg'
 import { ReactComponent as PauseIcon } from 'frontend/assets/pause-icon.svg'
+import { epicState } from 'frontend/state/epic_state'
+import { useRecoilValue } from 'recoil'
 
 type Props = {
   element?: DMQueueElement
@@ -37,7 +39,8 @@ function convertToTime(time: number) {
 }
 
 const DownloadManagerItem = ({ element, current, state }: Props) => {
-  const { amazon, epic, gog, showDialogModal } = useContext(ContextProvider)
+  const epic = useRecoilValue(epicState)
+  const { amazon, gog, showDialogModal } = useContext(ContextProvider)
   const { t } = useTranslation('gamepage')
   const { t: t2 } = useTranslation('translation')
 

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -64,6 +64,8 @@ import {
   SettingsButton
 } from './components'
 import { hasAnticheatInfo } from 'frontend/hooks/hasAnticheatInfo'
+import { epicState } from 'frontend/state/epic_state'
+import { useRecoilValue } from 'recoil'
 
 export default React.memo(function GamePage(): JSX.Element | null {
   const { appName, runner } = useParams() as { appName: string; runner: Runner }
@@ -77,9 +79,9 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
   const [showModal, setShowModal] = useState({ game: '', show: false })
   const [wikiInfo, setWikiInfo] = useState<WikiInfo | null>(null)
+  const epic = useRecoilValue(epicState)
 
   const {
-    epic,
     gog,
     gameUpdates,
     platform,

--- a/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
+++ b/src/frontend/screens/Library/components/RecentlyPlayed/index.tsx
@@ -4,6 +4,8 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import { GameInfo, Runner } from 'common/types'
 import GamesList from '../GamesList'
 import { configStore } from 'frontend/helpers/electronStores'
+import { epicState } from 'frontend/state/epic_state'
+import { useRecoilValue } from 'recoil'
 
 interface Props {
   handleModal: (appName: string, runner: Runner, gameInfo: GameInfo) => void
@@ -37,7 +39,8 @@ export default React.memo(function RecentlyPlayed({
   onlyInstalled
 }: Props) {
   const { t } = useTranslation()
-  const { epic, gog, sideloadedLibrary, amazon } = useContext(ContextProvider)
+  const epic = useRecoilValue(epicState)
+  const { gog, sideloadedLibrary, amazon } = useContext(ContextProvider)
   const [recentGames, setRecentGames] = useState<GameInfo[]>([])
 
   const loadRecentGames = async () => {

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -34,6 +34,8 @@ import {
 } from 'frontend/helpers/library'
 import RecentlyPlayed from './components/RecentlyPlayed'
 import { InstallModal } from './components'
+import { epicState } from 'frontend/state/epic_state'
+import { useRecoilValue } from 'recoil'
 
 const storage = window.localStorage
 
@@ -45,13 +47,14 @@ type ModalState = {
 }
 
 export default React.memo(function Library(): JSX.Element {
+  const epic = useRecoilValue(epicState)
+
   const {
     layout,
     libraryStatus,
     refreshing,
     refreshingInTheBackground,
     category,
-    epic,
     gog,
     amazon,
     sideloadedLibrary,

--- a/src/frontend/screens/Login/components/SIDLogin/index.tsx
+++ b/src/frontend/screens/Login/components/SIDLogin/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 export default function SIDLogin({ backdropClick }: Props) {
   const epicLoginUrl = 'https://legendary.gl/epiclogin'
 
-  const { epic } = useContext(ContextProvider)
+  const { epicLogin } = useContext(ContextProvider)
   const { t } = useTranslation('login')
   const [input, setInput] = useState('')
   const [status, setStatus] = useState({
@@ -38,7 +38,7 @@ export default function SIDLogin({ backdropClick }: Props) {
       loading: true,
       error: false
     })
-    await epic.login(sid).then(async (res) => {
+    await epicLogin(sid).then(async (res) => {
       console.log(res)
       if (res === 'done') {
         await window.api.getUserInfo()

--- a/src/frontend/screens/Login/index.tsx
+++ b/src/frontend/screens/Login/index.tsx
@@ -14,13 +14,17 @@ import { FlagPosition } from '../../components/UI/LanguageSelector'
 import SIDLogin from './components/SIDLogin'
 import ContextProvider from '../../state/ContextProvider'
 import { useAwaited } from '../../hooks/useAwaited'
+import { epicState } from 'frontend/state/epic_state'
+import { useRecoilValue } from 'recoil'
 
 export const epicLoginPath = '/loginweb/legendary'
 export const gogLoginPath = '/loginweb/gog'
 export const amazonLoginPath = '/loginweb/nile'
 
 export default React.memo(function NewLogin() {
-  const { epic, gog, amazon, refreshLibrary } = useContext(ContextProvider)
+  const epic = useRecoilValue(epicState)
+  const { epicLogout, gog, amazon, refreshLibrary } =
+    useContext(ContextProvider)
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [loading, setLoading] = useState(true)
@@ -111,7 +115,7 @@ export default React.memo(function NewLogin() {
               icon={() => <EpicLogo />}
               isLoggedIn={isEpicLoggedIn}
               user={epic.username}
-              logoutAction={epic.logout}
+              logoutAction={epicLogout}
               alternativeLoginAction={() => {
                 setShowSidLogin(true)
               }}

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -15,12 +15,15 @@ import { Runner, WebviewType } from 'common/types'
 import './index.css'
 import LoginWarning from '../Login/components/LoginWarning'
 import { NileLoginData } from 'common/types/nile'
+import { epicState } from 'frontend/state/epic_state'
+import { useRecoilValue } from 'recoil'
 
 export default function WebView() {
   const { i18n } = useTranslation()
   const { pathname, search } = useLocation()
   const { t } = useTranslation()
-  const { epic, gog, amazon, connectivity } = useContext(ContextProvider)
+  const epic = useRecoilValue(epicState)
+  const { epicLogin, gog, amazon, connectivity } = useContext(ContextProvider)
   const [loading, setLoading] = useState<{
     refresh: boolean
     message: string
@@ -149,7 +152,7 @@ export default function WebView() {
               refresh: true,
               message: t('status.logging', 'Logging In...')
             })
-            await epic.login(e.args[0])
+            await epicLogin(e.args[0])
             handleSuccessfulLogin()
           } catch (error) {
             console.error(error)

--- a/src/frontend/state/ContextProvider.tsx
+++ b/src/frontend/state/ContextProvider.tsx
@@ -4,11 +4,8 @@ import { ContextType } from 'frontend/types'
 
 const initialContext: ContextType = {
   category: 'all',
-  epic: {
-    library: [],
-    login: async () => Promise.resolve(''),
-    logout: async () => Promise.resolve()
-  },
+  epicLogin: async () => Promise.resolve(''),
+  epicLogout: async () => Promise.resolve(),
   gog: {
     library: [],
     login: async () => Promise.resolve(''),

--- a/src/frontend/state/GlobalStateFunctional.tsx
+++ b/src/frontend/state/GlobalStateFunctional.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { epicState } from './epic_state'
+import { useRecoilState } from 'recoil'
+import GlobalState from './GlobalState'
+
+interface Props {
+  children: JSX.Element
+}
+
+export function GlobalStateFunctional({ children }: Props) {
+  const [epic, setEpic] = useRecoilState(epicState)
+
+  const props = {
+    epic,
+    setEpic
+  }
+
+  return <GlobalState {...props}>{children}</GlobalState>
+}

--- a/src/frontend/state/epic_state.ts
+++ b/src/frontend/state/epic_state.ts
@@ -1,0 +1,16 @@
+import { GameInfo } from 'common/types'
+import { configStore, libraryStore } from 'frontend/helpers/electronStores'
+import { atom } from 'recoil'
+
+export interface EpicState {
+  library: GameInfo[]
+  username?: string
+}
+
+export const epicState = atom({
+  key: 'epicState',
+  default: {
+    library: libraryStore.get('library', []),
+    username: configStore.get_nodefault('userInfo.displayName')
+  } as EpicState
+})

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -65,12 +65,8 @@ export interface ContextType {
   setTheme: (themeName: string) => void
   zoomPercent: number
   setZoomPercent: (newZoomPercent: number) => void
-  epic: {
-    library: GameInfo[]
-    username?: string
-    login: (sid: string) => Promise<string>
-    logout: () => Promise<void>
-  }
+  epicLogin: (sid: string) => Promise<string>
+  epicLogout: () => Promise<void>
   gog: {
     library: GameInfo[]
     username?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -4584,6 +4584,11 @@ gulp-sort@^2.0.0:
   dependencies:
     through2 "^2.0.1"
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -7096,6 +7101,13 @@ recharts@^2.4.3:
     recharts-scale "^0.4.4"
     reduce-css-calc "^2.1.8"
     victory-vendor "^36.6.8"
+
+recoil@^0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"
+  integrity sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==
+  dependencies:
+    hamt_plus "1.0.2"
 
 redent@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
We have discussed this issue many times: the global state controls a lot of different global values and updating any of those triggers unnecessary re-renders throughout the app because it uses the Context API.

We talked many times about migrating to a more efficient state manager to be able to re-render only the components affected for a state changing instead.

I checked many options and Recoil https://recoiljs.org seems to be simple and it feels really close to `useState`, it's really easy to migrate to this tool without a lot of changes and we can do it gradually.

In this PR I'm migrating the epic library and username state to Recoil while keeping everything else in the GlobalState. With this approach we can slowly move different states at a time to Recoil in small targeted PRs until we move everything.

Any new global state we want to add we can now do it efficiently using Recoil (no need to actually update GlobalStateFunctional, we just need to add a new atom and use it with either useRecoilState or useRecoilValue where it's needed).

One limitation of Recoil is that it requires functional components and the GlobalState component is a class component, so, temporarily, we can use the new GlobalStateFunctional wrapper component to use recoil state and pass the state as props to GlobalState. Eventually we will be able to remove GlobalState completely because it will be migrated to a function component (which is also something we talked about doing many times).

This PR is really small cause it's the first, I plan to do some PRs moving more than one state at a time to not need dozens of PRs to move everything, but I plan to group them in a way that we could target the review/QA to specific places.

I imagine we'll still use the Context Api for some things, GlobalState doesn't only share state but also functions, and the SettingsContext and GameContext are already scoped to specific parts of the app, but for global state I'd like to move everything to be either a Recoil state OR a window object property (some things could be injected directly into the app with the preload.ts script since some things never change and don't need to be reactive).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
