### PR TITLE
[Fix] Resolve 7/8 dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "shlex": "2.1.2",
     "short-uuid": "4.2.2",
     "simple-keyboard": "3.5.33",
-    "steam-shortcut-editor": "3.1.1",
+    "steam-shortcut-editor": "3.1.3",
     "tslib": "2.5.0",
     "xvfb-maybe": "^0.2.1",
     "zod": "3.22.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6078,11 +6078,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-  integrity sha512-6X37Sq9KCpLSXEh8uM12AKYlviHPNNk4RxiGBn4cmKGJinbXBneWIV7iE/nXkM928O7ytHcHb6+X6Svl0f4hXg==
-
 lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -8058,12 +8053,12 @@ stat-mode@^1.0.0:
   resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-1.0.0.tgz#68b55cb61ea639ff57136f36b216a291800d1465"
   integrity sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==
 
-steam-shortcut-editor@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/steam-shortcut-editor/-/steam-shortcut-editor-3.1.1.tgz#9d9684bdbeed57d95fd07538236dcd3d19e5ab5d"
-  integrity sha512-zxDUqKz6kpLmiwGosKBCFKO769h95CNZa14+e9lvyj+6Ye73mmcH/1Z/MW0wpfRspstNZTzyAe3egPy+rHywbg==
+steam-shortcut-editor@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/steam-shortcut-editor/-/steam-shortcut-editor-3.1.3.tgz#7544a8de8a4c211ad4ed7f4b544dd32a79814fac"
+  integrity sha512-KATVeu6Y/DLlfbzCxs3RvVvBx9hPOxV/GkRrP6MqzkXQPpKHHVv/GYr1p1WUgU8cK0LWxbKgDdOBQNpOM7+uAw==
   dependencies:
-    lodash "4.17.4"
+    lodash "^4.17.21"
     object-sizeof "^1.2.0"
 
 stop-iteration-iterator@^1.0.0:


### PR DESCRIPTION
The version of `steam-shortcut-editor` we were using required an old version of lodash. In terms of functionality, nothing changed between 3.1.1 and 3.1.3, so we can just update it.

The last alert is about `axios`, which we can't easily update right now (we'd need #3218 for that).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
