### PR TITLE
[UX] Set the auto fixes feature ON by default

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -347,7 +347,7 @@ async function prepareWineLaunch(
     }
     if (
       GlobalConfig.get().getSettings().experimentalFeatures
-        ?.automaticWinetricksFixes
+        ?.automaticWinetricksFixes !== false
     ) {
       await installFixes(appName, runner)
     }

--- a/src/frontend/screens/Settings/components/ExperimentalFeatures.tsx
+++ b/src/frontend/screens/Settings/components/ExperimentalFeatures.tsx
@@ -19,7 +19,7 @@ const ExperimentalFeatures = () => {
     {
       enableNewDesign: false,
       enableHelp: false,
-      automaticWinetricksFixes: false
+      automaticWinetricksFixes: true
     }
   )
   const { handleExperimentalFeatures } = useContext(ContextProvider)

--- a/src/frontend/state/ContextProvider.tsx
+++ b/src/frontend/state/ContextProvider.tsx
@@ -94,7 +94,7 @@ const initialContext: ContextType = {
   experimentalFeatures: {
     enableNewDesign: false,
     enableHelp: false,
-    automaticWinetricksFixes: false
+    automaticWinetricksFixes: true
   },
   handleExperimentalFeatures: () => null,
   disableDialogBackdropClose: false,

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -215,7 +215,7 @@ class GlobalState extends PureComponent<Props> {
     experimentalFeatures: globalSettings?.experimentalFeatures || {
       enableNewDesign: false,
       enableHelp: false,
-      automaticWinetricksFixes: false
+      automaticWinetricksFixes: true
     },
     disableDialogBackdropClose: configStore.get(
       'disableDialogBackdropClose',


### PR DESCRIPTION
Currently, users have to know this experimental feature exists to enable it, but new users will most likely miss this (or skip it because it's experimental).

This PR changes the feature to be on by default instead and users then have to opt out if they want to not autoinstall fixes.

We haven't seen reports of this causing issues so far (but I don't know if it's because not many users are using this). I think it's a good default for a future release before promoting it from experimental.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
