### PR TITLE
[Fix] WINEPREFIX ignored when using GPTK

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -493,6 +493,8 @@ function setupWineEnvVars(
       break
     case 'crossover':
       ret.CX_BOTTLE = wineCrossoverBottle
+    case 'toolkit':
+      ret.WINEPREFIX = winePrefix
   }
   if (gameSettings.showFps) {
     isMac ? (ret.MTL_HUD_ENABLED = '1') : (ret.DXVK_HUD = 'fps')

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -493,8 +493,10 @@ function setupWineEnvVars(
       break
     case 'crossover':
       ret.CX_BOTTLE = wineCrossoverBottle
+      break
     case 'toolkit':
       ret.WINEPREFIX = winePrefix
+      break
   }
   if (gameSettings.showFps) {
     isMac ? (ret.MTL_HUD_ENABLED = '1') : (ret.DXVK_HUD = 'fps')


### PR DESCRIPTION
Just a quick fix to bug #3026. Without this fix, WINEPREFIX isn't set in the environment variables in the launch options, and therefore GPTK uses the user's default wine prefix (in my case ~/.wine). I doubt this fix is crazy perfect, but it's simple and it works!

Tested using Heroic latest on macOS 14.0 with Satisfactory Early Access. (The game is now using the right prefix's save files!)

----

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
