### PR TITLE
[DX] Require Node 16 or greater for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "name": "Heroic Games Launcher",
     "email": "heroicgameslauncher@protonmail.com"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "build": {
     "appId": "com.heroicgameslauncher.hgl",
     "productName": "Heroic",


### PR DESCRIPTION
We need at least Node 16 because we use the `replaceAll` function for strings.

Adding this will prevent wasting the time I wasted trying to figure out why a call to `replaceAll` was failing for me haha.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
