### PR TITLE
[Fix] Ensure manifest in install info

### DIFF
--- a/src/backend/downloadmanager/downloadqueue.ts
+++ b/src/backend/downloadmanager/downloadqueue.ts
@@ -126,12 +126,10 @@ async function addToQueue(element: DMQueueElement) {
   } else {
     const installInfo = await libraryManagerMap[
       element.params.runner
-    ].getInstallInfo(
-      element.params.appName,
-      element.params.platformToInstall,
-      element.params.branch,
-      element.params.build
-    )
+    ].getInstallInfo(element.params.appName, element.params.platformToInstall, {
+      branch: element.params.branch,
+      build: element.params.build
+    })
 
     element.params.size = installInfo?.manifest?.download_size
       ? getFileSize(installInfo?.manifest?.download_size)

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -779,8 +779,10 @@ ipcMain.handle(
       const info = await libraryManagerMap[runner].getInstallInfo(
         appName,
         installPlatform,
-        branch,
-        build
+        {
+          branch,
+          build
+        }
       )
       if (info === undefined) return null
       return info

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -375,12 +375,10 @@ export async function install(
 
   // Installation succeded
   // Save new game info to installed games store
-  const installInfo = await getInstallInfo(
-    appName,
-    installPlatform,
+  const installInfo = await getInstallInfo(appName, installPlatform, {
     branch,
     build
-  )
+  })
   if (installInfo === undefined) {
     logError('install info is undefined in GOG install', LogPrefix.Gog)
     return { status: 'error' }
@@ -1096,8 +1094,10 @@ export async function update(
     const installInfo = await getInstallInfo(
       appName,
       gameData.install.platform ?? 'windows',
-      updateOverwrites?.branch,
-      updateOverwrites?.build
+      {
+        branch: updateOverwrites?.branch,
+        build: updateOverwrites?.build
+      }
     )
     // TODO: use installInfo.game.builds
     const { etag } = await getMetaResponse(

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -495,15 +495,17 @@ export function getInstallAndGameInfo(slug: string): GameInfo | undefined {
  * Contains data like download size
  * @param appName
  * @param installPlatform
- * @param lang
+ * @param options
  * @returns InstallInfo object
  */
 export async function getInstallInfo(
   appName: string,
   installPlatform = 'windows',
-  branch = 'null',
-  build?: string
+  options?: { branch?: string; build?: string }
 ): Promise<GogInstallInfo | undefined> {
+  const branch = options?.branch || 'null'
+  const build = options?.build
+
   installPlatform = installPlatform.toLowerCase()
   if (installPlatform === 'mac') {
     installPlatform = 'osx'

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -495,7 +495,7 @@ export function getInstallAndGameInfo(slug: string): GameInfo | undefined {
  * Contains data like download size
  * @param appName
  * @param installPlatform
- * @param options
+ * @param options object with a `branch` ('null' if undefined) and `build` properties
  * @returns InstallInfo object
  */
 export async function getInstallInfo(

--- a/src/backend/storeManagers/sideload/library.ts
+++ b/src/backend/storeManagers/sideload/library.ts
@@ -1,10 +1,5 @@
 import { isMac } from 'backend/constants'
-import {
-  CallRunnerOptions,
-  ExecResult,
-  GameInfo,
-  InstallPlatform
-} from 'common/types'
+import { ExecResult, GameInfo } from 'common/types'
 import { readdirSync } from 'graceful-fs'
 import { dirname, join } from 'path'
 import { libraryStore } from './electronStores'
@@ -73,7 +68,7 @@ export function addNewApp({
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-export function installState(appName: string, state: boolean) {
+export function installState() {
   logWarning(`installState not implemented on Sideload Library Manager`)
 }
 
@@ -82,7 +77,7 @@ export async function refresh() {
   return null
 }
 
-export function getGameInfo(appName: string, forceReload?: boolean): GameInfo {
+export function getGameInfo(): GameInfo {
   logWarning(`getGameInfo not implemented on Sideload Library Manager`)
   return {
     app_name: '',
@@ -101,35 +96,25 @@ export async function listUpdateableGames(): Promise<string[]> {
   return []
 }
 
-export async function runRunnerCommand(
-  commandParts: string[],
-  options?: CallRunnerOptions
-): Promise<ExecResult> {
+export async function runRunnerCommand(): Promise<ExecResult> {
   logWarning(`runRunnerCommand not implemented on Sideload Library Manager`)
   return { stdout: '', stderr: '' }
 }
 
-export async function changeGameInstallPath(
-  appName: string,
-  newPath: string
-): Promise<void> {
+export async function changeGameInstallPath(): Promise<void> {
   logWarning(
     `changeGameInstallPath not implemented on Sideload Library Manager`
   )
 }
 
-export async function getInstallInfo(
-  appName: string,
-  installPlatform: InstallPlatform,
-  lang?: string
-): Promise<undefined> {
+export async function getInstallInfo(): Promise<undefined> {
   logWarning(`getInstallInfo not implemented on Sideload Library Manager`)
   return undefined
 }
 
 export const getLaunchOptions = () => []
 
-export function changeVersionPinnedStatus(appName: string, status: boolean) {
+export function changeVersionPinnedStatus() {
   logWarning(
     'changeVersionPinnedStatus not implemented on Sideload Library Manager'
   )

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -78,8 +78,12 @@ export interface LibraryManager {
   getInstallInfo: (
     appName: string,
     installPlatform: InstallPlatform,
-    branch?: string,
-    build?: string
+    options: {
+      branch?: string
+      build?: string
+      lang?: string
+      retries?: number
+    }
   ) => Promise<InstallInfo | undefined>
   listUpdateableGames: () => Promise<string[]>
   changeGameInstallPath: (appName: string, newPath: string) => Promise<void>


### PR DESCRIPTION
When getting the install info for legendary games, it sometimes happens that we have invalid data cached that doesn't have `manifest` info.

In the past that lead to the InstallDialog to be stuck fetching the install info forever, with the latest changes for the gogdl_refactor that produces a javascript exception killing the react app: `Error: Cannot use 'in' operator to search for 'perLangSize' in null]`

This PR addresses that with 3 changes:
- if the cached information for legendary does NOT have a `manifest` property, it doesn't use the cache and fetches a new one
- if the result of fetching the info does not have a `manifest` property, it's retried up to 3 times
- if the result of fetching the info does not have a `manifest` property after the retries, it throws an error instead of storing the wrong data

I had to do some changes in the parameters to be able to support different extra params for the different stores.

I understand this fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3249

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
