### PR TITLE
[Feat] Support Epic's launch-able addons/DLCs

### DIFF
--- a/src/backend/api/helpers.ts
+++ b/src/backend/api/helpers.ts
@@ -70,8 +70,8 @@ export const getGameInfo = async (appName: string, runner: Runner) =>
 export const getExtraInfo = async (appName: string, runner: Runner) =>
   ipcRenderer.invoke('getExtraInfo', appName, runner)
 
-export const getGOGLaunchOptions = async (appName: string) =>
-  ipcRenderer.invoke('getGOGLaunchOptions', appName)
+export const getLaunchOptions = async (appName: string, runner: Runner) =>
+  ipcRenderer.invoke('getLaunchOptions', appName, runner)
 
 export const getGameSettings = async (
   appName: string,

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1467,8 +1467,8 @@ ipcMain.handle('syncGOGSaves', async (event, gogSaves, appName, arg) =>
   gameManagerMap['gog'].syncSaves(appName, arg, '', gogSaves)
 )
 
-ipcMain.handle('getGOGLaunchOptions', async (event, appName: string) =>
-  GOGLibraryManager.getLaunchOptions(appName)
+ipcMain.handle('getLaunchOptions', async (event, appName, runner) =>
+  libraryManagerMap[runner].getLaunchOptions(appName)
 )
 
 ipcMain.handle(

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -963,7 +963,10 @@ let powerDisplayId: number | null
 // get pid/tid on launch and inject
 ipcMain.handle(
   'launch',
-  async (event, { appName, launchArguments, runner }): StatusPromise => {
+  async (
+    event,
+    { appName, launchArguments, runner, skipVersionCheck }
+  ): StatusPromise => {
     const game = gameManagerMap[runner].getGameInfo(appName)
     const gameSettings = await gameManagerMap[runner].getSettings(appName)
     const { autoSyncSaves, savesPath, gogSaves = [] } = gameSettings
@@ -1084,7 +1087,11 @@ ipcMain.handle(
       status: 'playing'
     })
 
-    const command = gameManagerMap[runner].launch(appName, launchArguments)
+    const command = gameManagerMap[runner].launch(
+      appName,
+      launchArguments,
+      skipVersionCheck
+    )
 
     const launchResult = await command.catch((exception) => {
       logError(exception, LogPrefix.Backend)

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -31,7 +31,9 @@ import {
   InstallArgs,
   InstalledInfo,
   InstallPlatform,
-  InstallProgress
+  InstallProgress,
+  LaunchOption,
+  BaseLaunchOption
 } from 'common/types'
 import { appendFileSync, existsSync, rmSync } from 'graceful-fs'
 import { gamesConfigPath, isWindows, isMac, isLinux } from '../../constants'
@@ -404,7 +406,7 @@ export async function removeShortcuts(appName: string) {
 
 export async function launch(
   appName: string,
-  launchArguments?: string
+  launchArguments?: LaunchOption
 ): Promise<boolean> {
   const gameSettings = await getSettings(appName)
   const gameInfo = getGameInfo(appName)
@@ -515,7 +517,9 @@ export async function launch(
     ...wineFlag,
     '--platform',
     gameInfo.install.platform.toLowerCase(),
-    ...shlex.split(launchArguments ?? ''),
+    ...shlex.split(
+      (launchArguments as BaseLaunchOption | undefined)?.parameters ?? ''
+    ),
     ...shlex.split(gameSettings.launcherArgs ?? '')
   ]
 

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -8,7 +8,8 @@ import {
   InstallArgs,
   InstallPlatform,
   InstallProgress,
-  WineCommandArgs
+  WineCommandArgs,
+  LaunchOption
 } from 'common/types'
 import { GameConfig } from '../../game_config'
 import { GlobalConfig } from '../../config'
@@ -752,7 +753,8 @@ export async function syncSaves(
 
 export async function launch(
   appName: string,
-  launchArguments?: string
+  launchArguments?: LaunchOption,
+  skipVersionCheck = false
 ): Promise<boolean> {
   const gameSettings = await getSettings(appName)
   const gameInfo = getGameInfo(appName)
@@ -838,10 +840,16 @@ export async function launch(
     wineFlags = getWineFlags(wineBin, wineType, shlex.join(wrappers))
   }
 
+  const appNameToLaunch =
+    launchArguments?.type === 'dlc' ? launchArguments.dlcAppName : appName
+
   const command: LegendaryCommand = {
     subcommand: 'launch',
-    appName: LegendaryAppName.parse(appName),
-    extraArguments: [launchArguments, gameSettings.launcherArgs]
+    appName: LegendaryAppName.parse(appNameToLaunch),
+    extraArguments: [
+      launchArguments?.type !== 'dlc' ? launchArguments?.parameters : undefined,
+      gameSettings.launcherArgs
+    ]
       .filter(Boolean)
       .join(' '),
     ...wineFlags

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -846,6 +846,7 @@ export async function launch(
       .join(' '),
     ...wineFlags
   }
+  if (skipVersionCheck) command['--skip-version-check'] = true
   if (languageCode) command['--language'] = NonEmptyString.parse(languageCode)
   if (gameSettings.targetExe)
     command['--override-exe'] = Path.parse(gameSettings.targetExe)

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -1,11 +1,13 @@
 import {
+  BaseLaunchOption,
   ExecResult,
   ExtraInfo,
   GameInfo,
   GameSettings,
   InstallArgs,
   InstallPlatform,
-  InstallProgress
+  InstallProgress,
+  LaunchOption
 } from 'common/types'
 import { InstallResult, RemoveArgs } from 'common/types/game_manager'
 import {
@@ -302,7 +304,7 @@ export async function removeShortcuts(appName: string) {
 
 export async function launch(
   appName: string,
-  launchArguments?: string
+  launchArguments?: LaunchOption
 ): Promise<boolean> {
   const gameSettings = await getSettings(appName)
   const gameInfo = getGameInfo(appName)
@@ -397,7 +399,9 @@ export async function launch(
     'launch',
     ...exeOverrideFlag, // Check if this works
     ...wineFlag,
-    ...shlex.split(launchArguments ?? ''),
+    ...shlex.split(
+      (launchArguments as BaseLaunchOption | undefined)?.parameters ?? ''
+    ),
     ...shlex.split(gameSettings.launcherArgs ?? ''),
     appName
   ]

--- a/src/backend/storeManagers/nile/library.ts
+++ b/src/backend/storeManagers/nile/library.ts
@@ -472,3 +472,5 @@ export async function runRunnerCommand(
     }
   )
 }
+
+export const getLaunchOptions = () => []

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -4,7 +4,8 @@ import {
   GameInfo,
   GameSettings,
   InstallArgs,
-  InstallPlatform
+  InstallPlatform,
+  LaunchOption
 } from 'common/types'
 import { libraryStore } from './electronStores'
 import { GameConfig } from '../../game_config'
@@ -69,7 +70,7 @@ export async function isGameAvailable(appName: string): Promise<boolean> {
 export async function launch(
   appName: string,
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  launchArguments?: string
+  launchArguments?: LaunchOption
 ): Promise<boolean> {
   return launchGame(appName, getGameInfo(appName), 'sideload')
 }

--- a/src/backend/storeManagers/sideload/library.ts
+++ b/src/backend/storeManagers/sideload/library.ts
@@ -126,3 +126,5 @@ export async function getInstallInfo(
   logWarning(`getInstallInfo not implemented on Sideload Library Manager`)
   return undefined
 }
+
+export const getLaunchOptions = () => []

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -277,7 +277,7 @@ interface AsyncIPCFunctions {
   toggleVKD3D: (args: ToolArgs) => Promise<boolean>
   toggleDXVKNVAPI: (args: ToolArgs) => Promise<boolean>
   pathExists: (path: string) => Promise<boolean>
-  getGOGLaunchOptions: (appName: string) => Promise<LaunchOption[]>
+  getLaunchOptions: (appName: string, runner: Runner) => Promise<LaunchOption[]>
   getGameOverride: () => Promise<GameOverride | null>
   getGameSdl: (appName: string) => Promise<SelectiveDownload[]>
   getPlaytimeFromRunner: (

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -1,4 +1,3 @@
-import { DownloadManagerState } from './../types'
 import { EventEmitter } from 'node:events'
 import {
   IpcMainEvent,
@@ -34,12 +33,13 @@ import {
   ConnectivityStatus,
   GamepadActionArgs,
   ExtraInfo,
-  LaunchOption
+  LaunchOption,
+  DownloadManagerState,
+  InstallInfo
 } from 'common/types'
-import { LegendaryInstallInfo, SelectiveDownload } from 'common/types/legendary'
-import { GOGCloudSavesLocation, GogInstallInfo } from 'common/types/gog'
+import { SelectiveDownload } from 'common/types/legendary'
+import { GOGCloudSavesLocation } from 'common/types/gog'
 import {
-  NileInstallInfo,
   NileLoginData,
   NileRegisterData,
   NileUserData
@@ -161,7 +161,7 @@ interface AsyncIPCFunctions {
     appName: string,
     runner: Runner,
     installPlatform: InstallPlatform
-  ) => Promise<LegendaryInstallInfo | GogInstallInfo | NileInstallInfo | null>
+  ) => Promise<InstallInfo | null>
   getUserInfo: () => Promise<UserInfo | undefined>
   getAmazonUserInfo: () => Promise<NileUserData | undefined>
   isLoggedIn: () => boolean

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -26,14 +26,23 @@ export interface ButtonOptions {
 
 export type LaunchParams = {
   appName: string
-  launchArguments: string
+  launchArguments?: LaunchOption
   runner: Runner
   skipVersionCheck?: boolean
 }
 
-export interface LaunchOption {
+export type LaunchOption = BaseLaunchOption | DLCLaunchOption
+
+export interface BaseLaunchOption {
+  type?: 'basic'
   name: string
   parameters: string
+}
+
+interface DLCLaunchOption {
+  type: 'dlc'
+  dlcAppName: string
+  dlcTitle: string
 }
 
 interface About {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -28,6 +28,7 @@ export type LaunchParams = {
   appName: string
   launchArguments: string
   runner: Runner
+  skipVersionCheck?: boolean
 }
 
 export interface LaunchOption {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,9 +1,17 @@
-import { GOGCloudSavesLocation, GogInstallPlatform } from './types/gog'
-import { LegendaryInstallPlatform, GameMetadataInner } from './types/legendary'
+import {
+  GOGCloudSavesLocation,
+  GogInstallInfo,
+  GogInstallPlatform
+} from './types/gog'
+import {
+  LegendaryInstallPlatform,
+  GameMetadataInner,
+  LegendaryInstallInfo
+} from './types/legendary'
 import { IpcRendererEvent, TitleBarOverlay } from 'electron'
 import { ChildProcess } from 'child_process'
 import type { HowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
-import { NileInstallPlatform } from './types/nile'
+import { NileInstallInfo, NileInstallPlatform } from './types/nile'
 
 export type Runner = 'legendary' | 'gog' | 'sideload' | 'nile'
 
@@ -728,3 +736,8 @@ interface GameScopeSettings {
   fpsLimiter: string
   fpsLimiterNoFocus: string
 }
+
+export type InstallInfo =
+  | LegendaryInstallInfo
+  | GogInstallInfo
+  | NileInstallInfo

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -5,7 +5,8 @@ import {
   GameSettings,
   ExecResult,
   InstallArgs,
-  InstallInfo
+  InstallInfo,
+  LaunchOption
 } from 'common/types'
 import { GOGCloudSavesLocation } from './gog'
 
@@ -41,7 +42,7 @@ export interface GameManager {
   removeShortcuts: (appName: string) => Promise<void>
   launch: (
     appName: string,
-    launchArguments?: string,
+    launchArguments?: LaunchOption,
     skipVersionCheck?: boolean
   ) => Promise<boolean>
   moveInstall: (
@@ -73,4 +74,7 @@ export interface LibraryManager {
   listUpdateableGames: () => Promise<string[]>
   changeGameInstallPath: (appName: string, newPath: string) => Promise<void>
   installState: (appName: string, state: boolean) => void
+  getLaunchOptions: (
+    appName: string
+  ) => LaunchOption[] | Promise<LaunchOption[]>
 }

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -39,7 +39,11 @@ export interface GameManager {
   isNative: (appName: string) => boolean
   addShortcuts: (appName: string, fromMenu?: boolean) => Promise<void>
   removeShortcuts: (appName: string) => Promise<void>
-  launch: (appName: string, launchArguments?: string) => Promise<boolean>
+  launch: (
+    appName: string,
+    launchArguments?: string,
+    skipVersionCheck?: boolean
+  ) => Promise<boolean>
   moveInstall: (
     appName: string,
     newInstallPath: string

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -4,11 +4,10 @@ import {
   InstallPlatform,
   GameSettings,
   ExecResult,
-  InstallArgs
+  InstallArgs,
+  InstallInfo
 } from 'common/types'
-import { GOGCloudSavesLocation, GogInstallInfo } from './gog'
-import { LegendaryInstallInfo } from './legendary'
-import { NileInstallInfo } from './nile'
+import { GOGCloudSavesLocation } from './gog'
 
 export interface InstallResult {
   status: 'done' | 'error' | 'abort'
@@ -66,9 +65,7 @@ export interface LibraryManager {
     appName: string,
     installPlatform: InstallPlatform,
     lang?: string
-  ) => Promise<
-    LegendaryInstallInfo | GogInstallInfo | NileInstallInfo | undefined
-  >
+  ) => Promise<InstallInfo | undefined>
   listUpdateableGames: () => Promise<string[]>
   changeGameInstallPath: (appName: string, newPath: string) => Promise<void>
   installState: (appName: string, state: boolean) => void

--- a/src/common/types/legendary.ts
+++ b/src/common/types/legendary.ts
@@ -100,6 +100,7 @@ type CustomAttributeType =
   | 'extraLaunchOption_001_Args'
   | 'extraLaunchOption_001_Name'
   | 'ThirdPartyManagedApp'
+  | 'AdditionalCommandLine'
 
 interface CustomAttributeValue {
   type: 'STRING'

--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -117,8 +117,6 @@ function getProgress(progress: InstallProgress): number {
   return 0
 }
 
-const getGOGLaunchOptions = window.api.getGOGLaunchOptions
-
 function removeSpecialcharacters(text: string): string {
   const regexp = new RegExp(
     /[:|/|*|?|<|>|\\|&|{|}|%|$|@|`|!|™|+|'|"|®]/,
@@ -161,6 +159,5 @@ export {
   updateGame,
   writeConfig,
   removeSpecialcharacters,
-  getStoreName,
-  getGOGLaunchOptions
+  getStoreName
 }

--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -3,11 +3,9 @@ import {
   InstallProgress,
   Runner,
   GameSettings,
-  InstallPlatform
+  InstallPlatform,
+  InstallInfo
 } from 'common/types'
-import { LegendaryInstallInfo } from 'common/types/legendary'
-import { GogInstallInfo } from 'common/types/gog'
-import { NileInstallInfo } from 'common/types/nile'
 
 import { install, launch, repair, updateGame } from './library'
 import * as fileSize from 'filesize'
@@ -77,7 +75,7 @@ const getInstallInfo = async (
   appName: string,
   runner: Runner,
   installPlatform: InstallPlatform
-): Promise<LegendaryInstallInfo | GogInstallInfo | NileInstallInfo | null> => {
+): Promise<InstallInfo | null> => {
   return window.api.getInstallInfo(
     appName,
     runner,

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -4,7 +4,8 @@ import {
   GameInfo,
   InstallProgress,
   Runner,
-  UpdateParams
+  UpdateParams,
+  LaunchOption
 } from 'common/types'
 
 import { TFunction } from 'i18next'
@@ -157,7 +158,7 @@ const repair = async (appName: string, runner: Runner): Promise<void> =>
 type LaunchOptions = {
   appName: string
   t: TFunction<'gamepage'>
-  launchArguments?: string
+  launchArguments?: LaunchOption
   runner: Runner
   hasUpdate: boolean
   showDialogModal: (options: DialogModalOptions) => void
@@ -166,7 +167,7 @@ type LaunchOptions = {
 const launch = async ({
   appName,
   t,
-  launchArguments = '',
+  launchArguments,
   runner,
   hasUpdate,
   showDialogModal

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -178,10 +178,8 @@ const launch = async ({
       return window.api.launch({
         appName,
         runner,
-        launchArguments:
-          launchArguments +
-          ' ' +
-          (runner === 'legendary' ? '--skip-version-check' : '')
+        launchArguments,
+        skipVersionCheck: true
       })
     }
 
@@ -210,10 +208,8 @@ const launch = async ({
                   window.api.launch({
                     appName,
                     runner,
-                    launchArguments:
-                      launchArguments +
-                      ' ' +
-                      (runner === 'legendary' ? '--skip-version-check' : '')
+                    launchArguments,
+                    skipVersionCheck: true
                   })
                 )
               }

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -26,11 +26,9 @@ import {
   GameInfo,
   GameSettings,
   Runner,
-  WikiInfo
+  WikiInfo,
+  InstallInfo
 } from 'common/types'
-import { LegendaryInstallInfo } from 'common/types/legendary'
-import { GogInstallInfo } from 'common/types/gog'
-import { NileInstallInfo } from 'common/types/nile'
 
 import GamePicture from '../GamePicture'
 import TimeContainer from '../TimeContainer'
@@ -98,9 +96,9 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const [progress, previousProgress] = hasProgress(appName)
 
   const [extraInfo, setExtraInfo] = useState<ExtraInfo | null>(null)
-  const [gameInstallInfo, setGameInstallInfo] = useState<
-    LegendaryInstallInfo | GogInstallInfo | NileInstallInfo | null
-  >(null)
+  const [gameInstallInfo, setGameInstallInfo] = useState<InstallInfo | null>(
+    null
+  )
   const [launchArguments, setLaunchArguments] = useState('')
   const [hasError, setHasError] = useState<{
     error: boolean

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -27,7 +27,8 @@ import {
   GameSettings,
   Runner,
   WikiInfo,
-  InstallInfo
+  InstallInfo,
+  LaunchOption
 } from 'common/types'
 
 import GamePicture from '../GamePicture'
@@ -99,7 +100,9 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const [gameInstallInfo, setGameInstallInfo] = useState<InstallInfo | null>(
     null
   )
-  const [launchArguments, setLaunchArguments] = useState('')
+  const [launchArguments, setLaunchArguments] = useState<
+    LaunchOption | undefined
+  >(undefined)
   const [hasError, setHasError] = useState<{
     error: boolean
     message: string | unknown
@@ -375,7 +378,6 @@ export default React.memo(function GamePage(): JSX.Element | null {
                   />
                   <LaunchOptions
                     gameInfo={gameInfo}
-                    launchArguments={launchArguments}
                     setLaunchArguments={setLaunchArguments}
                   />
 
@@ -426,7 +428,6 @@ export default React.memo(function GamePage(): JSX.Element | null {
                     />
                     <LaunchOptions
                       gameInfo={gameInfo}
-                      launchArguments={launchArguments}
                       setLaunchArguments={setLaunchArguments}
                     />
                     <div className="buttons">

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -9,12 +9,12 @@ import classNames from 'classnames'
 import {
   GameInfo,
   GameStatus,
+  InstallInfo,
   InstallPlatform,
   Runner,
   WineInstallation
 } from 'common/types'
-import { GogInstallInfo } from 'common/types/gog'
-import { LegendaryInstallInfo, SelectiveDownload } from 'common/types/legendary'
+import { SelectiveDownload } from 'common/types/legendary'
 import {
   PathSelectionBox,
   SelectField,
@@ -46,7 +46,6 @@ import { useTranslation } from 'react-i18next'
 import { AvailablePlatforms } from '../index'
 import { configStore } from 'frontend/helpers/electronStores'
 import DLCDownloadListing from './DLCDownloadListing'
-import { NileInstallInfo } from 'common/types/nile'
 import { hasAnticheatInfo } from 'frontend/hooks/hasAnticheatInfo'
 
 interface Props {
@@ -126,9 +125,9 @@ export default function DownloadDialog({
 
   const isWin = platform === 'win32'
 
-  const [gameInstallInfo, setGameInstallInfo] = useState<
-    LegendaryInstallInfo | GogInstallInfo | NileInstallInfo | null
-  >(null)
+  const [gameInstallInfo, setGameInstallInfo] = useState<InstallInfo | null>(
+    null
+  )
   const [installLanguages, setInstallLanguages] = useState(Array<string>())
   const [installLanguage, setInstallLanguage] = useState('')
 

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -1,4 +1,3 @@
-import { NileInstallInfo } from './../common/types/nile'
 import {
   AppSettings,
   GameInfo,
@@ -14,10 +13,9 @@ import {
   GameSettings,
   WikiInfo,
   ExtraInfo,
-  Status
+  Status,
+  InstallInfo
 } from 'common/types'
-import { GogInstallInfo } from 'common/types/gog'
-import { LegendaryInstallInfo } from 'common/types/legendary'
 import { NileLoginData, NileRegisterData } from 'common/types/nile'
 
 export type Category = 'all' | 'legendary' | 'gog' | 'sideload' | 'nile'
@@ -228,11 +226,7 @@ export interface GameContextType {
   gameInfo: GameInfo | null
   gameExtraInfo: ExtraInfo | null
   gameSettings: GameSettings | null
-  gameInstallInfo:
-    | LegendaryInstallInfo
-    | GogInstallInfo
-    | NileInstallInfo
-    | null
+  gameInstallInfo: InstallInfo | null
   is: {
     installing: boolean
     installingUbisoft: boolean


### PR DESCRIPTION
This PR adds support for launch-able DLCs (for Epic/Legendary), used for the recent Fortnite "Experiences" and the Unreal Editor for Fortnite

I can't test this *that* well, as I don't have a Windows system with Fortnite installed, but it appears to be working. Further tests from people on our Discord might be coming soon

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
