### PR TITLE
[Fix] Fix calculation of appName from command parts

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -956,8 +956,10 @@ function appNameFromCommandParts(commandParts: string[], runner: Runner) {
         // for GOGdl, between `launch` and the app name there's another element
         appNameIndex = idx + 2
       } else {
-        // for the `download` command it's right after
-        idx = commandParts.findIndex((value) => value === 'download')
+        // for the `download`, `repair` and `update` command it's right after
+        idx = commandParts.findIndex((value) =>
+          ['download', 'repair', 'update'].includes(value)
+        )
         if (idx > -1) {
           appNameIndex = idx + 1
         }
@@ -966,7 +968,7 @@ function appNameFromCommandParts(commandParts: string[], runner: Runner) {
     case 'legendary':
       // for legendary, the appName comes right after the commands
       idx = commandParts.findIndex((value) =>
-        ['launch', 'install'].includes(value)
+        ['launch', 'install', 'repair', 'update'].includes(value)
       )
       if (idx > -1) {
         appNameIndex = idx + 1
@@ -975,7 +977,7 @@ function appNameFromCommandParts(commandParts: string[], runner: Runner) {
     case 'nile':
       // for nile, we pass the appName as the last command part
       idx = commandParts.findIndex((value) =>
-        ['launch', 'install'].includes(value)
+        ['launch', 'install', 'update', 'verify'].includes(value)
       )
       if (idx > -1) {
         appNameIndex = commandParts.length - 1

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -945,13 +945,54 @@ interface RunnerProps {
 
 const commandsRunning = {}
 
+function appNameFromCommandParts(commandParts: string[], runner: Runner) {
+  let appNameIndex = -1
+  let idx = -1
+
+  switch (runner) {
+    case 'gog':
+      idx = commandParts.findIndex((value) => value === 'launch')
+      if (idx > -1) {
+        // for GOGdl, between `launch` and the app name there's another element
+        appNameIndex = idx + 2
+      } else {
+        // for the `download` command it's right after
+        idx = commandParts.findIndex((value) => value === 'download')
+        if (idx > -1) {
+          appNameIndex = idx + 1
+        }
+      }
+      break
+    case 'legendary':
+      // for legendary, the appName comes right after the commands
+      idx = commandParts.findIndex((value) =>
+        ['launch', 'install'].includes(value)
+      )
+      if (idx > -1) {
+        appNameIndex = idx + 1
+      }
+      break
+    case 'nile':
+      // for nile, we pass the appName as the last command part
+      idx = commandParts.findIndex((value) =>
+        ['launch', 'install'].includes(value)
+      )
+      if (idx > -1) {
+        appNameIndex = commandParts.length - 1
+      }
+      break
+  }
+
+  return appNameIndex > -1 ? commandParts[appNameIndex] : ''
+}
+
 async function callRunner(
   commandParts: string[],
   runner: RunnerProps,
   options?: CallRunnerOptions
 ): Promise<ExecResult> {
   const fullRunnerPath = join(runner.dir, runner.bin)
-  const appName = commandParts[commandParts.findIndex(() => 'launch') + 1]
+  const appName = appNameFromCommandParts(commandParts, runner.name)
 
   // Necessary to get rid of possible undefined or null entries, else
   // TypeError is triggered


### PR DESCRIPTION
After merging the changes to make logging async I found a bug with the code that gets the `appName` from the command parts. This was not a big problem before because it was used for the the abortId and some error handling, but with the new async logs the appName is used to find the log path and it was breaking.

The original code had 3 problems:
- if the command was not `launch`, it was still always adding 1 and picking a random value for the appName
- it was only handling `launch` but not other commands like `update`, `repair`, `verify` (for nile) or `download` (for gogdl)
- the appName is only the part after `'launch'` for legendary, for gogdl and nile the position in the array is different

This PR addresses:
- if the command is not one with an appName, we ignore it
- it handles install/download/update and repair/verify commands too
- it considers the runner name for the index of the appName in commandParts

To test the problem you can add a `console.log({ appName })` after the line I'm changing in this PR in callRunner.ts and see the different `appNames` that it's calculating in main.

Ideally, in the future, we could just pass the appName as a parameter, but that involves some refactoring that I'd rather do after a release and not before it.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
