### PR TITLE
[UX] Initial refresh in the background if any library is ready

### DIFF
--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -749,7 +749,7 @@ class GlobalState extends PureComponent<Props> {
 
   async componentDidMount() {
     const { t } = this.props
-    const { epic, gameUpdates = [], libraryStatus } = this.state
+    const { epic, gog, amazon, gameUpdates = [], libraryStatus } = this.state
 
     // Deals launching from protocol. Also checks if the game is already running
     window.api.handleLaunchGame(
@@ -864,7 +864,10 @@ class GlobalState extends PureComponent<Props> {
     if (legendaryUser || gogUser || amazonUser) {
       this.refreshLibrary({
         checkForUpdates: true,
-        runInBackground: Boolean(epic.library?.length)
+        runInBackground:
+          epic.library.length !== 0 ||
+          gog.library.length !== 0 ||
+          amazon.library.length !== 0
       })
     }
 


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3359
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3116

We have a bug in the logic that decides if the initial refresh is done in the background or not: it's only considering if we have epic games to show.

When users are NOT logged into epic, every time they open heroic the refresh is done in the foreground, taking way longer than it needs to to show the games.

This PR fixes that by considering the libraries of the 3 stores instead.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
