### PR TITLE
[UX] Add offline support filter

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -263,6 +263,7 @@
         "show_favourites_only": "Show Favourites only",
         "show_hidden": "Show Hidden",
         "show_installed_only": "Show Installed only",
+        "show_support_offline_only": "Show offline-supported only",
         "uncategorized": "Uncategorized"
     },
     "help": {

--- a/src/frontend/components/UI/LibraryFilters/index.tsx
+++ b/src/frontend/components/UI/LibraryFilters/index.tsx
@@ -28,7 +28,9 @@ export default function LibraryFilters() {
     storesFilters,
     setStoresFilters,
     platformsFilters,
-    setPlatformsFilters
+    setPlatformsFilters,
+    showSupportOfflineOnly,
+    setShowSupportOfflineOnly
   } = useContext(LibraryContext)
 
   const toggleShowHidden = () => {
@@ -45,6 +47,10 @@ export default function LibraryFilters() {
 
   const toggleOnlyInstalled = () => {
     setShowInstalledOnly(!showInstalledOnly)
+  }
+
+  const toggleOnlySupportOffline = () => {
+    setShowSupportOfflineOnly(!showSupportOfflineOnly)
   }
 
   const toggleStoreFilter = (store: Category) => {
@@ -192,6 +198,16 @@ export default function LibraryFilters() {
           handleChange={() => toggleOnlyInstalled()}
           value={showInstalledOnly}
           title={t('header.show_installed_only', 'Show Installed only')}
+        />
+        <ToggleSwitch
+          key="only-support-offline"
+          htmlId="only-support-offline"
+          handleChange={() => toggleOnlySupportOffline()}
+          value={showSupportOfflineOnly}
+          title={t(
+            'header.show_support_offline_only',
+            'Show offline-supported only'
+          )}
         />
         <hr />
         <button

--- a/src/frontend/screens/Library/LibraryContext.tsx
+++ b/src/frontend/screens/Library/LibraryContext.tsx
@@ -22,7 +22,9 @@ const initialContext: LibraryContextType = {
   sortDescending: true,
   setSortDescending: () => null,
   sortInstalled: true,
-  setSortInstalled: () => null
+  setSortInstalled: () => null,
+  showSupportOfflineOnly: false,
+  setShowSupportOfflineOnly: () => null
 }
 
 export default React.createContext(initialContext)

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -156,6 +156,14 @@ export default React.memo(function Library(): JSX.Element {
     setShowNonAvailable(value)
   }
 
+  const [showSupportOfflineOnly, setSupportOfflineOnly] = useState(
+    JSON.parse(storage.getItem('show_support_offline_only') || 'false')
+  )
+  const handleShowSupportOfflineOnly = (value: boolean) => {
+    storage.setItem('show_support_offline_only', JSON.stringify(value))
+    setSupportOfflineOnly(value)
+  }
+
   const [showModal, setShowModal] = useState<ModalState>({
     game: '',
     show: false,
@@ -399,6 +407,10 @@ export default React.memo(function Library(): JSX.Element {
         )
       }
 
+      if (showSupportOfflineOnly) {
+        library = library.filter((game) => game.canRunOffline)
+      }
+
       if (!showNonAvailable) {
         const nonAvailbleGames = storage.getItem('nonAvailableGames') || '[]'
         const nonAvailbleGamesArray = JSON.parse(nonAvailbleGames)
@@ -486,7 +498,8 @@ export default React.memo(function Library(): JSX.Element {
     hiddenGames,
     showFavouritesLibrary,
     showInstalledOnly,
-    showNonAvailable
+    showNonAvailable,
+    showSupportOfflineOnly
   ])
 
   // we need this to do proper `position: sticky` of the Add Game area
@@ -556,6 +569,8 @@ export default React.memo(function Library(): JSX.Element {
         setShowNonAvailable: handleShowNonAvailable,
         setSortDescending: handleSortDescending,
         setSortInstalled: handleSortInstalled,
+        showSupportOfflineOnly,
+        setShowSupportOfflineOnly: handleShowSupportOfflineOnly,
         sortDescending,
         sortInstalled
       }}

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -219,7 +219,9 @@ export interface LibraryContextType {
   sortDescending: boolean
   setSortDescending: (value: boolean) => void
   sortInstalled: boolean
-  setSortInstalled: (valur: boolean) => void
+  setSortInstalled: (value: boolean) => void
+  showSupportOfflineOnly: boolean
+  setShowSupportOfflineOnly: (value: boolean) => void
 }
 
 export interface GameContextType {


### PR DESCRIPTION
This PR adds a new filter to list only games flagged as supporting offline mode.

This can be really handy when deciding what to install for the steam deck for example knowing it would work on the go with no internet.

(I understand that some games are mislabeled, but we can't do anything about that)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
