### PR TITLE
Remove fixes file when a game is uninstalled

### DIFF
--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -13,6 +13,7 @@ import { fixesPath } from 'backend/constants'
 import path from 'path'
 import { existsSync, mkdirSync } from 'graceful-fs'
 import { platform } from 'os'
+import { storeMap } from 'common/utils'
 
 async function installQueueElement(params: InstallParams): Promise<{
   status: DMStatus
@@ -169,15 +170,9 @@ async function updateQueueElement(params: InstallParams): Promise<{
   }
 }
 
-const runnerToStore = {
-  legendary: 'epic',
-  gog: 'gog',
-  nile: 'amazon'
-}
-
 async function downloadFixesFor(appName: string, runner: Runner) {
-  const url = `https://raw.githubusercontent.com/Heroic-Games-Launcher/known-fixes/main/${appName}-${runnerToStore[runner]}.json`
-  const dest = path.join(fixesPath, `${appName}-${runnerToStore[runner]}.json`)
+  const url = `https://raw.githubusercontent.com/Heroic-Games-Launcher/known-fixes/main/${appName}-${storeMap[runner]}.json`
+  const dest = path.join(fixesPath, `${appName}-${storeMap[runner]}.json`)
   if (!existsSync(fixesPath)) {
     mkdirSync(fixesPath, { recursive: true })
   }

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -73,6 +73,7 @@ import {
   deleteAbortController
 } from './utils/aborthandler/aborthandler'
 import { download, isInstalled } from './wine/runtimes/runtimes'
+import { storeMap } from 'common/utils'
 
 async function prepareLaunch(
   gameSettings: GameSettings,
@@ -389,14 +390,8 @@ async function prepareWineLaunch(
   return { success: true, envVars: envVars }
 }
 
-const runnerToStore = {
-  legendary: 'epic',
-  gog: 'gog',
-  nile: 'amazon'
-}
-
 async function installFixes(appName: string, runner: Runner) {
-  const fixPath = join(fixesPath, `${appName}-${runnerToStore[runner]}.json`)
+  const fixPath = join(fixesPath, `${appName}-${storeMap[runner]}.json`)
 
   if (!existsSync(fixPath)) return
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -93,7 +93,8 @@ import {
   customThemesWikiLink,
   createNecessaryFolders,
   fixAsarPath,
-  isSnap
+  isSnap,
+  fixesPath
 } from './constants'
 import { handleProtocol } from './protocol'
 import {
@@ -151,6 +152,7 @@ import {
   getGameSdl
 } from 'backend/storeManagers/legendary/library'
 import { formatSystemInfo, getSystemInfo } from './utils/systeminfo'
+import { storeMap } from 'common/utils'
 
 app.commandLine?.appendSwitch('ozone-platform-hint', 'auto')
 
@@ -1237,6 +1239,14 @@ ipcMain.handle(
         removeIfExists(appName.concat('.json'))
         removeIfExists(appName.concat('.log'))
         removeIfExists(appName.concat('-lastPlay.log'))
+      }
+
+      const fixFilePath = path.join(
+        fixesPath,
+        `${appName}-${storeMap[runner]}.json`
+      )
+      if (existsSync(fixFilePath)) {
+        rmSync(fixFilePath)
       }
 
       notify({ title, body: i18next.t('notify.uninstalled') })

--- a/src/backend/wiki_game_info/gamesdb/utils.ts
+++ b/src/backend/wiki_game_info/gamesdb/utils.ts
@@ -2,6 +2,7 @@ import { GamesDBInfo, Runner } from 'common/types'
 import { logInfo, LogPrefix } from 'backend/logger/logger'
 import { GamesDBData } from 'common/types/gog'
 import { getGamesdbData } from 'backend/storeManagers/gog/library'
+import { storeMap } from 'common/utils'
 
 export async function getInfoFromGamesDB(
   title: string,
@@ -10,12 +11,6 @@ export async function getInfoFromGamesDB(
 ): Promise<GamesDBInfo | null> {
   logInfo(`Getting GamesDB data for ${title}`, LogPrefix.ExtraGameInfo)
 
-  const storeMap: { [key in Runner]: string | undefined } = {
-    legendary: 'epic',
-    gog: 'gog',
-    nile: 'amazon',
-    sideload: undefined
-  }
   const storeName = storeMap[runner]
   if (!storeName) {
     return { steamID: '' }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,0 +1,8 @@
+import { Runner } from './types'
+
+export const storeMap: { [key in Runner]: string | undefined } = {
+  legendary: 'epic',
+  gog: 'gog',
+  nile: 'amazon',
+  sideload: undefined
+}


### PR DESCRIPTION
In https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/3335 we are adding the feature to install known winetricks fixes. That downloads the `fixes` file from the https://github.com/Heroic-Games-Launcher/known-fixes repo during the installation of a game.

The problem is that we have no way or removing the file once the winetricks fix is not needed anymore, so if a game is downloaded today and a fix is not needed anymore in 2 months, if I install the game it will still run the winetricks commands.

This PR changes that so when a game is uninstalled, if a fixes file exists it gets deleted. That way, if we install the game in a few months and the fix is not needed, it won't be in the `known-fixes` repo and we don't download anything.

I did a small refactor cause I needed that map from runner to store and it was already defined in 3 other places

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
