### PR TITLE
Added the second AMD APU code value to Steam Deck detection

### DIFF
--- a/src/backend/utils/systeminfo/steamDeck.ts
+++ b/src/backend/utils/systeminfo/steamDeck.ts
@@ -7,7 +7,11 @@ type SteamDeckInfo =
   | { isDeck: false; model?: undefined }
 
 function getSteamDeckInfo(cpus: CpuInfo[], gpus: GPUInfo[]): SteamDeckInfo {
-  if (cpus[0]?.model !== 'AMD Custom APU 0405') return { isDeck: false }
+  if (
+    cpus[0]?.model !== 'AMD Custom APU 0405' &&
+    cpus[0]?.model !== 'AMD Custom APU 0932'
+  )
+    return { isDeck: false }
 
   const primaryGpu = gpus.at(0)
   if (!primaryGpu || primaryGpu.vendorId !== '1002') return { isDeck: false }


### PR DESCRIPTION
This should fix the https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3433

I've added the new APU name to the first check. If neither is true, isDeck is set to false.
