### PR TITLE
[Fix] Prevent useEffect infinite loops

### DIFF
--- a/src/frontend/screens/Settings/components/ExperimentalFeatures.tsx
+++ b/src/frontend/screens/Settings/components/ExperimentalFeatures.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react'
+import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import useSetting from 'frontend/hooks/useSetting'
 import { ToggleSwitch } from 'frontend/components/UI'
@@ -8,22 +8,20 @@ const FEATURES = ['enableNewDesign']
 
 const ExperimentalFeatures = () => {
   const { t } = useTranslation()
-  const [experimentalFeatures, setExprimentalFeatures] = useSetting(
+  const [experimentalFeatures, setExperimentalFeatures] = useSetting(
     'experimentalFeatures',
     { enableNewDesign: false }
   )
   const { handleExperimentalFeatures } = useContext(ContextProvider)
 
   const toggleFeature = (feature: string) => {
-    setExprimentalFeatures({
+    const newFeatures = {
       ...experimentalFeatures,
       [feature]: !experimentalFeatures[feature]
-    })
+    }
+    setExperimentalFeatures(newFeatures) // update settings
+    handleExperimentalFeatures(newFeatures) // update global state
   }
-
-  useEffect(() => {
-    handleExperimentalFeatures(experimentalFeatures)
-  }, [experimentalFeatures])
 
   /*
     Translations:

--- a/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
@@ -64,7 +64,7 @@ export default function AdvancedSettings() {
       setEosOverlayVersion(version ?? '')
     }
     getEosStatus()
-  }, [eosOverlayInstalled, eosOverlayVersion])
+  }, [])
 
   useEffect(() => {
     const getLatestEosOverlayVersion = async () => {
@@ -72,7 +72,7 @@ export default function AdvancedSettings() {
       setEosOverlayLatestVersion(version)
     }
     getLatestEosOverlayVersion()
-  }, [eosOverlayLatestVersion])
+  }, [])
 
   useEffect(() => {
     const { status } =
@@ -82,7 +82,7 @@ export default function AdvancedSettings() {
     setEosOverlayInstallingOrUpdating(
       status === 'installing' || status === 'updating'
     )
-  }, [eosOverlayInstallingOrUpdating])
+  }, [])
 
   useEffect(() => {
     const enabledGlobally = async () => {
@@ -91,7 +91,7 @@ export default function AdvancedSettings() {
       }
     }
     enabledGlobally()
-  }, [eosOverlayEnabledGlobally])
+  }, [])
 
   function getMainEosText() {
     if (eosOverlayInstalled && eosOverlayInstallingOrUpdating)


### PR DESCRIPTION
This PR fixes a problem I noticed in some components in the Advanced screen that include the state variable as a dependency for useEffects that update that state. This can lead to infinite loops and it's not correct to do it.

This can be seen when running a clean install of Heroic and going to Settings > Advanced, there's an infinite loop in the dev tools console.

This is solved once the experimental features are modified, but we shouldn't have this loop to begin with.

The useEffect that updates the Copy to clipboard status is safe because it returns early if false so it doesn't call a state setter.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
