### PR TITLE
[UX] Remember last url opened in the webview, reopen there

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -56,6 +56,7 @@ function App() {
               </Route>
             </Route>
             <Route path="/store-page" element={<WebView />} />
+            <Route path="/last-url" element={<WebView />} />
             <Route path="loginweb">
               <Route path=":runner" element={<WebView />} />
             </Route>

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -46,9 +46,9 @@ function App() {
             <Route path="/" element={<Navigate replace to="/library" />} />
             <Route path="/library" element={<Library />} />
             <Route path="login" element={<Login />} />
-            <Route path="epicstore" element={<WebView />} />
-            <Route path="gogstore" element={<WebView />} />
-            <Route path="amazonstore" element={<WebView />} />
+            <Route path="epicstore" element={<WebView store="epic" />} />
+            <Route path="gogstore" element={<WebView store="gog" />} />
+            <Route path="amazonstore" element={<WebView store="amazon" />} />
             <Route path="wiki" element={<WebView />} />
             <Route path="/gamepage">
               <Route path=":runner">

--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -93,8 +93,9 @@ export default function SidebarLinks() {
   }
 
   // if we have a stored last-url, default to the `/last-url` route
-  if (localStorage.getItem('last-url')) {
-    defaultStore = '/last-url'
+  const lastStore = localStorage.getItem('last-store')
+  if (lastStore) {
+    defaultStore = lastStore
   }
 
   return (

--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -48,7 +48,9 @@ export default function SidebarLinks() {
     handleExternalLinkDialog
   } = useContext(ContextProvider)
 
-  const isStore = location.pathname.includes('store')
+  const inWebviewScreen =
+    location.pathname.includes('store') ||
+    location.pathname.includes('last-url')
   const isSettings = location.pathname.includes('settings')
   const isWin = platform === 'win32'
 
@@ -88,6 +90,11 @@ export default function SidebarLinks() {
   } else if (!epic.username && gog.username) {
     // Otherwise, if not logged in to Epic Games, open GOG Store
     defaultStore = '/gogstore'
+  }
+
+  // if we have a stored last-url, default to the `/last-url` route
+  if (localStorage.getItem('last-url')) {
+    defaultStore = '/last-url'
   }
 
   return (
@@ -142,7 +149,7 @@ export default function SidebarLinks() {
             <span>{t('stores', 'Stores')}</span>
           </>
         </NavLink>
-        {isStore && (
+        {inWebviewScreen && (
           <div className="SidebarSubmenu">
             <NavLink
               data-testid="store"

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -16,7 +16,11 @@ import './index.css'
 import LoginWarning from '../Login/components/LoginWarning'
 import { NileLoginData } from 'common/types/nile'
 
-export default function WebView() {
+interface Props {
+  store?: 'epic' | 'gog' | 'amazon'
+}
+
+export default function WebView({ store }: Props) {
   const { i18n } = useTranslation()
   const { pathname, search } = useLocation()
   const { t } = useTranslation()
@@ -66,9 +70,9 @@ export default function WebView() {
   }
   let startUrl = urls[pathname]
 
-  // /last-page path uses the stored url for the webview
-  if (pathname === '/last-url') {
-    const lastUrl = localStorage.getItem('last-url')
+  if (store) {
+    localStorage.setItem('last-store', `/${store}store`)
+    const lastUrl = localStorage.getItem(`last-url-${store}`)
     if (lastUrl) {
       startUrl = lastUrl
     }
@@ -222,9 +226,9 @@ export default function WebView() {
 
   useEffect(() => {
     const webview = webviewRef.current
-    if (webview) {
+    if (webview && store) {
       const onNavigate = () => {
-        localStorage.setItem('last-url', webview.getURL())
+        localStorage.setItem(`last-url-${store}`, webview.getURL())
       }
 
       // this one is needed for gog/amazon
@@ -239,7 +243,7 @@ export default function WebView() {
     }
 
     return
-  }, [webviewRef.current])
+  }, [webviewRef.current, store])
 
   const [showLoginWarningFor, setShowLoginWarningFor] = useState<
     null | 'epic' | 'gog' | 'amazon'

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -66,6 +66,14 @@ export default function WebView() {
   }
   let startUrl = urls[pathname]
 
+  // /last-page path uses the stored url for the webview
+  if (pathname === '/last-url') {
+    const lastUrl = localStorage.getItem('last-url')
+    if (lastUrl) {
+      startUrl = lastUrl
+    }
+  }
+
   if (pathname.match(/store-page/)) {
     const searchParams = new URLSearchParams(search)
     const queryParam = searchParams.get('store-url')
@@ -211,6 +219,27 @@ export default function WebView() {
     }
     return
   }, [webviewRef.current, preloadPath, amazonLoginData])
+
+  useEffect(() => {
+    const webview = webviewRef.current
+    if (webview) {
+      const onNavigate = () => {
+        localStorage.setItem('last-url', webview.getURL())
+      }
+
+      // this one is needed for gog/amazon
+      webview.addEventListener('did-navigate', onNavigate)
+      // this one is needed for epic
+      webview.addEventListener('did-navigate-in-page', onNavigate)
+
+      return () => {
+        webview.removeEventListener('did-navigate', onNavigate)
+        webview.removeEventListener('did-navigate-in-page', onNavigate)
+      }
+    }
+
+    return
+  }, [webviewRef.current])
 
   const [showLoginWarningFor, setShowLoginWarningFor] = useState<
     null | 'epic' | 'gog' | 'amazon'


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/758

Now the last url that we navigate to in the webview is remembered and used when clicking the `stores` icon in the sidebar.

Users can still navigate to any of the stores with the sidebar submenu or the game's `Store page` links.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
