### PR TITLE
[Fix] Pass `--skip-sdl` when updating/repairing Epic games

### DIFF
--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -501,7 +501,8 @@ export async function update(
   const command: LegendaryCommand = {
     subcommand: 'update',
     appName: LegendaryAppName.parse(appName),
-    '-y': true
+    '-y': true,
+    '--skip-sdl': true
   }
   if (maxWorkers) command['--max-workers'] = PositiveInteger.parse(maxWorkers)
   if (downloadNoHttps) command['--no-https'] = true
@@ -669,7 +670,8 @@ export async function repair(appName: string): Promise<ExecResult> {
   const command: LegendaryCommand = {
     subcommand: 'repair',
     appName: LegendaryAppName.parse(appName),
-    '-y': true
+    '-y': true,
+    '--skip-sdl': true
   }
   if (maxWorkers) command['--max-workers'] = PositiveInteger.parse(maxWorkers)
   if (downloadNoHttps) command['--no-https'] = true


### PR DESCRIPTION
If we're updating/repairing a game with SDL that was either synced from EGS or imported (or is missing SDL tags for some other reason), the command will get stuck waiting for the user to choose these tags.
Passing `--skip-sdl` resolves this issue. It'll always set the "default" tags, which might not be the user's choice, but it's better than getting stuck like this.

Testing this yourself is probably not that easy. Could of course download a game with SDL, delete the tags from Legendary's config, and then try a repair in Heroic, but that's rather involved.
I've done precisely this, and this change indeed resolves the issue.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
