### PR TITLE
[UX] Fix position of dialog header

### DIFF
--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -37,6 +37,8 @@
 
 .Dialog__header {
   display: flex;
+  z-index: 1;
+  padding-bottom: var(--dialog-gap);
 }
 
 .Dialog__headerTitle {
@@ -49,6 +51,14 @@
 
 .Dialog__Close {
   padding: 0 var(--dialog-margin-horizontal) 0 0;
+  z-index: 2;
+}
+
+.Dialog__Close,
+.Dialog__header {
+  position: sticky;
+  top: 0px;
+  background: var(--modal-background);
 }
 
 .Dialog__CloseButton {
@@ -83,7 +93,7 @@
 }
 
 .Dialog__content {
-  padding: var(--dialog-gap) var(--dialog-margin-horizontal);
+  padding: 0 var(--dialog-margin-horizontal) var(--dialog-gap);
 }
 
 .Dialog__footer {

--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -24,6 +24,11 @@
     opacity 500ms,
     transform 500ms;
   max-width: min(700px, 85vw);
+  max-height: 95vh;
+
+  & img {
+    max-width: 100%;
+  }
 }
 .Dialog__element::backdrop {
   background: rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2609 by making all dialog headers static.

Also, now that we are not closing the dialogs when clicking outside (until we figure a solution for this https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3194) it was sometimes annoying to have to scroll up to close a dialog.

https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/a3f0cbd2-7f97-401d-b4ab-507c185f403a

This also fixes this issue with changelogs not having a height limit:

![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/d9a146e4-c93a-49c4-9157-b293a3e36a1e)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
