### PR TITLE
[Logs] Add more info in game logs

### DIFF
--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -412,54 +412,48 @@ class LogWriter {
         const systemInfo = await formatSystemInfo(info)
 
         appendFileSync(this.filePath, `System Info:\n${systemInfo}\n\n`)
-
-        // log game settings
-        const gameSettings = await gameManagerMap[runner].getSettings(app_name)
-        const gameSettingsString = JSON.stringify(gameSettings, null, '\t')
-        const startPlayingDate = new Date()
-
-        appendFileSync(
-          this.filePath,
-          `Game Settings: ${gameSettingsString}\n\n`
-        )
-
-        // log if EOS overlay is enabled for Epic games
-        if (runner === 'legendary') {
-          const enabled = await isEnabled(app_name)
-
-          appendFileSync(
-            this.filePath,
-            `EOS Overlay enabled? ${enabled ? 'Yes' : 'No'}\n`
-          )
-        }
-
-        // log winetricks packages if not native
-        if (notNative) {
-          const winetricksPackages = await Winetricks.listInstalled(
-            runner,
-            app_name
-          )
-
-          appendFileSync(
-            this.filePath,
-            `Winetricks packages installed: ${
-              winetricksPackages?.join(', ') || 'None'
-            }\n\n`
-          )
-        }
-
-        appendFileSync(
-          this.filePath,
-          `Game launched at: ${startPlayingDate}\n\n`
-        )
-
-        this.initialized = true
       } catch (error) {
         logError(
           ['Failed to fetch system information', error],
           LogPrefix.Backend
         )
       }
+
+      // log game settings
+      const gameSettings = await gameManagerMap[runner].getSettings(app_name)
+      const gameSettingsString = JSON.stringify(gameSettings, null, '\t')
+      const startPlayingDate = new Date()
+
+      appendFileSync(this.filePath, `Game Settings: ${gameSettingsString}\n\n`)
+
+      // log if EOS overlay is enabled for Epic games
+      if (runner === 'legendary') {
+        const enabled = await isEnabled(app_name)
+
+        appendFileSync(
+          this.filePath,
+          `EOS Overlay enabled? ${enabled ? 'Yes' : 'No'}\n`
+        )
+      }
+
+      // log winetricks packages if not native
+      if (notNative) {
+        const winetricksPackages = await Winetricks.listInstalled(
+          runner,
+          app_name
+        )
+
+        appendFileSync(
+          this.filePath,
+          `Winetricks packages installed: ${
+            winetricksPackages?.join(', ') || 'None'
+          }\n\n`
+        )
+      }
+
+      appendFileSync(this.filePath, `Game launched at: ${startPlayingDate}\n\n`)
+
+      this.initialized = true
     } catch (error) {
       logError(
         [`Failed to initialize log ${this.filePath}:`, error],
@@ -503,5 +497,8 @@ export function initGameLog(gameInfo: GameInfo) {
 }
 
 export function stopLogger(appName: string) {
+  logsWriters[appName].logMessage(
+    '============= End of game logs ============='
+  )
   delete logsWriters[appName]
 }

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1029,20 +1029,11 @@ ipcMain.handle(
       powerDisplayId = powerSaveBlocker.start('prevent-display-sleep')
     }
 
-    initGameLog(appName)
-
-    const gameSettingsString = JSON.stringify(gameSettings, null, '\t')
-    appendGameLog(
-      appName,
-      `Game Settings: ${gameSettingsString}\n` +
-        '\n' +
-        `Game launched at: ${startPlayingDate}\n` +
-        '\n'
-    )
+    initGameLog(game)
 
     if (logsDisabled) {
       appendGameLog(
-        appName,
+        game,
         'IMPORTANT: Logs are disabled. Enable logs before reporting an issue.'
       )
     }
@@ -1051,10 +1042,7 @@ ipcMain.handle(
 
     // check if isNative, if not, check if wine is valid
     if (!isNative) {
-      const isWineOkToLaunch = await checkWineBeforeLaunch(
-        appName,
-        gameSettings
-      )
+      const isWineOkToLaunch = await checkWineBeforeLaunch(game, gameSettings)
 
       if (!isWineOkToLaunch) {
         logError(
@@ -1090,7 +1078,7 @@ ipcMain.handle(
       .catch((exception) => {
         logError(exception, LogPrefix.Backend)
         appendGameLog(
-          appName,
+          game,
           `An exception occurred when launching the game:\n${exception.stack}`
         )
 

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -439,7 +439,7 @@ export async function launch(
     steamRuntime
   } = await prepareLaunch(gameSettings, gameInfo, isNative(appName))
   if (!launchPrepSuccess) {
-    appendGameLog(appName, `Launch aborted: ${launchPrepFailReason}`)
+    appendGameLog(gameInfo, `Launch aborted: ${launchPrepFailReason}`)
     showDialogBoxModalAuto({
       title: t('box.error.launchAborted', 'Launch aborted'),
       message: launchPrepFailReason!,
@@ -477,7 +477,7 @@ export async function launch(
       envVars: wineEnvVars
     } = await prepareWineLaunch('gog', appName)
     if (!wineLaunchPrepSuccess) {
-      appendGameLog(appName, `Launch aborted: ${wineLaunchPrepFailReason}`)
+      appendGameLog(gameInfo, `Launch aborted: ${wineLaunchPrepFailReason}`)
       if (wineLaunchPrepFailReason) {
         showDialogBoxModalAuto({
           title: t('box.error.launchAborted', 'Launch aborted'),
@@ -523,7 +523,7 @@ export async function launch(
     commandEnv,
     join(...Object.values(getGOGdlBin()))
   )
-  appendGameLog(appName, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
+  appendGameLog(gameInfo, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
 
   sendGameStatusUpdate({ appName, runner: 'gog', status: 'playing' })
 
@@ -539,7 +539,7 @@ export async function launch(
     wrappers,
     logMessagePrefix: `Launching ${gameInfo.title}`,
     onOutput: (output: string) => {
-      if (!logsDisabled) appendGameLog(appName, output)
+      if (!logsDisabled) appendGameLog(gameInfo, output)
     }
   })
 

--- a/src/backend/storeManagers/gog/setup.ts
+++ b/src/backend/storeManagers/gog/setup.ts
@@ -56,7 +56,7 @@ async function setup(
 
   const gameSettings = GameConfig.get(appName).config
   if (!isWindows) {
-    const isWineOkToLaunch = await checkWineBeforeLaunch(appName, gameSettings)
+    const isWineOkToLaunch = await checkWineBeforeLaunch(gameInfo, gameSettings)
 
     if (!isWineOkToLaunch) {
       logError(

--- a/src/backend/storeManagers/legendary/eos_overlay/eos_overlay.ts
+++ b/src/backend/storeManagers/legendary/eos_overlay/eos_overlay.ts
@@ -14,9 +14,11 @@ import { Path } from '../commands/base'
 import { LegendaryCommand } from '../commands'
 import { sendGameStatusUpdate } from 'backend/utils'
 
-const currentVersionPath = join(legendaryConfigPath, 'overlay_version.json')
-const installedVersionPath = join(legendaryConfigPath, 'overlay_install.json')
-const defaultInstallPath = join(toolsPath, 'eos_overlay')
+const currentVersionPath = () =>
+  join(legendaryConfigPath, 'overlay_version.json')
+const installedVersionPath = () =>
+  join(legendaryConfigPath, 'overlay_install.json')
+const defaultInstallPath = () => join(toolsPath, 'eos_overlay')
 const eosOverlayAppName = '98bc04bc842e4906993fd6d6644ffb8d'
 
 function getStatus(): {
@@ -29,7 +31,7 @@ function getStatus(): {
   }
 
   const { version, install_path } = JSON.parse(
-    readFileSync(installedVersionPath, 'utf-8')
+    readFileSync(installedVersionPath(), 'utf-8')
   )
 
   if (install_path !== defaultInstallPath) {
@@ -43,13 +45,13 @@ function getStatus(): {
 }
 
 async function getLatestVersion(): Promise<string> {
-  if (!existsSync(currentVersionPath)) {
+  if (!existsSync(currentVersionPath())) {
     // HACK: `overlay_version.json` isn't created when the overlay isn't installed
     if (!isInstalled()) {
       return ''
     }
     await updateInfo()
-    if (!existsSync(currentVersionPath)) {
+    if (!existsSync(currentVersionPath())) {
       logError(
         'EOS Overlay information not found after manual update. User is probably not logged in anymore',
         LogPrefix.Legendary
@@ -58,7 +60,7 @@ async function getLatestVersion(): Promise<string> {
     }
   }
   const { buildVersion }: { buildVersion: string } = JSON.parse(
-    readFileSync(currentVersionPath, 'utf-8')
+    readFileSync(currentVersionPath(), 'utf-8')
   ).data
   return buildVersion
 }
@@ -242,7 +244,7 @@ async function disable(appName: string) {
 }
 
 function isInstalled() {
-  return existsSync(installedVersionPath)
+  return existsSync(installedVersionPath())
 }
 
 /**

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -774,7 +774,7 @@ export async function launch(
     offlineMode
   } = await prepareLaunch(gameSettings, gameInfo, isNative(appName))
   if (!launchPrepSuccess) {
-    appendGameLog(appName, `Launch aborted: ${launchPrepFailReason}`)
+    appendGameLog(gameInfo, `Launch aborted: ${launchPrepFailReason}`)
     showDialogBoxModalAuto({
       title: t('box.error.launchAborted', 'Launch aborted'),
       message: launchPrepFailReason!,
@@ -811,7 +811,7 @@ export async function launch(
       envVars: wineEnvVars
     } = await prepareWineLaunch('legendary', appName)
     if (!wineLaunchPrepSuccess) {
-      appendGameLog(appName, `Launch aborted: ${wineLaunchPrepFailReason}`)
+      appendGameLog(gameInfo, `Launch aborted: ${wineLaunchPrepFailReason}`)
       if (wineLaunchPrepFailReason) {
         showDialogBoxModalAuto({
           title: t('box.error.launchAborted', 'Launch aborted'),
@@ -864,7 +864,7 @@ export async function launch(
     commandEnv,
     join(...Object.values(getLegendaryBin()))
   )
-  appendGameLog(appName, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
+  appendGameLog(gameInfo, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
 
   sendGameStatusUpdate({ appName, runner: 'legendary', status: 'playing' })
 
@@ -880,7 +880,7 @@ export async function launch(
     wrappers: wrappers,
     logMessagePrefix: `Launching ${gameInfo.title}`,
     onOutput: (output) => {
-      if (!logsDisabled) appendGameLog(appName, output)
+      if (!logsDisabled) appendGameLog(gameInfo, output)
     }
   })
 

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -320,7 +320,7 @@ export async function launch(
   } = await prepareLaunch(gameSettings, gameInfo, isNative())
 
   if (!launchPrepSuccess) {
-    appendGameLog(appName, `Launch aborted: ${launchPrepFailReason}`)
+    appendGameLog(gameInfo, `Launch aborted: ${launchPrepFailReason}`)
     showDialogBoxModalAuto({
       title: t('box.error.launchAborted', 'Launch aborted'),
       message: launchPrepFailReason!,
@@ -358,7 +358,7 @@ export async function launch(
       envVars: wineEnvVars
     } = await prepareWineLaunch('nile', appName)
     if (!wineLaunchPrepSuccess) {
-      appendGameLog(appName, `Launch aborted: ${wineLaunchPrepFailReason}`)
+      appendGameLog(gameInfo, `Launch aborted: ${wineLaunchPrepFailReason}`)
       if (wineLaunchPrepFailReason) {
         showDialogBoxModalAuto({
           title: t('box.error.launchAborted', 'Launch aborted'),
@@ -404,7 +404,7 @@ export async function launch(
     commandEnv,
     join(...Object.values(getNileBin()))
   )
-  appendGameLog(appName, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
+  appendGameLog(gameInfo, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
 
   sendGameStatusUpdate({ appName, runner: 'nile', status: 'playing' })
 
@@ -420,7 +420,7 @@ export async function launch(
     wrappers,
     logMessagePrefix: `Launching ${gameInfo.title}`,
     onOutput(output) {
-      if (!logsDisabled) appendGameLog(appName, output)
+      if (!logsDisabled) appendGameLog(gameInfo, output)
     }
   })
 

--- a/src/backend/storeManagers/nile/setup.ts
+++ b/src/backend/storeManagers/nile/setup.ts
@@ -23,6 +23,11 @@ export default async function setup(
   installedPath?: string
 ): Promise<void> {
   const gameInfo = getGameInfo(appName)
+  if (!gameInfo) {
+    logError([`Could not find game info for ${appName}. Skipping setup`])
+    return
+  }
+
   const basePath = installedPath ?? gameInfo?.install.install_path
   if (!basePath) {
     logError([
@@ -62,7 +67,7 @@ export default async function setup(
 
   const gameSettings = GameConfig.get(appName).config
   if (!isWindows) {
-    const isWineOkToLaunch = await checkWineBeforeLaunch(appName, gameSettings)
+    const isWineOkToLaunch = await checkWineBeforeLaunch(gameInfo, gameSettings)
 
     if (!isWineOkToLaunch) {
       logError(

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -173,7 +173,7 @@ export async function launchGame(
     )
 
     if (!launchPrepSuccess) {
-      appendGameLog(appName, `Launch aborted: ${launchPrepFailReason}`)
+      appendGameLog(gameInfo, `Launch aborted: ${launchPrepFailReason}`)
       showDialogBoxModalAuto({
         title: i18next.t('box.error.launchAborted', 'Launch aborted'),
         message: launchPrepFailReason!,

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -898,7 +898,7 @@ export async function downloadDefaultWine() {
 }
 
 export async function checkWineBeforeLaunch(
-  appName: string,
+  gameInfo: GameInfo,
   gameSettings: GameSettings
 ): Promise<boolean> {
   const wineIsValid = await validWine(gameSettings.wineVersion)
@@ -913,7 +913,7 @@ export async function checkWineBeforeLaunch(
       )
 
       appendGameLog(
-        appName,
+        gameInfo,
         `Wine version ${gameSettings.wineVersion.name} is not valid, trying another one.`
       )
     }
@@ -930,7 +930,7 @@ export async function checkWineBeforeLaunch(
       if (response === 0) {
         logInfo(`Changing wine version to ${defaultwine.name}`)
         gameSettings.wineVersion = defaultwine
-        GameConfig.get(appName).setSetting('wineVersion', defaultwine)
+        GameConfig.get(gameInfo.app_name).setSetting('wineVersion', defaultwine)
         return true
       } else {
         logInfo('User canceled the launch', LogPrefix.Backend)
@@ -947,7 +947,10 @@ export async function checkWineBeforeLaunch(
         if (firstFoundWine) {
           logInfo(`Changing wine version to ${firstFoundWine.name}`)
           gameSettings.wineVersion = firstFoundWine
-          GameConfig.get(appName).setSetting('wineVersion', firstFoundWine)
+          GameConfig.get(gameInfo.app_name).setSetting(
+            'wineVersion',
+            firstFoundWine
+          )
           return true
         }
       }
@@ -961,7 +964,10 @@ export async function checkWineBeforeLaunch(
         if (response === 0) {
           logInfo(`Changing wine version to ${firstFoundWine.name}`)
           gameSettings.wineVersion = firstFoundWine
-          GameConfig.get(appName).setSetting('wineVersion', firstFoundWine)
+          GameConfig.get(gameInfo.app_name).setSetting(
+            'wineVersion',
+            firstFoundWine
+          )
           return true
         } else {
           logInfo('User canceled the launch', LogPrefix.Backend)

--- a/src/backend/utils/systeminfo/index.ts
+++ b/src/backend/utils/systeminfo/index.ts
@@ -127,7 +127,9 @@ ${info.GPUs.map(
 OS: ${info.OS.name} ${info.OS.version} (${info.OS.platform})
 
 The current system is${info.steamDeckInfo.isDeck ? '' : ' not'} a Steam Deck${
-    info.steamDeckInfo.isDeck ? ` (model: ${info.steamDeckInfo.model})` : ''
+    info.steamDeckInfo.isDeck
+      ? ` (model: ${info.steamDeckInfo.model}) in ${info.steamDeckInfo.mode} mode`
+      : ''
   }
 We are${info.isFlatpak ? '' : ' not'} running inside a Flatpak container
 

--- a/src/backend/utils/systeminfo/steamDeck.ts
+++ b/src/backend/utils/systeminfo/steamDeck.ts
@@ -1,8 +1,9 @@
 import type { CpuInfo } from 'os'
 import type { GPUInfo } from './index'
+import { isSteamDeckGameMode } from 'backend/constants'
 
 type SteamDeckInfo =
-  | { isDeck: true; model: string }
+  | { isDeck: true; model: string; mode: 'game' | 'desktop' }
   | { isDeck: false; model?: undefined }
 
 function getSteamDeckInfo(cpus: CpuInfo[], gpus: GPUInfo[]): SteamDeckInfo {
@@ -11,11 +12,12 @@ function getSteamDeckInfo(cpus: CpuInfo[], gpus: GPUInfo[]): SteamDeckInfo {
   const primaryGpu = gpus.at(0)
   if (!primaryGpu || primaryGpu.vendorId !== '1002') return { isDeck: false }
 
+  const mode = isSteamDeckGameMode ? 'game' : 'desktop'
   switch (primaryGpu.deviceId) {
     case '163f':
-      return { isDeck: true, model: 'LCD' }
+      return { isDeck: true, model: 'LCD', mode }
     case '1435':
-      return { isDeck: true, model: 'OLED' }
+      return { isDeck: true, model: 'OLED', mode }
     default:
       return { isDeck: false }
   }


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3187, and fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3186 and fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3104

This PR adds more information in the logs to make them more useful when users share them over Discord.

New info:
- Name of the game/app
- Runner
- If it's native or not
- Install dir
- If the game is running in Desktop or Game mode (only on a Steamdeck)
- If the EOS overlay is enabled or not (for epic games only)
- If there are winetricks packages installed (for non-native games)
- Also added a `===== End of game logs =====` line at the end so we know users didn't cut log when sharing

I also included a few extra changes that I needed:
- I need the gameInfo in the log functions, so I had to update some code to handle game info instead of just app name
- Nile setup function was running even with undefined GameInfo
- I had to do a small refactor of the eos_overlay import because it was going in an import error
- Moved the log of the setting inside the initLog function to do that also async

The log now looks like this:

```
Launching "A Short Hike" (legendary)
Native? No
Installed in: /home/ariel/Games/Heroic/AShortHike

System Info:
CPU: 16x AMD Ryzen 7 3700X 8-Core Processor
Memory: 16.63 GB (used: 8.66 GB)
GPUs:
  GPU 0:
    Name: Advanced Micro Devices, Inc. [AMD/ATI] RX 5700 XT RAW II
    IDs: D=731f V=1002 SD=5701 SV=1682
    Driver: amdgpu
OS: Linux Mint 21.2 (Victoria) (linux)

The current system is not a Steam Deck
We are not running inside a Flatpak container

Software Versions:
  Heroic: 2.11.0 Kumachi
  Legendary: 0.20.34 Direct Intervention
  gogdl: 0.7.3
  Nile: 1.0.0 Jonathan Joestar

Game Settings: {
	"autoInstallDxvk": true,
	"autoInstallVkd3d": true,
	"preferSystemLibs": false,
	"enableEsync": true,
	"enableFsync": true,
	"nvidiaPrime": false,
	"enviromentOptions": [],
	"wrapperOptions": [],
	"showFps": false,
	"showMangohud": false,
	"useGameMode": false,
	"language": "",
	"wineVersion": {
		"bin": "/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/bin/wine",
		"name": "Wine - Wine-GE-Proton8-25",
		"type": "wine",
		"lib": "/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib64",
		"lib32": "/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib",
		"wineserver": "/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/bin/wineserver"
	},
	"winePrefix": "/home/ariel/Games/Heroic/Prefixes/A Short Hike",
	"wineCrossoverBottle": ""
}

EOS Overlay enabled? No
Winetricks packages installed: physx

Game launched at: Fri Jan 05 2024 23:00:30 GMT-0300 (hora estándar de Argentina)

Launch Command: HEROIC_APP_NAME=d6407c9e6fd54cb492b8c6635480d792 HEROIC_APP_RUNNER=legendary HEROIC_APP_SOURCE=epic LD_PRELOAD= DOTNET_BUNDLE_EXTRACT_BASE_DIR= DOTNET_ROOT= WINEPREFIX="/home/ariel/Games/Heroic/Prefixes/A Short Hike" WINEDLLOVERRIDES=winemenubuilder.exe=d WINE_FULLSCREEN_FSR=0 WINEESYNC=1 WINEFSYNC=1 ORIG_LD_LIBRARY_PATH= LD_LIBRARY_PATH=/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib64:/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib GST_PLUGIN_SYSTEM_PATH_1_0=/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib64/gstreamer-1.0:/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib/gstreamer-1.0 WINEDLLPATH=/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib64/wine:/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib/wine /home/ariel/dev/oss/HeroicGamesLauncher/public/bin/linux/legendary launch d6407c9e6fd54cb492b8c6635480d792 --wine /home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/bin/wine --language en

Game Log:
...
```

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
