### PR TITLE
[DX] Use path.join instead of / when generating a path

### DIFF
--- a/src/backend/logger/logfile.ts
+++ b/src/backend/logger/logfile.ts
@@ -13,7 +13,7 @@ import {
   lastLogFile
 } from '../constants'
 import { app } from 'electron'
-import path, { join } from 'path'
+import { join } from 'path'
 import { logError, LogPrefix, logsDisabled } from './logger'
 
 interface createLogFileReturn {
@@ -87,9 +87,9 @@ export function createNewLogFileAndClearOldOnes(): createLogFileReturn {
       })
         .filter((dirent) => dirent.isFile())
         .map((dirent) => dirent.name)
-        .filter((filename) => !keep.includes(`${logDir}${path.sep}${filename}`))
+        .filter((filename) => !keep.includes(join(logDir, filename)))
 
-      logs.forEach((log) => unlinkSync(`${logDir}${path.sep}${log}`))
+      logs.forEach((log) => unlinkSync(join(logDir, log)))
     } catch (error) {
       logError([`Removing old logs in ${logDir} failed with`, error], {
         prefix: LogPrefix.Backend,

--- a/src/backend/logger/logfile.ts
+++ b/src/backend/logger/logfile.ts
@@ -13,7 +13,7 @@ import {
   lastLogFile
 } from '../constants'
 import { app } from 'electron'
-import { join } from 'path'
+import path, { join } from 'path'
 import { logError, LogPrefix, logsDisabled } from './logger'
 
 interface createLogFileReturn {
@@ -87,9 +87,9 @@ export function createNewLogFileAndClearOldOnes(): createLogFileReturn {
       })
         .filter((dirent) => dirent.isFile())
         .map((dirent) => dirent.name)
-        .filter((filename) => !keep.includes(`${logDir}/${filename}`))
+        .filter((filename) => !keep.includes(`${logDir}${path.sep}${filename}`))
 
-      logs.forEach((log) => unlinkSync(`${logDir}/${log}`))
+      logs.forEach((log) => unlinkSync(`${logDir}${path.sep}${log}`))
     } catch (error) {
       logError([`Removing old logs in ${logDir} failed with`, error], {
         prefix: LogPrefix.Backend,


### PR DESCRIPTION
In this PR https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/3132 I broke the log files on Windows.

This PR fixes that by using the correct separator when creating the paths.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
