### PR TITLE
[Test/e2e] Add a mechanism to stub binaries

### DIFF
--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -4,14 +4,11 @@ import { electronTest } from './helpers'
 
 declare const window: { api: typeof import('../src/backend/api').default }
 
-electronTest('renders the first page', async (app) => {
-  const page = await app.firstWindow()
+electronTest('renders the first page', async (app, page) => {
   await expect(page).toHaveTitle('Heroic Games Launcher')
 })
 
-electronTest('gets heroic, legendary, and gog versions', async (app) => {
-  const page = await app.firstWindow()
-
+electronTest('gets heroic, legendary, and gog versions', async (app, page) => {
   await test.step('get heroic version', async () => {
     const heroicVersion = await page.evaluate(async () =>
       window.api.getHeroicVersion()

--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -13,7 +13,6 @@ electronTest('gets heroic, legendary, and gog versions', async (app, page) => {
     const heroicVersion = await page.evaluate(async () =>
       window.api.getHeroicVersion()
     )
-    console.log('Heroic Version: ', heroicVersion)
     // check that heroic version is newer or equal to 2.6.3
     expect(compareVersions(heroicVersion, '2.6.3')).toBeGreaterThanOrEqual(0)
   })
@@ -23,7 +22,6 @@ electronTest('gets heroic, legendary, and gog versions', async (app, page) => {
       window.api.getLegendaryVersion()
     )
     legendaryVersion = legendaryVersion.trim().split(' ')[0]
-    console.log('Legendary Version: ', legendaryVersion)
     expect(compareVersions(legendaryVersion, '0.20.32')).toBeGreaterThanOrEqual(
       0
     )
@@ -33,7 +31,6 @@ electronTest('gets heroic, legendary, and gog versions', async (app, page) => {
     const gogdlVersion = await page.evaluate(async () =>
       window.api.getGogdlVersion()
     )
-    console.log('Gogdl Version: ', gogdlVersion)
     expect(compareVersions(gogdlVersion, '0.7.1')).toBeGreaterThanOrEqual(0)
   })
 })

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -2,7 +2,7 @@ import { join } from 'path'
 import {
   test,
   _electron as electron,
-  type ElectronApplication,
+  ElectronApplication,
   Page
 } from '@playwright/test'
 
@@ -42,12 +42,31 @@ function electronTest(
 
 async function resetAllStubs(app: ElectronApplication) {
   await resetLegendaryCommandStub(app)
+  await resetGogdlCommandStub(app)
+  await resetNileCommandStub(app)
 }
 
-export async function resetLegendaryCommandStub(app: ElectronApplication) {
+async function resetLegendaryCommandStub(app: ElectronApplication) {
   await app.evaluate(({ ipcMain }) => {
     ipcMain.emit('resetLegendaryCommandStub')
   })
 }
 
-export { electronTest }
+async function resetGogdlCommandStub(app: ElectronApplication) {
+  await app.evaluate(({ ipcMain }) => {
+    ipcMain.emit('resetGogdlCommandStub')
+  })
+}
+
+async function resetNileCommandStub(app: ElectronApplication) {
+  await app.evaluate(({ ipcMain }) => {
+    ipcMain.emit('resetNileCommandStub')
+  })
+}
+
+export {
+  electronTest,
+  resetLegendaryCommandStub,
+  resetGogdlCommandStub,
+  resetNileCommandStub
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -46,7 +46,7 @@ async function resetAllStubs(app: ElectronApplication) {
 
 export async function resetLegendaryCommandStub(app: ElectronApplication) {
   await app.evaluate(({ ipcMain }) => {
-    ipcMain.emit('resetRunLegendaryCommandStub')
+    ipcMain.emit('resetLegendaryCommandStub')
   })
 }
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -2,7 +2,8 @@ import { join } from 'path'
 import {
   test,
   _electron as electron,
-  type ElectronApplication
+  type ElectronApplication,
+  Page
 } from '@playwright/test'
 
 const main_js = join(__dirname, '../build/main/main.js')
@@ -14,14 +15,38 @@ const main_js = join(__dirname, '../build/main/main.js')
  */
 function electronTest(
   name: string,
-  func: (app: ElectronApplication) => void | Promise<void>
+  func: (app: ElectronApplication, page: Page) => void | Promise<void>
 ) {
   test(name, async () => {
-    const app = await electron.launch({
+    const electronApp = await electron.launch({
       args: [main_js]
     })
-    await func(app)
-    await app.close()
+
+    // uncomment these lines to print electron's output
+    // electronApp
+    //   .process()!
+    //   .stdout?.on('data', (data) => console.log(`stdout: ${data}`))
+    // electronApp
+    //   .process()!
+    //   .stderr?.on('data', (error) => console.log(`stderr: ${error}`))
+
+    const page = await electronApp.firstWindow()
+
+    await func(electronApp, page)
+
+    await resetAllStubs(electronApp)
+
+    await electronApp.close()
+  })
+}
+
+async function resetAllStubs(app: ElectronApplication) {
+  await resetLegendaryCommandStub(app)
+}
+
+export async function resetLegendaryCommandStub(app: ElectronApplication) {
+  await app.evaluate(({ ipcMain }) => {
+    ipcMain.emit('resetRunLegendaryCommandStub')
   })
 }
 

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -58,8 +58,6 @@ electronTest('Settings', async (app, page) => {
     await expect(page.getByText('Nile Version: 1.1.1 JoJo')).toBeVisible()
   })
 
-  // TODO: add stubs for nile
-
   await test.step('shows the default experimental features', async () => {
     await expect(page.getByLabel('New design')).not.toBeChecked()
     await expect(page.getByLabel('Help component')).not.toBeChecked()

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,49 +1,39 @@
 import { expect, test } from '@playwright/test'
 import { electronTest } from './helpers'
-import { LegendaryCommand } from '../src/backend/storeManagers/legendary/commands'
 
 electronTest('Settings', async (app, page) => {
   // stub `legendary --version`
   await app.evaluate(({ ipcMain }) => {
-    ipcMain.emit(
-      'setRunLegendaryCommandStub',
-      function (command: LegendaryCommand) {
-        if (command['--version']) {
-          return {
-            stdout: 'legendary version "0.20.33", codename "Undue Alarm"',
-            stderr: ''
-          }
-        } else {
-          return {
-            stdout: '',
-            stderr: ''
-          }
-        }
+    ipcMain.emit('setRunLegendaryCommandStub', [
+      {
+        command: '--version',
+        stdout: 'legendary version "1.2.3", codename "Some Name"'
       }
-    )
+    ])
   })
 
   await test.step('shows the Advanced settings', async () => {
     await page.getByTestId('settings').click()
     page.getByText('Global Settings')
     await page.getByText('Advanced').click()
-    await page.waitForTimeout(1000)
   })
 
   await test.step('shows alternative binaries inputs', async () => {
-    expect(
+    await expect(
       page.getByLabel('Choose an Alternative Legendary Binary')
     ).toBeVisible()
-    expect(
+    await expect(
       page.getByLabel('Choose an Alternative GOGDL Binary to use')
     ).toBeVisible()
-    expect(page.getByLabel('Choose an Alternative Nile Binary')).toBeVisible()
+    await expect(
+      page.getByLabel('Choose an Alternative Nile Binary')
+    ).toBeVisible()
   })
 
   await test.step('shows the legendary version from the legendary command', async () => {
-    expect(
-      page.getByText('Legendary Version: 0.20.33 Undue Alarm')
-    ).toBeVisible()
+    expect(page.getByText('Legendary Version: 1.2.3 Some Name')).toBeVisible({
+      timeout: 10000
+    })
   })
 
   // TODO: add stubs for gogdl and nile
@@ -51,8 +41,10 @@ electronTest('Settings', async (app, page) => {
   // expect(page.getByText('Nile Version: 1.0.0 Jonathan Joestar')).toBeVisible()
 
   await test.step('shows the default experimental features', async () => {
-    expect(page.getByLabel('New design')).not.toBeChecked()
-    expect(page.getByLabel('Help component')).not.toBeChecked()
-    expect(page.getByLabel('Apply known fixes automatically')).toBeChecked()
+    await expect(page.getByLabel('New design')).not.toBeChecked()
+    await expect(page.getByLabel('Help component')).not.toBeChecked()
+    await expect(
+      page.getByLabel('Apply known fixes automatically')
+    ).toBeChecked()
   })
 })

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -4,10 +4,30 @@ import { electronTest } from './helpers'
 electronTest('Settings', async (app, page) => {
   // stub `legendary --version`
   await app.evaluate(({ ipcMain }) => {
-    ipcMain.emit('setRunLegendaryCommandStub', [
+    ipcMain.emit('setLegendaryCommandStub', [
       {
-        command: '--version',
+        commandParts: ['--version'],
         stdout: 'legendary version "1.2.3", codename "Some Name"'
+      }
+    ])
+  })
+
+  // stub `gogdl --version`
+  await app.evaluate(({ ipcMain }) => {
+    ipcMain.emit('setGogdlCommandStub', [
+      {
+        commandParts: ['--version'],
+        stdout: '2.3.4'
+      }
+    ])
+  })
+
+  // stub `nile --version`
+  await app.evaluate(({ ipcMain }) => {
+    ipcMain.emit('setNileCommandStub', [
+      {
+        commandParts: ['--version'],
+        stdout: '1.1.1 JoJo'
       }
     ])
   })
@@ -30,15 +50,15 @@ electronTest('Settings', async (app, page) => {
     ).toBeVisible()
   })
 
-  await test.step('shows the legendary version from the legendary command', async () => {
-    expect(page.getByText('Legendary Version: 1.2.3 Some Name')).toBeVisible({
-      timeout: 10000
-    })
+  await test.step('shows the binaries versions from the binaries', async () => {
+    await expect(
+      page.getByText('Legendary Version: 1.2.3 Some Name')
+    ).toBeVisible()
+    await expect(page.getByText('GOGDL Version: 2.3.4')).toBeVisible()
+    await expect(page.getByText('Nile Version: 1.1.1 JoJo')).toBeVisible()
   })
 
-  // TODO: add stubs for gogdl and nile
-  // expect(page.getByText('GOGDL Version: 1.0.0')).toBeVisible()
-  // expect(page.getByText('Nile Version: 1.0.0 Jonathan Joestar')).toBeVisible()
+  // TODO: add stubs for nile
 
   await test.step('shows the default experimental features', async () => {
     await expect(page.getByLabel('New design')).not.toBeChecked()

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test'
+import { electronTest } from './helpers'
+import { LegendaryCommand } from '../src/backend/storeManagers/legendary/commands'
+
+electronTest('Settings', async (app, page) => {
+  // stub `legendary --version`
+  await app.evaluate(({ ipcMain }) => {
+    ipcMain.emit(
+      'setRunLegendaryCommandStub',
+      function (command: LegendaryCommand) {
+        if (command['--version']) {
+          return {
+            stdout: 'legendary version "0.20.33", codename "Undue Alarm"',
+            stderr: ''
+          }
+        } else {
+          return {
+            stdout: '',
+            stderr: ''
+          }
+        }
+      }
+    )
+  })
+
+  await test.step('shows the Advanced settings', async () => {
+    await page.getByTestId('settings').click()
+    page.getByText('Global Settings')
+    await page.getByText('Advanced').click()
+    await page.waitForTimeout(1000)
+  })
+
+  await test.step('shows alternative binaries inputs', async () => {
+    expect(
+      page.getByLabel('Choose an Alternative Legendary Binary')
+    ).toBeVisible()
+    expect(
+      page.getByLabel('Choose an Alternative GOGDL Binary to use')
+    ).toBeVisible()
+    expect(page.getByLabel('Choose an Alternative Nile Binary')).toBeVisible()
+  })
+
+  await test.step('shows the legendary version from the legendary command', async () => {
+    expect(
+      page.getByText('Legendary Version: 0.20.33 Undue Alarm')
+    ).toBeVisible()
+  })
+
+  // TODO: add stubs for gogdl and nile
+  // expect(page.getByText('GOGDL Version: 1.0.0')).toBeVisible()
+  // expect(page.getByText('Nile Version: 1.0.0 Jonathan Joestar')).toBeVisible()
+
+  await test.step('shows the default experimental features', async () => {
+    expect(page.getByLabel('New design')).not.toBeChecked()
+    expect(page.getByLabel('Help component')).not.toBeChecked()
+    expect(page.getByLabel('Apply known fixes automatically')).toBeChecked()
+  })
+})

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -61,8 +61,5 @@ electronTest('Settings', async (app, page) => {
   await test.step('shows the default experimental features', async () => {
     await expect(page.getByLabel('New design')).not.toBeChecked()
     await expect(page.getByLabel('Help component')).not.toBeChecked()
-    await expect(
-      page.getByLabel('Apply known fixes automatically')
-    ).toBeChecked()
   })
 })

--- a/src/backend/anticheat/utils.ts
+++ b/src/backend/anticheat/utils.ts
@@ -6,6 +6,7 @@ import { runOnceWhenOnline } from '../online_monitor'
 import { axiosClient } from 'backend/utils'
 
 async function downloadAntiCheatData() {
+  if (process.env.CI === 'e2e') return
   if (isWindows) return
 
   runOnceWhenOnline(async () => {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -425,7 +425,7 @@ if (!gotTheLock) {
       handleProtocol([request.url])
       return new Response('Operation initiated.', { status: 201 })
     })
-    if (!app.isDefaultProtocolClient('heroic')) {
+    if (process.env.CI !== 'e2e' && !app.isDefaultProtocolClient('heroic')) {
       if (app.setAsDefaultProtocolClient('heroic')) {
         logInfo('Registered protocol with OS.', LogPrefix.Backend)
       } else {

--- a/src/backend/online_monitor.ts
+++ b/src/backend/online_monitor.ts
@@ -69,6 +69,11 @@ const ping = async (url: string, signal: AbortSignal) => {
 }
 
 const pingSites = () => {
+  if (process.env.CI === 'e2e') {
+    setStatus('online')
+    return
+  }
+
   logInfo(`Pinging external endpoints`, LogPrefix.Connection)
   abortController = new AbortController()
 

--- a/src/backend/storeManagers/gog/e2eMock.ts
+++ b/src/backend/storeManagers/gog/e2eMock.ts
@@ -1,6 +1,5 @@
 import { ipcMain } from 'electron'
 import { RunnerCommandStub } from 'common/types'
-import { LegendaryCommand } from './commands'
 
 /*
  * Multiple parts of a command can be set for the stub to be able to stub
@@ -13,15 +12,15 @@ import { LegendaryCommand } from './commands'
 const defaultStubs: RunnerCommandStub[] = [
   {
     commandParts: ['--version'],
-    stdout: 'legendary version "0.20.33", codename "Undue Alarm"'
+    stdout: '0.7.1'
   }
 ]
 
 let currentStubs = [...defaultStubs]
 
-export const runLegendaryCommandStub = (command: LegendaryCommand) => {
+export const runGogdlCommandStub = (command: string[]) => {
   const stub = currentStubs.find((stub) =>
-    stub.commandParts.every((part) => command[part])
+    stub.commandParts.every((part) => command.includes(part))
   )
 
   return {
@@ -30,11 +29,8 @@ export const runLegendaryCommandStub = (command: LegendaryCommand) => {
   }
 }
 
-// Add listeners to be called from e2e tests to stub the legendary command calls
+// Add listeners to be called from e2e tests to stub the gogdl command calls
 if (process.env.CI === 'e2e') {
-  ipcMain.on('setLegendaryCommandStub', (stubs) => (currentStubs = [...stubs]))
-  ipcMain.on(
-    'resetLegendaryCommandStub',
-    () => (currentStubs = [...defaultStubs])
-  )
+  ipcMain.on('setGogdlCommandStub', (stubs) => (currentStubs = [...stubs]))
+  ipcMain.on('resetGogdlCommandStub', () => (currentStubs = [...defaultStubs]))
 }

--- a/src/backend/storeManagers/gog/e2eMock.ts
+++ b/src/backend/storeManagers/gog/e2eMock.ts
@@ -8,6 +8,9 @@ import { RunnerCommandStub } from 'common/types'
  * The first stub for which all commandParts are included in the executed
  * command will be selected. The stubs should be declared from more
  * precise to less precise to avoid unreachable stubs.
+ *
+ * We can stub a Promise<ExecResult> as a response, or stub stdout/stderr
+ * values as an alternative to make the stubbing easier
  */
 const defaultStubs: RunnerCommandStub[] = [
   {
@@ -18,15 +21,17 @@ const defaultStubs: RunnerCommandStub[] = [
 
 let currentStubs = [...defaultStubs]
 
-export const runGogdlCommandStub = (command: string[]) => {
+export const runGogdlCommandStub = async (command: string[]) => {
   const stub = currentStubs.find((stub) =>
     stub.commandParts.every((part) => command.includes(part))
   )
 
-  return {
+  if (stub?.response) return stub.response
+
+  return Promise.resolve({
     stdout: stub?.stdout || '',
     stderr: stub?.stderr || ''
-  }
+  })
 }
 
 // Add listeners to be called from e2e tests to stub the gogdl command calls

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -52,6 +52,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { unzipSync } from 'node:zlib'
 import { readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { checkForRedistUpdates } from './redist'
+import { runGogdlCommandStub } from './e2eMock'
 
 const library: Map<string, GameInfo> = new Map()
 const installedGames: Map<string, InstalledInfo> = new Map()
@@ -1319,6 +1320,10 @@ export async function runRunnerCommand(
   commandParts: string[],
   options?: CallRunnerOptions
 ): Promise<ExecResult> {
+  if (process.env.CI === 'e2e') {
+    return runGogdlCommandStub(commandParts)
+  }
+
   const { dir, bin } = getGOGdlBin()
   const authConfig = join(app.getPath('userData'), 'gog_store', 'auth.json')
 

--- a/src/backend/storeManagers/legendary/e2eMock.ts
+++ b/src/backend/storeManagers/legendary/e2eMock.ts
@@ -9,25 +9,33 @@ import { LegendaryCommand } from './commands'
  * The first stub for which all commandParts are included in the executed
  * command will be selected. The stubs should be declared from more
  * precise to less precise to avoid unreachable stubs.
+ *
+ * We can stub a Promise<ExecResult> as a response, or stub stdout/stderr
+ * values as an alternative to make the stubbing easier
  */
 const defaultStubs: RunnerCommandStub[] = [
   {
     commandParts: ['--version'],
-    stdout: 'legendary version "0.20.33", codename "Undue Alarm"'
+    response: Promise.resolve({
+      stdout: 'legendary version "0.20.33", codename "Undue Alarm"',
+      stderr: ''
+    })
   }
 ]
 
 let currentStubs = [...defaultStubs]
 
-export const runLegendaryCommandStub = (command: LegendaryCommand) => {
+export const runLegendaryCommandStub = async (command: LegendaryCommand) => {
   const stub = currentStubs.find((stub) =>
     stub.commandParts.every((part) => command[part])
   )
 
-  return {
+  if (stub?.response) return stub.response
+
+  return Promise.resolve({
     stdout: stub?.stdout || '',
     stderr: stub?.stderr || ''
-  }
+  })
 }
 
 // Add listeners to be called from e2e tests to stub the legendary command calls

--- a/src/backend/storeManagers/legendary/e2eMock.ts
+++ b/src/backend/storeManagers/legendary/e2eMock.ts
@@ -1,0 +1,33 @@
+import { ipcMain } from 'electron'
+import { runLegendaryCommandStubFunction } from 'common/types'
+
+export let runLegendaryCommandStub: runLegendaryCommandStubFunction = () => {
+  return {
+    stdout: '',
+    stderr: ''
+  }
+}
+
+const resetRunLegendaryCommandStub = () => {
+  runLegendaryCommandStub = () => {
+    return {
+      stdout: '',
+      stderr: ''
+    }
+  }
+}
+
+const setRunLegendaryCommandStub = (fun: runLegendaryCommandStubFunction) =>
+  (runLegendaryCommandStub = fun)
+
+// Add listeners to be called from e2e tests to stub the
+// legendary command calls
+if (process.env.CI === 'e2e') {
+  ipcMain.on('setRunLegendaryCommandStub', (fun) => {
+    setRunLegendaryCommandStub(fun)
+  })
+
+  ipcMain.on('resetRunLegendaryCommandStub', () =>
+    resetRunLegendaryCommandStub()
+  )
+}

--- a/src/backend/storeManagers/legendary/e2eMock.ts
+++ b/src/backend/storeManagers/legendary/e2eMock.ts
@@ -1,33 +1,38 @@
 import { ipcMain } from 'electron'
-import { runLegendaryCommandStubFunction } from 'common/types'
+import { LegendaryStub } from 'common/types'
+import { LegendaryCommand } from './commands'
 
-export let runLegendaryCommandStub: runLegendaryCommandStubFunction = () => {
+const defaultStubs: LegendaryStub[] = [
+  {
+    command: '--version',
+    stdout: 'legendary version "0.20.33", codename "Undue Alarm"'
+  }
+]
+
+let currentStubs = [...defaultStubs]
+
+export const runLegendaryCommandStub = (command: LegendaryCommand) => {
+  const stub = currentStubs.find((stub) => command[stub.command])
+
   return {
-    stdout: '',
-    stderr: ''
+    stdout: stub?.stdout || '',
+    stderr: stub?.stderr || ''
   }
 }
 
-const resetRunLegendaryCommandStub = () => {
-  runLegendaryCommandStub = () => {
-    return {
-      stdout: '',
-      stderr: ''
-    }
-  }
-}
+const resetRunLegendaryCommandStubs = () => (currentStubs = [...defaultStubs])
 
-const setRunLegendaryCommandStub = (fun: runLegendaryCommandStubFunction) =>
-  (runLegendaryCommandStub = fun)
+const setRunLegendaryCommandStubs = (stubs: LegendaryStub[]) =>
+  (currentStubs = [...stubs])
 
 // Add listeners to be called from e2e tests to stub the
 // legendary command calls
 if (process.env.CI === 'e2e') {
-  ipcMain.on('setRunLegendaryCommandStub', (fun) => {
-    setRunLegendaryCommandStub(fun)
+  ipcMain.on('setRunLegendaryCommandStub', (stubs) => {
+    setRunLegendaryCommandStubs(stubs)
   })
 
   ipcMain.on('resetRunLegendaryCommandStub', () =>
-    resetRunLegendaryCommandStub()
+    resetRunLegendaryCommandStubs()
   )
 }

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -681,7 +681,7 @@ export async function runRunnerCommand(
   options?: CallRunnerOptions
 ): Promise<ExecResult> {
   if (process.env.CI === 'e2e') {
-    return runLegendaryCommandStub(command, options)
+    return runLegendaryCommandStub(command)
   }
 
   const { dir, bin } = getLegendaryBin()

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -58,6 +58,7 @@ import { Path } from 'backend/schemas'
 import shlex from 'shlex'
 import thirdParty from './thirdParty'
 import { Entries } from 'type-fest'
+import { runLegendaryCommandStub } from './e2eMock'
 
 const allGames: Set<string> = new Set()
 let installedGames: Map<string, InstalledJsonMetadata> = new Map()
@@ -679,6 +680,10 @@ export async function runRunnerCommand(
   command: LegendaryCommand,
   options?: CallRunnerOptions
 ): Promise<ExecResult> {
+  if (process.env.CI === 'e2e') {
+    return runLegendaryCommandStub(command, options)
+  }
+
   const { dir, bin } = getLegendaryBin()
 
   // Set LEGENDARY_CONFIG_PATH to a custom, Heroic-specific location so user-made

--- a/src/backend/storeManagers/nile/e2eMock.ts
+++ b/src/backend/storeManagers/nile/e2eMock.ts
@@ -8,6 +8,9 @@ import { RunnerCommandStub } from 'common/types'
  * The first stub for which all commandParts are included in the executed
  * command will be selected. The stubs should be declared from more
  * precise to less precise to avoid unreachable stubs.
+ *
+ * We can stub a Promise<ExecResult> as a response, or stub stdout/stderr
+ * values as an alternative to make the stubbing easier
  */
 const defaultStubs: RunnerCommandStub[] = [
   {
@@ -18,15 +21,17 @@ const defaultStubs: RunnerCommandStub[] = [
 
 let currentStubs = [...defaultStubs]
 
-export const runNileCommandStub = (command: string[]) => {
+export const runNileCommandStub = async (command: string[]) => {
   const stub = currentStubs.find((stub) =>
     stub.commandParts.every((part) => command.includes(part))
   )
 
-  return {
+  if (stub?.response) return stub.response
+
+  return Promise.resolve({
     stdout: stub?.stdout || '',
     stderr: stub?.stderr || ''
-  }
+  })
 }
 
 // Add listeners to be called from e2e tests to stub the nile command calls

--- a/src/backend/storeManagers/nile/e2eMock.ts
+++ b/src/backend/storeManagers/nile/e2eMock.ts
@@ -1,6 +1,5 @@
 import { ipcMain } from 'electron'
 import { RunnerCommandStub } from 'common/types'
-import { LegendaryCommand } from './commands'
 
 /*
  * Multiple parts of a command can be set for the stub to be able to stub
@@ -13,15 +12,15 @@ import { LegendaryCommand } from './commands'
 const defaultStubs: RunnerCommandStub[] = [
   {
     commandParts: ['--version'],
-    stdout: 'legendary version "0.20.33", codename "Undue Alarm"'
+    stdout: '1.0.0 Jonathan Joestar'
   }
 ]
 
 let currentStubs = [...defaultStubs]
 
-export const runLegendaryCommandStub = (command: LegendaryCommand) => {
+export const runNileCommandStub = (command: string[]) => {
   const stub = currentStubs.find((stub) =>
-    stub.commandParts.every((part) => command[part])
+    stub.commandParts.every((part) => command.includes(part))
   )
 
   return {
@@ -30,11 +29,8 @@ export const runLegendaryCommandStub = (command: LegendaryCommand) => {
   }
 }
 
-// Add listeners to be called from e2e tests to stub the legendary command calls
+// Add listeners to be called from e2e tests to stub the nile command calls
 if (process.env.CI === 'e2e') {
-  ipcMain.on('setLegendaryCommandStub', (stubs) => (currentStubs = [...stubs]))
-  ipcMain.on(
-    'resetLegendaryCommandStub',
-    () => (currentStubs = [...defaultStubs])
-  )
+  ipcMain.on('setNileCommandStub', (stubs) => (currentStubs = [...stubs]))
+  ipcMain.on('resetNileCommandStub', () => (currentStubs = [...defaultStubs]))
 }

--- a/src/backend/storeManagers/nile/library.ts
+++ b/src/backend/storeManagers/nile/library.ts
@@ -28,6 +28,7 @@ import { dirname, join } from 'path'
 import { app } from 'electron'
 import { copySync } from 'fs-extra'
 import { NileUser } from './user'
+import { runNileCommandStub } from './e2eMock'
 
 const installedGames: Map<string, NileInstallMetadataInfo> = new Map()
 const library: Map<string, GameInfo> = new Map()
@@ -466,6 +467,10 @@ export async function runRunnerCommand(
   commandParts: string[],
   options?: CallRunnerOptions
 ): Promise<ExecResult> {
+  if (process.env.CI === 'e2e') {
+    return runNileCommandStub(commandParts)
+  }
+
   const { dir, bin } = getNileBin()
 
   // Set NILE_CONFIG_PATH to a custom, Heroic-specific location so user-made

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -742,6 +742,8 @@ function detectVCRedist(mainWindow: BrowserWindow) {
 }
 
 const getLatestReleases = async (): Promise<Release[]> => {
+  if (process.env.CI === 'e2e') return []
+
   const newReleases: Release[] = []
   logInfo('Checking for new Heroic Updates', LogPrefix.Backend)
 
@@ -787,6 +789,8 @@ const getLatestReleases = async (): Promise<Release[]> => {
 }
 
 const getCurrentChangelog = async (): Promise<Release | null> => {
+  if (process.env.CI === 'e2e') return null
+
   logInfo('Checking for current version changelog', LogPrefix.Backend)
 
   try {

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -34,7 +34,7 @@ import {
   InstallInfo,
   WikiInfo,
   UploadedLogData,
-  LegendaryStub
+  RunnerCommandStub
 } from 'common/types'
 import { GameOverride, SelectiveDownload } from 'common/types/legendary'
 import { GOGCloudSavesLocation } from 'common/types/gog'
@@ -127,8 +127,12 @@ interface SyncIPCFunctions {
  * events don't have an IpcMainEvent first argument when handled
  */
 interface TestSyncIPCFunctions {
-  setRunLegendaryCommandStub: (stubs: LegendaryStub[]) => void
-  resetRunLegendaryCommandStub: () => void
+  setLegendaryCommandStub: (stubs: RunnerCommandStub[]) => void
+  resetLegendaryCommandStub: () => void
+  setGogdlCommandStub: (stubs: RunnerCommandStub[]) => void
+  resetGogdlCommandStub: () => void
+  setNileCommandStub: (stubs: RunnerCommandStub[]) => void
+  resetNileCommandStub: () => void
 }
 
 // ts-prune-ignore-next

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -33,7 +33,8 @@ import {
   DownloadManagerState,
   InstallInfo,
   WikiInfo,
-  UploadedLogData
+  UploadedLogData,
+  LegendaryStub
 } from 'common/types'
 import { GameOverride, SelectiveDownload } from 'common/types/legendary'
 import { GOGCloudSavesLocation } from 'common/types/gog'
@@ -43,7 +44,6 @@ import {
   NileUserData
 } from 'common/types/nile'
 import type { SystemInformation } from 'backend/utils/systeminfo'
-import { runLegendaryCommandStubFunction } from 'backend/storeManagers/legendary/e2eMock'
 
 /**
  * Some notes here:
@@ -127,7 +127,7 @@ interface SyncIPCFunctions {
  * events don't have an IpcMainEvent first argument when handled
  */
 interface TestSyncIPCFunctions {
-  setRunLegendaryCommandStub: (fun: runLegendaryCommandStubFunction) => void
+  setRunLegendaryCommandStub: (stubs: LegendaryStub[]) => void
   resetRunLegendaryCommandStub: () => void
 }
 

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -43,6 +43,7 @@ import {
   NileUserData
 } from 'common/types/nile'
 import type { SystemInformation } from 'backend/utils/systeminfo'
+import { runLegendaryCommandStubFunction } from 'backend/storeManagers/legendary/e2eMock'
 
 /**
  * Some notes here:
@@ -117,6 +118,17 @@ interface SyncIPCFunctions {
     runner: Runner,
     status: boolean
   ) => void
+}
+
+/*
+ * These events should only be used during tests to stub/mock
+ *
+ * We have to handle them in another interface because these
+ * events don't have an IpcMainEvent first argument when handled
+ */
+interface TestSyncIPCFunctions {
+  setRunLegendaryCommandStub: (fun: runLegendaryCommandStubFunction) => void
+  resetRunLegendaryCommandStub: () => void
 }
 
 // ts-prune-ignore-next
@@ -312,13 +324,20 @@ interface AsyncIPCFunctions {
 // ts-prune-ignore-next
 declare namespace Electron {
   class IpcMain extends EventEmitter {
-    public on: <
+    public on: (<
       Name extends keyof SyncIPCFunctions,
       Definition extends SyncIPCFunctions[Name]
     >(
       name: Name,
       callback: (e: IpcMainEvent, ...args: Parameters<Definition>) => void
-    ) => void
+    ) => void) &
+      (<
+        Name extends keyof TestSyncIPCFunctions,
+        Definition extends TestSyncIPCFunctions[Name]
+      >(
+        name: Name,
+        callback: (...args: Parameters<Definition>) => void
+      ) => void)
 
     public handle: <
       Name extends keyof AsyncIPCFunctions,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -778,6 +778,7 @@ export interface UploadedLogData {
 
 export interface RunnerCommandStub {
   commandParts: string[]
-  stdout: string
+  response?: Promise<ExecResult>
+  stdout?: string
   stderr?: string
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -12,7 +12,6 @@ import { TitleBarOverlay } from 'electron'
 import { ChildProcess } from 'child_process'
 import type { HowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
 import { NileInstallInfo, NileInstallPlatform } from './types/nile'
-import { LegendaryCommand } from 'backend/storeManagers/legendary/commands'
 
 export type Runner = 'legendary' | 'gog' | 'sideload' | 'nile'
 
@@ -777,7 +776,8 @@ export interface UploadedLogData {
   uploadedAt: number
 }
 
-export type runLegendaryCommandStubFunction = (
-  command: LegendaryCommand,
-  options?: CallRunnerOptions
-) => ExecResult
+export interface LegendaryStub {
+  command: string
+  stdout: string
+  stderr?: string
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -776,8 +776,8 @@ export interface UploadedLogData {
   uploadedAt: number
 }
 
-export interface LegendaryStub {
-  command: string
+export interface RunnerCommandStub {
+  commandParts: string[]
   stdout: string
   stderr?: string
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -12,6 +12,7 @@ import { TitleBarOverlay } from 'electron'
 import { ChildProcess } from 'child_process'
 import type { HowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
 import { NileInstallInfo, NileInstallPlatform } from './types/nile'
+import { LegendaryCommand } from 'backend/storeManagers/legendary/commands'
 
 export type Runner = 'legendary' | 'gog' | 'sideload' | 'nile'
 
@@ -775,3 +776,8 @@ export interface UploadedLogData {
   // Time the log file was uploaded (used to know whether it expired)
   uploadedAt: number
 }
+
+export type runLegendaryCommandStubFunction = (
+  command: LegendaryCommand,
+  options?: CallRunnerOptions
+) => ExecResult


### PR DESCRIPTION
This PR is an initial implementation to be able to stub binaries during e2e tests.

The current `e2e/api.spec.ts` tests are not really doing an e2e test: those tests are testing that the `window.api` functions return a version for each binary but are not really testing the boundaries of the app from the user point of view. They are more like an API test.

With this PR we can test navigating Heroic as a user would, going to Settings > Advanced where the versions are displayed, and we can now stub the binaries to test different outcomes. The current tests only stub a single stdout value, but the subbing supports setting a response Promise if we want to do something more complex to mimic a download progress for example?

I also added a few `if (process.env.CI === 'e2e')` guards in commands that were performing external requests, we shouldn't do that (and eventually we should also add a method to stub those to be able to test different scenarios).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
