### PR TITLE
[UX] Allow setting offline mode even if game does not have the metadata

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -711,6 +711,9 @@
             "sync": "Cloud Saves Sync",
             "systemInformation": "System Information"
         },
+        "offline": {
+            "warning": "This game does not explicitly allow offline mode, turn this on at your own risk. The game may not work."
+        },
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",
         "saves": {

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -86,10 +86,9 @@ async function prepareLaunch(
 
   // Check if the game needs an internet connection
   if (!gameInfo.canRunOffline && offlineMode) {
-    return {
-      success: false,
-      failureReason: 'Offline mode not supported'
-    }
+    logWarning(
+      'Offline Mode is on but the game does not allow offline mode explicitly.'
+    )
   }
 
   // Update Discord RPC if enabled

--- a/src/frontend/screens/Settings/components/OfflineMode.tsx
+++ b/src/frontend/screens/Settings/components/OfflineMode.tsx
@@ -4,6 +4,8 @@ import { ToggleSwitch } from 'frontend/components/UI'
 import { getGameInfo } from 'frontend/helpers'
 import useSetting from 'frontend/hooks/useSetting'
 import SettingsContext from '../SettingsContext'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 
 const OfflineMode = () => {
   const { t } = useTranslation()
@@ -26,17 +28,28 @@ const OfflineMode = () => {
 
   const [offlineMode, setOfflineMode] = useSetting('offlineMode', false)
 
-  if (isDefault || !canRunOffline) {
+  if (isDefault) {
     return <></>
   }
 
   return (
-    <ToggleSwitch
-      htmlId="offlinemode"
-      value={offlineMode}
-      handleChange={() => setOfflineMode(!offlineMode)}
-      title={t('setting.offlinemode')}
-    />
+    <>
+      <ToggleSwitch
+        htmlId="offlinemode"
+        value={offlineMode}
+        handleChange={() => setOfflineMode(!offlineMode)}
+        title={t('setting.offlinemode')}
+      />
+      {!canRunOffline && offlineMode && (
+        <div className="infoBox saves-warning">
+          <FontAwesomeIcon icon={faExclamationTriangle} color={'yellow'} />
+          {t(
+            'settings.offline.warning',
+            'This game does not explicitly allow offline mode, turn this on at your own risk. The game may not work.'
+          )}
+        </div>
+      )}
+    </>
   )
 }
 

--- a/src/frontend/screens/Settings/components/OfflineMode.tsx
+++ b/src/frontend/screens/Settings/components/OfflineMode.tsx
@@ -28,7 +28,7 @@ const OfflineMode = () => {
 
   const [offlineMode, setOfflineMode] = useSetting('offlineMode', false)
 
-  if (isDefault) {
+  if (isDefault || runner !== 'legendary') {
     return <></>
   }
 


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3383

Some games seem to not have the `CanRunOffline` metadata but still work fine in offline mode. This PR allows users to toggle that on so they can still try to run the game.

When the option is turned on and the game does not allow offline mode, this warning is displayed:

![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/d8d2b36b-8336-4fcb-9903-81c9a6c47630)

This will also solve a problem that users sometimes can't find the option and they ask over Discord. Now the option will be always there. In some cases it may not work but we have the warning to let users know it's not heroic's fault but the game not supporting offline mode.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
