### PR TITLE
[UI] Hide wine and install info for browser apps

### DIFF
--- a/src/frontend/screens/Game/GamePage/components/InstalledInfo.tsx
+++ b/src/frontend/screens/Game/GamePage/components/InstalledInfo.tsx
@@ -32,6 +32,15 @@ const InstalledInfo = ({ gameInfo }: Props) => {
     folder_name
   } = gameInfo
 
+  if (installPlatform === 'Browser') {
+    return (
+      <div style={{ textTransform: 'capitalize' }}>
+        <b>{t('info.installedPlatform', 'Installed Platform')}:</b>{' '}
+        {installPlatform}
+      </div>
+    )
+  }
+
   let install_path: string | undefined
   let install_size: string | undefined
   let version: string | undefined


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3055.

We were showing things like install path, wine, prefix for Browser app, all things that are unrelated to browser apps. Now we just show `Installed Platform: Browser`

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
