### PR TITLE
[Fix] Filter out -LoL build when installing wine at boot

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -858,7 +858,10 @@ export async function downloadDefaultWine() {
   // use Wine-GE type if on Linux and Wine-Crossover if on Mac
   const release = availableWine.filter((version) => {
     if (isLinux) {
-      return version.version.includes('Wine-GE-Proton')
+      return (
+        version.version.includes('Wine-GE-Proton') &&
+        !version.version.endsWith('-LoL')
+      )
     } else if (isMac) {
       return version.version.includes('Wine-Crossover')
     }


### PR DESCRIPTION
When Heroic is opened for the first time, if no wine is found it auto installs the latest available Wine-GE.

This was not filtering out the `LoL` builds.

You can test this behavior if you have other wines installed by going to main.ts and commenting out the `if` at:

```ts
  setTimeout(async () => {
    // Will download Wine if none was found
    const availableWine = await GlobalConfig.get().getAlternativeWine()
    DXVK.getLatest()
    Winetricks.download()
    if (!availableWine.length) {
      downloadDefaultWine()
    }
  }, 2500)
```

like:

```ts
  setTimeout(async () => {
    // Will download Wine if none was found
    DXVK.getLatest()
    Winetricks.download()
    downloadDefaultWine()
  }, 2500)
```

Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3511

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
