### PR TITLE
Fix Issue #2466 GamePage image is missing logo when available

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -231,6 +231,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       art_square,
       art_cover,
       art_background,
+      art_logo: logo = undefined,
       install: { platform: installPlatform },
       is_installed
     } = gameInfo
@@ -325,7 +326,11 @@ export default React.memo(function GamePage(): JSX.Element | null {
             {/* OLD DESIGN */}
             {!experimentalFeatures.enableNewDesign && (
               <>
-                <GamePicture art_square={art_square} store={runner} />
+                <GamePicture
+                  art_square={art_square}
+                  logo={logo}
+                  store={runner}
+                />
                 <NavLink
                   className="backButton"
                   to={backRoute}
@@ -394,7 +399,11 @@ export default React.memo(function GamePage(): JSX.Element | null {
                   <DotsMenu gameInfo={gameInfo} handleUpdate={handleUpdate} />
                   {!isBrowserGame && <SettingsButton gameInfo={gameInfo} />}
                   <div className="mainInfo">
-                    <GamePicture art_square={art_cover} store={runner} />
+                    <GamePicture
+                      art_square={art_cover}
+                      logo={logo}
+                      store={runner}
+                    />
                     <div className="store-icon">
                       <StoreLogos runner={runner} />
                     </div>

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -231,7 +231,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       art_square,
       art_cover,
       art_background,
-      art_logo: logo = undefined,
+      art_logo = undefined,
       install: { platform: installPlatform },
       is_installed
     } = gameInfo
@@ -328,7 +328,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
               <>
                 <GamePicture
                   art_square={art_square}
-                  logo={logo}
+                  art_logo={art_logo}
                   store={runner}
                 />
                 <NavLink
@@ -401,7 +401,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                   <div className="mainInfo">
                     <GamePicture
                       art_square={art_cover}
-                      logo={logo}
+                      art_logo={art_logo}
                       store={runner}
                     />
                     <div className="store-icon">

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -231,7 +231,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       art_square,
       art_cover,
       art_background,
-      art_logo = undefined,
+      art_logo,
       install: { platform: installPlatform },
       is_installed
     } = gameInfo

--- a/src/frontend/screens/Game/GamePicture/index.css
+++ b/src/frontend/screens/Game/GamePicture/index.css
@@ -35,7 +35,8 @@
 
 .gamePicture > .gameLogo {
   position: absolute;
-  bottom: 0;
-  width: 70%;
-  min-width: 140px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 50%;
 }

--- a/src/frontend/screens/Game/GamePicture/index.tsx
+++ b/src/frontend/screens/Game/GamePicture/index.tsx
@@ -6,13 +6,13 @@ import fallbackImage from 'frontend/assets/heroic_card.jpg'
 
 interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
   art_square: string
-  logo?: string | undefined
+  art_logo?: string | undefined
   store: string
 }
 
 function GamePicture({
   art_square,
-  logo = undefined,
+  art_logo = undefined,
   store,
   className,
   ...props
@@ -43,10 +43,10 @@ function GamePicture({
           {...props}
         />
       }
-      {logo && (
+      {art_logo && (
         <CachedImage
           alt="logo"
-          src={`${logo}?h=400&resize=1&w=300`}
+          src={`${art_logo}?h=400&resize=1&w=300`}
           className={`gameLogo`}
         />
       )}

--- a/src/frontend/screens/Game/GamePicture/index.tsx
+++ b/src/frontend/screens/Game/GamePicture/index.tsx
@@ -6,10 +6,17 @@ import fallbackImage from 'frontend/assets/heroic_card.jpg'
 
 interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
   art_square: string
+  logo?: string | undefined
   store: string
 }
 
-function GamePicture({ art_square, store, className, ...props }: Props) {
+function GamePicture({
+  art_square,
+  logo = undefined,
+  store,
+  className,
+  ...props
+}: Props) {
   function getImageFormatting() {
     if (art_square === 'fallback' || !art_square)
       return { src: fallbackImage, fallback: fallbackImage }
@@ -27,13 +34,22 @@ function GamePicture({ art_square, store, className, ...props }: Props) {
 
   return (
     <div className="gamePicture">
-      <CachedImage
-        alt="cover-art"
-        className={`gameImg ${className}`}
-        src={src}
-        fallback={fallback}
-        {...props}
-      />
+      {
+        <CachedImage
+          alt="cover-art"
+          className={`gameImg ${className}`}
+          src={src}
+          fallback={fallback}
+          {...props}
+        />
+      }
+      {logo && (
+        <CachedImage
+          alt="logo"
+          src={`${logo}?h=400&resize=1&w=300`}
+          className={`gameLogo`}
+        />
+      )}
     </div>
   )
 }

--- a/src/frontend/screens/Game/GamePicture/index.tsx
+++ b/src/frontend/screens/Game/GamePicture/index.tsx
@@ -12,7 +12,7 @@ interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
 
 function GamePicture({
   art_square,
-  art_logo = undefined,
+  art_logo,
   store,
   className,
   ...props
@@ -34,15 +34,13 @@ function GamePicture({
 
   return (
     <div className="gamePicture">
-      {
-        <CachedImage
-          alt="cover-art"
-          className={`gameImg ${className}`}
-          src={src}
-          fallback={fallback}
-          {...props}
-        />
-      }
+      <CachedImage
+        alt="cover-art"
+        className={`gameImg ${className}`}
+        src={src}
+        fallback={fallback}
+        {...props}
+      />
       {art_logo && (
         <CachedImage
           alt="logo"


### PR DESCRIPTION
Fix Issue #2466 GamePage image is missing logo when available

Add logo support in GamePage and GamePicture.
In GamePage component, add logo variable and pass it to GamePicture component. In GamePicture component, add logo parameter; add logo element (same as the CachedImage logo element in GameCard)

There was no need to add CSS, since there was  already CSS for logo in GamePicture  that positions it at the bottom center.


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
