### PR TITLE
[FIX] Reload library after GOG game install

### DIFF
--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -740,9 +740,8 @@ class GlobalState extends PureComponent<Props> {
         })
       }
 
-      if (runner !== 'gog') {
-        this.refreshLibrary({ runInBackground: true, library: runner })
-      }
+      this.refreshLibrary({ runInBackground: true, library: runner })
+
       this.setState({ libraryStatus: newLibraryStatus })
     }
   }


### PR DESCRIPTION
After installing a GOG game, the library is not updated with the new status.

We need to trigger a library refresh.

How to test:
- start installing a game
- stay in the library section until it ends
- the library is not updated
- change to different screens and go back, library still not updated
- click the refresh button, not library is updated

With this change:
- start installing a game
- stay in the library section until it ends
- a refresh is triggered in the background and the library is updated

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
