### PR TITLE
[Tech/Demo] Migrate Wine Manager status state to Zustand

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "steam-shortcut-editor": "3.1.3",
     "tslib": "2.5.0",
     "xvfb-maybe": "^0.2.1",
-    "zod": "3.22.3"
+    "zod": "3.22.3",
+    "zustand": "^4.4.7"
   },
   "devDependencies": {
     "@electron/notarize": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 11.10.6(@types/react@18.2.34)(react@18.2.0)
       '@emotion/styled':
         specifier: 11.10.6
-        version: 11.10.6(@emotion/react@11.10.6)(@types/react@18.2.34)(react@18.2.0)
+        version: 11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0)
       '@felipecrs/decompress-tarxz':
         specifier: 4.0.0
         version: 4.0.0
@@ -43,10 +43,10 @@ importers:
         version: 0.2.0(@fortawesome/fontawesome-svg-core@6.3.0)(react@18.2.0)
       '@mui/icons-material':
         specifier: 5.11.11
-        version: 5.11.11(@mui/material@5.11.12)(@types/react@18.2.34)(react@18.2.0)
+        version: 5.11.11(@mui/material@5.11.12(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@emotion/styled@11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.34)(react@18.2.0)
       '@mui/material':
         specifier: 5.11.12
-        version: 5.11.12(@emotion/react@11.10.6)(@emotion/styled@11.10.6)(@types/react@18.2.34)(react-dom@18.2.0)(react@18.2.0)
+        version: 5.11.12(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@emotion/styled@11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@node-steam/vdf':
         specifier: 2.2.0
         version: 2.2.0
@@ -73,7 +73,7 @@ importers:
         version: 4.3.2
       discord-rich-presence-typescript:
         specifier: 0.0.8
-        version: 0.0.8
+        version: 0.0.8(encoding@0.1.13)
       easydl:
         specifier: 1.1.0
         version: 1.1.0
@@ -106,7 +106,7 @@ importers:
         version: 2.1.1
       i18next-http-backend:
         specifier: 2.1.1
-        version: 2.1.1
+        version: 2.1.1(encoding@0.1.13)
       ini:
         specifier: 3.0.0
         version: 3.0.0
@@ -121,22 +121,22 @@ importers:
         version: 18.2.0
       react-beautiful-dnd:
         specifier: ^13.1.1
-        version: 13.1.1(react-dom@18.2.0)(react@18.2.0)
+        version: 13.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       react-i18next:
         specifier: 12.2.0
-        version: 12.2.0(i18next@22.4.11)(react-dom@18.2.0)(react@18.2.0)
+        version: 12.2.0(i18next@22.4.11)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-markdown:
         specifier: 8.0.5
         version: 8.0.5(@types/react@18.2.34)(react@18.2.0)
       react-router-dom:
         specifier: 6.9.0
-        version: 6.9.0(react-dom@18.2.0)(react@18.2.0)
+        version: 6.9.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       recharts:
         specifier: 2.4.3
-        version: 2.4.3(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.4.3(prop-types@15.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       sanitize-filename:
         specifier: 1.6.3
         version: 1.6.3
@@ -167,6 +167,9 @@ importers:
       zod:
         specifier: 3.22.3
         version: 3.22.3
+      zustand:
+        specifier: ^4.4.7
+        version: 4.5.2(@types/react@18.2.34)(react@18.2.0)
     devDependencies:
       '@electron/notarize':
         specifier: ^2.3.0
@@ -182,7 +185,7 @@ importers:
         version: 5.16.4
       '@testing-library/react':
         specifier: 14.0.0
-        version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+        version: 14.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@testing-library/user-event':
         specifier: 14.1.1
         version: 14.1.1(@testing-library/dom@9.0.1)
@@ -230,13 +233,13 @@ importers:
         version: 0.2.3
       '@typescript-eslint/eslint-plugin':
         specifier: 5.47.1
-        version: 5.47.1(@typescript-eslint/parser@5.47.1)(eslint@8.36.0)(typescript@4.9.4)
+        version: 5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.36.0)(typescript@4.9.4))(eslint@8.36.0)(typescript@4.9.4)
       '@typescript-eslint/parser':
         specifier: 5.47.1
         version: 5.47.1(eslint@8.36.0)(typescript@4.9.4)
       '@vitejs/plugin-react-swc':
         specifier: 3.2.0
-        version: 3.2.0(vite@3.2.8)
+        version: 3.2.0(vite@3.2.8(@types/node@18.15.0)(sass@1.59.2))
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
@@ -245,7 +248,7 @@ importers:
         version: https://codeload.github.com/castlabs/electron-releases/tar.gz/11c396ff7aa05e8fd8049193b58684f119cc0b8d
       electron-builder:
         specifier: 24.13.3
-        version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
+        version: 24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       electron-devtools-installer:
         specifier: 3.2.0
         version: 3.2.0
@@ -257,7 +260,7 @@ importers:
         version: 8.7.0(eslint@8.36.0)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.47.1)(eslint@8.36.0)
+        version: 2.27.5(@typescript-eslint/parser@5.47.1(eslint@8.36.0)(typescript@4.9.4))(eslint@8.36.0)
       eslint-plugin-react:
         specifier: 7.31.11
         version: 7.31.11(eslint@8.36.0)
@@ -272,7 +275,7 @@ importers:
         version: 7.7.0
       jest:
         specifier: 29.5.0
-        version: 29.5.0(@types/node@18.15.0)
+        version: 29.5.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0)
       node-gyp:
         specifier: ^10.0.1
         version: 10.1.0
@@ -290,7 +293,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.24.3)(jest@29.5.0)(typescript@4.9.4)
+        version: 29.0.5(@babel/core@7.24.3)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.3))(jest@29.5.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0))(typescript@4.9.4)
       ts-prune:
         specifier: 0.10.3
         version: 0.10.3
@@ -314,7 +317,7 @@ importers:
         version: 0.10.2
       vite-plugin-svgr:
         specifier: 2.4.0
-        version: 2.4.0(vite@3.2.8)
+        version: 2.4.0(rollup@2.79.1)(vite@3.2.8(@types/node@18.15.0)(sass@1.59.2))
 
 packages:
 
@@ -2318,7 +2321,6 @@ packages:
 
   discord-rpc@https://codeload.github.com/discordjs/rpc/tar.gz/9e7de2a6d917591f10a66389e62e1dc053c04fec:
     resolution: {tarball: https://codeload.github.com/discordjs/rpc/tar.gz/9e7de2a6d917591f10a66389e62e1dc053c04fec}
-    name: discord-rpc
     version: 4.0.1
 
   dmg-builder@24.13.3:
@@ -2410,7 +2412,6 @@ packages:
 
   electron@https://codeload.github.com/castlabs/electron-releases/tar.gz/11c396ff7aa05e8fd8049193b58684f119cc0b8d:
     resolution: {tarball: https://codeload.github.com/castlabs/electron-releases/tar.gz/11c396ff7aa05e8fd8049193b58684f119cc0b8d}
-    name: electron
     version: 29.1.3
     engines: {node: '>= 12.20.55'}
     hasBin: true
@@ -4519,7 +4520,6 @@ packages:
 
   register-scheme@https://codeload.github.com/devsnek/node-register-scheme/tar.gz/e7cc9a63a1f512565da44cb57316d9fb10750e17:
     resolution: {tarball: https://codeload.github.com/devsnek/node-register-scheme/tar.gz/e7cc9a63a1f512565da44cb57316d9fb10750e17}
-    name: register-scheme
     version: 0.0.2
 
   remark-parse@10.0.2:
@@ -5235,6 +5235,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
+  use-sync-external-store@1.2.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
   utf8-byte-length@1.0.4:
     resolution: {integrity: sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==}
 
@@ -5459,6 +5464,21 @@ packages:
 
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
+
+  zustand@4.5.2:
+    resolution: {integrity: sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -5778,9 +5798,10 @@ snapshots:
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
       '@emotion/utils': 1.2.1
       '@emotion/weak-memoize': 0.3.1
-      '@types/react': 18.2.34
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.34
 
   '@emotion/serialize@1.1.3':
     dependencies:
@@ -5792,7 +5813,7 @@ snapshots:
 
   '@emotion/sheet@1.2.2': {}
 
-  '@emotion/styled@11.10.6(@emotion/react@11.10.6)(@types/react@18.2.34)(react@18.2.0)':
+  '@emotion/styled@11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.1
       '@emotion/babel-plugin': 11.11.0
@@ -5801,8 +5822,9 @@ snapshots:
       '@emotion/serialize': 1.1.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
       '@emotion/utils': 1.2.1
-      '@types/react': 18.2.34
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.34
 
   '@emotion/unitless@0.8.1': {}
 
@@ -5986,7 +6008,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -6000,7 +6022,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.15.0)
+      jest-config: 29.7.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -6177,40 +6199,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mui/base@5.0.0-alpha.119(@types/react@18.2.34)(react-dom@18.2.0)(react@18.2.0)':
+  '@mui/base@5.0.0-alpha.119(@types/react@18.2.34)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.1
       '@emotion/is-prop-valid': 1.2.2
       '@mui/types': 7.2.14(@types/react@18.2.34)
       '@mui/utils': 5.15.14(@types/react@18.2.34)(react@18.2.0)
       '@popperjs/core': 2.11.8
-      '@types/react': 18.2.34
       clsx: 1.2.1
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-is: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.34
 
   '@mui/core-downloads-tracker@5.15.14': {}
 
-  '@mui/icons-material@5.11.11(@mui/material@5.11.12)(@types/react@18.2.34)(react@18.2.0)':
+  '@mui/icons-material@5.11.11(@mui/material@5.11.12(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@emotion/styled@11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.34)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.1
-      '@mui/material': 5.11.12(@emotion/react@11.10.6)(@emotion/styled@11.10.6)(@types/react@18.2.34)(react-dom@18.2.0)(react@18.2.0)
-      '@types/react': 18.2.34
+      '@mui/material': 5.11.12(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@emotion/styled@11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.34
 
-  '@mui/material@5.11.12(@emotion/react@11.10.6)(@emotion/styled@11.10.6)(@types/react@18.2.34)(react-dom@18.2.0)(react@18.2.0)':
+  '@mui/material@5.11.12(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@emotion/styled@11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.1
-      '@emotion/react': 11.10.6(@types/react@18.2.34)(react@18.2.0)
-      '@emotion/styled': 11.10.6(@emotion/react@11.10.6)(@types/react@18.2.34)(react@18.2.0)
-      '@mui/base': 5.0.0-alpha.119(@types/react@18.2.34)(react-dom@18.2.0)(react@18.2.0)
+      '@mui/base': 5.0.0-alpha.119(@types/react@18.2.34)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/core-downloads-tracker': 5.15.14
-      '@mui/system': 5.15.14(@emotion/react@11.10.6)(@emotion/styled@11.10.6)(@types/react@18.2.34)(react@18.2.0)
+      '@mui/system': 5.15.14(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@emotion/styled@11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0)
       '@mui/types': 7.2.14(@types/react@18.2.34)
       '@mui/utils': 5.15.14(@types/react@18.2.34)(react@18.2.0)
-      '@types/react': 18.2.34
       '@types/react-transition-group': 4.4.10
       clsx: 1.2.1
       csstype: 3.1.3
@@ -6218,53 +6239,61 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-is: 18.2.0
-      react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
+      react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    optionalDependencies:
+      '@emotion/react': 11.10.6(@types/react@18.2.34)(react@18.2.0)
+      '@emotion/styled': 11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0)
+      '@types/react': 18.2.34
 
   '@mui/private-theming@5.15.14(@types/react@18.2.34)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.1
       '@mui/utils': 5.15.14(@types/react@18.2.34)(react@18.2.0)
-      '@types/react': 18.2.34
       prop-types: 15.8.1
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.34
 
-  '@mui/styled-engine@5.15.14(@emotion/react@11.10.6)(@emotion/styled@11.10.6)(react@18.2.0)':
+  '@mui/styled-engine@5.15.14(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@emotion/styled@11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.1
       '@emotion/cache': 11.11.0
-      '@emotion/react': 11.10.6(@types/react@18.2.34)(react@18.2.0)
-      '@emotion/styled': 11.10.6(@emotion/react@11.10.6)(@types/react@18.2.34)(react@18.2.0)
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.2.0
+    optionalDependencies:
+      '@emotion/react': 11.10.6(@types/react@18.2.34)(react@18.2.0)
+      '@emotion/styled': 11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0)
 
-  '@mui/system@5.15.14(@emotion/react@11.10.6)(@emotion/styled@11.10.6)(@types/react@18.2.34)(react@18.2.0)':
+  '@mui/system@5.15.14(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@emotion/styled@11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.1
-      '@emotion/react': 11.10.6(@types/react@18.2.34)(react@18.2.0)
-      '@emotion/styled': 11.10.6(@emotion/react@11.10.6)(@types/react@18.2.34)(react@18.2.0)
       '@mui/private-theming': 5.15.14(@types/react@18.2.34)(react@18.2.0)
-      '@mui/styled-engine': 5.15.14(@emotion/react@11.10.6)(@emotion/styled@11.10.6)(react@18.2.0)
+      '@mui/styled-engine': 5.15.14(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@emotion/styled@11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0))(react@18.2.0)
       '@mui/types': 7.2.14(@types/react@18.2.34)
       '@mui/utils': 5.15.14(@types/react@18.2.34)(react@18.2.0)
-      '@types/react': 18.2.34
       clsx: 2.1.0
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.2.0
+    optionalDependencies:
+      '@emotion/react': 11.10.6(@types/react@18.2.34)(react@18.2.0)
+      '@emotion/styled': 11.10.6(@emotion/react@11.10.6(@types/react@18.2.34)(react@18.2.0))(@types/react@18.2.34)(react@18.2.0)
+      '@types/react': 18.2.34
 
   '@mui/types@7.2.14(@types/react@18.2.34)':
-    dependencies:
+    optionalDependencies:
       '@types/react': 18.2.34
 
   '@mui/utils@5.15.14(@types/react@18.2.34)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.1
       '@types/prop-types': 15.7.12
-      '@types/react': 18.2.34
       prop-types: 15.8.1
       react: 18.2.0
       react-is: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.34
 
   '@node-steam/vdf@2.2.0': {}
 
@@ -6305,11 +6334,13 @@ snapshots:
 
   '@remix-run/router@1.4.0': {}
 
-  '@rollup/pluginutils@5.1.0':
+  '@rollup/pluginutils@5.1.0(rollup@2.79.1)':
     dependencies:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 2.79.1
 
   '@shockpkg/icon-encoder@2.1.3':
     dependencies:
@@ -6476,7 +6507,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react@14.0.0(react-dom@18.2.0)(react@18.2.0)':
+  '@testing-library/react@14.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.1
       '@testing-library/dom': 9.0.1
@@ -6717,7 +6748,7 @@ snapshots:
       '@types/node': 18.15.0
     optional: true
 
-  '@typescript-eslint/eslint-plugin@5.47.1(@typescript-eslint/parser@5.47.1)(eslint@8.36.0)(typescript@4.9.4)':
+  '@typescript-eslint/eslint-plugin@5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.36.0)(typescript@4.9.4))(eslint@8.36.0)(typescript@4.9.4)':
     dependencies:
       '@typescript-eslint/parser': 5.47.1(eslint@8.36.0)(typescript@4.9.4)
       '@typescript-eslint/scope-manager': 5.47.1
@@ -6730,6 +6761,7 @@ snapshots:
       regexpp: 3.2.0
       semver: 7.5.2
       tsutils: 3.21.0(typescript@4.9.4)
+    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -6741,6 +6773,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.47.1(typescript@4.9.4)
       debug: 4.3.4
       eslint: 8.36.0
+    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -6757,6 +6790,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.36.0
       tsutils: 3.21.0(typescript@4.9.4)
+    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -6774,6 +6808,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.5.2
       tsutils: 3.21.0(typescript@4.9.4)
+    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -6787,6 +6822,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.5.2
       tsutils: 3.21.0(typescript@4.9.4)
+    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -6816,7 +6852,7 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.3
 
-  '@vitejs/plugin-react-swc@3.2.0(vite@3.2.8)':
+  '@vitejs/plugin-react-swc@3.2.0(vite@3.2.8(@types/node@18.15.0)(sass@1.59.2))':
     dependencies:
       '@swc/core': 1.4.11
       vite: 3.2.8(@types/node@18.15.0)(sass@1.59.2)
@@ -6885,7 +6921,7 @@ snapshots:
       indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.12.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.12.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -6935,7 +6971,7 @@ snapshots:
 
   app-builder-bin@4.0.0: {}
 
-  app-builder-lib@24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3):
+  app-builder-lib@24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.2.1
@@ -6949,7 +6985,7 @@ snapshots:
       builder-util-runtime: 9.2.4
       chromium-pickle-js: 0.2.0
       debug: 4.3.4
-      dmg-builder: 24.13.3(electron-builder-squirrel-windows@24.13.3)
+      dmg-builder: 24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       ejs: 3.1.9
       electron-builder-squirrel-windows: 24.13.3(dmg-builder@24.13.3)
       electron-publish: 24.13.1
@@ -7560,13 +7596,13 @@ snapshots:
 
   crc@4.3.2: {}
 
-  create-jest@29.7.0(@types/node@18.15.0):
+  create-jest@29.7.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
-      jest-config: 29.7.0(@types/node@18.15.0)
+      jest-config: 29.7.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -7579,9 +7615,9 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.3
 
-  cross-fetch@3.1.5:
+  cross-fetch@3.1.5(encoding@0.1.13):
     dependencies:
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
@@ -7709,7 +7745,9 @@ snapshots:
       is-stream: 1.1.0
       tar-stream: 1.6.2
 
-  dedent@1.5.1: {}
+  dedent@1.5.1(babel-plugin-macros@3.1.0):
+    optionalDependencies:
+      babel-plugin-macros: 3.1.0
 
   deep-is@0.1.4: {}
 
@@ -7755,17 +7793,17 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  discord-rich-presence-typescript@0.0.8:
+  discord-rich-presence-typescript@0.0.8(encoding@0.1.13):
     dependencies:
-      discord-rpc: https://codeload.github.com/discordjs/rpc/tar.gz/9e7de2a6d917591f10a66389e62e1dc053c04fec
+      discord-rpc: https://codeload.github.com/discordjs/rpc/tar.gz/9e7de2a6d917591f10a66389e62e1dc053c04fec(encoding@0.1.13)
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - utf-8-validate
 
-  discord-rpc@https://codeload.github.com/discordjs/rpc/tar.gz/9e7de2a6d917591f10a66389e62e1dc053c04fec:
+  discord-rpc@https://codeload.github.com/discordjs/rpc/tar.gz/9e7de2a6d917591f10a66389e62e1dc053c04fec(encoding@0.1.13):
     dependencies:
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       ws: 7.5.9
     optionalDependencies:
       register-scheme: https://codeload.github.com/devsnek/node-register-scheme/tar.gz/e7cc9a63a1f512565da44cb57316d9fb10750e17
@@ -7774,9 +7812,9 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
+  dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       fs-extra: 10.1.0
@@ -7862,7 +7900,7 @@ snapshots:
 
   electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       archiver: 5.3.2
       builder-util: 24.13.1
       fs-extra: 10.1.0
@@ -7870,13 +7908,13 @@ snapshots:
       - dmg-builder
       - supports-color
 
-  electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
+  electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       chalk: 4.1.2
-      dmg-builder: 24.13.3(electron-builder-squirrel-windows@24.13.3)
+      dmg-builder: 24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       fs-extra: 10.1.0
       is-ci: 3.0.1
       lazy-val: 1.0.5
@@ -8171,18 +8209,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.47.1)(eslint-import-resolver-node@0.3.9)(eslint@8.36.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.47.1(eslint@8.36.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.9)(eslint@8.36.0):
     dependencies:
-      '@typescript-eslint/parser': 5.47.1(eslint@8.36.0)(typescript@4.9.4)
       debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.47.1(eslint@8.36.0)(typescript@4.9.4)
       eslint: 8.36.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.47.1)(eslint@8.36.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.47.1(eslint@8.36.0)(typescript@4.9.4))(eslint@8.36.0):
     dependencies:
-      '@typescript-eslint/parser': 5.47.1(eslint@8.36.0)(typescript@4.9.4)
       array-includes: 3.1.8
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
@@ -8190,7 +8228,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.36.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.47.1)(eslint-import-resolver-node@0.3.9)(eslint@8.36.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.47.1(eslint@8.36.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.9)(eslint@8.36.0)
       has: 1.0.4
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -8199,6 +8237,8 @@ snapshots:
       resolve: 1.22.8
       semver: 6.3.1
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.47.1(eslint@8.36.0)(typescript@4.9.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -8798,9 +8838,9 @@ snapshots:
 
   i18next-fs-backend@2.1.1: {}
 
-  i18next-http-backend@2.1.1:
+  i18next-http-backend@2.1.1(encoding@0.1.13):
     dependencies:
-      cross-fetch: 3.1.5
+      cross-fetch: 3.1.5(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
@@ -9101,7 +9141,7 @@ snapshots:
       jest-util: 29.7.0
       p-limit: 3.1.0
 
-  jest-circus@29.7.0:
+  jest-circus@29.7.0(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/expect': 29.7.0
@@ -9110,7 +9150,7 @@ snapshots:
       '@types/node': 18.15.0
       chalk: 4.1.2
       co: 4.6.0
-      dedent: 1.5.1
+      dedent: 1.5.1(babel-plugin-macros@3.1.0)
       is-generator-fn: 2.1.0
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0
@@ -9127,16 +9167,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@18.15.0):
+  jest-cli@29.7.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.15.0)
+      create-jest: 29.7.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.15.0)
+      jest-config: 29.7.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -9146,19 +9186,18 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@18.15.0):
+  jest-config@29.7.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0):
     dependencies:
       '@babel/core': 7.24.3
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.15.0
       babel-jest: 29.7.0(@babel/core@7.24.3)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.10
-      jest-circus: 29.7.0
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
@@ -9171,6 +9210,8 @@ snapshots:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 18.15.0
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9252,7 +9293,7 @@ snapshots:
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
-    dependencies:
+    optionalDependencies:
       jest-resolve: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -9390,12 +9431,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.5.0(@types/node@18.15.0):
+  jest@29.5.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.15.0)
+      jest-cli: 29.7.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9885,13 +9926,17 @@ snapshots:
 
   node-addon-api@3.2.1: {}
 
-  node-fetch@2.6.7:
+  node-fetch@2.6.7(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
-  node-fetch@2.7.0:
+  node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-gyp-build@4.8.0: {}
 
@@ -10230,7 +10275,7 @@ snapshots:
 
   raf-schd@4.0.3: {}
 
-  react-beautiful-dnd@13.1.1(react-dom@18.2.0)(react@18.2.0):
+  react-beautiful-dnd@13.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.1
       css-box-model: 1.2.1
@@ -10238,7 +10283,7 @@ snapshots:
       raf-schd: 4.0.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-redux: 7.2.9(react-dom@18.2.0)(react@18.2.0)
+      react-redux: 7.2.9(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       redux: 4.2.1
       use-memo-one: 1.1.3(react@18.2.0)
     transitivePeerDependencies:
@@ -10250,12 +10295,13 @@ snapshots:
       react: 18.2.0
       scheduler: 0.23.0
 
-  react-i18next@12.2.0(i18next@22.4.11)(react-dom@18.2.0)(react@18.2.0):
+  react-i18next@12.2.0(i18next@22.4.11)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.1
       html-parse-stringify: 3.0.1
       i18next: 22.4.11
       react: 18.2.0
+    optionalDependencies:
       react-dom: 18.2.0(react@18.2.0)
 
   react-is@16.13.1: {}
@@ -10288,7 +10334,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-redux@7.2.9(react-dom@18.2.0)(react@18.2.0):
+  react-redux@7.2.9(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.1
       '@types/react-redux': 7.1.33
@@ -10296,16 +10342,17 @@ snapshots:
       loose-envify: 1.4.0
       prop-types: 15.8.1
       react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
       react-is: 17.0.2
+    optionalDependencies:
+      react-dom: 18.2.0(react@18.2.0)
 
-  react-resize-detector@7.1.2(react-dom@18.2.0)(react@18.2.0):
+  react-resize-detector@7.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       lodash: 4.17.21
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  react-router-dom@6.9.0(react-dom@18.2.0)(react@18.2.0):
+  react-router-dom@6.9.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@remix-run/router': 1.4.0
       react: 18.2.0
@@ -10317,15 +10364,15 @@ snapshots:
       '@remix-run/router': 1.4.0
       react: 18.2.0
 
-  react-smooth@2.0.5(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0):
+  react-smooth@2.0.5(prop-types@15.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       fast-equals: 5.0.1
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-transition-group: 2.9.0(react-dom@18.2.0)(react@18.2.0)
+      react-transition-group: 2.9.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  react-transition-group@2.9.0(react-dom@18.2.0)(react@18.2.0):
+  react-transition-group@2.9.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       dom-helpers: 3.4.0
       loose-envify: 1.4.0
@@ -10334,7 +10381,7 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       react-lifecycles-compat: 3.0.4
 
-  react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):
+  react-transition-group@4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.1
       dom-helpers: 5.2.1
@@ -10401,7 +10448,7 @@ snapshots:
     dependencies:
       decimal.js-light: 2.5.1
 
-  recharts@2.4.3(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0):
+  recharts@2.4.3(prop-types@15.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       classnames: 2.3.1
       eventemitter3: 4.0.7
@@ -10410,8 +10457,8 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-is: 16.13.1
-      react-resize-detector: 7.1.2(react-dom@18.2.0)(react@18.2.0)
-      react-smooth: 2.0.5(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
+      react-resize-detector: 7.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-smooth: 2.0.5(prop-types@15.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       recharts-scale: 0.4.5
       reduce-css-calc: 2.1.8
       victory-vendor: 36.9.2
@@ -11027,12 +11074,11 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.4
 
-  ts-jest@29.0.5(@babel/core@7.24.3)(jest@29.5.0)(typescript@4.9.4):
+  ts-jest@29.0.5(@babel/core@7.24.3)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.3))(jest@29.5.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0))(typescript@4.9.4):
     dependencies:
-      '@babel/core': 7.24.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@18.15.0)
+      jest: 29.5.0(@types/node@18.15.0)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -11040,6 +11086,10 @@ snapshots:
       semver: 7.5.2
       typescript: 4.9.4
       yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.24.3
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.24.3)
 
   ts-morph@17.0.1:
     dependencies:
@@ -11252,6 +11302,10 @@ snapshots:
     dependencies:
       react: 18.2.0
 
+  use-sync-external-store@1.2.0(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+
   utf8-byte-length@1.0.4: {}
 
   util-deprecate@1.0.2: {}
@@ -11363,9 +11417,9 @@ snapshots:
 
   vite-plugin-electron@0.10.2: {}
 
-  vite-plugin-svgr@2.4.0(vite@3.2.8):
+  vite-plugin-svgr@2.4.0(rollup@2.79.1)(vite@3.2.8(@types/node@18.15.0)(sass@1.59.2)):
     dependencies:
-      '@rollup/pluginutils': 5.1.0
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       '@svgr/core': 6.5.1
       vite: 3.2.8(@types/node@18.15.0)(sass@1.59.2)
     transitivePeerDependencies:
@@ -11374,14 +11428,14 @@ snapshots:
 
   vite@3.2.8(@types/node@18.15.0)(sass@1.59.2):
     dependencies:
-      '@types/node': 18.15.0
       esbuild: 0.15.18
       postcss: 8.4.38
       resolve: 1.22.8
       rollup: 2.79.1
-      sass: 1.59.2
     optionalDependencies:
+      '@types/node': 18.15.0
       fsevents: 2.3.3
+      sass: 1.59.2
 
   vlq@0.2.3: {}
 
@@ -11524,3 +11578,10 @@ snapshots:
       readable-stream: 3.6.2
 
   zod@3.22.3: {}
+
+  zustand@4.5.2(@types/react@18.2.34)(react@18.2.0):
+    dependencies:
+      use-sync-external-store: 1.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.34
+      react: 18.2.0

--- a/src/backend/api/wine.ts
+++ b/src/backend/api/wine.ts
@@ -3,9 +3,8 @@ import {
   RuntimeName,
   ToolArgs,
   WineVersionInfo,
-  ProgressInfo,
-  State,
-  Runner
+  Runner,
+  type WineManagerStatus
 } from 'common/types'
 
 export const toggleDXVK = async (args: ToolArgs) =>
@@ -27,11 +26,10 @@ export const showItemInFolder = (installDir: string) =>
   ipcRenderer.send('showItemInFolder', installDir)
 export const installWineVersion = async (
   release: WineVersionInfo
-): Promise<'error' | 'abort' | 'success'> =>
-  ipcRenderer.invoke('installWineVersion', release)
+): Promise<void> => ipcRenderer.invoke('installWineVersion', release)
 export const removeWineVersion = async (
   release: WineVersionInfo
-): Promise<boolean> => ipcRenderer.invoke('removeWineVersion', release)
+): Promise<void> => ipcRenderer.invoke('removeWineVersion', release)
 export const refreshWineVersionInfo = async (fetch?: boolean): Promise<void> =>
   ipcRenderer.invoke('refreshWineVersionInfo', fetch)
 
@@ -48,18 +46,15 @@ export const handleProgressOfWinetricks = (
 }
 
 export const handleProgressOfWineManager = (
-  version: string,
   callback: (
     e: Electron.IpcRendererEvent,
-    progress: {
-      state: State
-      progress: ProgressInfo
-    }
+    version: string,
+    progress: WineManagerStatus
   ) => void
 ): (() => void) => {
-  ipcRenderer.on('progressOfWineManager' + version, callback)
+  ipcRenderer.on('progressOfWineManager', callback)
   return () => {
-    ipcRenderer.removeListener('progressOfWineManager' + version, callback)
+    ipcRenderer.removeListener('progressOfWineManager', callback)
   }
 }
 

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -7,8 +7,6 @@ import {
   Release,
   GameInfo,
   GameSettings,
-  State,
-  ProgressInfo,
   GameStatus
 } from 'common/types'
 import axios from 'axios'
@@ -89,6 +87,7 @@ import {
   deviceNameCache,
   vendorNameCache
 } from './utils/systeminfo/gpu/pci_ids'
+import type { WineManagerStatus } from 'common/types'
 
 const execAsync = promisify(exec)
 
@@ -898,11 +897,8 @@ export async function downloadDefaultWine() {
   }
 
   // download the latest version
-  const onProgress = (state: State, progress?: ProgressInfo) => {
-    sendFrontendMessage(`progressOfWineManager${release.version}`, {
-      state,
-      progress
-    })
+  const onProgress = (state: WineManagerStatus) => {
+    sendFrontendMessage('progressOfWineManager', release.version, state)
   }
   const result = await installWineVersion(release, onProgress)
 

--- a/src/backend/wine/manager/downloader/__tests__/utilities/unzip.test.ts
+++ b/src/backend/wine/manager/downloader/__tests__/utilities/unzip.test.ts
@@ -14,7 +14,6 @@ jest.mock('@xhmikosr/decompress-targz', () => {
 jest.mock('@felipecrs/decompress-tarxz', () => {
   return jest.fn().mockImplementation(() => {})
 })
-const workDir = process.cwd()
 
 describe('Utilities - Unzip', () => {
   test('unzip file fails because of invalid archive path', async () => {
@@ -36,9 +35,7 @@ describe('Utilities - Unzip', () => {
         unzipDir: __dirname,
         onProgress: progress
       })
-    ).rejects.toStrictEqual(
-      `Archive path ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities is not a file!`
-    )
+    ).rejects.toStrictEqual(`Archive path ${__dirname} is not a file!`)
   })
 
   test('unzip file fails because of invalid install path', async () => {
@@ -67,7 +64,7 @@ describe('Utilities - Unzip', () => {
         onProgress: progress
       })
     ).resolves.toStrictEqual(
-      `Succesfully unzip ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.xz to ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip.`
+      `Succesfully unzip ${__dirname}/../test_data/test.tar.xz to ${installDir}.`
     )
 
     if (existsSync(installDir)) {
@@ -90,7 +87,7 @@ describe('Utilities - Unzip', () => {
         onProgress: progress
       })
     ).resolves.toStrictEqual(
-      `Succesfully unzip ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.gz to ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip.`
+      `Succesfully unzip ${__dirname}/../test_data/test.tar.gz to ${installDir}.`
     )
 
     if (existsSync(installDir)) {
@@ -113,7 +110,7 @@ describe('Utilities - Unzip', () => {
         onProgress: progress
       })
     ).resolves.toStrictEqual(
-      `Succesfully unzip ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.gz to ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip.`
+      `Succesfully unzip ${__dirname}/../test_data/test.tar.gz to ${installDir}.`
     )
 
     await expect(
@@ -124,14 +121,14 @@ describe('Utilities - Unzip', () => {
         onProgress: progress
       })
     ).resolves.toStrictEqual(
-      `Succesfully unzip ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/../test_data/test.tar.gz to ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities/test_unzip.`
+      `Succesfully unzip ${__dirname}/../test_data/test.tar.gz to ${installDir}.`
     )
 
     if (existsSync(installDir)) {
       rmSync(installDir, { recursive: true })
     }
 
-    expect(progress).toBeCalledWith('unzipping')
-    expect(progress).toBeCalledWith('idle')
+    expect(progress).toBeCalledWith({ status: 'unzipping' })
+    expect(progress).toBeCalledWith({ status: 'idle' })
   })
 })

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -17,7 +17,7 @@ import {
   WINECROSSOVER_URL,
   WINESTAGINGMACOS_URL
 } from './constants'
-import { VersionInfo, Repositorys, State, ProgressInfo } from 'common/types'
+import { VersionInfo, Repositorys } from 'common/types'
 import {
   fetchReleases,
   getFolderSize,
@@ -25,6 +25,7 @@ import {
   unzipFile
 } from './utilities'
 import { axiosClient, calculateEta, downloadFile } from 'backend/utils'
+import type { WineManagerStatus } from 'common/types'
 
 interface getVersionsProps {
   repositorys?: Repositorys[]
@@ -150,7 +151,7 @@ interface installProps {
   versionInfo: VersionInfo
   installDir: string
   overwrite?: boolean
-  onProgress?: (state: State, progress?: ProgressInfo) => void
+  onProgress?: (state: WineManagerStatus) => void
   abortSignal?: AbortSignal
 }
 
@@ -247,7 +248,8 @@ async function installVersion({
       versionInfo.downsize
     )
 
-    onProgress('downloading', {
+    onProgress({
+      status: 'downloading',
       percentage,
       eta: eta!,
       avgSpeed: downloadSpeed

--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -2,7 +2,7 @@ import { isMac } from '../../../constants'
 import { existsSync, statSync, unlinkSync } from 'graceful-fs'
 import { spawnSync } from 'child_process'
 
-import { ProgressInfo, State, VersionInfo, Type } from 'common/types'
+import { VersionInfo, Type, type WineManagerStatus } from 'common/types'
 import { axiosClient, extractFiles } from 'backend/utils'
 
 interface fetchProps {
@@ -116,7 +116,7 @@ interface unzipProps {
   filePath: string
   unzipDir: string
   overwrite?: boolean
-  onProgress: (state: State, progress?: ProgressInfo) => void
+  onProgress: (state: WineManagerStatus) => void
   abortSignal?: AbortSignal
 }
 
@@ -151,15 +151,15 @@ async function unzipFile({
 
     extractFiles({ path: filePath, destination: unzipDir, strip: 1 })
       .then(() => {
-        onProgress('idle')
+        onProgress({ status: 'idle' })
         resolve(`Succesfully unzip ${filePath} to ${unzipDir}.`)
       })
       .catch((error) => {
-        onProgress('idle')
+        onProgress({ status: 'idle' })
         reject(`Unzip of ${filePath} failed with:\n ${error}!`)
       })
 
-    onProgress('unzipping')
+    onProgress({ status: 'unzipping' })
   })
 }
 

--- a/src/backend/wine/manager/ipc_handler.ts
+++ b/src/backend/wine/manager/ipc_handler.ts
@@ -1,5 +1,4 @@
 import { ipcMain } from 'electron'
-import { ProgressInfo, State } from 'common/types'
 import {
   installWineVersion,
   removeWineVersion,
@@ -7,16 +6,40 @@ import {
 } from './utils'
 import { logError, LogPrefix } from '../../logger/logger'
 import { sendFrontendMessage } from '../../main_window'
+import type { WineManagerStatus } from 'common/types'
+import { notify } from '../../dialog/dialog'
+import { t } from 'i18next'
 
 ipcMain.handle('installWineVersion', async (e, release) => {
-  const onProgress = (state: State, progress?: ProgressInfo) => {
-    sendFrontendMessage(`progressOfWineManager${release.version}`, {
-      state,
-      progress
-    })
+  const onProgress = (state: WineManagerStatus) => {
+    sendFrontendMessage('progressOfWineManager', release.version, state)
   }
+
+  notify({ title: release.version, body: t('notify.install.startInstall') })
+  onProgress({
+    status: 'downloading',
+    percentage: 0,
+    avgSpeed: 0,
+    eta: '00:00:00'
+  })
+
   const result = await installWineVersion(release, onProgress)
-  return result
+
+  let notifyBody: string | null = null
+  switch (result) {
+    case 'error':
+      notifyBody = t('notify.install.error')
+      break
+    case 'abort':
+      notifyBody = t('notify.install.canceled')
+      break
+    case 'success':
+      notifyBody = t('notify.install.finished')
+  }
+  if (notifyBody) notify({ title: release.version, body: notifyBody })
+  onProgress({
+    status: 'idle'
+  })
 })
 
 ipcMain.handle('refreshWineVersionInfo', async (e, fetch?) => {
@@ -29,6 +52,7 @@ ipcMain.handle('refreshWineVersionInfo', async (e, fetch?) => {
   }
 })
 
-ipcMain.handle('removeWineVersion', async (e, release) =>
-  removeWineVersion(release)
-)
+ipcMain.handle('removeWineVersion', async (e, release) => {
+  const result = await removeWineVersion(release)
+  if (result) notify({ title: release.version, body: t('notify.uninstalled') })
+})

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -7,10 +7,9 @@ import { existsSync, mkdirSync, rmSync } from 'graceful-fs'
 import { logError, logInfo, LogPrefix, logWarning } from '../../logger/logger'
 import {
   WineVersionInfo,
-  ProgressInfo,
   Repositorys,
-  State,
-  VersionInfo
+  VersionInfo,
+  WineManagerStatus
 } from 'common/types'
 
 import { getAvailableVersions, installVersion } from './downloader/main'
@@ -89,7 +88,7 @@ async function updateWineVersionInfos(
 
 async function installWineVersion(
   release: WineVersionInfo,
-  onProgress: (state: State, progress?: ProgressInfo) => void
+  onProgress: (status: WineManagerStatus) => void
 ) {
   let updatedInfo: WineVersionInfo
   const variant = release.hasUpdate ? 'update' : 'installation'

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -224,11 +224,9 @@ interface AsyncIPCFunctions {
   }) => Promise<void>
   isNative: (args: { appName: string; runner: Runner }) => boolean
   getLogContent: (appNameOrRunner: string) => string
-  installWineVersion: (
-    release: WineVersionInfo
-  ) => Promise<'error' | 'abort' | 'success'>
+  installWineVersion: (release: WineVersionInfo) => Promise<void>
   refreshWineVersionInfo: (fetch?: boolean) => Promise<void>
-  removeWineVersion: (release: WineVersionInfo) => Promise<boolean>
+  removeWineVersion: (release: WineVersionInfo) => Promise<void>
   shortcutsExists: (appName: string, runner: Runner) => boolean
   addToSteam: (appName: string, runner: Runner) => Promise<boolean>
   removeFromSteam: (appName: string, runner: Runner) => Promise<void>

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -714,19 +714,9 @@ export enum Repositorys {
   WINESTAGINGMACOS
 }
 
-/**
- * Type for the progress callback state
- */
-export type State = 'downloading' | 'unzipping' | 'idle'
-
-/**
- * Interface for the information that progress callback returns
- */
-export interface ProgressInfo {
-  percentage: number
-  avgSpeed: number
-  eta: string
-}
+export type WineManagerStatus =
+  | { status: 'idle' | 'unzipping' }
+  | { status: 'downloading'; percentage: number; avgSpeed: number; eta: string }
 
 export interface WineManagerUISettings {
   value: string

--- a/src/common/types/frontend_messages.ts
+++ b/src/common/types/frontend_messages.ts
@@ -6,10 +6,9 @@ import type {
   DownloadManagerState,
   GameInfo,
   GameStatus,
-  ProgressInfo,
   RecentGame,
   Runner,
-  State
+  WineManagerStatus
 } from 'common/types'
 
 type FrontendMessages = {
@@ -42,13 +41,10 @@ type FrontendMessages = {
     messages: string[]
     installingComponent: string
   }) => void
+  progressOfWineManager: (version: string, progress: WineManagerStatus) => void
   'installing-winetricks-component': (component: string) => void
 
   [key: `progressUpdate${string}`]: (progress: GameStatus) => void
-  [key: `progressOfWineManager${string}`]: (progress: {
-    state: State
-    progress?: ProgressInfo
-  }) => void
 
   // Used inside tests, so we can be a bit lenient with the type checking here
   message: (...params: unknown[]) => void

--- a/src/frontend/screens/WineManager/state.ts
+++ b/src/frontend/screens/WineManager/state.ts
@@ -1,0 +1,13 @@
+import type { WineManagerStatus } from 'common/types'
+import { create } from 'zustand'
+
+const useWineManagerState = create<
+  // FIXME: Enable noUncheckedIndexedAccess in tsconfig to remove this `undefined`
+  Record<string, WineManagerStatus | undefined>
+>(() => ({}))
+
+window.api.handleProgressOfWineManager((_e, version, progress) => {
+  useWineManagerState.setState({ [version]: progress })
+})
+
+export default useWineManagerState


### PR DESCRIPTION
This is a proof-of-concept of using Zustand (https://github.com/pmndrs/zustand) for one of our many states-to-be-managed

I don't know how much I have to explain here, the code looks very straight-forward *to me*, but it's probably confusing in some places if you're not used to the syntax. Please ask questions! With that said, a general explanation:

First off, we've had somewhat of a code split here before (with some state being updated by the Frontend and some by the Backend). This *would* work just fine now as well, but I thought I might as well move everything over to the Backend while I'm at it. Thus, the `installWineVersion` and `removeWineVersion` IPC callbacks no longer return anything, instead settings state directly themselves

On the Frontend side, we first create a store to hold our state (in our case, the easiest structure is a Record, mapping wine version names to their state), and then give the Backend an option to update this state using the (already present but now somewhat modified) `progressOfWineManager` Frontend message.
The WineItem components then listen to their respective version's state updates (using `useShallow` to really only re-render when the specific version changes). Everything else is then handled by Zustand and React

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
