### PR TITLE
[UI] Fix regression of missing background image in game page

### DIFF
--- a/src/frontend/App.css
+++ b/src/frontend/App.css
@@ -41,7 +41,9 @@ body {
   grid-area: content;
   flex-direction: column;
   min-height: 100%;
-  background: var(--gradient-body-background, var(--body-background));
+  &:not(:has(.gameConfigContainer img.backgroundImage)) {
+    background: var(--gradient-body-background, var(--body-background));
+  }
 }
 
 .App .content .UpdateComponent--topLevel {


### PR DESCRIPTION
After the changes needed from the Electron upgrade, the blurred background image in the game page got lost. This PR fixes that by only setting the background color IF there's no backgroundImage element in it.

Before:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/2d3c8a44-cd93-4bb2-982c-225eea1d91a0)

After:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/591f5b2f-0641-4ca9-93e6-ef25fdd30905)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
