### PR TITLE
[FIX] Electron 27: Make sure the app uses 100% of the screen for short content

### DIFF
--- a/src/frontend/App.css
+++ b/src/frontend/App.css
@@ -26,6 +26,7 @@ body {
   grid-template-columns: min-content 1fr;
   grid-template-areas: 'offline offline' 'sidebar content' 'sidebar controller';
   grid-template-rows: min-content 1fr min-content;
+  min-height: 100vh;
 }
 
 .App .Sidebar {


### PR DESCRIPTION
This PR https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/3170 includes a change removing some CSS properties. That broke the game page when there's not a lot of content in big screens (I was testing on a small screen only).

This is how it looks when I zoom out in the current main branch:
<img width="1122" alt="Screenshot 2023-10-29 at 4 10 17 PM" src="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/88f2a089-f02c-4fc5-a837-7a7343dbee43">

The content is not expanding.

This PR fixes that.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
