### PR TITLE
[Fix] Handle possible undefined GOG images

### DIFF
--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -653,19 +653,23 @@ export async function gogToUnifiedInfo(
     // @ts-expect-error TODO: Handle this somehow
     return {}
   }
+
+  const art_cover =
+    info.game?.logo?.url_format
+      ?.replace('{formatter}', '')
+      .replace('{ext}', 'jpg') || `https:${galaxyProductInfo?.images.logo2x}`
+
   const object: GameInfo = {
     runner: 'gog',
     store_url: galaxyProductInfo?.links.product_card,
     developer: info.game.developers.map((dev) => dev.name).join(', '),
     app_name: String(info.external_id),
-    art_cover:
-      info.game?.logo?.url_format
-        ?.replace('{formatter}', '')
-        .replace('{ext}', 'jpg') || `https:${galaxyProductInfo?.images.logo2x}`,
-    art_square: info.game.vertical_cover.url_format
-      .replace('{formatter}', '')
-      .replace('{ext}', 'jpg'),
-    art_background: info.game.background.url_format
+    art_cover,
+    art_square:
+      info.game.vertical_cover?.url_format
+        .replace('{formatter}', '')
+        .replace('{ext}', 'jpg') || art_cover, // fallback to art_cover if undefined
+    art_background: info.game.background?.url_format
       .replace('{formatter}', '')
       .replace('{ext}', 'webp'),
     cloud_save_enabled: false,

--- a/src/common/types/gog.ts
+++ b/src/common/types/gog.ts
@@ -231,10 +231,10 @@ interface GamesDBDataInner extends GamesDBDataBase {
   horizontal_artwork: {
     url_format: string
   }
-  background: {
+  background?: {
     url_format: string
   }
-  vertical_cover: {
+  vertical_cover?: {
     url_format: string
   }
   cover: {


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3272
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3310

I saw linguin's comment in https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3272#issuecomment-1850785650 and I wanted to extract that into a smaller PR to fix these 2 issues. When I did that I noticed there's was one issue with no fallback for `art_square` if undefined so I had to do some changes on top of that code.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
