### PR TITLE
[UX] Show error if using Wine-LoL for not League of Legends

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -76,6 +76,10 @@
                 "message": "Something went wrong with the update, please check the logs or try again later!",
                 "title": "Update Error"
             },
+            "wine-lol-not-lol": {
+                "message": "Wine-GE-Proton-LoL is being used for a game that is not \"League of Legends\". Please install a Wine-GE-Proton version that does not end in -LoL using the Wine Manager section and configure it in the game's settings.",
+                "title": "Incompatible Wine Version"
+            },
             "winetricks": {
                 "message": "Winetricks returned the following error during execution:{{newLine}}{{error}}",
                 "title": "Winetricks error"

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -78,6 +78,8 @@ import { download, isInstalled } from './wine/runtimes/runtimes'
 import { storeMap } from 'common/utils'
 import { runWineCommandOnGame } from './storeManagers/legendary/games'
 
+const leagueOfLegendsAppId = '64b0c77d07f644e6a2326a1fd7ab9926'
+
 async function prepareLaunch(
   gameSettings: GameSettings,
   gameInfo: GameInfo,
@@ -283,6 +285,25 @@ async function prepareWineLaunch(
   const gameSettings =
     GameConfig.get(appName).config ||
     (await GameConfig.get(appName).getSettings())
+
+  // warn about using Wine-GE-LoL when the game is not League Of Legends
+  if (
+    appName !== leagueOfLegendsAppId &&
+    gameSettings.wineVersion.name.endsWith('-LoL')
+  ) {
+    showDialogBoxModalAuto({
+      title: i18next.t(
+        'box.error.wine-lol-not-lol.title',
+        'Incompatible Wine Version'
+      ),
+      message: i18next.t(
+        'box.error.wine-lol-not-lol.message',
+        `Wine-GE-Proton-LoL is being used for a game that is not "League of Legends". Please install a Wine-GE-Proton version that does not end in -LoL using the Wine Manager section and configure it in the game's settings.`
+      ),
+      type: 'ERROR'
+    })
+    return { success: false }
+  }
 
   if (!(await validWine(gameSettings.wineVersion))) {
     const defaultWine = GlobalConfig.get().getSettings().wineVersion


### PR DESCRIPTION
Because of this bug we had https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/3512, a lot of users end up with Wine-GE-Proton-LoL installed and configured by default. Some users also do that by mistake.

This PR adds an error message to prevent users from using Wine-GE-LoL for games that are not League of Legends from Epic.

![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/b81fd31c-ae87-4675-9620-d008aa6a69e7)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
