### PR TITLE
[UI] Fix style of Filters button in some themes

### DIFF
--- a/src/frontend/components/UI/LibraryFilters/index.tsx
+++ b/src/frontend/components/UI/LibraryFilters/index.tsx
@@ -81,7 +81,9 @@ export default function LibraryFilters() {
 
   return (
     <div className="libraryFilters">
-      <button className="button">{t('header.filters', 'Filters')}</button>
+      <button className="button is-primary">
+        {t('header.filters', 'Filters')}
+      </button>
       <div className="dropdown">
         {epic.username && storeToggle('legendary')}
         {gog.username && storeToggle('gog')}


### PR DESCRIPTION
Reported in discord: The new "Filters" button is not visible in some themes (Old school heroic, zombie, zombie classic):
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/82766ecc-ea10-4e62-81f4-3738e749ef54)

After (zombie classic as an example):
<img width="357" alt="Screenshot 2023-11-29 at 8 04 52 PM" src="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/9ded4e95-460c-4135-92ab-a26222fd969d">


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
