### PR TITLE
[PROTON]: use run verb for setup commands

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -338,7 +338,7 @@ async function prepareWineLaunch(
       sendFrontendMessage('gameStatusUpdate', {
         appName,
         runner: 'gog',
-        status: 'playing'
+        status: 'launching'
       })
     }
     if (runner === 'nile') {
@@ -436,7 +436,7 @@ async function installFixes(appName: string, runner: Runner) {
         await runWineCommandOnGame(appName, {
           commandParts: [fullPath],
           wait: true,
-          protonVerb: 'waitforexitandrun'
+          protonVerb: 'run'
         })
       }
     }

--- a/src/backend/storeManagers/nile/setup.ts
+++ b/src/backend/storeManagers/nile/setup.ts
@@ -114,7 +114,7 @@ export default async function setup(
       gameInstallPath: basePath,
       commandParts: [action.Command, ...exeArguments],
       wait: true,
-      protonVerb: 'waitforexitandrun',
+      protonVerb: 'run',
       startFolder: basePath
     })
   }

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -259,7 +259,7 @@ export const DXVK = {
           gameSettings,
           commandParts: unregisterDll,
           wait: true,
-          protonVerb: 'waitforexitandrun'
+          protonVerb: 'run'
         })
       })
       dlls32.forEach(async (dll) => {
@@ -276,7 +276,7 @@ export const DXVK = {
           gameSettings,
           commandParts: unregisterDll,
           wait: true,
-          protonVerb: 'waitforexitandrun'
+          protonVerb: 'run'
         })
       })
       return true
@@ -339,7 +339,7 @@ export const DXVK = {
         gameSettings,
         commandParts: registerDll,
         wait: true,
-        protonVerb: 'waitforexitandrun'
+        protonVerb: 'run'
       })
     })
     dlls32.forEach(async (dll) => {
@@ -359,7 +359,7 @@ export const DXVK = {
         gameSettings,
         commandParts: registerDll,
         wait: true,
-        protonVerb: 'waitforexitandrun'
+        protonVerb: 'run'
       })
     })
 
@@ -398,7 +398,7 @@ export const DXVK = {
             gameSettings,
             commandParts: regModNvngx,
             wait: true,
-            protonVerb: 'waitforexitandrun'
+            protonVerb: 'run'
           })
         } else {
           logWarning(


### PR DESCRIPTION
We were using `waitforexitandrun` for setup commands, which is slow as it first ensures that wineserver exited properly.
`run` is made for exactly the purpose of setup. With that we can re-use wineserver process and in turn make it faster. 

I also made changes to legendary's setup, as it was using function that could recursively call itself in some conditions. This change is here to prevent that from happening in the future when we make changes to when game setup commands are executed.

Proton-GE relies on the verb to determine if it should apply protonfixes, which will be useful for us with introduction of ULWGL.

There is one command I'm not yet sure about - `shutdownWine` function. I'll take care of it in ULWGL PR though

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
