### PR TITLE
[Fix] Don't disable controller when disabling logs

### DIFF
--- a/src/frontend/screens/Settings/components/DisableLogs.tsx
+++ b/src/frontend/screens/Settings/components/DisableLogs.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
 import useSetting from 'frontend/hooks/useSetting'
-import { toggleControllerIsDisabled } from 'frontend/helpers/gamepad'
 import { ToggleSwitch } from 'frontend/components/UI'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
@@ -9,10 +8,6 @@ import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 const DisableLogs = () => {
   const { t } = useTranslation()
   const [disableLogs, setDisableLogs] = useSetting('disableLogs', false)
-
-  useEffect(() => {
-    toggleControllerIsDisabled(disableLogs)
-  }, [disableLogs])
 
   return (
     <div className="toggleRow">


### PR DESCRIPTION
When I implemented the option to disable logs, I copied the component used to disable the controller to have the boilerplate and I didn't remove a part of the code.

Because of that, when disabling/enabling logs, that was also enabling/disabling the controller flag.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
