### PR TITLE
[FIX-macOS] Wine Downloader fails to extract files 

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1353,13 +1353,13 @@ async function extractFiles({ path, destination, strip = 0 }: ExtractOptions) {
     try {
       await extractNative(path, destination, strip)
     } catch (error) {
-      logError(`Error: ${error}`, LogPrefix.Backend)
+      logError(['Error:', error], LogPrefix.Backend)
     }
   } else {
     try {
       await extractDecompress(path, destination, strip)
     } catch (error) {
-      logError(`Error: ${error}`, LogPrefix.Backend)
+      logError(['Error:', error], LogPrefix.Backend)
     }
   }
 }
@@ -1398,7 +1398,7 @@ async function extractDecompress(
       strip
     })
   } catch (error) {
-    logError(`Error: ${error}`, LogPrefix.Backend)
+    logError(['Error:', error], LogPrefix.Backend)
   }
 }
 


### PR DESCRIPTION
This fixes #3202 

But it also get back to using `tar` on Linux except for Snaps. so if you do not have a mac to test, just test the behavior on linux, it is the same.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
