### PR TITLE
[UX] Add Accessibility option to disable closing dialogs when clicking outside

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3,6 +3,7 @@
         "actions_font_family_no_default": "Actions Font Family (Default: ",
         "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family_no_default": "Content Font Family (Default: ",
+        "disable_dialog_backdrop_close": "Disable closing dialogs by clicking outside",
         "fonts": "Fonts",
         "title": "Accessibility",
         "zoom": "Zoom"

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -34,6 +34,7 @@ export interface StoreStructure {
     contentFontFamily: string
     actionsFontFamily: string
     allTilesInColor: boolean
+    disableDialogBackdropClose: boolean
     language: string
     'general-logs': {
       currentLogFile: string

--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -29,7 +29,8 @@
   background: rgba(0, 0, 0, 0.4);
 }
 
-.Dialog__element:popover-open {
+.Dialog__element:popover-open,
+.Dialog__element[open] {
   opacity: 1;
   transform: translateY(0);
   box-shadow: 0px 0px 0px 100vmax var(--modal-backdrop);

--- a/src/frontend/screens/Accessibility/index.tsx
+++ b/src/frontend/screens/Accessibility/index.tsx
@@ -26,7 +26,9 @@ export default React.memo(function Accessibility() {
     allTilesInColor,
     setAllTilesInColor,
     setPrimaryFontFamily,
-    setSecondaryFontFamily
+    setSecondaryFontFamily,
+    disableDialogBackdropClose,
+    setDisableDialogBackdropClose
   } = useContext(ContextProvider)
 
   hasHelp(
@@ -188,6 +190,7 @@ export default React.memo(function Accessibility() {
         </SelectField>
 
         <ThemeSelector />
+
         <span className="setting">
           <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
             <ToggleSwitch
@@ -199,6 +202,22 @@ export default React.memo(function Accessibility() {
               title={t(
                 'accessibility.all_tiles_in_color',
                 'Show all game tiles in color'
+              )}
+            />
+          </label>
+        </span>
+
+        <span className="setting">
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <ToggleSwitch
+              htmlId="disableDialogBackdropClose"
+              value={disableDialogBackdropClose}
+              handleChange={() => {
+                setDisableDialogBackdropClose(!disableDialogBackdropClose)
+              }}
+              title={t(
+                'accessibility.disable_dialog_backdrop_close',
+                'Disable closing dialogs by clicking outside'
               )}
             />
           </label>

--- a/src/frontend/state/ContextProvider.tsx
+++ b/src/frontend/state/ContextProvider.tsx
@@ -96,7 +96,9 @@ const initialContext: ContextType = {
     enableHelp: false,
     automaticWinetricksFixes: false
   },
-  handleExperimentalFeatures: () => null
+  handleExperimentalFeatures: () => null,
+  disableDialogBackdropClose: false,
+  setDisableDialogBackdropClose: () => null
 }
 
 export default React.createContext(initialContext)

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -113,6 +113,7 @@ interface StateProps {
   }
   helpItems: { [key: string]: HelpItem }
   experimentalFeatures: ExperimentalFeatures
+  disableDialogBackdropClose: boolean
 }
 
 // function to load the new key or fallback to the old one
@@ -215,7 +216,11 @@ class GlobalState extends PureComponent<Props> {
       enableNewDesign: false,
       enableHelp: false,
       automaticWinetricksFixes: false
-    }
+    },
+    disableDialogBackdropClose: configStore.get(
+      'disableDialogBackdropClose',
+      false
+    )
   }
 
   setCurrentCustomCategories = (newCustomCategories: string[]) => {
@@ -267,6 +272,11 @@ class GlobalState extends PureComponent<Props> {
   setAllTilesInColor = (value: boolean) => {
     configStore.set('allTilesInColor', value)
     this.setState({ allTilesInColor: value })
+  }
+
+  setDisableDialogBackdropClose = (value: boolean) => {
+    configStore.set('disableDialogBackdropClose', value)
+    this.setState({ disableDialogBackdropClose: value })
   }
 
   setSideBarCollapsed = (value: boolean) => {
@@ -1013,7 +1023,8 @@ class GlobalState extends PureComponent<Props> {
             items: this.state.helpItems,
             addHelpItem: this.addHelpItem,
             removeHelpItem: this.removeHelpItem
-          }
+          },
+          setDisableDialogBackdropClose: this.setDisableDialogBackdropClose
         }}
       >
         {this.props.children}

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -117,6 +117,8 @@ export interface ContextType {
   }
   experimentalFeatures: ExperimentalFeatures
   handleExperimentalFeatures: (newSetting: ExperimentalFeatures) => void
+  disableDialogBackdropClose: boolean
+  setDisableDialogBackdropClose: (value: boolean) => void
 }
 
 export type DialogModalOptions = {


### PR DESCRIPTION
This PR adds an Accessibility option to let users decide if they want the dialogs to be closed or not when clicking outside.

Clicking outside of dialogs currently (not in main but in the stable release) closes dialogs without any confirmation by the user. This is problematic because clicking outside by mistake can mean information is lost.

Current main branch disables the click outside to close the dialog, but some users might want that to work (it's a common thing to do).

This PR gives the users the option to pick which behavior they want.

One thing I noticed is that disabling the click outside also disables closing dialogs with the `Esc` key, so I added a handled for that too.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
