### PR TITLE
Disable gamepad console log in devtools

### DIFF
--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -307,7 +307,7 @@ export const initGamepad = () => {
       const controller = gamepads[index]
       if (!controller) return
 
-      logState(index)
+      // logState(index)
 
       const buttons = controller.buttons
       const axes = controller.axes

--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -334,24 +334,24 @@ export const initGamepad = () => {
     requestAnimationFrame(updateStatus)
   }
 
-  function logState(index: number) {
-    const controller = navigator.getGamepads()[index]
-    if (!controller) return
+  // function logState(index: number) {
+  //   const controller = navigator.getGamepads()[index]
+  //   if (!controller) return
 
-    const buttons = controller.buttons
-    const axes = controller.axes
+  //   const buttons = controller.buttons
+  //   const axes = controller.axes
 
-    for (const button in buttons) {
-      if (buttons[button].pressed)
-        console.log(`button ${button} pressed ${buttons[button].value}`)
-    }
-    for (const axis in axes) {
-      if (axes[axis] < -0.2 && axes[axis] >= -1)
-        console.log(`axis ${axis} activated negative`)
-      if (axes[axis] > 0.2 && axes[axis] <= 1)
-        console.log(`axis ${axis} activated positive`)
-    }
-  }
+  //   for (const button in buttons) {
+  //     if (buttons[button].pressed)
+  //       console.log(`button ${button} pressed ${buttons[button].value}`)
+  //   }
+  //   for (const axis in axes) {
+  //     if (axes[axis] < -0.2 && axes[axis] >= -1)
+  //       console.log(`axis ${axis} activated negative`)
+  //     if (axes[axis] > 0.2 && axes[axis] <= 1)
+  //       console.log(`axis ${axis} activated positive`)
+  //   }
+  // }
 
   function connecthandler(e: GamepadEvent) {
     console.log('controller connected event')


### PR DESCRIPTION
This was turned on at some point for debugging something and it's not really useful now, it just adds noise in the dev tools console when using a gamepad.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
