### PR TITLE
[Fix] Workflows: Disable publishing when building the AppImage

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -40,7 +40,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snapcraftIdEdge }}
         if: runner.os == 'Linux' && inputs.publish-snap
       - name: Build AppImage version
-        run: yarn dist:linux AppImage
+        run: yarn dist:linux AppImage --publish=never
         if: runner.os == 'Linux'
       - name: Upload built version
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Electron-Builder tries to be smart and auto-enables publishing if if's on the main branch of a repo (at least it seems that way, it doesn't do this in the PR workflow; can't find anything about this in the docs), which then promptly fails.
Explicitly turn it off

I can't test this locally, let's hope 3rd time's the charm

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
