### PR TITLE
[UI] Fix extra scroll when UpdateComponent is displayed in the library

### DIFF
--- a/src/frontend/screens/Library/index.css
+++ b/src/frontend/screens/Library/index.css
@@ -86,3 +86,9 @@
 #backToTopBtn:hover {
   opacity: 1;
 }
+
+.listing {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3403

The content was not using the space correctly when the UpdateComponent was displayed while a top section was visible.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
