### PR TITLE
Fixed french amazon prime gaming translations

### DIFF
--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -707,6 +707,6 @@
         "title": "Titre"
     },
     "amazon": "Amazon",
-    "Amazon Games": "Jeux Amazon",
-    "prime-gaming": "Premier jeu"
+    "Amazon Games": "Amazon Games",
+    "prime-gaming": "Prime Gaming"
 }


### PR DESCRIPTION
I've changed the French translation of Prime Gaming to "Prime Gaming" from "Premier jeu", and Amazon Games to "Amazon Games" from "Jeux Amazon".

It's also what they called their service on the French version of their site.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
