### PR TITLE
[UX] Show game title in uninstall dialog

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -35,8 +35,8 @@
         "uninstall": {
             "cannotUninstallEpic": "Epic games cannot be uninstalled while another Epic game is being installed.",
             "checkbox": "Remove prefix: {{prefix}}{{newLine}}Note: This can't be undone and will also remove not backed up save files.",
-            "dlc": "Do you want to Uninstall this DLC?",
-            "message": "Do you want to uninstall this game?",
+            "dlc": "Do you want to uninstall \"{{title}}\" (DLC)?",
+            "message": "Do you want to uninstall \"{{title}}\"?",
             "prefix_warning": "The Wine prefix for this game is the default prefix. If you really want to delete it, you have to do it manually.",
             "settingcheckbox": "Erase settings and remove log{{newLine}}Note: This can't be undone. Any modified settings will be forgotten and log will be deleted.",
             "title": "Uninstall"

--- a/src/frontend/components/UI/UninstallModal/index.tsx
+++ b/src/frontend/components/UI/UninstallModal/index.tsx
@@ -35,6 +35,7 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
   const navigate = useNavigate()
   const location = useLocation()
   const { installingEpicGame } = useContext(ContextProvider)
+  const [gameTitle, setGameTitle] = useState('')
 
   const checkIfIsNative = async () => {
     // This assumes native games are installed should be changed in the future
@@ -57,6 +58,8 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
     if (!gameInfo) {
       return
     }
+
+    setGameTitle(gameInfo.title)
 
     const { install } = gameInfo
     if (install.platform?.toLowerCase() !== 'windows') {
@@ -133,11 +136,14 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
           <DialogContent>
             <div className="uninstallModalMessage">
               {isDlc
-                ? t(
-                    'gamepage:box.uninstall.dlc',
-                    'Do you want to Uninstall this DLC?'
-                  )
-                : t('gamepage:box.uninstall.message')}
+                ? t('gamepage:box.uninstall.dlc', {
+                    defaultValue: 'Do you want to uninstall "{{title}}" (DLC)?',
+                    title: gameTitle
+                  })
+                : t('gamepage:box.uninstall.message', {
+                    defaultValue: 'Do you want to uninstall "{{title}}"?',
+                    title: gameTitle
+                  })}
             </div>
             {showWineCheckbox && (
               <ToggleSwitch


### PR DESCRIPTION
When uninstalling a native game, there's no mention of the game that is going to be uninstalled:

![Captura de pantalla de 2023-12-20 22-38-42](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/af93c6d0-e3d8-43c2-837f-a6a6f4818696)

This can be problematic, because if a user clicks the wrong card to uninstall a game, they can end up uninstalling the wrong one.

Also the copy is confusing `Do you want to uninstall this game?` but it doesn't say which

This PR adds the title of the game in the message, so it's more clear:

![Captura de pantalla de 2023-12-20 22-49-22](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/81b8ae46-0923-4621-a035-1702f94ea2ff)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
