### PR TITLE
[Refactor] Move the library status/filters out of the GlobalContext into a LibraryContext

### DIFF
--- a/src/frontend/components/UI/ActionIcons/index.tsx
+++ b/src/frontend/components/UI/ActionIcons/index.tsx
@@ -14,7 +14,7 @@ import {
 } from '@fortawesome/free-regular-svg-icons'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React, { useCallback, useContext } from 'react'
+import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import ContextProvider from 'frontend/state/ContextProvider'
 import FormControl from '../FormControl'
@@ -22,47 +22,30 @@ import './index.css'
 import { Runner } from 'common/types'
 import { Visibility, VisibilityOff } from '@mui/icons-material'
 import classNames from 'classnames'
+import LibraryContext from 'frontend/screens/Library/LibraryContext'
 
 interface Props {
-  sortDescending: boolean
-  sortInstalled: boolean
-  toggleSortDescending: () => void
-  toggleSortinstalled: () => void
   library: Runner | 'all'
 }
 
-export default React.memo(function ActionIcons({
-  library,
-  sortDescending,
-  toggleSortDescending,
-  sortInstalled,
-  toggleSortinstalled
-}: Props) {
+export default React.memo(function ActionIcons({ library }: Props) {
   const { t } = useTranslation()
+  const { refreshLibrary, refreshing } = useContext(ContextProvider)
+
   const {
-    refreshLibrary,
     handleLayout,
     layout,
     showHidden,
     setShowHidden,
     showFavourites,
-    refreshing,
     setShowFavourites,
     showNonAvailable,
-    setShowNonAvailable
-  } = useContext(ContextProvider)
-
-  const toggleNonAvailable = useCallback(() => {
-    setShowNonAvailable(!showNonAvailable)
-  }, [showNonAvailable])
-
-  const toggleShowHidden = useCallback(() => {
-    setShowHidden(!showHidden)
-  }, [showHidden])
-
-  const toggleShowFavourites = useCallback(() => {
-    setShowFavourites(!showFavourites)
-  }, [showFavourites])
+    setShowNonAvailable,
+    sortDescending,
+    setSortDescending,
+    sortInstalled,
+    setSortInstalled
+  } = useContext(LibraryContext)
 
   const showHiddenTitle = showHidden
     ? t('header.ignore_hidden', 'Ignore Hidden')
@@ -109,7 +92,7 @@ export default React.memo(function ActionIcons({
               ? t('library.sortDescending', 'Sort Descending')
               : t('library.sortAscending', 'Sort Ascending')
           }
-          onClick={() => toggleSortDescending()}
+          onClick={() => setSortDescending(!sortDescending)}
         >
           <FontAwesomeIcon
             className="FormControl__segmentedFaIcon"
@@ -119,7 +102,7 @@ export default React.memo(function ActionIcons({
         <button
           className="FormControl__button"
           title={t('library.sortByStatus', 'Sort by Status')}
-          onClick={() => toggleSortinstalled()}
+          onClick={() => setSortInstalled(!sortInstalled)}
         >
           <FontAwesomeIcon
             className="FormControl__segmentedFaIcon"
@@ -131,7 +114,7 @@ export default React.memo(function ActionIcons({
             active: showFavourites
           })}
           title={showFavouritesTitle}
-          onClick={toggleShowFavourites}
+          onClick={() => setShowFavourites(!showFavourites)}
         >
           <FontAwesomeIcon
             className="FormControl__segmentedFaIcon"
@@ -141,7 +124,7 @@ export default React.memo(function ActionIcons({
         <button
           className="FormControl__button"
           title={showNonAvailableTitle}
-          onClick={toggleNonAvailable}
+          onClick={() => setShowNonAvailable(!showNonAvailable)}
         >
           <FontAwesomeIcon
             className="FormControl__segmentedFaIcon"
@@ -151,7 +134,7 @@ export default React.memo(function ActionIcons({
         <button
           className="FormControl__button"
           title={showHiddenTitle}
-          onClick={toggleShowHidden}
+          onClick={() => setShowHidden(!showHidden)}
         >
           {showHidden ? <Visibility /> : <VisibilityOff />}
         </button>

--- a/src/frontend/components/UI/LibrarySearchBar/index.tsx
+++ b/src/frontend/components/UI/LibrarySearchBar/index.tsx
@@ -4,6 +4,7 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import { GameInfo } from '../../../../common/types'
 import SearchBar from '../SearchBar'
 import { useTranslation } from 'react-i18next'
+import LibraryContext from 'frontend/screens/Library/LibraryContext'
 
 function fixFilter(text: string) {
   const regex = new RegExp(/([?\\|*|+|(|)|[|]|])+/, 'g')
@@ -17,8 +18,8 @@ const RUNNER_TO_STORE = {
 }
 
 export default function LibrarySearchBar() {
-  const { handleSearch, filterText, epic, gog, sideloadedLibrary, amazon } =
-    useContext(ContextProvider)
+  const { epic, gog, sideloadedLibrary, amazon } = useContext(ContextProvider)
+  const { handleSearch, filterText } = useContext(LibraryContext)
   const navigate = useNavigate()
   const { t } = useTranslation()
 

--- a/src/frontend/components/UI/PlatformFilter/index.tsx
+++ b/src/frontend/components/UI/PlatformFilter/index.tsx
@@ -7,11 +7,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import ContextProvider from 'frontend/state/ContextProvider'
 import './index.css'
 import { faGlobe } from '@fortawesome/free-solid-svg-icons'
+import LibraryContext from 'frontend/screens/Library/LibraryContext'
 
 export default function PlatformFilter() {
   const { t } = useTranslation()
-  const { category, filterPlatform, handlePlatformFilter, platform } =
-    useContext(ContextProvider)
+  const { platform } = useContext(ContextProvider)
+  const { category, filterPlatform, handlePlatformFilter } =
+    useContext(LibraryContext)
 
   const isMac = platform === 'darwin'
   const isLinux = platform === 'linux'

--- a/src/frontend/components/UI/StoreFilter/index.tsx
+++ b/src/frontend/components/UI/StoreFilter/index.tsx
@@ -3,10 +3,11 @@ import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import FormControl from 'frontend/components/UI/FormControl'
 import ContextProvider from 'frontend/state/ContextProvider'
+import LibraryContext from 'frontend/screens/Library/LibraryContext'
 
 export default React.memo(function StoreFilter() {
-  const { category, handleCategory, gog, epic, amazon } =
-    useContext(ContextProvider)
+  const { gog, epic, amazon } = useContext(ContextProvider)
+  const { category, handleCategory } = useContext(LibraryContext)
   const { t } = useTranslation()
 
   const isGOGLoggedin = gog.username

--- a/src/frontend/screens/Library/LibraryContext.tsx
+++ b/src/frontend/screens/Library/LibraryContext.tsx
@@ -16,7 +16,11 @@ const initialContext: LibraryContextType = {
   showFavourites: false,
   setShowNonAvailable: () => null,
   showNonAvailable: false,
-  setShowFavourites: () => null
+  setShowFavourites: () => null,
+  sortDescending: true,
+  setSortDescending: () => null,
+  sortInstalled: true,
+  setSortInstalled: () => null
 }
 
 export default React.createContext(initialContext)

--- a/src/frontend/screens/Library/LibraryContext.tsx
+++ b/src/frontend/screens/Library/LibraryContext.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import { LibraryContextType } from 'frontend/types'
+
+const initialContext: LibraryContextType = {
+  category: 'all',
+  filterText: '',
+  filterPlatform: 'all',
+  handleCategory: () => null,
+  handleLayout: () => null,
+  handlePlatformFilter: () => null,
+  handleSearch: () => null,
+  layout: 'grid',
+  showHidden: false,
+  setShowHidden: () => null,
+  showFavourites: false,
+  setShowNonAvailable: () => null,
+  showNonAvailable: false,
+  setShowFavourites: () => null
+}
+
+export default React.createContext(initialContext)

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -39,6 +39,7 @@ import StoreLogos from 'frontend/components/UI/StoreLogos'
 import UninstallModal from 'frontend/components/UI/UninstallModal'
 import { getCardStatus, getImageFormatting } from './constants'
 import { hasStatus } from 'frontend/hooks/hasStatus'
+import LibraryContext from '../../LibraryContext'
 
 interface Card {
   buttonClick: () => void
@@ -87,7 +88,6 @@ const GameCard = ({
   const navigate = useNavigate()
 
   const {
-    layout,
     hiddenGames,
     favouriteGames,
     allTilesInColor,
@@ -95,6 +95,8 @@ const GameCard = ({
     setIsSettingsModalOpen,
     activeController
   } = useContext(ContextProvider)
+
+  const { layout } = useContext(LibraryContext)
 
   const {
     title,

--- a/src/frontend/screens/Library/components/LibraryHeader/index.tsx
+++ b/src/frontend/screens/Library/components/LibraryHeader/index.tsx
@@ -2,32 +2,22 @@ import React, { useContext, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionIcons from 'frontend/components/UI/ActionIcons'
 import { amazonCategories, epicCategories } from 'frontend/helpers/library'
-import ContextProvider from 'frontend/state/ContextProvider'
 import { GameInfo } from 'common/types'
 import { getLibraryTitle } from '../../constants'
+import LibraryContext from '../../LibraryContext'
 import './index.css'
-
-const storage = window.localStorage
 
 type Props = {
   list: GameInfo[]
-  sortDescending: boolean
-  sortInstalled: boolean
-  setSortInstalled: (value: boolean) => void
-  setSortDescending: (value: boolean) => void
   handleAddGameButtonClick: () => void
 }
 
 export default React.memo(function LibraryHeader({
   list,
-  sortInstalled,
-  sortDescending,
-  setSortDescending,
-  setSortInstalled,
   handleAddGameButtonClick
 }: Props) {
   const { t } = useTranslation()
-  const { category, showFavourites } = useContext(ContextProvider)
+  const { category, showFavourites } = useContext(LibraryContext)
 
   const numberOfGames = useMemo(() => {
     if (!list) {
@@ -41,16 +31,6 @@ export default React.memo(function LibraryHeader({
     const total = list.length - dlcCount
     return total > 0 ? `${total}` : 0
   }, [list, category])
-
-  function handleSortDescending() {
-    setSortDescending(!sortDescending)
-    storage.setItem('sortDescending', JSON.stringify(!sortDescending))
-  }
-
-  function handleSortInstalled() {
-    setSortInstalled(!sortInstalled)
-    storage.setItem('sortInstalled', JSON.stringify(!sortInstalled))
-  }
 
   function getLibrary() {
     if (category === 'all') {
@@ -87,13 +67,7 @@ export default React.memo(function LibraryHeader({
             {t('add_game', 'Add Game')}
           </button>
         </span>
-        <ActionIcons
-          sortDescending={sortDescending}
-          toggleSortDescending={() => handleSortDescending()}
-          sortInstalled={sortInstalled}
-          library={getLibrary()}
-          toggleSortinstalled={() => handleSortInstalled()}
-        />
+        <ActionIcons library={getLibrary()} />
       </div>
     </h5>
   )

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -62,18 +62,51 @@ export default React.memo(function Library(): JSX.Element {
   } = useContext(ContextProvider)
 
   const [layout, setLayout] = useState(storage.getItem('layout') || 'grid')
+  const handleLayout = (layout: string) => {
+    storage.setItem('layout', layout)
+    setLayout(layout)
+  }
+
   const [category, setCategory] = useState(
     (storage.getItem('category') as Category) || 'legendary'
   )
+  const handleCategory = (category: Category) => {
+    storage.setItem('category', category)
+    setCategory(category)
+  }
+
   const [filterText, setFilterText] = useState('')
-  const [filterPlatform, setFilterPlatform] = useState('all')
+  const [filterPlatform, setFilterPlatform] = useState(
+    storage.getItem('filterPlatform') || 'all'
+  )
+  const handlePlatformFilter = (filterPlatform: string) => {
+    storage.setItem('filterPlatform', filterPlatform)
+    setFilterPlatform(filterPlatform)
+  }
+
   const [showHidden, setShowHidden] = useState(
     JSON.parse(storage.getItem('show_hidden') || 'false')
   )
+  const handleShowHidden = (value: boolean) => {
+    storage.setItem('show_hidden', JSON.stringify(value))
+    setShowHidden(value)
+  }
+
   const [showFavouritesLibrary, setShowFavourites] = useState(
     JSON.parse(storage.getItem('show_favorites') || 'false')
   )
-  const [showNonAvailable, setShowNonAvailable] = useState(true)
+  const handleShowFavourites = (value: boolean) => {
+    storage.setItem('show_favorites', JSON.stringify(value))
+    setShowFavourites(value)
+  }
+
+  const [showNonAvailable, setShowNonAvailable] = useState(
+    JSON.parse(storage.getItem('show_non_available') || 'true')
+  )
+  const handleShowNonAvailable = (value: boolean) => {
+    storage.setItem('show_non_available', JSON.stringify(value))
+    setShowNonAvailable(value)
+  }
 
   const [showModal, setShowModal] = useState<ModalState>({
     game: '',
@@ -84,9 +117,19 @@ export default React.memo(function Library(): JSX.Element {
   const [sortDescending, setSortDescending] = useState(
     JSON.parse(storage?.getItem('sortDescending') || 'false')
   )
+  function handleSortDescending(value: boolean) {
+    storage.setItem('sortDescending', JSON.stringify(value))
+    setSortDescending(value)
+  }
+
   const [sortInstalled, setSortInstalled] = useState(
     JSON.parse(storage?.getItem('sortInstalled') || 'true')
   )
+  function handleSortInstalled(value: boolean) {
+    storage.setItem('sortInstalled', JSON.stringify(value))
+    setSortInstalled(value)
+  }
+
   const { t } = useTranslation()
   const backToTopElement = useRef(null)
   const listing = useRef<HTMLDivElement>(null)
@@ -355,45 +398,27 @@ export default React.memo(function Library(): JSX.Element {
     )
   }
 
-  const handleSearch = (input: string) => setFilterText(input)
-  const handlePlatformFilter = (filterPlatform: string) =>
-    setFilterPlatform(filterPlatform)
-  const handleLayout = (layout: string) => setLayout(layout)
-  const handleCategory = (category: Category) => setCategory(category)
-
-  useEffect(() => {
-    storage.setItem('layout', layout)
-  }, [layout])
-
-  useEffect(() => {
-    storage.setItem('category', category)
-  }, [category])
-
-  useEffect(() => {
-    storage.setItem('show_hidden', JSON.stringify(showHidden))
-  }, [showHidden])
-
-  useEffect(() => {
-    storage.setItem('show_favorites', JSON.stringify(showFavourites))
-  }, [showFavourites])
-
   return (
     <LibraryContext.Provider
       value={{
         category,
         layout,
         showHidden,
-        showFavourites,
+        showFavourites: showFavouritesLibrary,
         showNonAvailable,
         filterPlatform,
         filterText,
         handleCategory: handleCategory,
         handleLayout: handleLayout,
         handlePlatformFilter: handlePlatformFilter,
-        handleSearch: handleSearch,
-        setShowHidden: setShowHidden,
-        setShowFavourites: setShowFavourites,
-        setShowNonAvailable: setShowNonAvailable
+        handleSearch: setFilterText,
+        setShowHidden: handleShowHidden,
+        setShowFavourites: handleShowFavourites,
+        setShowNonAvailable: handleShowNonAvailable,
+        setSortDescending: handleSortDescending,
+        setSortInstalled: handleSortInstalled,
+        sortDescending,
+        sortInstalled
       }}
     >
       <Header />
@@ -421,10 +446,6 @@ export default React.memo(function Library(): JSX.Element {
 
         <LibraryHeader
           list={libraryToShow}
-          setSortDescending={setSortDescending}
-          setSortInstalled={setSortInstalled}
-          sortDescending={sortDescending}
-          sortInstalled={sortInstalled}
           handleAddGameButtonClick={() => handleModal('', 'sideload', null)}
         />
 

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -283,13 +283,13 @@ export default React.memo(function Library(): JSX.Element {
       })
     }
     return tempArray
-  }, [showFavourites, favouriteGames, epic, gog])
+  }, [showFavourites, showFavouritesLibrary, favouriteGames, epic, gog])
 
   // select library
   const libraryToShow = useMemo(() => {
     let library: Array<GameInfo> = []
     if (showFavouritesLibrary) {
-      library = [...favourites].filter((game) =>
+      library = favourites.filter((game) =>
         category === 'all' ? game : game?.runner === category
       )
     } else {

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -34,6 +34,8 @@ import {
 } from 'frontend/helpers/library'
 import RecentlyPlayed from './components/RecentlyPlayed'
 import { InstallModal } from './components'
+import LibraryContext from './LibraryContext'
+import { Category } from 'frontend/types'
 
 const storage = window.localStorage
 
@@ -46,26 +48,32 @@ type ModalState = {
 
 export default React.memo(function Library(): JSX.Element {
   const {
-    layout,
     libraryStatus,
     refreshing,
     refreshingInTheBackground,
-    category,
     epic,
     gog,
     amazon,
     sideloadedLibrary,
     favouriteGames,
     libraryTopSection,
-    filterText,
     platform,
-    filterPlatform,
-    hiddenGames,
-    showHidden,
-    handleCategory,
-    showFavourites: showFavouritesLibrary,
-    showNonAvailable
+    hiddenGames
   } = useContext(ContextProvider)
+
+  const [layout, setLayout] = useState(storage.getItem('layout') || 'grid')
+  const [category, setCategory] = useState(
+    (storage.getItem('category') as Category) || 'legendary'
+  )
+  const [filterText, setFilterText] = useState('')
+  const [filterPlatform, setFilterPlatform] = useState('all')
+  const [showHidden, setShowHidden] = useState(
+    JSON.parse(storage.getItem('show_hidden') || 'false')
+  )
+  const [showFavouritesLibrary, setShowFavourites] = useState(
+    JSON.parse(storage.getItem('show_favorites') || 'false')
+  )
+  const [showNonAvailable, setShowNonAvailable] = useState(true)
 
   const [showModal, setShowModal] = useState<ModalState>({
     game: '',
@@ -347,8 +355,47 @@ export default React.memo(function Library(): JSX.Element {
     )
   }
 
+  const handleSearch = (input: string) => setFilterText(input)
+  const handlePlatformFilter = (filterPlatform: string) =>
+    setFilterPlatform(filterPlatform)
+  const handleLayout = (layout: string) => setLayout(layout)
+  const handleCategory = (category: Category) => setCategory(category)
+
+  useEffect(() => {
+    storage.setItem('layout', layout)
+  }, [layout])
+
+  useEffect(() => {
+    storage.setItem('category', category)
+  }, [category])
+
+  useEffect(() => {
+    storage.setItem('show_hidden', JSON.stringify(showHidden))
+  }, [showHidden])
+
+  useEffect(() => {
+    storage.setItem('show_favorites', JSON.stringify(showFavourites))
+  }, [showFavourites])
+
   return (
-    <>
+    <LibraryContext.Provider
+      value={{
+        category,
+        layout,
+        showHidden,
+        showFavourites,
+        showNonAvailable,
+        filterPlatform,
+        filterText,
+        handleCategory: handleCategory,
+        handleLayout: handleLayout,
+        handlePlatformFilter: handlePlatformFilter,
+        handleSearch: handleSearch,
+        setShowHidden: setShowHidden,
+        setShowFavourites: setShowFavourites,
+        setShowNonAvailable: setShowNonAvailable
+      }}
+    >
       <Header />
 
       <div className="listing" ref={listing}>
@@ -411,6 +458,6 @@ export default React.memo(function Library(): JSX.Element {
           }
         />
       )}
-    </>
+    </LibraryContext.Provider>
   )
 })

--- a/src/frontend/state/ContextProvider.tsx
+++ b/src/frontend/state/ContextProvider.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { ContextType } from 'frontend/types'
 
 const initialContext: ContextType = {
-  category: 'all',
   epic: {
     library: [],
     login: async () => Promise.resolve(''),
@@ -28,14 +27,7 @@ const initialContext: ContextType = {
   },
   sideloadedLibrary: [],
   error: false,
-  filterText: '',
-  filterPlatform: 'all',
   gameUpdates: [],
-  handleCategory: () => null,
-  handleLayout: () => null,
-  handlePlatformFilter: () => null,
-  handleSearch: () => null,
-  layout: 'grid',
   libraryStatus: [],
   libraryTopSection: 'disabled',
   handleLibraryTopSection: () => null,
@@ -53,12 +45,6 @@ const initialContext: ContextType = {
     add: () => null,
     remove: () => null
   },
-  showHidden: false,
-  setShowHidden: () => null,
-  showFavourites: false,
-  setShowNonAvailable: () => null,
-  showNonAvailable: false,
-  setShowFavourites: () => null,
   favouriteGames: {
     list: [],
     add: () => null,

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -326,7 +326,7 @@ class GlobalState extends PureComponent<Props> {
   }
 
   handleSuccessfulLogin = (runner: Runner) => {
-    // this.handleCategory('all')
+    storage.setItem('category', 'all')
     this.refreshLibrary({
       runInBackground: false,
       library: runner
@@ -638,10 +638,7 @@ class GlobalState extends PureComponent<Props> {
   async componentDidMount() {
     const { t } = this.props
     const { epic, gameUpdates = [], libraryStatus } = this.state
-    // const oldCategory: string = category
-    // if (oldCategory === 'epic') {
-    //   this.handleCategory('all')
-    // }
+
     // Deals launching from protocol. Also checks if the game is already running
     window.api.handleLaunchGame(
       async (

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -13,11 +13,7 @@ import {
   LibraryTopSectionOptions,
   ExperimentalFeatures
 } from 'common/types'
-import {
-  Category,
-  DialogModalOptions,
-  ExternalLinkDialogOptions
-} from 'frontend/types'
+import { DialogModalOptions, ExternalLinkDialogOptions } from 'frontend/types'
 import { withTranslation } from 'react-i18next'
 import {
   getGameInfo,
@@ -59,7 +55,6 @@ interface Props {
 }
 
 interface StateProps {
-  category: Category
   epic: {
     library: GameInfo[]
     username?: string
@@ -75,20 +70,14 @@ interface StateProps {
   }
   wineVersions: WineVersionInfo[]
   error: boolean
-  filterText: string
-  filterPlatform: string
   gameUpdates: string[]
   language: string
-  layout: string
   libraryStatus: GameStatus[]
   libraryTopSection: string
   platform: NodeJS.Platform | 'unknown'
   refreshing: boolean
   refreshingInTheBackground: boolean
   hiddenGames: HiddenGame[]
-  showHidden: boolean
-  showFavourites: boolean
-  showNonAvailable: boolean
   favouriteGames: FavouriteGame[]
   theme: string
   zoomPercent: number
@@ -139,7 +128,6 @@ class GlobalState extends PureComponent<Props> {
     return games
   }
   state: StateProps = {
-    category: (storage.getItem('category') as Category) || 'legendary',
     epic: {
       library: libraryStore.get('library', []),
       username: configStore.get_nodefault('userInfo.displayName')
@@ -155,20 +143,14 @@ class GlobalState extends PureComponent<Props> {
     },
     wineVersions: wineDownloaderInfoStore.get('wine-releases', []),
     error: false,
-    filterText: '',
-    filterPlatform: 'all',
     gameUpdates: [],
     language: this.props.i18n.language,
-    layout: storage.getItem('layout') || 'grid',
     libraryStatus: [],
     libraryTopSection: globalSettings?.libraryTopSection || 'disabled',
     platform: 'unknown',
     refreshing: false,
     refreshingInTheBackground: true,
     hiddenGames: configStore.get('games.hidden', []),
-    showHidden: JSON.parse(storage.getItem('show_hidden') || 'false'),
-    showFavourites: JSON.parse(storage.getItem('show_favorites') || 'false'),
-    showNonAvailable: true,
     sidebarCollapsed: JSON.parse(
       storage.getItem('sidebar_collapsed') || 'false'
     ),
@@ -246,18 +228,6 @@ class GlobalState extends PureComponent<Props> {
   setAllTilesInColor = (value: boolean) => {
     configStore.set('allTilesInColor', value)
     this.setState({ allTilesInColor: value })
-  }
-
-  setShowHidden = (value: boolean) => {
-    this.setState({ showHidden: value })
-  }
-
-  setShowFavourites = (value: boolean) => {
-    this.setState({ showFavourites: value })
-  }
-
-  setShowNonAvailable = (value: boolean) => {
-    this.setState({ showNonAvailable: value })
   }
 
   setSideBarCollapsed = (value: boolean) => {
@@ -356,7 +326,7 @@ class GlobalState extends PureComponent<Props> {
   }
 
   handleSuccessfulLogin = (runner: Runner) => {
-    this.handleCategory('all')
+    // this.handleCategory('all')
     this.refreshLibrary({
       runInBackground: false,
       library: runner
@@ -593,12 +563,6 @@ class GlobalState extends PureComponent<Props> {
       })
   }
 
-  handleSearch = (input: string) => this.setState({ filterText: input })
-  handlePlatformFilter = (filterPlatform: string) =>
-    this.setState({ filterPlatform })
-  handleLayout = (layout: string) => this.setState({ layout })
-  handleCategory = (category: Category) => this.setState({ category })
-
   handleGameStatus = async ({
     appName,
     status,
@@ -673,11 +637,11 @@ class GlobalState extends PureComponent<Props> {
 
   async componentDidMount() {
     const { t } = this.props
-    const { epic, gameUpdates = [], libraryStatus, category } = this.state
-    const oldCategory: string = category
-    if (oldCategory === 'epic') {
-      this.handleCategory('all')
-    }
+    const { epic, gameUpdates = [], libraryStatus } = this.state
+    // const oldCategory: string = category
+    // if (oldCategory === 'epic') {
+    //   this.handleCategory('all')
+    // }
     // Deals launching from protocol. Also checks if the game is already running
     window.api.handleLaunchGame(
       async (
@@ -813,20 +777,12 @@ class GlobalState extends PureComponent<Props> {
     const {
       gameUpdates,
       libraryStatus,
-      layout,
-      category,
-      showHidden,
-      showFavourites,
       sidebarCollapsed,
       hideChangelogsOnStartup,
       lastChangelogShown
     } = this.state
 
-    storage.setItem('category', category)
-    storage.setItem('layout', layout)
     storage.setItem('updates', JSON.stringify(gameUpdates))
-    storage.setItem('show_hidden', JSON.stringify(showHidden))
-    storage.setItem('show_favorites', JSON.stringify(showFavourites))
     storage.setItem('sidebar_collapsed', JSON.stringify(sidebarCollapsed))
     storage.setItem('hide_changelogs', JSON.stringify(hideChangelogsOnStartup))
     storage.setItem('last_changelog', JSON.stringify(lastChangelogShown))
@@ -881,10 +837,6 @@ class GlobalState extends PureComponent<Props> {
             login: this.amazonLogin,
             logout: this.amazonLogout
           },
-          handleCategory: this.handleCategory,
-          handleLayout: this.handleLayout,
-          handlePlatformFilter: this.handlePlatformFilter,
-          handleSearch: this.handleSearch,
           setLanguage: this.setLanguage,
           isRTL,
           refresh: this.refresh,
@@ -895,9 +847,6 @@ class GlobalState extends PureComponent<Props> {
             add: this.hideGame,
             remove: this.unhideGame
           },
-          setShowHidden: this.setShowHidden,
-          setShowFavourites: this.setShowFavourites,
-          setShowNonAvailable: this.setShowNonAvailable,
           favouriteGames: {
             list: favouriteGames,
             add: this.addGameToFavourites,

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -186,6 +186,10 @@ export interface LibraryContextType {
   setShowFavourites: (value: boolean) => void
   showNonAvailable: boolean
   setShowNonAvailable: (value: boolean) => void
+  sortDescending: boolean
+  setSortDescending: (value: boolean) => void
+  sortInstalled: boolean
+  setSortInstalled: (valur: boolean) => void
 }
 
 export interface GameContextType {

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -23,19 +23,11 @@ import { NileLoginData, NileRegisterData } from 'common/types/nile'
 export type Category = 'all' | 'legendary' | 'gog' | 'sideload' | 'nile'
 
 export interface ContextType {
-  category: Category
   error: boolean
-  filterText: string
-  filterPlatform: string
   gameUpdates: string[]
   isRTL: boolean
   language: string
   setLanguage: (newLanguage: string) => void
-  handleCategory: (value: Category) => void
-  handlePlatformFilter: (value: string) => void
-  handleLayout: (value: string) => void
-  handleSearch: (input: string) => void
-  layout: string
   libraryStatus: GameStatus[]
   libraryTopSection: string
   handleLibraryTopSection: (value: LibraryTopSectionOptions) => void
@@ -55,12 +47,6 @@ export interface ContextType {
     add: (appNameToAdd: string, appTitle: string) => void
     remove: (appNameToRemove: string) => void
   }
-  showHidden: boolean
-  setShowHidden: (value: boolean) => void
-  showFavourites: boolean
-  setShowFavourites: (value: boolean) => void
-  showNonAvailable: boolean
-  setShowNonAvailable: (value: boolean) => void
   theme: string
   setTheme: (themeName: string) => void
   zoomPercent: number
@@ -183,6 +169,23 @@ export interface SettingsContextType {
   gameInfo: GameInfo | null
   isMacNative: boolean
   isLinuxNative: boolean
+}
+
+export interface LibraryContextType {
+  category: Category
+  filterText: string
+  filterPlatform: string
+  handleCategory: (value: Category) => void
+  handlePlatformFilter: (value: string) => void
+  handleLayout: (value: string) => void
+  handleSearch: (input: string) => void
+  layout: string
+  showHidden: boolean
+  setShowHidden: (value: boolean) => void
+  showFavourites: boolean
+  setShowFavourites: (value: boolean) => void
+  showNonAvailable: boolean
+  setShowNonAvailable: (value: boolean) => void
 }
 
 export interface GameContextType {


### PR DESCRIPTION
I started working on implementing some redesign for the library and noticed the current state management of the library is spread all over the place:
- most state is in GlobalState
- some state is in Library
- some state is in the children of the library

The state of the library doesn't need to be global, moving that out saves extra re-renderings, like re-rendering the sidebar when the search changes. Also, decoupling the different components will make it easier for me to implement some of the design changes for the filtering. It also makes the code more consistent, ActionIcons was updating the local storage of the browser to store the values of some filters but the other filters were updated by GlobalState.

Now all these:
- search text
- platform filter
- store filter
- sorting
- layout
- visibility filter

are handled by the Library component and shared with a context to also avoid prop drilling

One more thing I noticed and fixed: the platform filter and the toggle to show/hide non-available games were not getting stored

this also makes the global state simpler for whenever we move out of the global context into a state store

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
