### PR TITLE
[Fix] Wait for legendary refresh to finish before storing array

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -163,7 +163,7 @@ export async function refresh(): Promise<ExecResult | null> {
     return defaultExecResult
   }
 
-  refreshLegendary()
+  await refreshLegendary()
   loadGamesInAccount()
   refreshInstalled()
 


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3450

We were not waiting for the promise to finish, so the library was not updated with the new results from legendary, we were writing the old library to the store instead, requiring a second reload to get things updated.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
