### PR TITLE
[UX] Improvements when using a controller to navigate the interface

### DIFF
--- a/src/frontend/components/UI/Dialog/components/Dialog.tsx
+++ b/src/frontend/components/UI/Dialog/components/Dialog.tsx
@@ -5,7 +5,8 @@ import React, {
   SyntheticEvent,
   useCallback,
   useEffect,
-  useRef
+  useRef,
+  useState
 } from 'react'
 
 interface DialogProps {
@@ -24,12 +25,24 @@ export const Dialog: React.FC<DialogProps> = ({
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const onCloseRef = useRef(onClose)
   onCloseRef.current = onClose
+  const [focusOnClose, setFocusOnClose] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    setFocusOnClose(document.querySelector('*:focus') as HTMLElement)
+  }, [])
+
+  const close = () => {
+    onCloseRef.current()
+    if (focusOnClose) {
+      setTimeout(() => focusOnClose.focus(), 200)
+    }
+  }
 
   useEffect(() => {
     const dialog = dialogRef.current
     if (dialog) {
       const cancel = () => {
-        onCloseRef.current()
+        close()
       }
       dialog.addEventListener('cancel', cancel)
       dialog['showModal']()
@@ -52,7 +65,7 @@ export const Dialog: React.FC<DialogProps> = ({
           ev.offsetY < 0 ||
           ev.offsetY > tg.offsetHeight
         ) {
-          onClose()
+          close()
         }
       }
     },
@@ -68,7 +81,7 @@ export const Dialog: React.FC<DialogProps> = ({
       >
         {showCloseButton && (
           <div className="Dialog__Close">
-            <button className="Dialog__CloseButton" onClick={onClose}>
+            <button className="Dialog__CloseButton" onClick={close}>
               <FontAwesomeIcon className="Dialog__CloseIcon" icon={faXmark} />
             </button>
           </div>

--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -132,8 +132,9 @@ export const initGamepad = () => {
             // closes the keyboard if present
             VirtualKeyboardController.destroy()
             return
-          } else if (insideInstallDialog()) {
-            closeInstallDialog()
+          } else if (insideDialog()) {
+            closeDialog()
+            return
           } else if (isSelect()) {
             // closes the select dropdown and re-focus element
             const el = currentElement()
@@ -261,18 +262,18 @@ export const initGamepad = () => {
     return true
   }
 
-  function insideInstallDialog() {
+  function insideDialog() {
     const el = currentElement()
     if (!el) return false
 
-    return !!el.closest('.InstallModal__dialog')
+    return !!el.closest('.Dialog__element')
   }
 
-  function closeInstallDialog() {
+  function closeDialog() {
     const el = currentElement()
     if (!el) return false
 
-    const dialog = el.closest('.InstallModal__dialog')
+    const dialog = el.closest('.Dialog__element')
     if (!dialog) return false
 
     const closeButton = dialog.querySelector<HTMLButtonElement>(

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -27,13 +27,16 @@ const scrollCardIntoView = (ev: FocusEvent) => {
 
   if (rect.top < 100) {
     // if it's too close to the top, scroll a bit down
-    window.scrollTo(0, trgt.parentElement!.offsetTop - 200)
+    window.scrollTo({
+      top: trgt.parentElement!.offsetTop - 200,
+      behavior: 'smooth'
+    })
   } else if (rect.bottom > windowHeight - 100) {
     // if it's too close to the bottom, scroll a bit up
-    window.scrollTo(
-      0,
-      trgt.parentElement!.offsetTop - windowHeight + rect.height + 150
-    )
+    window.scrollTo({
+      top: trgt.parentElement!.offsetTop - windowHeight + rect.height + 150,
+      behavior: 'smooth'
+    })
   }
 }
 


### PR DESCRIPTION
This PR improves the UX of heroic with a controller with a few tweaks:

- Pressing the `B` button (in the steam deck layout, I think it's `O` if using a PS controller) now closes any dialog, not only the install dialog, and it doesn't go back in history if a dialog is open

This was really annoying, now we can press `B` to close the Settings dialog, Categories dialog, or the Uninstall dialog for example

- After closing a dialog, the element that was focused before opening it gains focus again

this was REALLY annoying, it feels way better now, for example when opening the settings or logs for a card, after closing the dialog we are still focused on the same card instead of nowhere

- When moving the focus in the library, now cards are scrolled into view so they are completely visible

this fixes an issue that when you were at the top or bottom of the screen, you had to do a few more moves to actually get the screen to scroll before the focus changes to the next element

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
