### PR TITLE
[UX] Update order in library when an install starts

### DIFF
--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -17,13 +17,7 @@ import Fuse from 'fuse.js'
 import ContextProvider from 'frontend/state/ContextProvider'
 
 import GamesList from './components/GamesList'
-import {
-  FavouriteGame,
-  GameInfo,
-  GameStatus,
-  HiddenGame,
-  Runner
-} from 'common/types'
+import { FavouriteGame, GameInfo, HiddenGame, Runner } from 'common/types'
 import ErrorComponent from 'frontend/components/UI/ErrorComponent'
 import LibraryHeader from './components/LibraryHeader'
 import {
@@ -242,15 +236,13 @@ export default React.memo(function Library(): JSX.Element {
   }
 
   // cache list of games being installed
-  const [installing, setInstalling] = useState<string[]>([])
-
-  useEffect(() => {
-    const newInstalling = libraryStatus
-      .filter((st: GameStatus) => st.status === 'installing')
-      .map((st: GameStatus) => st.appName)
-
-    setInstalling(newInstalling)
-  }, [libraryStatus])
+  const installing = useMemo(
+    () =>
+      libraryStatus
+        .filter((st) => st.status === 'installing')
+        .map((st) => st.appName),
+    [libraryStatus]
+  )
 
   const filterByPlatform = (library: GameInfo[]) => {
     if (!library) {
@@ -521,6 +513,7 @@ export default React.memo(function Library(): JSX.Element {
     gog.library,
     amazon.library,
     filterText,
+    installing,
     sortDescending,
     sortInstalled,
     showHidden,


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2001

We have code to sort games by: installed > installing > not installed, but when an installation starts it's currently not being sorted unless a re-render is triggered.

This PR fixes that.

To test this you can start installing a game and the card doesn't move to the top, then change to another screen, go back to the library and it's now sorted.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
