### PR TITLE
[GOG] trim titles for games

### DIFF
--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -970,7 +970,7 @@ export async function gogToUnifiedInfo(
     is_installed: false,
     namespace: galaxyProductInfo?.slug,
     save_folder: '',
-    title: galaxyProductInfo?.title ?? info.game.title['en-US'] ?? '',
+    title: (galaxyProductInfo?.title ?? info.game.title['en-US'] ?? '').trim(),
     canRunOffline: true,
     is_mac_native: Boolean(
       info.supported_operating_systems.find((os) => os.slug === 'osx')


### PR DESCRIPTION
Turns out sometimes there can be a space at the end....


Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
