### PR TITLE
[Fix] Steam Shortcuts / Make checkIfAlreadyAdded case-insensitive

### DIFF
--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -184,7 +184,13 @@ function checkIfShortcutObjectIsValid(
  */
 function checkIfAlreadyAdded(object: Partial<ShortcutObject>, title: string) {
   const shortcuts = object.shortcuts ?? []
-  return shortcuts.findIndex((entry) => entry.AppName === title)
+  return shortcuts.findIndex(
+    (entry) =>
+      entry[
+        Object.keys(entry).find((key) => key.toLowerCase() === 'appname') ??
+          'AppName'
+      ] === title
+  )
 }
 
 /**

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -425,7 +425,12 @@ async function removeNonSteamGame(props: {
     const shortcutObj = content.shortcuts.at(index)!
 
     const exe = shortcutObj.Exe
-    const appName = shortcutObj.AppName
+    const appName =
+      shortcutObj[
+        Object.keys(shortcutObj).find(
+          (key) => key.toLowerCase() === 'appname'
+        ) ?? 'AppName'
+      ]
 
     // remove
     content.shortcuts.splice(index, 1)

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -145,6 +145,17 @@ function hasParameterCaseInsensitive(object: ShortcutEntry, key: string) {
   return Object.keys(object).some((k) => k.toLowerCase() === keyAsLowercase)
 }
 
+/** Return AppName property case insensitive
+ *  @param {Object} object
+ *  @returns Title of Shortcut Entry
+ */
+function getAppName(object: ShortcutEntry) {
+  const foundkey =
+    Object.keys(object).find((key) => key.toLowerCase() === 'appname') ??
+    'AppName'
+  return object[foundkey]
+}
+
 /**
  * Check if the parsed object of a shortcuts.vdf is valid.
  * @param object @see Partial<ShortcutObject>
@@ -184,13 +195,7 @@ function checkIfShortcutObjectIsValid(
  */
 function checkIfAlreadyAdded(object: Partial<ShortcutObject>, title: string) {
   const shortcuts = object.shortcuts ?? []
-  return shortcuts.findIndex(
-    (entry) =>
-      entry[
-        Object.keys(entry).find((key) => key.toLowerCase() === 'appname') ??
-          'AppName'
-      ] === title
-  )
+  return shortcuts.findIndex((entry) => getAppName(entry) === title)
 }
 
 /**
@@ -425,12 +430,7 @@ async function removeNonSteamGame(props: {
     const shortcutObj = content.shortcuts.at(index)!
 
     const exe = shortcutObj.Exe
-    const appName =
-      shortcutObj[
-        Object.keys(shortcutObj).find(
-          (key) => key.toLowerCase() === 'appname'
-        ) ?? 'AppName'
-      ]
+    const appName = getAppName(shortcutObj)
 
     // remove
     content.shortcuts.splice(index, 1)


### PR DESCRIPTION
This change should make checkIfAlreadyAdded insensitive to the case of 'AppName' so if it changes it'll still be recognized and able to be removed and not double added.

Fixes #3124 

Change is based on [this StackOverflow post](https://stackoverflow.com/a/47538066)

Tested but not on a completely clean install

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
