### PR TITLE
[Mac] Allow setting the prefixes folder on Mac too

### DIFF
--- a/src/frontend/screens/Settings/components/WinePrefixesBasePath.tsx
+++ b/src/frontend/screens/Settings/components/WinePrefixesBasePath.tsx
@@ -9,9 +9,9 @@ const WinePrefixesBasePath = () => {
   const { t } = useTranslation()
   const { platform } = useContext(ContextProvider)
   const { isDefault } = useContext(SettingsContext)
-  const isLinux = platform === 'linux'
+  const isWindows = platform === 'win32'
 
-  if (!isDefault || !isLinux) {
+  if (!isDefault || isWindows) {
     return <></>
   }
 


### PR DESCRIPTION
This option is present only on Linux, but we should also allow users to set this on Mac for the "wines" that work with prefixes like Wine-Staging.

Currently the prefixes dir is the default `~/Games/Heroic/Prefixes/default` and can't be changed.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
