### PR TITLE
[FIX] Linux Icon when sideloading games

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -60,7 +60,7 @@ export default React.memo(function InstallModal({
     {
       name: 'Linux',
       available: isLinux && (isSideload || isLinuxNative),
-      value: 'linux',
+      value: 'Linux',
       icon: faLinux
     },
     {


### PR DESCRIPTION
There was a linux logo display issue when we click on add game.
I set up the code locally and test the issue. So there was an issue with displaying of linux logo. Then I wne t through the code and found that the value assigned to linux was 'linux' but it should be 'Linux' instead.
Solved the problem !!
<--- Put the description here --->

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
