### PR TITLE
[Fix] Prevent error if experimental features setting is undefined

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -347,7 +347,7 @@ async function prepareWineLaunch(
     }
     if (
       GlobalConfig.get().getSettings().experimentalFeatures
-        .automaticWinetricksFixes
+        ?.automaticWinetricksFixes
     ) {
       await installFixes(appName, runner)
     }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -91,7 +91,7 @@ export interface AppSettings extends GameSettings {
   egsLinkedPath: string
   enableUpdates: boolean
   exitToTray: boolean
-  experimentalFeatures: ExperimentalFeatures
+  experimentalFeatures?: ExperimentalFeatures
   framelessWindow: boolean
   hideChangelogsOnStartup: boolean
   libraryTopSection: LibraryTopSectionOptions


### PR DESCRIPTION
There can be scenarios where the experimental features setting is undefined (when upgrading Heroic from versions that didn't have this setting for example), an can cause this error:

```
(01:07:10) ERROR:   [Backend]:          TypeError: Cannot read properties of undefined (reading 'automaticWinetricksFixes')
    at prepareWineLaunch (/home/mathis/Heroic/Source2/build/electron/main.68379776.js:7616:62)
    at async Module.launch$1 [as launch] (/home/mathis/Heroic/Source2/build/electron/main.68379776.js:5069:9)
    at async /home/mathis/Heroic/Source2/build/electron/main.68379776.js:35138:26
    at async WebContents.<anonymous> (node:electron/js2c/browser_init:2:88992)
```

This PR prevents that.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
