### PR TITLE
[FIX] Apply top padding only to external link warning dialog

### DIFF
--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -13,7 +13,6 @@
   display: flex;
   flex-direction: column;
   padding: 0;
-  padding-top: 20px;
   overflow: auto;
   border: solid 1px var(--modal-border);
   border-radius: 10px;
@@ -26,6 +25,10 @@
     transform 500ms;
   max-width: min(700px, 85vw);
   max-height: 95vh;
+
+  &.ExternalLinkWarning__dialog {
+    padding-top: var(--dialog-margin-vertical);
+  }
 
   & img {
     max-width: 100%;

--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -14,6 +14,7 @@
   flex-direction: column;
   padding: 0;
   overflow: auto;
+  padding-top: var(--dialog-margin-vertical);
   border: solid 1px var(--modal-border);
   border-radius: 10px;
   background: var(--modal-background);
@@ -26,8 +27,9 @@
   max-width: min(700px, 85vw);
   max-height: 95vh;
 
-  &.ExternalLinkWarning__dialog {
-    padding-top: var(--dialog-margin-vertical);
+  /* remove padding top when there's a header element, it has its own padding */
+  &:has(.Dialog__header) {
+    padding-top: 0px;
   }
 
   & img {

--- a/src/frontend/components/UI/ExternalLinkDialog/index.tsx
+++ b/src/frontend/components/UI/ExternalLinkDialog/index.tsx
@@ -31,11 +31,7 @@ export default function ExternalLinkDialog() {
   }
 
   return externalLinkDialogOptions.showDialog ? (
-    <Dialog
-      onClose={onClose}
-      showCloseButton={false}
-      className="ExternalLinkWarning__dialog"
-    >
+    <Dialog onClose={onClose} showCloseButton={false}>
       <DialogContent>
         {t('externalLink.warning', 'You are about to open an external link.')}
         <br></br>

--- a/src/frontend/components/UI/ExternalLinkDialog/index.tsx
+++ b/src/frontend/components/UI/ExternalLinkDialog/index.tsx
@@ -31,7 +31,11 @@ export default function ExternalLinkDialog() {
   }
 
   return externalLinkDialogOptions.showDialog ? (
-    <Dialog onClose={onClose} showCloseButton={false}>
+    <Dialog
+      onClose={onClose}
+      showCloseButton={false}
+      className="ExternalLinkWarning__dialog"
+    >
       <DialogContent>
         {t('externalLink.warning', 'You are about to open an external link.')}
         <br></br>

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -158,7 +158,7 @@ export default React.memo(function InstallModal({
       <Dialog
         onClose={backdropClick}
         showCloseButton
-        className={'InstallModal__dialog'}
+        className="InstallModal__dialog"
       >
         {showDownloadDialog ? (
           <DownloadDialog


### PR DESCRIPTION
There was a regression with this change https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/commit/bda0871bb1e2d324091154549f2842be864cfe14#diff-d9b11fef9fc96a7cf2707aa13652ab1309131d88dcdba70f00cd97fcccc25830R16 causing all dialogs to have extra top padding.

Causing this visual glitch:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/5e7d657b-eb31-4aed-955d-83db957b5d12)

This PR fixes that by applying the padding only to the external link warning dialog.

I also changed the hardcoded `20px` to the css property that's used at the bottom so it's more theme-friendly.

(we should re-write this component in the future, it's using margin properties as padding)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
