### PR TITLE
[Fix] Caching in `downloadFile`

### DIFF
--- a/src/backend/utils/inet/downloader/index.ts
+++ b/src/backend/utils/inet/downloader/index.ts
@@ -51,8 +51,7 @@ async function downloadFile(
   if (options.maxCache && options.writeToFile) {
     const stats = await stat(options.writeToFile).catch(() => null)
     if (stats) {
-      if (stats.birthtime.valueOf() + options.maxCache * 1000 >= Date.now()) {
-        console.log('Returning cached value for', url)
+      if (stats.mtimeMs + options.maxCache * 1000 >= Date.now()) {
         switch (options.axiosConfig?.responseType) {
           case 'text':
             return readFile(options.writeToFile, 'utf-8')

--- a/src/backend/utils/systeminfo/gpu/pci_ids.ts
+++ b/src/backend/utils/systeminfo/gpu/pci_ids.ts
@@ -33,7 +33,7 @@ async function getPicIds(): Promise<typeof pciIdsMap | null> {
       responseType: 'text'
     },
     writeToFile: path.join(toolsPath, 'pci.ids'),
-    maxCache: 7 * DAYS
+    maxCache: 30 * DAYS
   }).catch((error) => error as AxiosError)
   if (axios.isAxiosError(pciIdsFile)) return null
 


### PR DESCRIPTION
We were looking at the birthtime of the file, which doesn't actually get updated when re-downloading (as such, nothing was ever cached).

A *very quick* local test suggests that this is working, but I don't have the time to properly test this on multiple systems/OSs right now.

In case this does work as-is everywhere, I've also created the [pci_ids_stable_branch](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/tree/pci_ids_stable_branch) branch from our latest release and the two commits, ideally we'd release this ASAP as a 2.12.1.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
