### PR TITLE
[UX/Linux] Open main window when clicking the Tray icon

### DIFF
--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -30,6 +30,10 @@ export const initTrayIcon = async (mainWindow: BrowserWindow) => {
     mainWindow.show()
   })
 
+  appIcon.on('click', () => {
+    mainWindow.show()
+  })
+
   ipcMain.on('changeLanguage', async () => {
     await loadContextMenu()
   })

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -26,10 +26,6 @@ export const initTrayIcon = async (mainWindow: BrowserWindow) => {
   appIcon.setToolTip('Heroic')
 
   // event listeners
-  appIcon.on('double-click', () => {
-    mainWindow.show()
-  })
-
   appIcon.on('click', () => {
     mainWindow.show()
   })


### PR DESCRIPTION
We were using the `double-click` event but that only works on Mac and Windows, not on Linux https://www.electronjs.org/docs/latest/api/tray#event-double-click-macos-windows

This PR changes the code to use `click` instead which works on all platforms.

Other electron apps like discord or slack work like this too.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
