### PR TITLE
[UX] Simplify install dialog hiding wine settings by default. Warn about shared wine directory

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -200,7 +200,7 @@
     "setting": {
         "show-wine-settings": "Show Wine settings",
         "use-default-wine-settings": "Use Default Wine Settings",
-        "warn-use-default-wine-settings": "Only use this option if you know what you are doing.<br/>Sharing the same prefix for multiple games can create problems<br/>if their dependencies are incompatible.",
+        "warn-use-default-wine-settings": "Only use this option if you know what you are doing.<br/>Sharing the same prefix for multiple games can create problems if their dependencies are incompatible.",
         "winecrossoverbottle": "CrossOver Bottle"
     },
     "sideload": {

--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -198,7 +198,9 @@
         "title": "Select components to Install"
     },
     "setting": {
+        "show-wine-settings": "Show Wine settings",
         "use-default-wine-settings": "Use Default Wine Settings",
+        "warn-use-default-wine-settings": "Only use this option if you know what you are doing.<br/>Sharing the same prefix for multiple games can create problems<br/>if their dependencies are incompatible.",
         "winecrossoverbottle": "CrossOver Bottle"
     },
     "sideload": {

--- a/src/frontend/components/UI/PathSelectionBox/index.tsx
+++ b/src/frontend/components/UI/PathSelectionBox/index.tsx
@@ -27,6 +27,7 @@ interface Props {
   noDeleteButton?: boolean
   label?: string
   afterInput?: ReactNode
+  disabled?: boolean
 }
 
 const PathSelectionBox = ({
@@ -41,7 +42,8 @@ const PathSelectionBox = ({
   noDeleteButton = false,
   htmlId,
   label,
-  afterInput
+  afterInput,
+  disabled = false
 }: Props) => {
   const { t } = useTranslation()
   // We only send `onPathChange` updates when the user is done editing, so we
@@ -83,7 +85,7 @@ const PathSelectionBox = ({
       onIconClick={handleIconClick}
       placeholder={placeholder}
       icon={!noDeleteButton && path ? <Backspace /> : <Folder />}
-      disabled={!canEditPath}
+      disabled={!canEditPath || disabled}
       htmlId={htmlId}
       label={label}
       afterInput={afterInput}

--- a/src/frontend/components/UI/TextInputField/index.css
+++ b/src/frontend/components/UI/TextInputField/index.css
@@ -24,6 +24,11 @@
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   min-width: 100px;
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
 }
 
 .textInputFieldWrapper label {
@@ -45,6 +50,12 @@
   background: none;
   color: var(--text-default);
   padding: var(--space-3xs) var(--space-2xs);
+  &:disabled {
+    opacity: 0.7;
+    .MuiSvgIcon-root {
+      cursor: not-allowed;
+    }
+  }
 }
 
 .textInputFieldWrapper .inputIcon ~ input {

--- a/src/frontend/components/UI/TextInputWithIconField/index.tsx
+++ b/src/frontend/components/UI/TextInputWithIconField/index.tsx
@@ -19,13 +19,19 @@ interface TextInputWithIconFieldProps {
 const TextInputWithIconField = ({
   icon,
   onIconClick,
+  disabled = false,
   ...props
 }: TextInputWithIconFieldProps) => {
   return (
     <TextInputField
       {...props}
+      disabled={disabled}
       inputIcon={
-        <SvgButton onClick={onIconClick} className="inputIcon">
+        <SvgButton
+          disabled={disabled}
+          onClick={onIconClick}
+          className="inputIcon"
+        >
           {icon}
         </SvgButton>
       }

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -654,7 +654,6 @@ export default function DownloadDialog({
             />
           </div>
         )}
-        {children}
         {(haveDLCs || haveSDL) && (
           <div className="InstallModal__sectionHeader">
             {t('sdl.title', 'Select components to Install')}:
@@ -686,6 +685,7 @@ export default function DownloadDialog({
             setDlcsToInstall={setDlcsToInstall}
           />
         )}
+        {children}
       </DialogContent>
       <DialogFooter>
         <button

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -6,8 +6,10 @@ import {
 } from 'frontend/components/UI'
 import React from 'react'
 import { WineInstallation } from 'common/types'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { removeSpecialcharacters } from 'frontend/helpers'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faWarning } from '@fortawesome/free-solid-svg-icons'
 
 type Props = {
   setWineVersion: React.Dispatch<
@@ -32,10 +34,11 @@ export default function WineSelector({
   crossoverBottle,
   setCrossoverBottle
 }: Props) {
-  const { t } = useTranslation('gamepage')
+  const { t, i18n } = useTranslation('gamepage')
 
   const [useDefaultSettings, setUseDefaultSettings] = React.useState(false)
   const [description, setDescription] = React.useState('')
+  const [configureWine, setConfigureWine] = React.useState(false)
 
   React.useEffect(() => {
     const getAppSettings = async () => {
@@ -75,18 +78,43 @@ export default function WineSelector({
 
   return (
     <>
-      <ToggleSwitch
-        htmlId="use-wine-defaults"
-        title={t(
-          'setting.use-default-wine-settings',
-          'Use Default Wine Settings'
-        )}
-        value={useDefaultSettings}
-        handleChange={() => setUseDefaultSettings(!useDefaultSettings)}
-        description={description}
-      />
-      {!useDefaultSettings && (
+      {!configureWine && (
+        <ToggleSwitch
+          htmlId="show-advanced"
+          title={t('setting.show-wine-settings', 'Show Wine settings')}
+          value={configureWine}
+          handleChange={() => setConfigureWine(!configureWine)}
+        />
+      )}
+
+      {configureWine && (
         <>
+          <ToggleSwitch
+            htmlId="use-wine-defaults"
+            title={t(
+              'setting.use-default-wine-settings',
+              'Use Default Wine Settings'
+            )}
+            value={useDefaultSettings}
+            handleChange={() => setUseDefaultSettings(!useDefaultSettings)}
+            description={description}
+          />
+          {useDefaultSettings && (
+            <div className="infoBox">
+              <FontAwesomeIcon icon={faWarning} />
+              <Trans
+                i18n={i18n}
+                i18nKey="setting.warn-use-default-wine-settings"
+                ns="gamepage"
+              >
+                Only use this option if you know what you are doing.
+                <br />
+                Sharing the same prefix for multiple games can create problems
+                <br />
+                if their dependencies are incompatible.
+              </Trans>
+            </div>
+          )}
           {showPrefix && (
             <PathSelectionBox
               type="directory"
@@ -96,6 +124,7 @@ export default function WineSelector({
               label={t('install.wineprefix', 'WinePrefix')}
               htmlId="setinstallpath"
               noDeleteButton
+              disabled={useDefaultSettings}
             />
           )}
           {showBottle && (
@@ -104,6 +133,7 @@ export default function WineSelector({
               htmlId="crossoverBottle"
               value={crossoverBottle}
               onChange={(event) => setCrossoverBottle(event.target.value)}
+              disabled={useDefaultSettings}
             />
           )}
 
@@ -111,6 +141,7 @@ export default function WineSelector({
             label={`${t('install.wineversion')}:`}
             htmlId="wineVersion"
             value={wineVersion?.name || ''}
+            disabled={useDefaultSettings}
             onChange={(e) =>
               setWineVersion(
                 wineVersionList.find(

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -38,7 +38,6 @@ export default function WineSelector({
 
   const [useDefaultSettings, setUseDefaultSettings] = React.useState(false)
   const [description, setDescription] = React.useState('')
-  const [configureWine, setConfigureWine] = React.useState(false)
 
   React.useEffect(() => {
     const getAppSettings = async () => {
@@ -78,16 +77,10 @@ export default function WineSelector({
 
   return (
     <>
-      {!configureWine && (
-        <ToggleSwitch
-          htmlId="show-advanced"
-          title={t('setting.show-wine-settings', 'Show Wine settings')}
-          value={configureWine}
-          handleChange={() => setConfigureWine(!configureWine)}
-        />
-      )}
-
-      {configureWine && (
+      <details>
+        <summary>
+          {t('setting.show-wine-settings', 'Show Wine settings')}
+        </summary>
         <>
           <ToggleSwitch
             htmlId="use-wine-defaults"
@@ -157,7 +150,7 @@ export default function WineSelector({
               ))}
           </SelectField>
         </>
-      )}
+      </details>
     </>
   )
 }

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -110,7 +110,6 @@ export default function WineSelector({
                 Only use this option if you know what you are doing.
                 <br />
                 Sharing the same prefix for multiple games can create problems
-                <br />
                 if their dependencies are incompatible.
               </Trans>
             </div>

--- a/src/frontend/screens/Library/components/InstallModal/index.scss
+++ b/src/frontend/screens/Library/components/InstallModal/index.scss
@@ -11,6 +11,10 @@
       margin-inline-end: 0.5rem;
     }
   }
+
+  & summary {
+    font-size: var(--text-lg);
+  }
 }
 
 .InstallModal__dialog > .anticheatInfo {

--- a/src/frontend/screens/Library/components/InstallModal/index.scss
+++ b/src/frontend/screens/Library/components/InstallModal/index.scss
@@ -5,8 +5,11 @@
   min-width: fit-content;
   max-width: 80vw;
 
-  .infoBox svg {
-    margin-inline-end: 0.5rem;
+  .infoBox {
+    max-width: 630px; // kidna magic number, TODO: find a better way to limit this width
+    svg {
+      margin-inline-end: 0.5rem;
+    }
   }
 }
 

--- a/src/frontend/screens/Library/components/InstallModal/index.scss
+++ b/src/frontend/screens/Library/components/InstallModal/index.scss
@@ -4,6 +4,10 @@
   max-height: 90vh;
   min-width: fit-content;
   max-width: 80vw;
+
+  .infoBox svg {
+    margin-inline-end: 0.5rem;
+  }
 }
 
 .InstallModal__dialog > .anticheatInfo {


### PR DESCRIPTION
It's really common to see support requests of users that clicked the `Use Default Wine Settings` without understanding what it is for.

This PR aims to solve that with 2 things:
- the wine settings are hidden behind a checkbox (most users don't really need to touch those fields ever, the install dialog is simpler)
- then, if they check `Use Default Wine Settings` a warning is displayed to tell them to not use this option if they don't know what they are doing

Also, now when checking the `Use Default Wine Settings` option, the wine and prefix field are not hidden so users can see what that check box is doing (the fields are disabled so they don't change them).

![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/859f25ec-b4a8-483e-8c75-3be66e86a4ef)

![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/9e52c658-7338-44ec-9846-41e24bc4c485)

![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/c9a2456d-24c9-4982-8adf-400ee4d88293)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
