### PR TITLE
Support additional gamescope options

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -297,6 +297,7 @@
         },
         "gamemode": "Feral GameMode applies automatic and temporary tweaks to the system when running games. Enabling may improve performance.",
         "gamescope": {
+            "additionalOptions": "Additional commandline flags to pass into gamescope.",
             "fpsLimiter": "The amount of frames gamescope should limit to. E.g. 60",
             "fpsLimiterNoFocus": "The frame rate limit gamescope should limit per second if the game is not focused.",
             "gameHeight": "The height resolution used by the game. A 16:9 aspect ratio is assumed by gamescope.",
@@ -478,6 +479,7 @@
             "title": "Game Arguments (To run after the command):"
         },
         "gamescope": {
+            "additionalOptions": "Additional Options",
             "borderless": "Borderless",
             "fpsLimiter": "FPS Limiter",
             "fpsLimiterNoFocus": "FPS Limiter (No Focus)",

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -214,6 +214,10 @@ async function prepareLaunch(
         }
       }
 
+      gameScopeCommand.push(
+        ...shlex.split(gameSettings.gamescope.additionalOptions)
+      )
+
       // Note: needs to be the last option
       gameScopeCommand.push('--')
     }

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -215,7 +215,7 @@ async function prepareLaunch(
       }
 
       gameScopeCommand.push(
-        ...shlex.split(gameSettings.gamescope.additionalOptions)
+        ...shlex.split(gameSettings.gamescope.additionalOptions ?? '')
       )
 
       // Note: needs to be the last option

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -770,6 +770,7 @@ interface GameScopeSettings {
   upscaleMethod: string
   fpsLimiter: string
   fpsLimiterNoFocus: string
+  additionalOptions: string
 }
 
 export type InstallInfo =

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -25,7 +25,8 @@ const Gamescope = () => {
     upscaleWidth: '',
     upscaleMethod: 'fsr',
     fpsLimiter: '',
-    fpsLimiterNoFocus: ''
+    fpsLimiterNoFocus: '',
+    additionalOptions: ''
   })
   const [fetching, setFetching] = useState(true)
   const [isInstalled, setIsInstalled] = useState(false)
@@ -352,6 +353,29 @@ const Gamescope = () => {
           />
         </div>
       )}
+      {/* Additional Options */}
+      <TextInputField
+        label={t('options.gamescope.additionalOptions', 'Additional Options')}
+        htmlId="additionalOptions"
+        placeholder=""
+        value={gamescope.additionalOptions}
+        afterInput={
+          <FontAwesomeIcon
+            className="helpIcon"
+            icon={faCircleInfo}
+            title={t(
+              'help.gamescope.additionalOptions',
+              'Additional commandline flags to pass into gamescope.'
+            )}
+          />
+        }
+        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+          setGamescope({
+            ...gamescope,
+            additionalOptions: event.currentTarget.value
+          })
+        }
+      />
     </div>
   )
 }

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -369,7 +369,7 @@ const Gamescope = () => {
             )}
           />
         }
-        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+        onBlur={(event: ChangeEvent<HTMLInputElement>) =>
           setGamescope({
             ...gamescope,
             additionalOptions: event.currentTarget.value

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -31,7 +31,9 @@ const Gamescope = () => {
   const [fetching, setFetching] = useState(true)
   const [isInstalled, setIsInstalled] = useState(false)
 
-  const [additionalOptions, setAdditionalOptions] = useState(gamescope.additionalOptions)
+  const [additionalOptions, setAdditionalOptions] = useState(
+    gamescope.additionalOptions
+  )
 
   useEffect(() => {
     setFetching(true)

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -31,6 +31,8 @@ const Gamescope = () => {
   const [fetching, setFetching] = useState(true)
   const [isInstalled, setIsInstalled] = useState(false)
 
+  const [additionalOptions, setAdditionalOptions] = useState(gamescope.additionalOptions)
+
   useEffect(() => {
     setFetching(true)
     window.api
@@ -358,7 +360,7 @@ const Gamescope = () => {
         label={t('options.gamescope.additionalOptions', 'Additional Options')}
         htmlId="additionalOptions"
         placeholder=""
-        value={gamescope.additionalOptions}
+        value={additionalOptions}
         afterInput={
           <FontAwesomeIcon
             className="helpIcon"
@@ -369,7 +371,10 @@ const Gamescope = () => {
             )}
           />
         }
-        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+          setAdditionalOptions(event.currentTarget.value)
+        }}
+        onBlur={(event: ChangeEvent<HTMLInputElement>) =>
           setGamescope({
             ...gamescope,
             additionalOptions: event.currentTarget.value

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -369,7 +369,7 @@ const Gamescope = () => {
             )}
           />
         }
-        onBlur={(event: ChangeEvent<HTMLInputElement>) =>
+        onChange={(event: ChangeEvent<HTMLInputElement>) =>
           setGamescope({
             ...gamescope,
             additionalOptions: event.currentTarget.value


### PR DESCRIPTION
Funny story behind this PR: I was trying to play some random Styx game from GOG that had broken mouse capture on kwin wayland, I opened it through gamescope, it works but on the wrong monitor this time, then I wrote the code for this PR really quickly to change the displays, and guess what ... gamescope doesn't support changing the displays. I will have to make a PR there as well

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
