### PR TITLE
Revert logging if the EOS overlay is enabled

### DIFF
--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -15,7 +15,6 @@ import { formatSystemInfo, getSystemInfo } from '../utils/systeminfo'
 import { appendFile, writeFile } from 'fs/promises'
 import { gamesConfigPath } from 'backend/constants'
 import { gameManagerMap } from 'backend/storeManagers'
-import { isEnabled } from 'backend/storeManagers/legendary/eos_overlay/eos_overlay'
 import { Winetricks } from 'backend/tools'
 import { platform } from 'os'
 
@@ -428,16 +427,6 @@ class LogWriter {
         this.filePath,
         `Game Settings: ${gameSettingsString}\n\n`
       )
-
-      // log if EOS overlay is enabled for Epic games
-      if (runner === 'legendary') {
-        const enabled = await isEnabled(app_name)
-
-        await appendFile(
-          this.filePath,
-          `EOS Overlay enabled? ${enabled ? 'Yes' : 'No'}\n`
-        )
-      }
 
       // log winetricks packages if not native
       if (notNative) {


### PR DESCRIPTION
In a previous PR I added a line to log if the EOS overlay is enabled or not: this https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/3394/files#diff-3b36a7de185377bbb618ac5e7bc20b0780c6ea78b5d5ac53c7b9a7469448a988R429-R437

This works fine when the prefix is already created but produces an error when the prefix is not ready yet. We have to log this information after making sure the prefix is initialized.

I'll revert this change for now since this other PR https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/3356 will enable the EOS overlay by default anyway

We can include this in the log in the future (I just don't want this to be a blocker or a problem for a release).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
