### PR TITLE
[Fix/Tech] Fixup Snap publishing in `build-base` workflow

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install --no-install-recommends -y snapcraft
           yarn dist:linux Snap --publish=always
         env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snapcraftEdgeId }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snapcraftIdEdge }}
         if: runner.os == 'Linux' && inputs.publish-snap
       - name: Build AppImage version
         run: yarn dist:linux AppImage

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2022, ubuntu-22.04, macos-12]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Of course, the *one thing* I can't test locally breaks
The workflow tried to access `snapcraftEdgeId`, but the secret in question is named `snapcraftIdEdge`

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
