### PR TITLE
[Fix] Prevent storing external urls for stores

### DIFF
--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -93,7 +93,7 @@ export default function SidebarLinks() {
   }
 
   // if we have a stored last-url, default to the `/last-url` route
-  const lastStore = localStorage.getItem('last-store')
+  const lastStore = sessionStorage.getItem('last-store')
   if (lastStore) {
     defaultStore = lastStore
   }

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -20,6 +20,19 @@ interface Props {
   store?: 'epic' | 'gog' | 'amazon'
 }
 
+const validStoredUrl = (url: string, store: 'epic' | 'gog' | 'amazon') => {
+  switch (store) {
+    case 'epic':
+      return url.includes('epicgames.com')
+    case 'gog':
+      return url.includes('gog.com')
+    case 'amazon':
+      return url.includes('gaming.amazon.com')
+    default:
+      return false
+  }
+}
+
 export default function WebView({ store }: Props) {
   const { i18n } = useTranslation()
   const { pathname, search } = useLocation()
@@ -73,7 +86,7 @@ export default function WebView({ store }: Props) {
   if (store) {
     localStorage.setItem('last-store', `/${store}store`)
     const lastUrl = localStorage.getItem(`last-url-${store}`)
-    if (lastUrl) {
+    if (lastUrl && validStoredUrl(lastUrl, store)) {
       startUrl = lastUrl
     }
   }
@@ -228,7 +241,10 @@ export default function WebView({ store }: Props) {
     const webview = webviewRef.current
     if (webview && store) {
       const onNavigate = () => {
-        localStorage.setItem(`last-url-${store}`, webview.getURL())
+        const url = webview.getURL()
+        if (validStoredUrl(url, store)) {
+          localStorage.setItem(`last-url-${store}`, webview.getURL())
+        }
       }
 
       // this one is needed for gog/amazon

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -84,8 +84,8 @@ export default function WebView({ store }: Props) {
   let startUrl = urls[pathname]
 
   if (store) {
-    localStorage.setItem('last-store', `/${store}store`)
-    const lastUrl = localStorage.getItem(`last-url-${store}`)
+    sessionStorage.setItem('last-store', `/${store}store`)
+    const lastUrl = sessionStorage.getItem(`last-url-${store}`)
     if (lastUrl && validStoredUrl(lastUrl, store)) {
       startUrl = lastUrl
     }
@@ -243,7 +243,7 @@ export default function WebView({ store }: Props) {
       const onNavigate = () => {
         const url = webview.getURL()
         if (validStoredUrl(url, store)) {
-          localStorage.setItem(`last-url-${store}`, webview.getURL())
+          sessionStorage.setItem(`last-url-${store}`, webview.getURL())
         }
       }
 


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3200

We now store the last url visited when navigating the stores, but we can store external urls and then there's no way to go back to the store.

With this PR we now only store urls that are allowed instead of storing everything. And in case a user already has an invalid url stored, we now also check to only re-open in the url if it's one of the allowed.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
