### PR TITLE
[Refactor] Download known fixes from store folder

### DIFF
--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -181,7 +181,7 @@ async function updateQueueElement(params: InstallParams): Promise<{
 }
 
 async function downloadFixesFor(appName: string, runner: Runner) {
-  const url = `https://raw.githubusercontent.com/Heroic-Games-Launcher/known-fixes/main/${appName}-${storeMap[runner]}.json`
+  const url = `https://raw.githubusercontent.com/Heroic-Games-Launcher/known-fixes/main/${storeMap[runner]}/${appName}-${storeMap[runner]}.json`
   const dest = path.join(fixesPath, `${appName}-${storeMap[runner]}.json`)
   if (!existsSync(fixesPath)) {
     mkdirSync(fixesPath, { recursive: true })


### PR DESCRIPTION
This PR changes the URL used to download known fixes to use a folder for the store instead of downloading them from the root of the repo.

I already updated the repo to support downloading the files from folders https://github.com/Heroic-Games-Launcher/known-fixes

The repo will support both the root dir and the folder temporarily so it works with 2.12.0 and the next versions, and eventually we can remove the duplication of that repo once Heroic 2.12.0 is not more.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
