### PR TITLE
Cleanup `platform` checks. Remove old code.

### DIFF
--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -40,10 +40,3 @@ electronTest('gets heroic, legendary, and gog versions', async (app) => {
     expect(compareVersions(gogdlVersion, '0.7.1')).toBeGreaterThanOrEqual(0)
   })
 })
-
-electronTest('test ipcMainInvokeHandler', async (app) => {
-  const page = await app.firstWindow()
-  const platform = await page.evaluate(async () => window.api.getPlatform())
-  console.log('Platform: ', platform)
-  expect(platform).toEqual(process.platform)
-})

--- a/src/backend/api/helpers.ts
+++ b/src/backend/api/helpers.ts
@@ -28,8 +28,6 @@ export const createNewWindow = (url: string) =>
 export const readConfig = async (file: 'library' | 'user') =>
   ipcRenderer.invoke('readConfig', file)
 
-export const getPlatform = async () => ipcRenderer.invoke('getPlatform')
-
 export const isLoggedIn = async () => ipcRenderer.invoke('isLoggedIn')
 
 export const writeConfig = async (data: {

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -275,13 +275,6 @@ class GlobalConfigV0 extends GlobalConfig {
       winePrefix
     } as AppSettings
 
-    // TODO: Remove this after a couple of stable releases
-    // Get settings only from config-store
-    const currentConfigStore = configStore.get_nodefault('settings')
-    if (!currentConfigStore?.defaultInstallPath) {
-      configStore.set('settings', settings)
-    }
-
     return settings
   }
 

--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'child_process'
-import { homedir, platform } from 'os'
+import { homedir } from 'os'
 import { join, resolve } from 'path'
 import { parse } from '@node-steam/vdf'
 
@@ -27,9 +27,9 @@ const fontsStore = new TypeCheckedStoreBackend('fontsStore', {
   name: 'fonts'
 })
 
-const isMac = platform() === 'darwin'
-const isWindows = platform() === 'win32'
-const isLinux = platform() === 'linux'
+const isMac = process.platform === 'darwin'
+const isWindows = process.platform === 'win32'
+const isLinux = process.platform === 'linux'
 const isSteamDeckGameMode = process.env.XDG_CURRENT_DESKTOP === 'gamescope'
 const isCLIFullscreen = process.argv.includes('--fullscreen')
 const isCLINoGui = process.argv.includes('--no-gui')
@@ -214,7 +214,7 @@ const necessaryFoldersByPlatform = {
 }
 
 export function createNecessaryFolders() {
-  necessaryFoldersByPlatform[platform()].forEach((folder: string) => {
+  necessaryFoldersByPlatform[process.platform].forEach((folder: string) => {
     if (!existsSync(folder)) {
       mkdirSync(folder)
     }

--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -9,10 +9,9 @@ import { DMStatus, InstallParams, Runner } from 'common/types'
 import i18next from 'i18next'
 import { notify, showDialogBoxModalAuto } from '../dialog/dialog'
 import { isOnline } from '../online_monitor'
-import { fixesPath } from 'backend/constants'
+import { fixesPath, isWindows } from 'backend/constants'
 import path from 'path'
 import { existsSync, mkdirSync } from 'graceful-fs'
-import { platform } from 'os'
 import { storeMap } from 'common/utils'
 
 async function installQueueElement(params: InstallParams): Promise<{
@@ -75,7 +74,7 @@ async function installQueueElement(params: InstallParams): Promise<{
   }
 
   try {
-    if (platform() !== 'win32') {
+    if (!isWindows) {
       downloadFixesFor(appName, runner)
     }
 

--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -13,9 +13,8 @@ import { getGOGdlBin, getLegendaryBin } from 'backend/utils'
 import { join } from 'path'
 import { formatSystemInfo, getSystemInfo } from '../utils/systeminfo'
 import { appendFile, writeFile } from 'fs/promises'
-import { gamesConfigPath } from 'backend/constants'
+import { gamesConfigPath, isWindows } from 'backend/constants'
 import { gameManagerMap } from 'backend/storeManagers'
-import { platform } from 'os'
 
 export enum LogPrefix {
   General = '',
@@ -392,7 +391,7 @@ class LogWriter {
     const notNative =
       ['windows', 'Windows', 'Win32'].includes(
         this.gameInfo.install.platform || ''
-      ) && platform() !== 'win32'
+      ) && !isWindows
 
     // init log file and then append message if any
     try {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -24,7 +24,7 @@ import {
 } from 'electron'
 import 'backend/updater'
 import { autoUpdater } from 'electron-updater'
-import { cpus, platform } from 'os'
+import { cpus } from 'os'
 import {
   access,
   constants,
@@ -94,7 +94,9 @@ import {
   createNecessaryFolders,
   fixAsarPath,
   isSnap,
-  fixesPath
+  fixesPath,
+  isWindows,
+  isMac
 } from './constants'
 import { handleProtocol } from './protocol'
 import {
@@ -160,7 +162,6 @@ import { storeMap } from 'common/utils'
 app.commandLine?.appendSwitch('ozone-platform-hint', 'auto')
 
 const { showOpenDialog } = dialog
-const isWindows = platform() === 'win32'
 
 async function initializeWindow(): Promise<BrowserWindow> {
   createNecessaryFolders()
@@ -234,9 +235,7 @@ async function initializeWindow(): Promise<BrowserWindow> {
     handleExit()
   })
 
-  if (isWindows) {
-    detectVCRedist(mainWindow)
-  }
+  detectVCRedist(mainWindow)
 
   if (process.env.VITE_DEV_SERVER_URL) {
     if (!process.env.HEROIC_NO_REACT_DEVTOOLS) {
@@ -637,7 +636,7 @@ ipcMain.on('quit', async () => handleExit())
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+  if (!isMac) {
     app.quit()
   }
 })

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -338,15 +338,6 @@ if (!gotTheLock) {
       app.setAppUserModelId('Heroic Games Launcher')
     }
 
-    // TODO: Remove this after a couple of stable releases
-    // Affects only current users, not new installs
-    const settings = GlobalConfig.get().getSettings()
-    const { language } = settings
-    const currentConfigStore = configStore.get_nodefault('settings')
-    if (!currentConfigStore?.defaultInstallPath) {
-      configStore.set('settings', settings)
-    }
-
     runOnceWhenOnline(async () => {
       const isLoggedIn = LegendaryUser.isLoggedIn()
 
@@ -363,6 +354,8 @@ if (!gotTheLock) {
         GOGUser.getUserDetails()
       }
     })
+
+    const settings = GlobalConfig.get().getSettings()
 
     // Make sure lock is not present when starting up
     playtimeSyncQueue.delete('lock')
@@ -383,7 +376,7 @@ if (!gotTheLock) {
       returnEmptyString: false,
       returnNull: false,
       fallbackLng: 'en',
-      lng: language,
+      lng: settings.language,
       supportedLngs: [
         'ar',
         'az',
@@ -445,8 +438,7 @@ if (!gotTheLock) {
       logWarning('Protocol already registered.', LogPrefix.Backend)
     }
 
-    const { startInTray } = GlobalConfig.get().getSettings()
-    const headless = isCLINoGui || startInTray
+    const headless = isCLINoGui || settings.startInTray
     if (!headless) {
       mainWindow.once('ready-to-show', () => {
         const props = configStore.get_nodefault('window-props')

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -830,12 +830,12 @@ ipcMain.handle('getAlternativeWine', async () =>
   GlobalConfig.get().getAlternativeWine()
 )
 
-ipcMain.handle('readConfig', async (event, config_class) => {
-  if (config_class === 'library') {
+ipcMain.handle('readConfig', async (event, configClass) => {
+  if (configClass === 'library') {
     await libraryManagerMap['legendary'].refresh()
     return LegendaryLibraryManager.getListOfGames()
   }
-  const userInfo = await LegendaryUser.getUserInfo()
+  const userInfo = LegendaryUser.getUserInfo()
   return userInfo?.displayName ?? ''
 })
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -429,7 +429,6 @@ if (!gotTheLock) {
       ]
     })
 
-    GOGUser.migrateCredentialsConfig()
     const mainWindow = await initializeWindow()
 
     protocol.handle('heroic', (request) => {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -707,8 +707,6 @@ ipcMain.handle('isFlatpak', () => isFlatpak)
 ipcMain.handle('getGameOverride', async () => getGameOverride())
 ipcMain.handle('getGameSdl', async (event, appName) => getGameSdl(appName))
 
-ipcMain.handle('getPlatform', () => process.platform)
-
 ipcMain.handle('showUpdateSetting', () => !isFlatpak)
 
 ipcMain.handle('getLatestReleases', async () => {

--- a/src/backend/main_window.ts
+++ b/src/backend/main_window.ts
@@ -1,7 +1,7 @@
 import { AppSettings, WindowProps } from 'common/types'
 import { BrowserWindow, screen } from 'electron'
 import path from 'path'
-import { configStore } from './constants'
+import { configStore, isLinux } from './constants'
 
 let mainWindow: BrowserWindow | null = null
 
@@ -61,11 +61,11 @@ export const createMainWindow = () => {
   const settings = configStore.get('settings', <AppSettings>{})
   if (settings?.framelessWindow) {
     // use native overlay controls where supported
-    if (['darwin', 'win32'].includes(process.platform)) {
+    if (isLinux) {
+      windowProps.frame = false
+    } else {
       windowProps.titleBarStyle = 'hidden'
       windowProps.titleBarOverlay = true
-    } else {
-      windowProps.frame = false
     }
   }
 

--- a/src/backend/main_window.ts
+++ b/src/backend/main_window.ts
@@ -1,7 +1,7 @@
 import { AppSettings, WindowProps } from 'common/types'
 import { BrowserWindow, screen } from 'electron'
 import path from 'path'
-import { configStore, isLinux } from './constants'
+import { configStore } from './constants'
 
 let mainWindow: BrowserWindow | null = null
 
@@ -61,11 +61,11 @@ export const createMainWindow = () => {
   const settings = configStore.get('settings', <AppSettings>{})
   if (settings?.framelessWindow) {
     // use native overlay controls where supported
-    if (isLinux) {
-      windowProps.frame = false
-    } else {
+    if (['darwin', 'win32'].includes(process.platform)) {
       windowProps.titleBarStyle = 'hidden'
       windowProps.titleBarOverlay = true
+    } else {
+      windowProps.frame = false
     }
   }
 

--- a/src/backend/preload.ts
+++ b/src/backend/preload.ts
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld(
   'isSteamDeckGameMode',
   process.env.XDG_CURRENT_DESKTOP === 'gamescope'
 )
+contextBridge.exposeInMainWorld('platform', process.platform)
 
 if (navigator.userAgent.includes('Windows')) {
   Object.defineProperty(navigator, 'platform', {

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -696,19 +696,6 @@ export async function getInstallInfo(
     }
   }
   installInfoStore.set(installInfoStoreKey, info)
-  if (!info) {
-    logWarning(
-      [
-        'Failed to get Install Info for',
-        `${appName}`,
-        `using ${installPlatform} as platform,`,
-        'returning empty object'
-      ],
-      LogPrefix.Gog
-    )
-    // @ts-expect-error TODO: Handle this better
-    return {}
-  }
   return info
 }
 

--- a/src/backend/storeManagers/gog/user.ts
+++ b/src/backend/storeManagers/gog/user.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { writeFileSync, existsSync, unlinkSync } from 'graceful-fs'
+import { existsSync, unlinkSync } from 'graceful-fs'
 import { logError, logInfo, LogPrefix, logWarning } from '../../logger/logger'
 import { GOGLoginData } from 'common/types'
 import { configStore } from './electronStores'
@@ -113,26 +113,6 @@ export class GOGUser {
       logSanitizer: authLogSanitizer
     })
     return JSON.parse(stdout)
-  }
-
-  /**
-   * Migrates existing authorization config to one supported by gogdl
-   */
-  public static migrateCredentialsConfig() {
-    if (!configStore.has('credentials')) {
-      return
-    }
-
-    const credentials = configStore.get_nodefault('credentials')
-    if (credentials?.loginTime)
-      credentials.loginTime = credentials?.loginTime / 1000
-
-    writeFileSync(
-      gogdlAuthConfig,
-      JSON.stringify({ '46899977096215655': credentials })
-    )
-    configStore.delete('credentials')
-    configStore.set('isLoggedIn', true)
   }
 
   public static logout() {

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -36,7 +36,8 @@ import {
   isWindows,
   installed,
   configStore,
-  isCLINoGui
+  isCLINoGui,
+  isLinux
 } from '../../constants'
 import {
   appendGameLog,
@@ -945,7 +946,7 @@ export async function stop(appName: string, stopWine = true) {
   // not a perfect solution but it's the only choice for now
 
   // @adityaruplaha: this is kinda arbitary and I don't understand it.
-  const pattern = process.platform === 'linux' ? appName : 'legendary'
+  const pattern = isLinux ? appName : 'legendary'
   killPattern(pattern)
 
   if (stopWine && !isNative(appName)) {

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -27,7 +27,7 @@ import {
   logInfo,
   logsDisabled
 } from 'backend/logger/logger'
-import { isWindows } from 'backend/constants'
+import { isLinux, isWindows } from 'backend/constants'
 import { GameConfig } from 'backend/game_config'
 import {
   getRunnerCallWithoutCredentials,
@@ -556,7 +556,7 @@ export async function forceUninstall(appName: string) {
 }
 
 export async function stop(appName: string, stopWine = true) {
-  const pattern = process.platform === 'linux' ? appName : 'nile'
+  const pattern = isLinux ? appName : 'nile'
   killPattern(pattern)
 
   if (stopWine && !isNative()) {

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -151,7 +151,6 @@ interface AsyncIPCFunctions {
   isMaximized: () => boolean
   isMinimized: () => boolean
   isFlatpak: () => boolean
-  getPlatform: () => NodeJS.Platform
   showUpdateSetting: () => boolean
   getLatestReleases: () => Promise<Release[]>
   getCurrentChangelog: () => Promise<Release | null>

--- a/src/frontend/helpers/index.ts
+++ b/src/frontend/helpers/index.ts
@@ -18,8 +18,6 @@ const notify = (args: { title: string; body: string }) =>
 
 const loginPage = window.api.openLoginPage
 
-const getPlatform = window.api.getPlatform
-
 const sidInfoPage = window.api.openSidInfoPage
 
 const handleQuit = window.api.quit
@@ -163,7 +161,6 @@ export {
   getGameSettings,
   getInstallInfo,
   getLegendaryConfig,
-  getPlatform,
   getProgress,
   handleQuit,
   install,

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -85,7 +85,7 @@ export default React.memo(function Library(): JSX.Element {
     initialStoresfilters = JSON.parse(storesFiltersString) as StoresFilters
   } else {
     // Else, use the old `category` filter
-    // TODO: we can remove this eventually after a few releases
+    // TODO: we can remove this eventually after a few releases and just use the code of the if
     const storedCategory = (storage.getItem('category') as Category) || 'all'
     initialStoresfilters = {
       legendary: epicCategories.includes(storedCategory),
@@ -112,7 +112,7 @@ export default React.memo(function Library(): JSX.Element {
     ) as PlatformsFilters
   } else {
     // Else, use the old `category` filter
-    // TODO: we can remove this eventually after a few releases
+    // TODO: we can remove this eventually after a few releases and just use the code of the if
     const storedCategory = storage.getItem('filterPlatform') || 'all'
     initialPlatformsfilters = {
       win: ['all', 'win'].includes(storedCategory),

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -19,13 +19,7 @@ import {
   HelpItem
 } from 'frontend/types'
 import { withTranslation } from 'react-i18next'
-import {
-  getGameInfo,
-  getLegendaryConfig,
-  getPlatform,
-  launch,
-  notify
-} from '../helpers'
+import { getGameInfo, getLegendaryConfig, launch, notify } from '../helpers'
 import { i18n, t, TFunction } from 'i18next'
 
 import ContextProvider from './ContextProvider'
@@ -78,7 +72,7 @@ interface StateProps {
   language: string
   libraryStatus: GameStatus[]
   libraryTopSection: string
-  platform: NodeJS.Platform | 'unknown'
+  platform: NodeJS.Platform
   refreshing: boolean
   refreshingInTheBackground: boolean
   hiddenGames: HiddenGame[]
@@ -172,7 +166,7 @@ class GlobalState extends PureComponent<Props> {
     language: this.props.i18n.language,
     libraryStatus: [],
     libraryTopSection: globalSettings?.libraryTopSection || 'disabled',
-    platform: 'unknown',
+    platform: window.platform,
     refreshing: false,
     refreshingInTheBackground: true,
     hiddenGames: configStore.get('games.hidden', []),
@@ -853,7 +847,6 @@ class GlobalState extends PureComponent<Props> {
     const legendaryUser = configStore.has('userInfo')
     const gogUser = gogConfigStore.has('userData')
     const amazonUser = nileConfigStore.has('userData')
-    const platform = await getPlatform()
 
     if (legendaryUser) {
       await window.api.getUserInfo()
@@ -867,8 +860,6 @@ class GlobalState extends PureComponent<Props> {
       const storedGameUpdates = JSON.parse(storage.getItem('updates') || '[]')
       this.setState({ gameUpdates: storedGameUpdates })
     }
-
-    this.setState({ platform })
 
     if (legendaryUser || gogUser || amazonUser) {
       this.refreshLibrary({

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -164,6 +164,7 @@ declare global {
     ) => Promise<string>
     setTheme: (themeClass: string) => void
     isSteamDeckGameMode: boolean
+    platform: NodeJS.Platform
   }
 
   interface WindowEventMap {


### PR DESCRIPTION
This PR does 3 cleanup/refactor tasks:

- remove some code that is not really needed anymore (I'll add comments in the diff)
- use `isWindows/Linux/Mac` constants when possible instead of `process.platform` or `platform()`
- expose the platform name in the preload file so we don't need the extra IPC calls to get that info

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
