### PR TITLE
Electron 27: more fixes (gallery lazy load)

### DIFF
--- a/src/frontend/App.css
+++ b/src/frontend/App.css
@@ -16,11 +16,8 @@
   /* Measurements */
 }
 
-body,
-html,
-#root,
-.App {
-  min-height: 100vh;
+body {
+  height: 100vh;
 }
 
 .App {

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -34,7 +34,6 @@ const GamesList = ({
   useEffect(() => {
     if (library.length) {
       const options = {
-        root: document.querySelector('.listing'),
         rootMargin: '500px',
         threshold: 0
       }
@@ -54,7 +53,7 @@ const GamesList = ({
           }
         })
 
-        // dispatch an event with the newley visible cards
+        // dispatch an event with the newly visible cards
         // check GameCard for the other side of this detection
         window.dispatchEvent(
           new CustomEvent('visible-cards', { detail: { appNames: entered } })

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -390,7 +390,6 @@ export default React.memo(function Library(): JSX.Element {
 
       // adding a timeout so we don't run this for every resize event
       timer = setTimeout(() => {
-        console.log('fired')
         const header = document.querySelector('.Header')
         if (header) {
           const headerHeight = header.getBoundingClientRect().height


### PR DESCRIPTION
After using the latest main with Electron 27 I noticed the library felt slow and it was because the lazy loading of the elements below the fold broke with all the changes related to which element is the scroll element.

This PR fixes that to render it fast again.

I also removed a leftover console.log.

I'll keep testing to see if I find any other issue.


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
