### PR TITLE
[UI] Fix width of image in Add Game dialog

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.scss
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.scss
@@ -10,7 +10,7 @@
   .imageIcons {
     margin-block: var(--space-lg) 0;
     margin-inline: 0 var(--space-lg);
-    width: min-content;
+    width: auto;
   }
 
   .appImage {


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3423

Before:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/1b6ae385-3ac3-47fa-9b7b-0b5c464b3114)

After:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/e14d4f75-e08d-46e9-8b43-56122e1eaf0b)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
