### PR TITLE
[Tech] Refactor how we write to game logs

### DIFF
--- a/src/backend/logger/logfile.ts
+++ b/src/backend/logger/logfile.ts
@@ -6,10 +6,15 @@ import {
   appendFileSync
 } from 'graceful-fs'
 
-import { configStore, currentLogFile, gamesConfigPath } from '../constants'
+import { configStore, currentLogFile } from '../constants'
 import { app } from 'electron'
 import { join } from 'path'
-import { logError, LogPrefix, logsDisabled } from './logger'
+import {
+  lastPlayLogFileLocation,
+  logError,
+  LogPrefix,
+  logsDisabled
+} from './logger'
 
 interface createLogFileReturn {
   currentLogFile: string
@@ -135,7 +140,7 @@ export function getLogFile(appNameOrRunner: string): string {
     case 'nile':
       return logs.nileLogFile
     default:
-      return join(gamesConfigPath, appNameOrRunner + '-lastPlay.log')
+      return lastPlayLogFileLocation(appNameOrRunner)
   }
 }
 

--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -12,6 +12,8 @@ import { GlobalConfig } from 'backend/config'
 import { getGOGdlBin, getLegendaryBin } from 'backend/utils'
 import { join } from 'path'
 import { formatSystemInfo, getSystemInfo } from '../utils/systeminfo'
+import { appendFileSync, writeFileSync } from 'graceful-fs'
+import { gamesConfigPath } from 'backend/constants'
 
 export enum LogPrefix {
   General = '',
@@ -343,4 +345,20 @@ export function logChangedSetting(
       LogPrefix.Backend
     )
   })
+}
+
+export function lastPlayLogFileLocation(appName: string) {
+  return join(gamesConfigPath, `${appName}-lastPlay.log`)
+}
+
+export function logFileLocation(appName: string) {
+  return join(gamesConfigPath, `${appName}.log`)
+}
+
+export function appendGameLog(appName: string, message: string) {
+  appendFileSync(lastPlayLogFileLocation(appName), message)
+}
+
+export function initGameLog(appName: string, message: string) {
+  writeFileSync(lastPlayLogFileLocation(appName), message)
 }

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -35,8 +35,8 @@ import {
   InstallPlatform,
   InstallProgress
 } from 'common/types'
-import { appendFileSync, existsSync, rmSync } from 'graceful-fs'
-import { gamesConfigPath, isWindows, isMac, isLinux } from '../../constants'
+import { existsSync, rmSync } from 'graceful-fs'
+import { isWindows, isMac, isLinux } from '../../constants'
 import {
   configStore,
   installedGamesStore,
@@ -44,8 +44,10 @@ import {
   syncStore
 } from './electronStores'
 import {
+  appendGameLog,
   logDebug,
   logError,
+  logFileLocation,
   logInfo,
   LogPrefix,
   logsDisabled,
@@ -80,7 +82,6 @@ import { t } from 'i18next'
 import { showDialogBoxModalAuto } from '../../dialog/dialog'
 import { sendFrontendMessage } from '../../main_window'
 import { RemoveArgs } from 'common/types/game_manager'
-import { logFileLocation } from 'backend/storeManagers/storeManagerCommon/games'
 import { getWineFlagsArray } from 'backend/utils/compatibility_layers'
 import axios, { AxiosError } from 'axios'
 import { isOnline, runOnceWhenOnline } from 'backend/online_monitor'
@@ -288,8 +289,6 @@ export async function install(
       ? 'osx'
       : (platformToInstall.toLowerCase() as GogInstallPlatform)
 
-  const logPath = join(gamesConfigPath, appName + '.log')
-
   const commandParts: string[] = [
     'download',
     appName,
@@ -309,7 +308,7 @@ export async function install(
 
   const res = await runGogdlCommand(commandParts, {
     abortId: appName,
-    logFile: logPath,
+    logFile: logFileLocation(appName),
     onOutput,
     logMessagePrefix: `Installing ${appName}`
   })
@@ -438,10 +437,7 @@ export async function launch(
     steamRuntime
   } = await prepareLaunch(gameSettings, gameInfo, isNative(appName))
   if (!launchPrepSuccess) {
-    appendFileSync(
-      logFileLocation(appName),
-      `Launch aborted: ${launchPrepFailReason}`
-    )
+    appendGameLog(appName, `Launch aborted: ${launchPrepFailReason}`)
     showDialogBoxModalAuto({
       title: t('box.error.launchAborted', 'Launch aborted'),
       message: launchPrepFailReason!,
@@ -479,10 +475,7 @@ export async function launch(
       envVars: wineEnvVars
     } = await prepareWineLaunch('gog', appName)
     if (!wineLaunchPrepSuccess) {
-      appendFileSync(
-        logFileLocation(appName),
-        `Launch aborted: ${wineLaunchPrepFailReason}`
-      )
+      appendGameLog(appName, `Launch aborted: ${wineLaunchPrepFailReason}`)
       if (wineLaunchPrepFailReason) {
         showDialogBoxModalAuto({
           title: t('box.error.launchAborted', 'Launch aborted'),
@@ -526,10 +519,7 @@ export async function launch(
     commandEnv,
     join(...Object.values(getGOGdlBin()))
   )
-  appendFileSync(
-    logFileLocation(appName),
-    `Launch Command: ${fullCommand}\n\nGame Log:\n`
-  )
+  appendGameLog(appName, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
 
   const { error, abort } = await runGogdlCommand(commandParts, {
     abortId: appName,
@@ -537,7 +527,7 @@ export async function launch(
     wrappers,
     logMessagePrefix: `Launching ${gameInfo.title}`,
     onOutput: (output: string) => {
-      if (!logsDisabled) appendFileSync(logFileLocation(appName), output)
+      if (!logsDisabled) appendGameLog(appName, output)
     }
   })
 
@@ -833,7 +823,7 @@ async function getCommandParameters(appName: string) {
   const { maxWorkers } = GlobalConfig.get().getSettings()
   const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
   const gameData = getGameInfo(appName)
-  const logPath = join(gamesConfigPath, appName + '.log')
+  const logPath = logFileLocation(appName)
   const credentials = await GOGUser.getCredentials()
 
   const withDlcs = gameData.install.installedWithDLCs

--- a/src/backend/storeManagers/gog/setup.ts
+++ b/src/backend/storeManagers/gog/setup.ts
@@ -16,7 +16,6 @@ import { isWindows } from '../../constants'
 import ini from 'ini'
 import { isOnline } from '../../online_monitor'
 import { getWinePath, runWineCommand, verifyWinePrefix } from '../../launcher'
-import { logFileLocation } from 'backend/storeManagers/storeManagerCommon/games'
 import { getGameInfo as getGogLibraryGameInfo } from 'backend/storeManagers/gog/library'
 const nonNativePathSeparator = path.sep === '/' ? '\\' : '/'
 
@@ -50,11 +49,7 @@ async function setup(
 
   const gameSettings = GameConfig.get(appName).config
   if (!isWindows) {
-    const isWineOkToLaunch = await checkWineBeforeLaunch(
-      appName,
-      gameSettings,
-      logFileLocation(appName)
-    )
+    const isWineOkToLaunch = await checkWineBeforeLaunch(appName, gameSettings)
 
     if (!isWineOkToLaunch) {
       logError(

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, existsSync } from 'graceful-fs'
+import { existsSync } from 'graceful-fs'
 import axios from 'axios'
 
 import {
@@ -35,10 +35,16 @@ import {
   isWindows,
   installed,
   configStore,
-  gamesConfigPath,
   isCLINoGui
 } from '../../constants'
-import { logError, logInfo, LogPrefix, logsDisabled } from '../../logger/logger'
+import {
+  appendGameLog,
+  logError,
+  logFileLocation,
+  logInfo,
+  LogPrefix,
+  logsDisabled
+} from '../../logger/logger'
 import {
   prepareLaunch,
   prepareWineLaunch,
@@ -63,7 +69,6 @@ import { showDialogBoxModalAuto } from '../../dialog/dialog'
 import { Catalog, Product } from 'common/types/epic-graphql'
 import { sendFrontendMessage } from '../../main_window'
 import { RemoveArgs } from 'common/types/game_manager'
-import { logFileLocation } from 'backend/storeManagers/storeManagerCommon/games'
 import {
   AllowedWineFlags,
   getWineFlags
@@ -489,7 +494,6 @@ export async function update(
   const { maxWorkers, downloadNoHttps } = GlobalConfig.get().getSettings()
   const installPlatform = getGameInfo(appName).install.platform!
   const info = await getInstallInfo(appName, installPlatform)
-  const logPath = join(gamesConfigPath, appName + '.log')
 
   const command: LegendaryCommand = {
     subcommand: 'update',
@@ -510,7 +514,7 @@ export async function update(
 
   const res = await runLegendaryCommand(command, {
     abortId: appName,
-    logFile: logPath,
+    logFile: logFileLocation(appName),
     onOutput,
     logMessagePrefix: `Updating ${appName}`
   })
@@ -565,7 +569,7 @@ export async function install(
   const { maxWorkers, downloadNoHttps } = GlobalConfig.get().getSettings()
   const info = await getInstallInfo(appName, platformToInstall)
 
-  const logPath = join(gamesConfigPath, appName + '.log')
+  const logPath = logFileLocation(appName)
 
   const command: LegendaryCommand = {
     subcommand: 'install',
@@ -659,8 +663,6 @@ export async function uninstall({ appName }: RemoveArgs): Promise<ExecResult> {
 export async function repair(appName: string): Promise<ExecResult> {
   const { maxWorkers, downloadNoHttps } = GlobalConfig.get().getSettings()
 
-  const logPath = join(gamesConfigPath, appName + '.log')
-
   const command: LegendaryCommand = {
     subcommand: 'repair',
     appName: LegendaryAppName.parse(appName),
@@ -671,7 +673,7 @@ export async function repair(appName: string): Promise<ExecResult> {
 
   const res = await runLegendaryCommand(command, {
     abortId: appName,
-    logFile: logPath,
+    logFile: logFileLocation(appName),
     logMessagePrefix: `Repairing ${appName}`
   })
 
@@ -770,10 +772,7 @@ export async function launch(
     offlineMode
   } = await prepareLaunch(gameSettings, gameInfo, isNative(appName))
   if (!launchPrepSuccess) {
-    appendFileSync(
-      logFileLocation(appName),
-      `Launch aborted: ${launchPrepFailReason}`
-    )
+    appendGameLog(appName, `Launch aborted: ${launchPrepFailReason}`)
     showDialogBoxModalAuto({
       title: t('box.error.launchAborted', 'Launch aborted'),
       message: launchPrepFailReason!,
@@ -810,10 +809,7 @@ export async function launch(
       envVars: wineEnvVars
     } = await prepareWineLaunch('legendary', appName)
     if (!wineLaunchPrepSuccess) {
-      appendFileSync(
-        logFileLocation(appName),
-        `Launch aborted: ${wineLaunchPrepFailReason}`
-      )
+      appendGameLog(appName, `Launch aborted: ${wineLaunchPrepFailReason}`)
       if (wineLaunchPrepFailReason) {
         showDialogBoxModalAuto({
           title: t('box.error.launchAborted', 'Launch aborted'),
@@ -859,10 +855,7 @@ export async function launch(
     commandEnv,
     join(...Object.values(getLegendaryBin()))
   )
-  appendFileSync(
-    logFileLocation(appName),
-    `Launch Command: ${fullCommand}\n\nGame Log:\n`
-  )
+  appendGameLog(appName, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
 
   const { error } = await runLegendaryCommand(command, {
     abortId: appName,
@@ -870,7 +863,7 @@ export async function launch(
     wrappers: wrappers,
     logMessagePrefix: `Launching ${gameInfo.title}`,
     onOutput: (output) => {
-      if (!logsDisabled) appendFileSync(logFileLocation(appName), output)
+      if (!logsDisabled) appendGameLog(appName, output)
     }
   })
 

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -18,12 +18,14 @@ import {
 } from './library'
 import {
   LogPrefix,
+  appendGameLog,
   logDebug,
   logError,
+  logFileLocation,
   logInfo,
   logsDisabled
 } from 'backend/logger/logger'
-import { gamesConfigPath, isWindows } from 'backend/constants'
+import { isWindows } from 'backend/constants'
 import { GameConfig } from 'backend/game_config'
 import {
   getRunnerCallWithoutCredentials,
@@ -34,8 +36,7 @@ import {
   setupWrapperEnvVars,
   setupWrappers
 } from 'backend/launcher'
-import { appendFileSync, existsSync } from 'graceful-fs'
-import { logFileLocation } from 'backend/storeManagers/storeManagerCommon/games'
+import { existsSync } from 'graceful-fs'
 import { showDialogBoxModalAuto } from 'backend/dialog/dialog'
 import { t } from 'i18next'
 import { getWineFlagsArray } from 'backend/utils/compatibility_layers'
@@ -108,10 +109,9 @@ export async function importGame(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   platform: InstallPlatform
 ): Promise<ExecResult> {
-  const logPath = join(gamesConfigPath, `${appName}.log`)
   const res = await runNileCommand(['import', '--path', folderPath, appName], {
     abortId: appName,
-    logFile: logPath,
+    logFile: logFileLocation(appName),
     logMessagePrefix: `Importing ${appName}`
   })
 
@@ -242,8 +242,6 @@ export async function install(
   const { maxWorkers } = GlobalConfig.get().getSettings()
   const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
 
-  const logPath = join(gamesConfigPath, `${appName}.log`)
-
   const commandParts = ['install', '--base-path', path, ...workers, appName]
 
   const onOutput = (data: string) => {
@@ -252,7 +250,7 @@ export async function install(
 
   const res = await runNileCommand(commandParts, {
     abortId: appName,
-    logFile: logPath,
+    logFile: logFileLocation(appName),
     onOutput,
     logMessagePrefix: `Installing ${appName}`
   })
@@ -320,10 +318,7 @@ export async function launch(
   } = await prepareLaunch(gameSettings, gameInfo, isNative())
 
   if (!launchPrepSuccess) {
-    appendFileSync(
-      logFileLocation(appName),
-      `Launch aborted: ${launchPrepFailReason}`
-    )
+    appendGameLog(appName, `Launch aborted: ${launchPrepFailReason}`)
     showDialogBoxModalAuto({
       title: t('box.error.launchAborted', 'Launch aborted'),
       message: launchPrepFailReason!,
@@ -361,10 +356,7 @@ export async function launch(
       envVars: wineEnvVars
     } = await prepareWineLaunch('nile', appName)
     if (!wineLaunchPrepSuccess) {
-      appendFileSync(
-        logFileLocation(appName),
-        `Launch aborted: ${wineLaunchPrepFailReason}`
-      )
+      appendGameLog(appName, `Launch aborted: ${wineLaunchPrepFailReason}`)
       if (wineLaunchPrepFailReason) {
         showDialogBoxModalAuto({
           title: t('box.error.launchAborted', 'Launch aborted'),
@@ -408,10 +400,7 @@ export async function launch(
     commandEnv,
     join(...Object.values(getNileBin()))
   )
-  appendFileSync(
-    logFileLocation(appName),
-    `Launch Command: ${fullCommand}\n\nGame Log:\n`
-  )
+  appendGameLog(appName, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
 
   const { error } = await runNileCommand(commandParts, {
     abortId: appName,
@@ -419,7 +408,7 @@ export async function launch(
     wrappers,
     logMessagePrefix: `Launching ${gameInfo.title}`,
     onOutput(output) {
-      if (!logsDisabled) appendFileSync(logFileLocation(appName), output)
+      if (!logsDisabled) appendGameLog(appName, output)
     }
   })
 
@@ -470,12 +459,11 @@ export async function repair(appName: string): Promise<ExecResult> {
   }
 
   logDebug([appName, 'is installed at', install_path], LogPrefix.Nile)
-  const logPath = join(gamesConfigPath, `${appName}.log`)
   const res = await runNileCommand(
     ['verify', '--path', install_path, appName],
     {
       abortId: appName,
-      logFile: logPath,
+      logFile: logFileLocation(appName),
       logMessagePrefix: `Repairing ${appName}`
     }
   )
@@ -516,8 +504,6 @@ export async function update(appName: string): Promise<InstallResult> {
   const { maxWorkers } = GlobalConfig.get().getSettings()
   const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
 
-  const logPath = join(gamesConfigPath, `${appName}.log`)
-
   const commandParts = ['update', ...workers, appName]
 
   const onOutput = (data: string) => {
@@ -526,7 +512,7 @@ export async function update(appName: string): Promise<InstallResult> {
 
   const res = await runNileCommand(commandParts, {
     abortId: appName,
-    logFile: logPath,
+    logFile: logFileLocation(appName),
     onOutput,
     logMessagePrefix: `Updating ${appName}`
   })

--- a/src/backend/storeManagers/nile/setup.ts
+++ b/src/backend/storeManagers/nile/setup.ts
@@ -9,7 +9,6 @@ import { fetchFuelJSON, getGameInfo } from './library'
 import { GameConfig } from 'backend/game_config'
 import { isWindows } from 'backend/constants'
 import { checkWineBeforeLaunch, spawnAsync } from 'backend/utils'
-import { logFileLocation } from '../storeManagerCommon/games'
 import { runWineCommand, verifyWinePrefix } from 'backend/launcher'
 
 /**
@@ -58,11 +57,7 @@ export default async function setup(
 
   const gameSettings = GameConfig.get(appName).config
   if (!isWindows) {
-    const isWineOkToLaunch = await checkWineBeforeLaunch(
-      appName,
-      gameSettings,
-      logFileLocation(appName)
-    )
+    const isWineOkToLaunch = await checkWineBeforeLaunch(appName, gameSettings)
 
     if (!isWineOkToLaunch) {
       logError(

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -1,9 +1,15 @@
 import { GameInfo, GameSettings, Runner } from 'common/types'
 import { GameConfig } from '../../game_config'
-import { isMac, isLinux, gamesConfigPath, icon } from '../../constants'
-import { logInfo, LogPrefix, logWarning } from '../../logger/logger'
-import { dirname, join } from 'path'
-import { appendFileSync, constants as FS_CONSTANTS } from 'graceful-fs'
+import { isMac, isLinux, icon } from '../../constants'
+import {
+  appendGameLog,
+  lastPlayLogFileLocation,
+  logInfo,
+  LogPrefix,
+  logWarning
+} from '../../logger/logger'
+import { dirname } from 'path'
+import { constants as FS_CONSTANTS } from 'graceful-fs'
 import i18next from 'i18next'
 import {
   callRunner,
@@ -30,10 +36,6 @@ async function getAppSettings(appName: string): Promise<GameSettings> {
     GameConfig.get(appName).config ||
     (await GameConfig.get(appName).getSettings())
   )
-}
-
-export function logFileLocation(appName: string) {
-  return join(gamesConfigPath, `${appName}-lastPlay.log`)
 }
 
 type BrowserGameOptions = {
@@ -170,10 +172,7 @@ export async function launchGame(
     )
 
     if (!launchPrepSuccess) {
-      appendFileSync(
-        logFileLocation(appName),
-        `Launch aborted: ${launchPrepFailReason}`
-      )
+      appendGameLog(appName, `Launch aborted: ${launchPrepFailReason}`)
       showDialogBoxModalAuto({
         title: i18next.t('box.error.launchAborted', 'Launch aborted'),
         message: launchPrepFailReason!,
@@ -220,7 +219,7 @@ export async function launchGame(
         {
           env,
           wrappers,
-          logFile: logFileLocation(appName),
+          logFile: lastPlayLogFileLocation(appName),
           logMessagePrefix: LogPrefix.Backend
         }
       )
@@ -245,7 +244,7 @@ export async function launchGame(
       startFolder: dirname(executable),
       options: {
         wrappers,
-        logFile: logFileLocation(appName),
+        logFile: lastPlayLogFileLocation(appName),
         logMessagePrefix: LogPrefix.Backend
       }
     })

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -20,7 +20,7 @@ import {
   SpawnOptions,
   spawnSync
 } from 'child_process'
-import { appendFileSync, existsSync, rmSync } from 'graceful-fs'
+import { existsSync, rmSync } from 'graceful-fs'
 import { promisify } from 'util'
 import i18next, { t } from 'i18next'
 
@@ -39,6 +39,7 @@ import {
   isSnap
 } from './constants'
 import {
+  appendGameLog,
   logError,
   logInfo,
   LogPrefix,
@@ -898,8 +899,7 @@ export async function downloadDefaultWine() {
 
 export async function checkWineBeforeLaunch(
   appName: string,
-  gameSettings: GameSettings,
-  logFileLocation: string
+  gameSettings: GameSettings
 ): Promise<boolean> {
   const wineIsValid = await validWine(gameSettings.wineVersion)
 
@@ -912,8 +912,8 @@ export async function checkWineBeforeLaunch(
         LogPrefix.Backend
       )
 
-      appendFileSync(
-        logFileLocation,
+      appendGameLog(
+        appName,
         `Wine version ${gameSettings.wineVersion.name} is not valid, trying another one.`
       )
     }


### PR DESCRIPTION
We currently use explicit calls to `writeFileSync` and `appendFileSync` when we want to write game logs. This PR extracts that into more descriptive logger helper methods (`initGameLog` and `appendGameLog`) to simplify the usage so we can abstract the actual file name calculation and writing of the content.

I'm doing this because I want to add more logging and make it all async in the future, so I want to first simplify the API.

Nothing is changed in the functionality, logs should work just the same as before.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
