### PR TITLE
[Logs] Log installed Winetricks packages when launching game

### DIFF
--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -384,7 +384,7 @@ class LogWriter {
     if (this.initialized && !this.timeoutId) this.appendMessages()
   }
 
-  async initLog(afterInit: Promise<string> | null) {
+  async initLog(afterInit?: Promise<string>) {
     const { app_name, runner } = this.gameInfo
 
     const notNative =
@@ -471,10 +471,7 @@ export function appendGameLog(gameInfo: GameInfo, message: string) {
   logsWriters[gameInfo.app_name]?.logMessage(message)
 }
 
-export function initGameLog(
-  gameInfo: GameInfo,
-  afterInit: Promise<string> | null
-) {
+export function initGameLog(gameInfo: GameInfo, afterInit?: Promise<string>) {
   logsWriters[gameInfo.app_name] ??= new LogWriter(gameInfo)
   logsWriters[gameInfo.app_name].initLog(afterInit)
 }

--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -384,7 +384,7 @@ class LogWriter {
     if (this.initialized && !this.timeoutId) this.appendMessages()
   }
 
-  async initLog() {
+  async initLog(afterInit: Promise<string> | null) {
     const { app_name, runner } = this.gameInfo
 
     const notNative =
@@ -430,6 +430,10 @@ class LogWriter {
         `Game launched at: ${startPlayingDate}\n\n`
       )
 
+      if (afterInit) {
+        await appendFile(this.filePath, await afterInit)
+      }
+
       this.initialized = true
     } catch (error) {
       logError(
@@ -467,9 +471,12 @@ export function appendGameLog(gameInfo: GameInfo, message: string) {
   logsWriters[gameInfo.app_name]?.logMessage(message)
 }
 
-export function initGameLog(gameInfo: GameInfo) {
+export function initGameLog(
+  gameInfo: GameInfo,
+  afterInit: Promise<string> | null
+) {
   logsWriters[gameInfo.app_name] ??= new LogWriter(gameInfo)
-  logsWriters[gameInfo.app_name].initLog()
+  logsWriters[gameInfo.app_name].initLog(afterInit)
 }
 
 export function stopLogger(appName: string) {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1033,15 +1033,6 @@ ipcMain.handle(
       powerDisplayId = powerSaveBlocker.start('prevent-display-sleep')
     }
 
-    initGameLog(game)
-
-    if (logsDisabled) {
-      appendGameLog(
-        game,
-        'IMPORTANT: Logs are disabled. Enable logs before reporting an issue.'
-      )
-    }
-
     const isNative = gameManagerMap[runner].isNative(appName)
 
     // check if isNative, if not, check if wine is valid
@@ -1064,6 +1055,25 @@ ipcMain.handle(
 
         return { status: 'error' }
       }
+    }
+
+    // log installed winetricks packages if non Native
+    const afterLogInit = !isNative
+      ? Winetricks.listInstalled(runner, appName).then((installedPackages) => {
+          const packagesString = installedPackages
+            ? installedPackages.join(', ')
+            : 'none'
+          return `Winetricks packages: ${packagesString}\n\n`
+        })
+      : null
+
+    initGameLog(game, afterLogInit)
+
+    if (logsDisabled) {
+      appendGameLog(
+        game,
+        'IMPORTANT: Logs are disabled. Enable logs before reporting an issue.'
+      )
     }
 
     sendGameStatusUpdate({

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1077,7 +1077,7 @@ ipcMain.handle(
       initGameLog(game, afterLogInit)
     } else {
       // init game log without winetricks packages if native
-      initGameLog(game, null)
+      initGameLog(game)
     }
 
     if (logsDisabled) {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1045,6 +1045,14 @@ ipcMain.handle(
           LogPrefix.Backend
         )
 
+        // init game log and show error message
+        initGameLog(
+          game,
+          Promise.resolve(
+            `Was not possible to launch using ${gameSettings.wineVersion.name}`
+          )
+        )
+
         sendGameStatusUpdate({
           appName,
           runner,
@@ -1055,19 +1063,22 @@ ipcMain.handle(
 
         return { status: 'error' }
       }
-    }
 
-    // log installed winetricks packages if non Native
-    const afterLogInit = !isNative
-      ? Winetricks.listInstalled(runner, appName).then((installedPackages) => {
+      // init game log and log winetricks packages if non-native
+      const afterLogInit = Winetricks.listInstalled(runner, appName).then(
+        (installedPackages) => {
           const packagesString = installedPackages
             ? installedPackages.join(', ')
             : 'none'
           return `Winetricks packages: ${packagesString}\n\n`
-        })
-      : null
+        }
+      )
 
-    initGameLog(game, afterLogInit)
+      initGameLog(game, afterLogInit)
+    } else {
+      // init game log without winetricks packages if native
+      initGameLog(game, null)
+    }
 
     if (logsDisabled) {
       appendGameLog(

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -39,7 +39,6 @@ import {
   isSnap
 } from './constants'
 import {
-  appendGameLog,
   logError,
   logInfo,
   LogPrefix,
@@ -911,11 +910,6 @@ export async function checkWineBeforeLaunch(
       logError(
         `Wine version ${gameSettings.wineVersion.name} is not valid, trying another one.`,
         LogPrefix.Backend
-      )
-
-      appendGameLog(
-        gameInfo,
-        `Wine version ${gameSettings.wineVersion.name} is not valid, trying another one.`
       )
     }
 


### PR DESCRIPTION
Before the previous release I had to rever this change because calling winetricks before the wineprefix was ready was creating insues.

This PR fixes that by only logging Winetricks packages if the wine prefix was created successfully.

I added the `afterInit` async callback so it can be printed at the right position of the logs and still be async.

Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3104

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
