### PR TITLE
[FIX] handle clear download item

### DIFF
--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
@@ -12,7 +12,6 @@ import { hasProgress } from 'frontend/hooks/hasProgress'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { useNavigate } from 'react-router-dom'
 import { ReactComponent as PlayIcon } from 'frontend/assets/play-icon.svg'
-import { ReactComponent as DownIcon } from 'frontend/assets/down-icon.svg'
 import { ReactComponent as PauseIcon } from 'frontend/assets/pause-icon.svg'
 
 type Props = {

--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
@@ -19,6 +19,7 @@ type Props = {
   element?: DMQueueElement
   current: boolean
   state?: DownloadManagerState
+  handleClearItem?: (appName: string) => void
 }
 
 const options: Intl.DateTimeFormatOptions = {
@@ -36,7 +37,12 @@ function convertToTime(time: number) {
   }
 }
 
-const DownloadManagerItem = ({ element, current, state }: Props) => {
+const DownloadManagerItem = ({
+  element,
+  current,
+  state,
+  handleClearItem
+}: Props) => {
   const { amazon, epic, gog, showDialogModal } = useContext(ContextProvider)
   const { t } = useTranslation('gamepage')
   const { t: t2 } = useTranslation('translation')
@@ -115,8 +121,10 @@ const DownloadManagerItem = ({ element, current, state }: Props) => {
   // using one element for the different states so it doesn't
   // lose focus from the button when using a game controller
   const handleMainActionClick = () => {
-    if (finished || canceled) {
+    if (finished) {
       return goToGamePage()
+    } else if (canceled) {
+      handleClearItem && handleClearItem(appName)
     }
 
     current ? stopInstallation() : window.api.removeFromDMQueue(appName)
@@ -141,7 +149,7 @@ const DownloadManagerItem = ({ element, current, state }: Props) => {
     }
 
     if (canceled) {
-      return <DownIcon className="installIcon" />
+      return <StopIcon className="installIcon" />
     }
 
     return <StopIcon className="cancelIcon" />

--- a/src/frontend/screens/DownloadManager/index.tsx
+++ b/src/frontend/screens/DownloadManager/index.tsx
@@ -61,6 +61,17 @@ export default React.memo(function DownloadManager(): JSX.Element | null {
     downloadManagerStore.set('finished', [])
   }
 
+  const handleClearItem = (appName: string) => {
+    const filteredFinishedElem = finishedElem?.filter(
+      (e) => e.params.appName !== appName
+    )
+    setFinishedElem(filteredFinishedElem)
+    downloadManagerStore.set(
+      'finished',
+      filteredFinishedElem ? filteredFinishedElem : []
+    )
+  }
+
   const doneElements =
     (finishedElem?.length &&
       finishedElem.sort((a, b) => {
@@ -150,7 +161,12 @@ export default React.memo(function DownloadManager(): JSX.Element | null {
             <div className="dmItemList">
               <DownloadManagerHeader time="finished" />
               {doneElements.map((el, key) => (
-                <DownloadManagerItem key={key} element={el} current={false} />
+                <DownloadManagerItem
+                  key={key}
+                  element={el}
+                  current={false}
+                  handleClearItem={handleClearItem}
+                />
               ))}
             </div>
           </div>


### PR DESCRIPTION
https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2485

* Changed cancelled items Icon to StopIcon
* Added functionality to remove individual item from completed list
* Cancelled item main action button now removes individual item from "finished" list instead of linking to game page

**Current Behavior:**
When a downloading item is cancelled, it is put into the "Completed" List.
A Download icon is then displayed with the item.
The icon's tooltip says "Remove from downloads"
When clicked, item is NOT removed from Downloads and user is taken to the software's profile page.

**Fixed Behavior**
When a downloading item is cancelled, it is put into the "Completed" List.
An "X"  icon is then displayed with the item.
The icon's tooltip says "Remove from downloads"
The item is removed from downloads when clicked

**Current**
![invalid](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/14855999/2b7ea15d-c438-428b-98d5-06aa2781cd21)

**Fixed**

![valid](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/14855999/44fa7fc3-6d0f-41bb-9b25-4b221d414a9b)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
