### PR TITLE
[Tech] Truly ignore `flatpak-build`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 sign/**
+flatpak-build/**

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/package.json
+++ b/package.json
@@ -217,8 +217,8 @@
     "flatpak:prepare-release": "node ./flatpak/prepareFlatpak.js release",
     "i18n": "i18next --silent",
     "prepare": "husky install",
-    "prettier": "prettier --check . '!flatpak-build'",
-    "prettier-fix": "prettier --write . '!flatpak-build'"
+    "prettier": "prettier --check .",
+    "prettier-fix": "prettier --write ."
   },
   "eslintConfig": {
     "extends": [
@@ -259,7 +259,7 @@
     "jest": "29.5.0",
     "node-gyp": "^10.0.1",
     "playwright": "1.32.1",
-    "prettier": "2.8.1",
+    "prettier": "3.0.3",
     "pretty-quick": "3.1.3",
     "sass": "1.59.2",
     "tmp": "0.2.1",

--- a/src/backend/storeManagers/index.ts
+++ b/src/backend/storeManagers/index.ts
@@ -59,13 +59,11 @@ function getDMElement(gameInfo: GameInfo, appName: string) {
 export function autoUpdate(runner: Runner, gamesToUpdate: string[]) {
   const logPrefix = RunnerToLogPrefixMap[runner]
   gamesToUpdate.forEach(async (appName) => {
-    const { ignoreGameUpdates } = await gameManagerMap[runner].getSettings(
-      appName
-    )
+    const { ignoreGameUpdates } =
+      await gameManagerMap[runner].getSettings(appName)
     const gameInfo = gameManagerMap[runner].getGameInfo(appName)
-    const gameIsAvailable = await gameManagerMap[runner].isGameAvailable(
-      appName
-    )
+    const gameIsAvailable =
+      await gameManagerMap[runner].isGameAvailable(appName)
     if (!ignoreGameUpdates && gameIsAvailable) {
       logInfo(`Auto-Updating ${gameInfo.title}`, logPrefix)
       const dmQueueElement: DMQueueElement = getDMElement(gameInfo, appName)

--- a/src/backend/storeManagers/legendary/eos_overlay/eos_overlay.ts
+++ b/src/backend/storeManagers/legendary/eos_overlay/eos_overlay.ts
@@ -223,9 +223,8 @@ async function enable(
 async function disable(appName: string) {
   let prefix = ''
   if (isLinux) {
-    const { winePrefix, wineVersion } = await gameManagerMap[
-      'legendary'
-    ].getSettings(appName)
+    const { winePrefix, wineVersion } =
+      await gameManagerMap['legendary'].getSettings(appName)
     prefix =
       wineVersion.type === 'proton' ? join(winePrefix, 'pfx') : winePrefix
   }
@@ -256,9 +255,8 @@ async function isEnabled(appName?: string) {
 
   let prefix = ''
   if (isLinux && appName) {
-    const { winePrefix, wineVersion } = await gameManagerMap[
-      'legendary'
-    ].getSettings(appName)
+    const { winePrefix, wineVersion } =
+      await gameManagerMap['legendary'].getSettings(appName)
     prefix =
       wineVersion.type === 'proton' ? join(winePrefix, 'pfx') : winePrefix
   }

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -348,7 +348,10 @@ async function errorHandler({
 // If you ever modify this range of characters, please also add them to nile
 // source as this function is used to determine how game directory will be named
 function removeSpecialcharacters(text: string): string {
-  const regexp = new RegExp(/[:|/|*|?|<|>|\\|&|{|}|%|$|@|`|!|™|+|'|"|®]/, 'gi')
+  const regexp = new RegExp(
+    /[:|/|*|?|<|>|\\|&|{|}|%|$|@|`|!|™|+|'|"|®]/,
+    'gi'
+  )
   return text.replaceAll(regexp, '')
 }
 

--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -20,7 +20,9 @@
   color: var(--text-default);
   opacity: 0;
   transform: translateY(50px);
-  transition: opacity 500ms, transform 500ms;
+  transition:
+    opacity 500ms,
+    transform 500ms;
   max-width: min(700px, 85vw);
 }
 

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -25,9 +25,14 @@
     ),
     linear-gradient(135deg, var(--text-secondary) 50%, transparent 50%),
     linear-gradient(to right, #ccc, #ccc);
-  background-position: calc(100% - 20px) calc(50% + 1px),
-    calc(100% - 15px) calc(50% + 1px), calc(100% - 40px) 50%;
-  background-size: 5px 5px, 5px 5px, 1px 70%;
+  background-position:
+    calc(100% - 20px) calc(50% + 1px),
+    calc(100% - 15px) calc(50% + 1px),
+    calc(100% - 40px) 50%;
+  background-size:
+    5px 5px,
+    5px 5px,
+    1px 70%;
   background-repeat: no-repeat;
   margin: 0;
   -webkit-box-sizing: border-box;
@@ -39,7 +44,9 @@
 }
 
 .selectFieldWrapper.isRTL select {
-  background-position: calc(15px) calc(50% + 1px), calc(20px) calc(50% + 1px),
+  background-position:
+    calc(15px) calc(50% + 1px),
+    calc(20px) calc(50% + 1px),
     calc(40px) 50%;
 }
 

--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -122,7 +122,10 @@ function getProgress(progress: InstallProgress): number {
 const getGOGLaunchOptions = window.api.getGOGLaunchOptions
 
 function removeSpecialcharacters(text: string): string {
-  const regexp = new RegExp(/[:|/|*|?|<|>|\\|&|{|}|%|$|@|`|!|™|+|'|"|®]/, 'gi')
+  const regexp = new RegExp(
+    /[:|/|*|?|<|>|\\|&|{|}|%|$|@|`|!|™|+|'|"|®]/,
+    'gi'
+  )
   return text.replaceAll(regexp, '')
 }
 

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -198,7 +198,14 @@ export default React.memo(function GamePage(): JSX.Element | null {
       }
     }
     updateConfig()
-  }, [status, epic.library, gog.library, gameInfo, isSettingsModalOpen, isOffline])
+  }, [
+    status,
+    epic.library,
+    gog.library,
+    gameInfo,
+    isSettingsModalOpen,
+    isOffline
+  ])
 
   useEffect(() => {
     window.api

--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -285,7 +285,9 @@
 
 .gameImg,
 .gameLogo {
-  transition: all 0.2s, opacity 0.5s;
+  transition:
+    all 0.2s,
+    opacity 0.5s;
 }
 
 .gameImg:not(.installed),

--- a/src/frontend/screens/Settings/components/BattlEyeRuntime.tsx
+++ b/src/frontend/screens/Settings/components/BattlEyeRuntime.tsx
@@ -21,9 +21,8 @@ const BattlEyeRuntime = () => {
 
   const handleBattlEyeRuntime = async () => {
     if (!battlEyeRuntime) {
-      const isInstalled = await window.api.isRuntimeInstalled(
-        'battleye_runtime'
-      )
+      const isInstalled =
+        await window.api.isRuntimeInstalled('battleye_runtime')
       if (!isInstalled) {
         setInstalling(true)
         const success = await window.api.downloadRuntime('battleye_runtime')

--- a/src/frontend/styles/_typography.scss
+++ b/src/frontend/styles/_typography.scss
@@ -63,9 +63,19 @@ xl	23.04	1.44
 
 body {
   font-size: 1rem;
-  font-family: var(--secondary-font-family), -apple-system, BlinkMacSystemFont,
-    'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
-    'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family:
+    var(--secondary-font-family),
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    'Roboto',
+    'Oxygen',
+    'Ubuntu',
+    'Cantarell',
+    'Fira Sans',
+    'Droid Sans',
+    'Helvetica Neue',
+    sans-serif;
   font-style: normal;
   font-weight: var(--regular);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -620,9 +620,9 @@
   integrity sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==
 
 "@eslint/eslintrc@^2.0.1":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.2.tgz#c6936b4b328c64496692f76944e755738be62396"
-  integrity sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.3.tgz#797470a75fe0fbd5a53350ee715e85e87baff22d"
+  integrity sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7141,10 +7141,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
-  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
+prettier@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
 
 pretty-format@^27.0.2:
   version "27.5.1"


### PR DESCRIPTION
This is an alternative PR to #2748
I didn't like the fact that we had to explicitly add the folder when invoking Prettier in the first place. It's already in our `.prettierignore`, so it should be... ignored. Newer versions of Prettier do this correctly, so this was solved by a simple update (and subsequently fixing all the new formatting rules)
In the process, I noticed that ESLint also had problems with this folder. Adding it to `.eslintignore` was all *it* needed

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] N/A - Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
