### PR TITLE
[UI] Add link to join Discord server in the "Report a problem..." dialog

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -601,6 +601,7 @@
             "copy-to-clipboard": "Copy log content to clipboard",
             "instructions": "Join our Discord and look for the \"#-support\" section. Read the pinned \"Read Me First | Frequently Asked Questions\" thread and follow the instructions to share these logs and any relevant information about your problem.",
             "instructions_title": "How to report a problem?",
+            "join-heroic-discord": "Join our Discord",
             "no-file": "No log file found",
             "show-in-folder": "Show log file in folder"
         },

--- a/src/frontend/screens/Settings/sections/LogSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/LogSettings/index.tsx
@@ -9,6 +9,8 @@ import SettingsContext from '../../SettingsContext'
 import './index.css'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { GameInfo } from 'common/types'
+import { openDiscordLink } from 'frontend/helpers'
+import { faDiscord } from '@fortawesome/free-brands-svg-icons'
 
 interface LogBoxProps {
   logFileContent: string
@@ -212,6 +214,20 @@ export default function LogSettings() {
                   'setting.log.copy-to-clipboard',
                   'Copy log content to clipboard.'
                 )}
+              </span>
+            </div>
+          </a>
+          <a
+            onClick={openDiscordLink}
+            title={t('setting.log.join-heroic-discord', 'Join our Discord')}
+            className="button is-footer"
+          >
+            <div className="button-icontext-flex">
+              <div className="button-icon-flex">
+                <FontAwesomeIcon icon={faDiscord} />
+              </div>
+              <span className="button-icon-text">
+                {t('setting.log.join-heroic-discord', 'Join our Discord')}
               </span>
             </div>
           </a>


### PR DESCRIPTION
Added a "Join our Discord" button in the "Report a problem running this game" window. 

![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/84299080/d7d35dce-09a6-4f42-b9f1-10bcfd8b06ec)

Fixes #3296

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
