### PR TITLE
Only try to do EOS operations on a path if there's actually a Wineprefix there

### DIFF
--- a/src/backend/storeManagers/legendary/commands/base.ts
+++ b/src/backend/storeManagers/legendary/commands/base.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import path from 'path'
 import { hasGame } from '../library'
+import { existsSync } from 'graceful-fs'
 
 export const LegendaryAppName = z
   .string()
@@ -35,3 +36,8 @@ export type URL = z.infer<typeof URL>
 // FIXME: This doesn't feel right
 export const URI = z.union([Path, URL])
 export type URI = z.infer<typeof URI>
+
+export const ValidWinePrefix = Path.refine((potPath) =>
+  existsSync(path.join(potPath, 'user.reg'))
+).brand('ValidWinePrefix')
+export type ValidWinePrefix = z.infer<typeof ValidWinePrefix>

--- a/src/backend/storeManagers/legendary/commands/eos_overlay.ts
+++ b/src/backend/storeManagers/legendary/commands/eos_overlay.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { LegendaryAppName, NonEmptyString, Path } from './base'
+import { LegendaryAppName, NonEmptyString, Path, ValidWinePrefix } from './base'
 
 const EosOverlayAction = z.enum([
   'install',
@@ -15,7 +15,7 @@ interface EosOverlayCommand {
   subcommand: 'eos-overlay'
   action: EosOverlayAction
   '--path'?: Path
-  '--prefix'?: Path
+  '--prefix'?: ValidWinePrefix
   '--app'?: LegendaryAppName
   '--bottle'?: NonEmptyString
 }

--- a/src/backend/storeManagers/legendary/eos_overlay/eos_overlay.ts
+++ b/src/backend/storeManagers/legendary/eos_overlay/eos_overlay.ts
@@ -1,18 +1,19 @@
-import { gameManagerMap } from '../../index'
-import { callAbortController } from '../../../utils/aborthandler/aborthandler'
 import { dialog } from 'electron'
 import { existsSync, readFileSync } from 'graceful-fs'
 import { t } from 'i18next'
 import { join } from 'path'
 
-import { toolsPath, isLinux, legendaryConfigPath } from '../../../constants'
-import { logError, LogPrefix, logWarning } from '../../../logger/logger'
-import { runRunnerCommand as runLegendaryCommand } from '../library'
-import { verifyWinePrefix } from '../../../launcher'
-import { setCurrentDownloadSize } from '../games'
-import { Path } from '../commands/base'
-import { LegendaryCommand } from '../commands'
+import { toolsPath, isLinux, legendaryConfigPath } from 'backend/constants'
+import { logError, LogPrefix, logWarning } from 'backend/logger/logger'
+import { callAbortController } from 'backend/utils/aborthandler/aborthandler'
 import { sendGameStatusUpdate } from 'backend/utils'
+import { gameManagerMap } from '../..'
+import { LegendaryCommand } from '../commands'
+import { Path, ValidWinePrefix } from '../commands/base'
+import { setCurrentDownloadSize } from '../games'
+import { runRunnerCommand as runLegendaryCommand } from '../library'
+
+import type { Runner } from 'common/types'
 
 const currentVersionPath = join(legendaryConfigPath, 'overlay_version.json')
 const installedVersionPath = join(legendaryConfigPath, 'overlay_install.json')
@@ -185,14 +186,6 @@ async function remove(): Promise<boolean> {
 async function enable(
   appName: string
 ): Promise<{ wasEnabled: boolean; installNow?: boolean }> {
-  let prefix = ''
-  if (isLinux) {
-    const gameSettings = await gameManagerMap['legendary'].getSettings(appName)
-    await verifyWinePrefix(gameSettings)
-    const { winePrefix, wineVersion } = gameSettings
-    prefix =
-      wineVersion.type === 'proton' ? join(winePrefix, 'pfx') : winePrefix
-  }
   if (!isInstalled()) {
     const { response } = await dialog.showMessageBox({
       title: t('setting.eosOverlay.notInstalledTitle', 'Overlay not installed'),
@@ -206,11 +199,16 @@ async function enable(
     return { wasEnabled: false, installNow: response === 0 }
   }
 
+  const prefix = await getWinePrefixFolder(appName)
+  // Can't install the overlay if we don't have a valid prefix
+  // FIXME: Notify the user about this
+  if (prefix === false) return { wasEnabled: false }
+
   const command: LegendaryCommand = {
     subcommand: 'eos-overlay',
     action: 'enable'
   }
-  if (prefix) command['--prefix'] = Path.parse(prefix)
+  if (prefix) command['--prefix'] = prefix
 
   await runLegendaryCommand(command, {
     abortId: eosOverlayAppName,
@@ -221,19 +219,15 @@ async function enable(
 }
 
 async function disable(appName: string) {
-  let prefix = ''
-  if (isLinux) {
-    const { winePrefix, wineVersion } =
-      await gameManagerMap['legendary'].getSettings(appName)
-    prefix =
-      wineVersion.type === 'proton' ? join(winePrefix, 'pfx') : winePrefix
-  }
+  const prefix = await getWinePrefixFolder(appName)
+  // If we don't have a valid prefix anymore, we have nothing to disable
+  if (prefix === false) return
 
   const command: LegendaryCommand = {
     subcommand: 'eos-overlay',
     action: 'disable'
   }
-  if (prefix) command['--prefix'] = Path.parse(prefix)
+  if (prefix) command['--prefix'] = prefix
 
   await runLegendaryCommand(command, {
     abortId: eosOverlayAppName,
@@ -250,22 +244,17 @@ function isInstalled() {
  * @param appName required on Linux, does nothing on Windows
  * @returns Enabled = True; Disabled = False
  */
-async function isEnabled(appName?: string) {
+async function isEnabled(appName?: string): Promise<boolean> {
   let enabled = false
 
-  let prefix = ''
-  if (isLinux && appName) {
-    const { winePrefix, wineVersion } =
-      await gameManagerMap['legendary'].getSettings(appName)
-    prefix =
-      wineVersion.type === 'proton' ? join(winePrefix, 'pfx') : winePrefix
-  }
+  const prefix = await getWinePrefixFolder(appName)
+  if (prefix === false) return false
 
   const command: LegendaryCommand = {
     subcommand: 'eos-overlay',
     action: 'info'
   }
-  if (prefix) command['--prefix'] = Path.parse(prefix)
+  if (prefix) command['--prefix'] = prefix
 
   await runLegendaryCommand(command, {
     abortId: eosOverlayAppName,
@@ -278,6 +267,26 @@ async function isEnabled(appName?: string) {
     logMessagePrefix: 'Checking if EOS Overlay is enabled'
   })
   return enabled
+}
+
+/**
+ * Returns the path to the "real" Wineprefix folder (where "drive_c" and "user.reg" is) for a game
+ * @returns null if a prefix can't be returned (we're not on Linux / don't have an AppName)
+ * @returns false if parsing the prefix path failed (in other words there is a prefix path set, but it doesn't contain a valid prefix)
+ * @returns ValidWinePrefix (a folder that is verified to contain a Wineprefix) otherwise
+ */
+async function getWinePrefixFolder(
+  appName?: string,
+  runner: Runner = 'legendary'
+): Promise<ValidWinePrefix | null | false> {
+  if (!isLinux || !appName) return null
+
+  const { winePrefix, wineVersion } =
+    await gameManagerMap[runner].getSettings(appName)
+  const prefixPath =
+    wineVersion.type === 'proton' ? join(winePrefix, 'pfx') : winePrefix
+  const maybePrefix = ValidWinePrefix.safeParse(prefixPath)
+  return maybePrefix.success ? maybePrefix.data : false
 }
 
 export {


### PR DESCRIPTION
Previously, trying to enable/disable/check the status of the EOS overlay for a game with an invalid prefix directory would lead to an error message.
We're now handling this correctly (not enabling/disabling it, always reporting that it's disabled)

Technically, this works by adding:
- a new type, `ValidWinePrefix`. It's an extension of the `Path` type, meaning it already makes sure the string inside it is a valid path, and it now also verifies that there's a `user.reg` file inside the directory it's pointing to
- a new function inside the EOS handler, `getWinePrefixFolder`. It deduplicates some of the logic used in the `enable`/`disable`/`isEnabled`, and now also makes sure the configured prefix path is contains a valid prefix

Error message before:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/34034631/5aef8122-fb57-4b40-920e-89dd19b51295)

No error message now:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/34034631/5c58e022-2bdf-446b-b1d6-67b4c37ae844)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
