### PR TITLE
backend: log download progress with fixed precision numbers

### DIFF
--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -247,8 +247,8 @@ export function onInstallOrUpdateOutput(
     logInfo(
       [
         `Progress for ${getGameInfo(appName).title}:`,
-        `${progress.percent}%/${progress.bytes}/${progress.eta}`.trim(),
-        `Down: ${progress.downSpeed}MB/s / Disk: ${progress.diskSpeed}MB/s`
+        `${progress.percent?.toFixed(2)}%/${progress.bytes}/${progress.eta}`.trim(),
+        `Down: ${progress.downSpeed?.toFixed(2)}MB/s / Disk: ${progress.diskSpeed?.toFixed(1)}MB/s`
       ],
       LogPrefix.Gog
     )

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -462,8 +462,8 @@ export function onInstallOrUpdateOutput(
     logInfo(
       [
         `Progress for ${getGameInfo(appName).title}:`,
-        `${progress.percent}%/${progress.bytes}/${progress.eta}`.trim(),
-        `Down: ${progress.downSpeed}MB/s / Disk: ${progress.diskSpeed}MB/s`
+        `${progress.percent?.toFixed(2)}%/${progress.bytes}/${progress.eta}`.trim(),
+        `Down: ${progress.downSpeed?.toFixed(2)}MB/s / Disk: ${progress.diskSpeed?.toFixed(1)}MB/s`
       ],
       LogPrefix.Legendary
     )

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -219,8 +219,8 @@ export function onInstallOrUpdateOutput(
     logInfo(
       [
         `Progress for ${getGameInfo(appName).title}:`,
-        `${progress.percent}%/${progress.bytes}/${progress.eta}`.trim(),
-        `Down: ${progress.downSpeed}MB/s / Disk: ${progress.diskSpeed}MB/s`
+        `${progress.percent?.toFixed(2)}%/${progress.bytes}/${progress.eta}`.trim(),
+        `Down: ${progress.downSpeed?.toFixed(2)}MB/s / Disk: ${progress.diskSpeed?.toFixed(1)}MB/s`
       ],
       LogPrefix.Nile
     )


### PR DESCRIPTION
This will greatly reduce the amount of jumping columns due to numbers pretty printing the fractional part and dropping ".000"

Ideally one would use i18n locale-aware format with [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat), there it seems possible to match the width+precision parameters from printf in C.

I based the code on [this example](https://www.mycompiler.io/view/IvoKOzCukUz):

```js
let arr = [0.0, 1.123, 5.1234, 6.1236, 10.123, 50.750, 60.1, 99.99, 100]
for (const num of arr) {
    process.stdout.write(`Number is: ${num?.toFixed(3)}\n`);
}

process.stdout.write(`Number is: ${undefined?.toFixed(3)}\n`);
```

```
Number is: 0.000
Number is: 1.123
Number is: 5.123
Number is: 6.124
Number is: 10.123
Number is: 50.750
Number is: 60.100
Number is: 99.990
Number is: 100.000
Number is: undefined
```

So if for example previously it [looked like this](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3353):

```
[Legendary]:        Progress for Fall Guys: 69.89%/524.34MB/00:34:00 Down: 0MB/s / Disk: 0MB/s
[Legendary]:        Progress for Fall Guys: 69.91%/525.32MB/00:34:00 Down: 0.97MB/s / Disk: 1MB/s
[Legendary]:        Progress for Fall Guys: 69.91%/525.32MB/00:34:03 Down: 0MB/s / Disk: 0MB/s
[Legendary]:        Progress for Fall Guys: 69.92%/526.28MB/00:34:04 Down: 0.96MB/s / Disk: 1MB/s
```

With the fixed precision:

```
[Legendary]:        Progress for Fall Guys: 69.89%/524.34MB/00:34:00 Down: 0.00MB/s / Disk: 0.0MB/s
[Legendary]:        Progress for Fall Guys: 69.91%/525.32MB/00:34:00 Down: 0.97MB/s / Disk: 1.0MB/s
[Legendary]:        Progress for Fall Guys: 69.91%/525.32MB/00:34:03 Down: 0.00MB/s / Disk: 0.0MB/s
[Legendary]:        Progress for Fall Guys: 69.92%/526.28MB/00:34:04 Down: 0.96MB/s / Disk: 1.0MB/s
```

If the integer part jumps from 9 to 10, it'll still get wider but it's still an improvement. I did not format progress.bytes because it's never parsed into integer/float above.

Finally there's a fair amount of duplicated code between gog/epic/nile games.ts. Someone with an idea of TS might want to take a look at.

---

Nothing tested, I don't have a working dev install either. This is only a proposal.

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
