### PR TITLE
[Fix/UX] Check config before calling autoupdater

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -201,7 +201,7 @@ async function initializeWindow(): Promise<BrowserWindow> {
     }, 5000)
   }
 
-  GlobalConfig.get()
+  const globalConf = GlobalConfig.get().getSettings()
 
   mainWindow.setIcon(icon)
   app.commandLine.appendSwitch('enable-spatial-navigation')
@@ -253,7 +253,9 @@ async function initializeWindow(): Promise<BrowserWindow> {
   } else {
     Menu.setApplicationMenu(null)
     mainWindow.loadURL(`file://${path.join(publicDir, '../build/index.html')}`)
-    autoUpdater.checkForUpdates()
+    if (globalConf.checkForUpdatesOnStartup) {
+      autoUpdater.checkForUpdates()
+    }
   }
 
   // Changelog links workaround


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3524

We were always calling `autoUpdater.checkForUpdates` even if the setting was turned off.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
