### PR TITLE
Revert printing winetricks packages in logs

### DIFF
--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -15,7 +15,6 @@ import { formatSystemInfo, getSystemInfo } from '../utils/systeminfo'
 import { appendFile, writeFile } from 'fs/promises'
 import { gamesConfigPath } from 'backend/constants'
 import { gameManagerMap } from 'backend/storeManagers'
-import { Winetricks } from 'backend/tools'
 import { platform } from 'os'
 
 export enum LogPrefix {
@@ -427,21 +426,6 @@ class LogWriter {
         this.filePath,
         `Game Settings: ${gameSettingsString}\n\n`
       )
-
-      // log winetricks packages if not native
-      if (notNative) {
-        const winetricksPackages = await Winetricks.listInstalled(
-          runner,
-          app_name
-        )
-
-        await appendFile(
-          this.filePath,
-          `Winetricks packages installed: ${
-            winetricksPackages?.join(', ') || 'None'
-          }\n\n`
-        )
-      }
 
       await appendFile(
         this.filePath,


### PR DESCRIPTION
Similar to https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/3404

With the new information in the logs, one of the lines was the list of winetricks packages installed. The problem is that, when the prefix is not yet created, this call to get the winetricks packages initializes the prefix at the wrong point of the process and all the setup code is skipped.

I'll revert this for now, in the future I'll make change some of this to add the logs only after the prefix is ready.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
