### PR TITLE
Delete old logs, keep only the last 2

### DIFF
--- a/src/backend/logger/__tests__/logfile.test.ts
+++ b/src/backend/logger/__tests__/logfile.test.ts
@@ -31,16 +31,18 @@ describeSkipOnWindows('logger/logfile.ts', () => {
 
     logfile.createNewLogFileAndClearOldOnes()
 
+    const year = `${new Date().getFullYear()}`
+
     expect(spyOpenSync).toBeCalledWith(
-      expect.stringContaining('invalid/heroic-'),
+      expect.stringContaining(`invalid/${year}-`),
       'w'
     )
     expect(spyAppGetPath).toBeCalledWith('logs')
     expect(logError).toBeCalledWith(
       [
-        expect.stringContaining(`Open invalid/heroic-`),
+        expect.stringContaining(`Open invalid/${year}-`),
         expect.objectContaining(
-          Error("ENOENT: no such file or directory, open 'invalid/heroic-")
+          Error(`ENOENT: no such file or directory, open 'invalid/${year}-`)
         )
       ],
       { prefix: 'Backend', skipLogToFile: true }

--- a/src/backend/logger/logfile.ts
+++ b/src/backend/logger/logfile.ts
@@ -46,48 +46,19 @@ const createLogFile = (filePath: string) => {
 export function createNewLogFileAndClearOldOnes(): createLogFileReturn {
   const date = new Date()
   const logDir = app.getPath('logs')
-  const fmtDate = date.toISOString().replaceAll(':', '_')
-  const newLogFile = join(logDir, `heroic-${fmtDate}.log`)
-  const newLegendaryLogFile = join(logDir, `legendary-${fmtDate}.log`)
-  const newGogdlLogFile = join(logDir, `gogdl-${fmtDate}.log`)
-  const newNileLogFile = join(logDir, `nile-${fmtDate}.log`)
+  const fmtDate = date
+    .toISOString()
+    .replaceAll(':', '_')
+    .replace(/\.\d\d\dZ/, '')
+  const newLogFile = join(logDir, `${fmtDate}-heroic.log`)
+  const newLegendaryLogFile = join(logDir, `${fmtDate}-legendary.log`)
+  const newGogdlLogFile = join(logDir, `${fmtDate}-gogdl.log`)
+  const newNileLogFile = join(logDir, `${fmtDate}-nile.log`)
 
   createLogFile(newLogFile)
   createLogFile(newLegendaryLogFile)
   createLogFile(newGogdlLogFile)
   createLogFile(newNileLogFile)
-
-  // Clean out logs that are more than a month old
-  if (existsSync(logDir)) {
-    try {
-      const oneMonthAgo = new Date()
-      oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
-
-      const logs = readdirSync(logDir, {
-        withFileTypes: true
-      })
-        .filter((dirent) => dirent.isFile())
-        .map((dirent) => dirent.name)
-
-      logs.forEach((log) => {
-        if (log.match(/(heroic|legendary|gogdl|nile)-/)) {
-          const dateString = log
-            .replace(/(heroic|legendary|gogdl|nile)-/, '')
-            .replace('.log', '')
-            .replaceAll('_', ':')
-          const logDate = new Date(dateString)
-          if (logDate <= oneMonthAgo) {
-            unlinkSync(`${logDir}/${log}`)
-          }
-        }
-      })
-    } catch (error) {
-      logError([`Removing old logs in ${logDir} failed with`, error], {
-        prefix: LogPrefix.Backend,
-        skipLogToFile: true
-      })
-    }
-  }
 
   const logs = configStore.get('general-logs', {
     currentLogFile: '',
@@ -96,6 +67,36 @@ export function createNewLogFileAndClearOldOnes(): createLogFileReturn {
     gogdlLogFile: '',
     nileLogFile: ''
   })
+
+  const keep = [
+    newLogFile,
+    newLegendaryLogFile,
+    newGogdlLogFile,
+    newNileLogFile,
+    logs.currentLogFile,
+    logs.legendaryLogFile,
+    logs.gogdlLogFile,
+    logs.nileLogFile
+  ]
+
+  // Keep only the last 2 files for each log
+  if (existsSync(logDir)) {
+    try {
+      const logs = readdirSync(logDir, {
+        withFileTypes: true
+      })
+        .filter((dirent) => dirent.isFile())
+        .map((dirent) => dirent.name)
+        .filter((filename) => !keep.includes(`${logDir}/${filename}`))
+
+      logs.forEach((log) => unlinkSync(`${logDir}/${log}`))
+    } catch (error) {
+      logError([`Removing old logs in ${logDir} failed with`, error], {
+        prefix: LogPrefix.Backend,
+        skipLogToFile: true
+      })
+    }
+  }
 
   logs.lastLogFile = logs.currentLogFile
   logs.currentLogFile = newLogFile


### PR DESCRIPTION
This PR changes the logic to delete old log files. Instead of deleting things older than 1 month ago, we delete everything except the last 2 launches of the app.

Older logs haven't really been useful when debugging problems, there's no need to keep them.

I did include 2 more changes:
- I moved the date to the beginning of the filename, so it's easier to see the logs for the different stores from the same date
- I removed the milliseconds from the datetime, we don't need that precision and it just makes the filename harder to read

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
