### PR TITLE
Small Formatting Changes

### DIFF
--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: column;
   padding: 0;
+  padding-top: 20px;
   overflow: auto;
   border: solid 1px var(--modal-border);
   border-radius: 10px;

--- a/src/frontend/screens/Settings/sections/SystemInfo/cpu.tsx
+++ b/src/frontend/screens/Settings/sections/SystemInfo/cpu.tsx
@@ -16,7 +16,7 @@ function CPUCard({ cpu }: { cpu: SystemInformation['CPU'] }) {
       <Typography variant="h6">
         {t('settings.systemInformation.cpu', 'CPU:')}
       </Typography>
-      <Grid container>
+      <Grid container spacing={1}>
         <Grid item xs={2}>
           <VendorLogo model={model} />
         </Grid>


### PR DESCRIPTION
1. Added Padding to the pop up window so it looks more consistent.
Before the change:
<img width="288" alt="image" src="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/139783925/c29c10ee-dcbe-4bb5-862e-4e7dd8ea04c6">

After the change
<img width="239" alt="image" src="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/139783925/8115ffd2-9ce6-4b1a-a019-67f16d5290d9">


2. Added "spacing={1}" to cpu.tsx for consistency in logo sizes. Tested on Apple logo. Same argument can be found in gpu.tsx. The lack of this command in cpu.tsx made the logo appear just slightly bigger
Before the change:
<img width="133" alt="image" src="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/139783925/404df6f8-a236-47ad-b4fa-874f115aa6ff">

After the change
<img width="135" alt="image" src="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/139783925/ff062759-aec3-4976-a885-3275256b6294">


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [yes ] Tested the feature and it's working on a current and clean install.
- [yes ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [yes ] Created / Updated Tests (If necessary)
- [yes ] Created / Updated documentation (If necessary)
