### PR TITLE
[Fix] Sideloaded games on Windows

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -993,6 +993,10 @@ async function callRunner(
   let bin = runner.bin
   let fullRunnerPath = join(runner.dir, bin)
 
+  // macOS/Linux: `spawn`ing an executable in the current working directory
+  // requires a "./"
+  if (!isWindows) bin = './' + bin
+
   // On Windows: Use PowerShell's `Start-Process` to wait for the process and
   // its children to exit, provided PowerShell is available
   if (shouldUsePowerShell === null)

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1005,10 +1005,10 @@ async function callRunner(
       'Start-Process',
       `"\`"${fullRunnerPath}\`""`,
       '-Wait',
-      '-ArgumentList',
-      argsAsString,
       '-NoNewWindow'
     ]
+    if (argsAsString) commandParts.push('-ArgumentList', argsAsString)
+
     bin = fullRunnerPath = 'powershell'
   }
 

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -8,7 +8,7 @@ import {
   LogPrefix,
   logWarning
 } from '../../logger/logger'
-import { dirname } from 'path'
+import { basename, dirname } from 'path'
 import { constants as FS_CONSTANTS } from 'graceful-fs'
 import i18next from 'i18next'
 import {
@@ -220,7 +220,7 @@ export async function launchGame(
         {
           name: runner,
           logPrefix: LogPrefix.Backend,
-          bin: executable,
+          bin: basename(executable),
           dir: dirname(executable)
         },
         {

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -428,12 +428,7 @@ function showItemInFolder(item: string) {
 
 function splitPathAndName(fullPath: string): { dir: string; bin: string } {
   const dir = dirname(fullPath)
-  let bin = basename(fullPath)
-  // On Windows, you can just launch executables that are in the current working directory
-  // On Linux, you have to add a ./
-  if (!isWindows) {
-    bin = './' + bin
-  }
+  const bin = basename(fullPath)
   // Make sure to always return this as `dir, bin` to not break path
   // resolution when using `join(...Object.values(...))`
   return { dir, bin }


### PR DESCRIPTION
With my changes to callRunner (to use PowerShell on Windows), sideloaded games actually broke on Windows (for two different reasons!)
This fixes both of those problems (details as always in commit messages)

To test:
Well, try to run sideloaded games on Windows. Won't work on 2.13.0, will work with this PR.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
