### PR TITLE
[Fix] Only download Winetricks every 7 days

### DIFF
--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -50,6 +50,10 @@ import { lt as semverLt } from 'semver'
 import { createAbortController } from '../utils/aborthandler/aborthandler'
 import { gameManagerMap } from '../storeManagers'
 import { sendFrontendMessage } from '../main_window'
+import {
+  DAYS,
+  downloadFile as downloadFileInet
+} from '../utils/inet/downloader'
 
 interface Tool {
   name: string
@@ -443,9 +447,11 @@ export const Winetricks = {
 
     try {
       logInfo('Downloading Winetricks', LogPrefix.WineTricks)
-      const res = await axios.get(url, { timeout: 1000 })
-      const file = res.data
-      writeFileSync(path, file)
+      await downloadFileInet(url, {
+        writeToFile: path,
+        maxCache: 7 * DAYS,
+        axiosConfig: { responseType: 'text' }
+      })
       await chmod(path, 0o755)
       return
     } catch (error) {


### PR DESCRIPTION
Before, we'd re-download Winetricks on every Heroic startup. This isn't a good idea for many reasons

`utils/inet`'s `downloadFile` function already has the option to cache if the file it's pointing to is younger than X seconds, so we can just use it.
Ideally we'd consolidate the two `downloadFile`s into one, but they have a very different featureset & function, so that'd be a larger refactor

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
