### PR TITLE
Remove remote debugger access

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -152,7 +152,6 @@ import {
 } from 'backend/storeManagers/legendary/library'
 import { formatSystemInfo, getSystemInfo } from './utils/systeminfo'
 
-app.commandLine?.appendSwitch('remote-debugging-port', '9222')
 app.commandLine?.appendSwitch('ozone-platform-hint', 'auto')
 
 const { showOpenDialog } = dialog


### PR DESCRIPTION
This PR removes the configuration that enabled the chrome remote debugger access.

It was adding during the stores refactor.

We don't really need it for development since we already turn on the dev tools inside heroic, and it's insecure to have that enabled in production releases since other apps can access information without the user knowing. Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3126

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
