### PR TITLE
[Fix] Prevent last run output to leak to next run's logs

### DIFF
--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -476,8 +476,10 @@ export function initGameLog(gameInfo: GameInfo) {
 }
 
 export function stopLogger(appName: string) {
-  logsWriters[appName].logMessage(
-    '============= End of game logs ============='
-  )
-  delete logsWriters[appName]
+  setTimeout(() => {
+    logsWriters[appName].logMessage(
+      '============= End of game logs ============='
+    )
+    delete logsWriters[appName]
+  }, 100)
 }

--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -361,7 +361,7 @@ const logsWriters: Record<string, LogWriter> = {}
 
 class LogWriter {
   gameInfo: GameInfo
-  queue: string[] | undefined
+  queue: string[]
   initialized: boolean
   timeoutId: NodeJS.Timeout | undefined
   filePath: string
@@ -370,11 +370,10 @@ class LogWriter {
     this.gameInfo = gameInfo
     this.initialized = false
     this.filePath = lastPlayLogFileLocation(gameInfo.app_name)
+    this.queue = []
   }
 
   logMessage(message: string) {
-    this.queue ??= []
-
     // push messages to append to the log
     this.queue.push(message)
 
@@ -466,8 +465,7 @@ class LogWriter {
 }
 
 export function appendGameLog(gameInfo: GameInfo, message: string) {
-  logsWriters[gameInfo.app_name] ??= new LogWriter(gameInfo)
-  logsWriters[gameInfo.app_name].logMessage(message)
+  logsWriters[gameInfo.app_name]?.logMessage(message)
 }
 
 export function initGameLog(gameInfo: GameInfo) {
@@ -476,10 +474,8 @@ export function initGameLog(gameInfo: GameInfo) {
 }
 
 export function stopLogger(appName: string) {
-  setTimeout(() => {
-    logsWriters[appName].logMessage(
-      '============= End of game logs ============='
-    )
-    delete logsWriters[appName]
-  }, 100)
+  logsWriters[appName].logMessage(
+    '============= End of game logs ============='
+  )
+  delete logsWriters[appName]
 }


### PR DESCRIPTION
There is a small an inoffensive bug with gog games and logs, but it can cause confusion during support requests:
the gogdl command prints the launch command to the output a moment after the process ends, when a game launch is aborted, this happens AFTER Heroic calls the `stopLogger` method. This causes a new logger to be initialized with that last message in the queue, and it's used in the next run, printing a message from a previous run before the actual run's logs.

This PR fixes that by only initializing the logger when calling `initGameLog` and not on appends.

This is how this can be tested in the current release:
- start a GOG game
- abort the launch as soon as possible
- launch the game again
- now let it start and close the game correctly
- open the game logs

Notice that there are 2 `Launch command` lines in the log:
```
Launch command: ['/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/bin/wine', "/home/ariel/Games/Heroic/Alwa's Awakening/AlwasAwakening.exe"]

Launch Command: HEROIC_APP_NAME=1396087560 HEROIC_APP_RUNNER=gog HEROIC_APP_SOURCE=gog LD_PRELOAD= DOTNET_BUNDLE_EXTRACT_BASE_DIR= DOTNET_ROOT= WINEPREFIX="/home/ariel/Games/Heroic/Prefixes/Alwas Awakening" WINEDLLOVERRIDES=winemenubuilder.exe=d WINE_FULLSCREEN_FSR=0 WINEESYNC=1 WINEFSYNC=1 ORIG_LD_LIBRARY_PATH= LD_LIBRARY_PATH=/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib64:/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib GST_PLUGIN_SYSTEM_PATH_1_0=/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib64/gstreamer-1.0:/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib/gstreamer-1.0 WINEDLLPATH=/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib64/wine:/home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/lib/wine /home/ariel/dev/oss/HeroicGamesLauncher/public/bin/linux/gogdl launch "/home/ariel/Games/Heroic/Alwa's Awakening" 1396087560 --wine /home/ariel/.config/heroic/tools/wine/Wine-GE-Proton8-25/bin/wine --platform windows
```

First line is the last output of gogdl.
Second line is the actual launch command from the current run printed by Heroic.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
