### PR TITLE
[UX] Warn about the use of %command% and env variables in game arguments

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -433,6 +433,10 @@
             "info": "Set environment variables to append to the command."
         },
         "gameargs": {
+            "error": {
+                "command": "The %command% syntax from Steam is not valid as game arguments.",
+                "env": "Environment variables must be configured in the table below."
+            },
             "placeholder": "Put here the Launcher Arguments",
             "title": "Game Arguments (To run after the command):"
         },

--- a/src/frontend/screens/Settings/components/LauncherArgs.tsx
+++ b/src/frontend/screens/Settings/components/LauncherArgs.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useContext } from 'react'
+import React, { ChangeEvent, useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { InfoBox, TextInputField } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
@@ -8,9 +8,30 @@ const LauncherArgs = () => {
   const { t } = useTranslation()
   const { isDefault } = useContext(SettingsContext)
   const [launcherArgs, setLauncherArgs] = useSetting('launcherArgs', '')
+  const [error, setError] = useState('')
 
   const handleLauncherArgs = (event: ChangeEvent<HTMLInputElement>) =>
     setLauncherArgs(event.currentTarget.value)
+
+  useEffect(() => {
+    if (launcherArgs.match(/%command/)) {
+      setError(
+        t(
+          'options.gameargs.error.command',
+          'The %command% syntax from Steam is not valid as game arguments.'
+        )
+      )
+    } else if (launcherArgs.match(/[A-Z_]+=\S/)) {
+      setError(
+        t(
+          'options.gameargs.error.env',
+          'Environment variables must be configured in the table below.'
+        )
+      )
+    } else {
+      setError('')
+    }
+  }, [launcherArgs])
 
   if (isDefault) {
     return <></>
@@ -28,6 +49,11 @@ const LauncherArgs = () => {
     </InfoBox>
   )
 
+  let errorDiv = <></>
+  if (error) {
+    errorDiv = <p className="error">{error}</p>
+  }
+
   return (
     <TextInputField
       label={t('options.gameargs.title')}
@@ -35,7 +61,12 @@ const LauncherArgs = () => {
       placeholder={t('options.gameargs.placeholder')}
       value={launcherArgs}
       onChange={handleLauncherArgs}
-      afterInput={launcherArgsInfo}
+      afterInput={
+        <>
+          {errorDiv}
+          {launcherArgsInfo}
+        </>
+      }
     />
   )
 }


### PR DESCRIPTION
It's really common for users trying to make a game work to read instructions for Steam and try to apply them in Heroic.

It happened many times that users would set environment variables and the `%command%` placeholder in the `Game Arguments` of Heroic and that usually creates more problems.

This PR adds some error messages when we detect env variables or the `%command%` placeholder so users can see it's incorrect.


https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/2c1ddb3c-aa02-40fc-8797-555dc45775d4


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
