### PR TITLE
Fixes related to "Installing Prerequisites" status

### DIFF
--- a/src/backend/storeManagers/gog/setup.ts
+++ b/src/backend/storeManagers/gog/setup.ts
@@ -9,12 +9,7 @@ import {
 import { copySync } from 'fs-extra'
 import path from 'node:path'
 import { GameInfo, InstalledInfo } from 'common/types'
-import {
-  checkWineBeforeLaunch,
-  getShellPath,
-  sendGameStatusUpdate,
-  spawnAsync
-} from '../../utils'
+import { checkWineBeforeLaunch, getShellPath, spawnAsync } from '../../utils'
 import { GameConfig } from '../../game_config'
 import { logError, logInfo, LogPrefix, logWarning } from '../../logger/logger'
 import { isWindows } from '../../constants'
@@ -51,8 +46,6 @@ async function setup(
     'Running setup instructions, if you notice issues with launching a game, please report it on our Discord server',
     LogPrefix.Gog
   )
-
-  sendGameStatusUpdate({ appName, runner: 'gog', status: 'prerequisites' })
 
   const gameSettings = GameConfig.get(appName).config
   if (!isWindows) {

--- a/src/backend/storeManagers/nile/setup.ts
+++ b/src/backend/storeManagers/nile/setup.ts
@@ -58,7 +58,6 @@ export default async function setup(
     'Running setup instructions, if you notice issues with launching a game, please report it on our Discord server',
     LogPrefix.Nile
   )
-  sendGameStatusUpdate({ appName, runner: 'nile', status: 'prerequisites' })
 
   const gameSettings = GameConfig.get(appName).config
   if (!isWindows) {
@@ -76,6 +75,9 @@ export default async function setup(
   }
 
   logDebug(['PostInstall:', fuel.PostInstall], LogPrefix.Nile)
+
+  sendGameStatusUpdate({ appName, runner: 'nile', status: 'prerequisites' })
+
   // Actual setup logic
   for (const action of fuel.PostInstall) {
     const exeArguments = action.Args ?? []

--- a/src/backend/tools/ipc_handler.ts
+++ b/src/backend/tools/ipc_handler.ts
@@ -3,7 +3,7 @@ import { ipcMain } from 'electron'
 import { Winetricks, runWineCommandOnGame } from '.'
 import path from 'path'
 import { isWindows } from 'backend/constants'
-import { execAsync } from 'backend/utils'
+import { execAsync, sendGameStatusUpdate } from 'backend/utils'
 
 ipcMain.handle(
   'runWineCommandForGame',
@@ -48,6 +48,8 @@ ipcMain.handle('callTool', async (event, { tool, exe, appName, runner }) => {
       }
       break
   }
+
+  sendGameStatusUpdate({ appName, runner, status: 'done' })
 })
 
 ipcMain.on('winetricksInstall', async (event, { runner, appName, component }) =>


### PR DESCRIPTION
This fixes 2 issues:

- we were showing the `Installing Prerequisites` for GOG games but we don't really do that yet
- we were setting the `Installing Prerequisites` status when running an exe on the prefix but never resetting that state

I also moved the `Installing Prerequisites` status for the Amazon setup to be displayed after the prefix is verified instead of before, to happen right before the post install step.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
