### PR TITLE
[Fix] Use 'includes' instead of 'match' to filter winetricks

### DIFF
--- a/src/frontend/components/UI/Winetricks/WinetricksSearch/index.tsx
+++ b/src/frontend/components/UI/Winetricks/WinetricksSearch/index.tsx
@@ -27,7 +27,7 @@ export default function WinetricksSearchBar({
       setSearchResults([])
     } else {
       let filtered = allComponents.filter((component) =>
-        component.match(search)
+        component.includes(search)
       )
       filtered = filtered.filter((component) => !installed?.includes(component))
       setSearchResults(filtered)


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3379

Using `includes` does a substring check while `match` does a regexp check which creates an error.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
