### PR TITLE
[UI/FIX] Fix context menu font

### DIFF
--- a/src/frontend/screens/Library/components/ContextMenu/index.css
+++ b/src/frontend/screens/Library/components/ContextMenu/index.css
@@ -6,6 +6,9 @@
   background: var(--navbar-background);
   color: var(--accent);
   border-radius: 10px;
+}
+
+.contextMenu > .MuiPaper-root > .MuiMenu-list > .MuiMenuItem-root {
   font-family: var(--primary-font-family);
 }
 


### PR DESCRIPTION
after (subtle difference):
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/45927311/3d1afce5-8f59-4476-b699-d315c7a76b51)

this has been triggering my OCD for like 6 months now, pls merge lol

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
