### PR TITLE
[UI] Fix height of install and settings dialogs

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/index.scss
+++ b/src/frontend/screens/Library/components/InstallModal/index.scss
@@ -1,10 +1,9 @@
 .InstallModal__dialog {
   width: 700px;
   min-height: fit-content;
+  max-height: 90vh;
   min-width: fit-content;
   max-width: 80vw;
-  height: 90vh;
-  max-height: 1000px;
 }
 
 .InstallModal__dialog > .anticheatInfo {

--- a/src/frontend/screens/Settings/components/SettingsModal/index.scss
+++ b/src/frontend/screens/Settings/components/SettingsModal/index.scss
@@ -10,3 +10,17 @@
     width: 100%;
   }
 }
+
+.InstallModal__dialog:has(.settingsDialogContent) {
+  margin-top: max(2rem, 13vh);
+  @media screen and (max-height: 800px) {
+    margin-top: max(2rem, 8vh);
+    .settingsDialogContent {
+      min-height: 70vh;
+    }
+  }
+
+  @media screen and (max-height: 700px) {
+    margin-top: max(2rem, 6vh);
+  }
+}


### PR DESCRIPTION
After one of my last PRs, the install dialog is too tall even when not enough content. This PR fixes that by making the install modal use the height on its content while also letting the settings be bigger to use more height in small screens.

Before:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/e6bcaa55-25fd-4a9b-bea6-c9165bab51fb)

After:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/fdc36da5-3531-4ffa-bf27-53c65c09e62a)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
