### PR TITLE
[UX] Prefer using release dates from each runner

### DIFF
--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -101,11 +101,17 @@ export async function getExtraInfo(appName: string): Promise<ExtraInfo> {
   }
 
   const reqs = await createReqsArray(appName, targetPlatform)
-  const storeUrl = (await getGamesData(appName))?._links.store.href
+  const data = await getGamesData(appName)
+  const storeUrl = data?._links.store.href
+  const releaseDate = data?._embedded.product?.globalReleaseDate?.substring(
+    0,
+    19
+  )
 
   const extra: ExtraInfo = {
     about: gameInfo.extra?.about,
     reqs,
+    releaseDate,
     storeUrl
   }
   return extra

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -187,6 +187,7 @@ async function getExtraFromAPI(slug: string): Promise<ExtraInfo | null> {
       return {
         about: about.data.about,
         reqs: about.data.requirements.systems[0].details,
+        releaseDate: about.data.meta.releaseDate?.substring(0, 19),
         storeUrl: `https://www.epicgames.com/store/product/${slug}`
       }
     } else {

--- a/src/backend/wiki_game_info/wiki_game_info.ts
+++ b/src/backend/wiki_game_info/wiki_game_info.ts
@@ -40,7 +40,9 @@ export async function getWikiGameInfo(
 
     let steamInfo = null
     if (isLinux) {
-      const steamID = pcgamingwiki?.steamID || gamesdb?.steamID
+      // gamesdb is more accurate since we always query by appName
+      // pcgamingwiki is queried by title in most cases
+      const steamID = gamesdb?.steamID || pcgamingwiki?.steamID
       const [protondb, steamdeck] = await Promise.all([
         getInfoFromProtonDB(steamID),
         getSteamDeckComp(steamID)

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -118,6 +118,7 @@ export type ExecResult = {
 export interface ExtraInfo {
   about?: About
   reqs: Reqs[]
+  releaseDate?: string
   storeUrl?: string
 }
 

--- a/src/frontend/screens/Game/GamePage/components/ReleaseDate.tsx
+++ b/src/frontend/screens/Game/GamePage/components/ReleaseDate.tsx
@@ -4,6 +4,7 @@ import GameContext from '../../GameContext'
 
 type ReleaseDateProps = {
   date: string[] | undefined
+  runnerDate: string | undefined
 }
 
 // convert date to current locale using Intl module
@@ -16,7 +17,7 @@ function convertDate(date: string) {
 
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
-    month: 'long',
+    month: 'numeric',
     day: 'numeric'
   }
 
@@ -30,7 +31,7 @@ function convertDate(date: string) {
   return dateObj.toLocaleDateString(undefined, options)
 }
 
-const ReleaseDate: React.FC<ReleaseDateProps> = ({ date }) => {
+const ReleaseDate: React.FC<ReleaseDateProps> = ({ date, runnerDate }) => {
   const { is } = useContext(GameContext)
 
   const { t } = useTranslation()
@@ -40,24 +41,26 @@ const ReleaseDate: React.FC<ReleaseDateProps> = ({ date }) => {
   }
 
   const getReleaseDate = () => {
-    let windowsReleaseDate = ''
+    let windowsReleaseDate = runnerDate
 
-    for (let i = 0; i < date.length; i++) {
-      const [platformName, releaseDate] = date[i].split(': ')
+    if (!windowsReleaseDate) {
+      for (let i = 0; i < date.length; i++) {
+        const [platformName, releaseDate] = date[i].split(': ')
 
-      if (platformName === 'Windows') {
-        windowsReleaseDate = releaseDate
-      }
+        if (platformName === 'Windows') {
+          windowsReleaseDate = releaseDate
+        }
 
-      if (
-        (platformName === 'Linux' && is.linuxNative && is.linux) ||
-        (platformName === 'OS X' && is.macNative && is.mac)
-      ) {
-        return convertDate(releaseDate)
+        if (
+          (platformName === 'Linux' && is.linuxNative && is.linux) ||
+          (platformName === 'OS X' && is.macNative && is.mac)
+        ) {
+          return convertDate(releaseDate)
+        }
       }
     }
 
-    return convertDate(windowsReleaseDate)
+    return convertDate(windowsReleaseDate || '')
   }
 
   if (!getReleaseDate()) {

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -374,7 +374,10 @@ export default React.memo(function GamePage(): JSX.Element | null {
                   <div className="infoWrapper">
                     <Genres genres={wikiInfo?.pcgamingwiki?.genres || []} />
                     <Developer gameInfo={gameInfo} />
-                    <ReleaseDate date={wikiInfo?.pcgamingwiki?.releaseDate} />
+                    <ReleaseDate
+                      runnerDate={extraInfo?.releaseDate}
+                      date={wikiInfo?.pcgamingwiki?.releaseDate}
+                    />
                     <Description />
                     <CloudSavesSync gameInfo={gameInfo} />
                     <DownloadSizeInfo gameInfo={gameInfo} />
@@ -435,7 +438,10 @@ export default React.memo(function GamePage(): JSX.Element | null {
                     <h1>{title}</h1>
                     <Genres genres={wikiInfo?.pcgamingwiki?.genres || []} />
                     <Developer gameInfo={gameInfo} />
-                    <ReleaseDate date={wikiInfo?.pcgamingwiki?.releaseDate} />
+                    <ReleaseDate
+                      runnerDate={extraInfo?.releaseDate}
+                      date={wikiInfo?.pcgamingwiki?.releaseDate}
+                    />
                     <Description />
                     {!notInstallable && (
                       <TimeContainer runner={runner} game={appName} />


### PR DESCRIPTION
Now we'll use release dates obtained from each runners API. We were already making a requests to obtain a store URL for example, so I just re-used that.

I skipped that for Amazon for now...  
We have each game's release for each entry in nile's `library.json`, we'd probably need to include that data in GameInfo object.


Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
