### PR TITLE
[UX] Allow going back to a previous screen when no more webview history

### DIFF
--- a/src/frontend/components/UI/WebviewControls/index.tsx
+++ b/src/frontend/components/UI/WebviewControls/index.tsx
@@ -35,7 +35,7 @@ export default function WebviewControls({
 }: WebviewControlsProps) {
   const [url, setUrl] = React.useState(initURL)
   const { t } = useTranslation()
-  const [canGoBack, setCanGoBack] = useState(false)
+  const [webviewGoBack, setWebviewGoBack] = useState(false)
   const [canGoForward, setCanGoForward] = useState(false)
 
   useEffect(() => {
@@ -44,11 +44,11 @@ export default function WebviewControls({
       webview.addEventListener('did-navigate-in-page', eventCallback)
       webview.addEventListener('did-navigate', eventCallback)
       webview.addEventListener('did-navigate-in-page', () => {
-        setCanGoBack(webview.canGoBack())
+        setWebviewGoBack(webview.canGoBack())
         setCanGoForward(webview.canGoForward())
       })
       webview.addEventListener('did-navigate', () => {
-        setCanGoBack(webview.canGoBack())
+        setWebviewGoBack(webview.canGoBack())
         setCanGoForward(webview.canGoForward())
       })
       return () => {
@@ -66,7 +66,11 @@ export default function WebviewControls({
           return webview?.reload()
         }
         if (event === 'back') {
-          return webview?.goBack()
+          if (!webviewGoBack) {
+            return history.back()
+          } else {
+            return webview?.goBack()
+          }
         }
         if (event === 'forward') {
           return webview?.goForward()
@@ -85,7 +89,6 @@ export default function WebviewControls({
           className="WebviewControls__icon"
           title={t('webview.controls.back')}
           onClick={() => handleButtons('back')}
-          disabled={!canGoBack}
         >
           <ArrowBackOutlined />
         </SvgButton>

--- a/src/frontend/components/UI/WebviewControls/index.tsx
+++ b/src/frontend/components/UI/WebviewControls/index.tsx
@@ -66,10 +66,10 @@ export default function WebviewControls({
           return webview?.reload()
         }
         if (event === 'back') {
-          if (!webviewGoBack) {
-            return history.back()
-          } else {
+          if (webviewGoBack) {
             return webview?.goBack()
+          } else {
+            return history.back()
           }
         }
         if (event === 'forward') {


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3399

Now we can go back to whatever opened the webview, we can go back to the game page after clicking `Store page` in the game page.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
