### PR TITLE
[Fix/UI] Fix status after aborting wine installation. Make width of progress more stable

### DIFF
--- a/src/frontend/screens/WineManager/components/WineItem/index.tsx
+++ b/src/frontend/screens/WineManager/components/WineItem/index.tsx
@@ -94,6 +94,11 @@ const WineItem = ({
           default:
             break
         }
+
+        setProgress({
+          state: 'idle',
+          progress: { percentage: 0, avgSpeed: 0, eta: '00:00:00' }
+        })
       })
   }
 
@@ -211,15 +216,10 @@ function getProgressElement(progress: ProgressInfo) {
 
   const percentageAsString = `${percentage.toFixed(2)}%`
   const etaAsString = `${eta}`
-
   return (
-    <p
-      style={{
-        color: '#0BD58C',
-        fontStyle: 'italic'
-      }}
-    >
-      {percentageAsString} ({etaAsString})
+    <p className="progress">
+      {percentageAsString}
+      <br />({etaAsString})
     </p>
   )
 }


### PR DESCRIPTION
This PR fixes 2 problems related to the download progress of wines:

- After canceling the installation of a wine, the progress was stuck as `downloading` instead of reverting back to idle state. Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3328

- The width of the progress was not constant so it kept jumping around as wider/narrower digits changed. Now I added a new line and it's centered so it doesn't move that much:

![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/987616fb-8945-4106-9978-683680670b19)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
