### PR TITLE
[FIX] Mark wineprefixes starting with XDG_RUNTIME_DIR as invalid

### DIFF
--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -103,6 +103,8 @@ export const getFonts = async (reload: boolean) =>
   ipcRenderer.invoke('getFonts', reload)
 export const checkDiskSpace = async (installPath: string) =>
   ipcRenderer.invoke('checkDiskSpace', installPath)
+export const checkWinePrefix = async (prefix: string) =>
+  ipcRenderer.invoke('checkWinePrefix', prefix)
 export const getGOGLinuxInstallersLangs = async (appName: string) =>
   ipcRenderer.invoke('getGOGLinuxInstallersLangs', appName)
 export const getAlternativeWine = async () =>

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -600,6 +600,16 @@ ipcMain.handle('checkDiskSpace', async (event, folder) => {
   })
 })
 
+ipcMain.handle('checkWinePrefix', async (event, prefix) => {
+  const isValidFlatpakPath = !(
+    isFlatpak && prefix.startsWith(process.env.XDG_RUNTIME_DIR || '/run/user/')
+  )
+
+  logDebug(`Checking wine prefix ${prefix}`, LogPrefix.Backend)
+
+  return isValidFlatpakPath
+})
+
 ipcMain.handle('isFrameless', () => isFrameless())
 ipcMain.handle('isMinimized', () => !!getMainWindow()?.isMinimized())
 ipcMain.handle('isMaximized', () => !!getMainWindow()?.isMaximized())

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -122,6 +122,7 @@ interface AsyncIPCFunctions {
   addToDMQueue: (element: DMQueueElement) => Promise<void>
   kill: (appName: string, runner: Runner) => Promise<void>
   checkDiskSpace: (folder: string) => Promise<DiskSpaceData>
+  checkWinePrefix: (prefix: string) => Promise<boolean>
   callTool: (args: Tools) => Promise<void>
   runWineCommand: (
     args: WineCommandArgs

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -60,6 +60,7 @@ interface Props {
   wineVersion: WineInstallation | undefined
   children: React.ReactNode
   gameInfo: GameInfo
+  validWinePrefix: boolean
 }
 
 type DiskSpaceInfo = {
@@ -116,7 +117,8 @@ export default function DownloadDialog({
   wineVersion,
   children,
   gameInfo,
-  crossoverBottle
+  crossoverBottle,
+  validWinePrefix
 }: Props) {
   const previousProgress = JSON.parse(
     storage.getItem(appName) || '{}'
@@ -422,7 +424,8 @@ export default function DownloadDialog({
     installPath &&
     gameInstallInfo?.manifest?.download_size &&
     !gettingInstallInfo &&
-    validFlatpakPath
+    validFlatpakPath &&
+    validWinePrefix
 
   const showDlcSelector =
     runner === 'legendary' && DLCList && DLCList?.length > 0

--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -34,6 +34,7 @@ type Props = {
   platformToInstall: InstallPlatform
   backdropClick: () => void
   appName?: string
+  validWinePrefix: boolean
 }
 
 export default function SideloadDialog({
@@ -45,7 +46,8 @@ export default function SideloadDialog({
   platformToInstall,
   setWinePrefix,
   children,
-  appName
+  appName,
+  validWinePrefix
 }: Props) {
   const { t } = useTranslation('gamepage')
   const [title, setTitle] = useState<string | never>(
@@ -389,7 +391,12 @@ export default function SideloadDialog({
         <button
           onClick={async () => handleInstall()}
           className={`button is-success`}
-          disabled={(!selectedExe.length && !gameUrl) || addingApp || searching}
+          disabled={
+            (!selectedExe.length && !gameUrl) ||
+            addingApp ||
+            searching ||
+            !validWinePrefix
+          }
         >
           {addingApp && <FontAwesomeIcon icon={faSpinner} spin />}
           {!addingApp && t('button.finish', 'Finish')}

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -15,11 +15,13 @@ type Props = {
   >
   setWinePrefix: React.Dispatch<React.SetStateAction<string>>
   setCrossoverBottle: React.Dispatch<React.SetStateAction<string>>
+  setValidWinePrefix: React.Dispatch<React.SetStateAction<boolean>>
   winePrefix: string
   crossoverBottle: string
   wineVersionList: WineInstallation[]
   wineVersion: WineInstallation | undefined
   title?: string
+  validWinePrefix: boolean
 }
 
 export default function WineSelector({
@@ -30,7 +32,9 @@ export default function WineSelector({
   wineVersion,
   title = 'sideload',
   crossoverBottle,
-  setCrossoverBottle
+  setCrossoverBottle,
+  setValidWinePrefix,
+  validWinePrefix
 }: Props) {
   const { t } = useTranslation('gamepage')
 
@@ -66,6 +70,8 @@ export default function WineSelector({
         setWinePrefix(sugestedWinePrefix)
         setWineVersion(wineVersion || undefined)
       }
+
+      setValidWinePrefix(await window.api.checkWinePrefix(winePrefix))
     }
     getAppSettings()
   }, [useDefaultSettings])
@@ -90,13 +96,24 @@ export default function WineSelector({
           {showPrefix && (
             <PathSelectionBox
               type="directory"
-              onPathChange={setWinePrefix}
+              onPathChange={async (path) => {
+                setWinePrefix(path)
+                setValidWinePrefix(await window.api.checkWinePrefix(path))
+              }}
               path={winePrefix}
               pathDialogTitle={t('box.wineprefix', 'Select WinePrefix Folder')}
               label={t('install.wineprefix', 'WinePrefix')}
               htmlId="setinstallpath"
               noDeleteButton
             />
+          )}
+          {!validWinePrefix && (
+            <span className="error">
+              {`${t(
+                'install.flatpak-path-not-writtable',
+                'Error: Sandbox access not granted to this path, data loss will occur.'
+              )}`}
+            </span>
           )}
           {showBottle && (
             <TextInputField

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -47,6 +47,7 @@ export default React.memo(function InstallModal({
   const [wineVersion, setWineVersion] = useState<WineInstallation>()
   const [wineVersionList, setWineVersionList] = useState<WineInstallation[]>([])
   const [crossoverBottle, setCrossoverBottle] = useState('')
+  const [validWinePrefix, setValidWinePrefix] = useState(true)
 
   const isLinuxNative = Boolean(gameInfo?.is_linux_native)
   const isMacNative = Boolean(gameInfo?.is_mac_native)
@@ -171,6 +172,7 @@ export default React.memo(function InstallModal({
             platformToInstall={platformToInstall}
             gameInfo={gameInfo}
             crossoverBottle={crossoverBottle}
+            validWinePrefix={validWinePrefix}
           >
             {platformSelection()}
             {hasWine ? (
@@ -183,6 +185,8 @@ export default React.memo(function InstallModal({
                 setWineVersion={setWineVersion}
                 crossoverBottle={crossoverBottle}
                 setCrossoverBottle={setCrossoverBottle}
+                setValidWinePrefix={setValidWinePrefix}
+                validWinePrefix={validWinePrefix}
               />
             ) : null}
           </DownloadDialog>
@@ -196,6 +200,7 @@ export default React.memo(function InstallModal({
             platformToInstall={platformToInstall}
             appName={appName}
             crossoverBottle={crossoverBottle}
+            validWinePrefix={validWinePrefix}
           >
             {platformSelection()}
             {hasWine ? (
@@ -207,6 +212,8 @@ export default React.memo(function InstallModal({
                 setWineVersion={setWineVersion}
                 crossoverBottle={crossoverBottle}
                 setCrossoverBottle={setCrossoverBottle}
+                setValidWinePrefix={setValidWinePrefix}
+                validWinePrefix={validWinePrefix}
               />
             ) : null}
           </SideloadDialog>


### PR DESCRIPTION
Prevents more user error

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
