### PR TITLE
[UX] Add support for autoinstallation of files from game folder

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -592,7 +592,7 @@
         "esync": "Enable Esync",
         "exit-to-tray": "Exit to System Tray",
         "experimental_features": {
-            "automaticWinetricksFixes": "Apply known Winetricks fixes automatically",
+            "automaticWinetricksFixes": "Apply known fixes automatically",
             "enableHelp": "Help component",
             "enableNewDesign": "New design"
         },

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -11,7 +11,8 @@ import {
   WineInstallation,
   WineCommandArgs,
   SteamRuntime,
-  GameSettings
+  GameSettings,
+  KnowFixesInfo
 } from 'common/types'
 // This handles launching games, prefix creation etc..
 
@@ -74,6 +75,7 @@ import {
 } from './utils/aborthandler/aborthandler'
 import { download, isInstalled } from './wine/runtimes/runtimes'
 import { storeMap } from 'common/utils'
+import { runWineCommandOnGame } from './storeManagers/legendary/games'
 
 async function prepareLaunch(
   gameSettings: GameSettings,
@@ -395,23 +397,44 @@ async function installFixes(appName: string, runner: Runner) {
   if (!existsSync(fixPath)) return
 
   try {
-    const fixesContent = JSON.parse(readFileSync(fixPath).toString())
+    const fixesContent = JSON.parse(
+      readFileSync(fixPath).toString()
+    ) as KnowFixesInfo
 
-    sendGameStatusUpdate({
-      appName,
-      runner: runner,
-      status: 'winetricks'
-    })
+    if (fixesContent.winetricks) {
+      sendGameStatusUpdate({
+        appName,
+        runner: runner,
+        status: 'winetricks'
+      })
 
-    for (const winetricksPackage of fixesContent.winetricks) {
-      await Winetricks.install(runner, appName, winetricksPackage)
+      for (const winetricksPackage of fixesContent.winetricks) {
+        await Winetricks.install(runner, appName, winetricksPackage)
+      }
+    }
+
+    if (fixesContent.runInPrefix) {
+      const gameInfo = gameManagerMap[runner].getGameInfo(appName)
+
+      sendGameStatusUpdate({
+        appName,
+        runner: runner,
+        status: 'prerequisites'
+      })
+
+      for (const filePath of fixesContent.runInPrefix) {
+        const fullPath = join(gameInfo.install.install_path!, filePath)
+        await runWineCommandOnGame(appName, {
+          commandParts: [fullPath],
+          wait: true,
+          protonVerb: 'waitforexitandrun'
+        })
+      }
     }
   } catch (error) {
     // if we fail to download the json file, it can be malformed causing
     // JSON.parse to throw an exception
-    logWarning(
-      `Known winetricks fixes could not be applied, ignoring.\n${error}`
-    )
+    logWarning(`Known fixes could not be applied, ignoring.\n${error}`)
   }
 }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -757,3 +757,10 @@ export type InstallInfo =
   | LegendaryInstallInfo
   | GogInstallInfo
   | NileInstallInfo
+
+export interface KnowFixesInfo {
+  title: string
+  notes?: Record<string, string>
+  winetricks?: string[]
+  runInPrefix?: string[]
+}

--- a/src/frontend/screens/Settings/components/ExperimentalFeatures.tsx
+++ b/src/frontend/screens/Settings/components/ExperimentalFeatures.tsx
@@ -37,7 +37,7 @@ const ExperimentalFeatures = () => {
     Translations:
     t('setting.experimental_features.enableNewDesign', 'New design')
     t('setting.experimental_features.enableHelp', 'Help component')
-    t('setting.experimental_features.automaticWinetricksFixes', 'Apply known Winetricks fixes automatically')
+    t('setting.experimental_features.automaticWinetricksFixes', 'Apply known fixes automatically')
   */
 
   return (


### PR DESCRIPTION
This PR extends the feature that applies automatic winetricks fixes by supporting also automatic `run exe in prefix` actions.

Sometimes, some games include files that has to be executed that are not listed as prerequisites. The most common case is FallGuys that requires the installation of the EpicOnlineServices to solve the `Missing Files` error.

This can be used for any game that needs a similar tweak by adding content in the https://github.com/Heroic-Games-Launcher/known-fixes repo.

You can use Fall Guys to test this feature.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
