### PR TITLE
[FIX] Fix z-index of folder icons in install dialog

### DIFF
--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -49,7 +49,7 @@
 
 .Dialog__header {
   display: flex;
-  z-index: 1;
+  z-index: 2;
   padding-bottom: var(--dialog-gap);
 }
 
@@ -63,7 +63,7 @@
 
 .Dialog__Close {
   padding: 0 var(--dialog-margin-horizontal) 0 0;
-  z-index: 2;
+  z-index: 3;
 }
 
 .Dialog__Close,


### PR DESCRIPTION
This PR fixes a small visual issue in the dialog: when the content is scrolled, icons have a z-index that is display above the header:
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/188464/6c9b94c2-cf32-4df6-98f7-75c08303d9cc)

This PR fixes that by setting a higher z-index for the header and close elements.

(In the future I'll refactor the input elements to not use z-index at all, but for now this is a quick fix for the release)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
