### PR TITLE
[FIX]: set initial state properly for password modal

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/BranchSelector.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/BranchSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { SelectField, TextInputField } from 'frontend/components/UI'
 import { useTranslation } from 'react-i18next'
 import { Dialog, DialogContent } from 'frontend/components/UI/Dialog'
@@ -25,7 +25,12 @@ export default function BranchSelector({
 
   const [showBranchPasswordInput, setShowBranchPasswordInput] =
     useState<boolean>(false)
-  const [branchPassword, setBranchPassword] = useState<string>('')
+  const [branchPassword, setBranchPassword] =
+    useState<string>(savedBranchPassword)
+
+  useEffect(() => {
+    setBranchPassword(savedBranchPassword)
+  }, [savedBranchPassword])
 
   return (
     <div>


### PR DESCRIPTION
Since we are loading password from backend asynchronously we need to add useEffect that will react to those changes. It's a small but annoying bug

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
