### PR TITLE
[Fix] Skip symlinks during size calculation

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -75,7 +75,7 @@ import {
   updateWineVersionInfos,
   wineDownloaderInfoStore
 } from './wine/manager/utils'
-import { readdir, stat } from 'fs/promises'
+import { readdir, lstat } from 'fs/promises'
 import { getHeroicVersion } from './utils/systeminfo/heroicVersion'
 import { backendEvents } from './backend_events'
 import { wikiGameInfoStore } from './wiki_game_info/electronStore'
@@ -1188,8 +1188,11 @@ function removeFolder(path: string, folderName: string) {
 }
 
 async function getPathDiskSize(path: string): Promise<number> {
-  const statData = await stat(path)
+  const statData = await lstat(path)
   let size = 0
+  if (statData.isSymbolicLink()) {
+    return 0
+  }
   if (statData.isDirectory()) {
     const contents = await readdir(path)
 


### PR DESCRIPTION
This PR fixes an issue when calculating the install size of GOG games if the game includes symlinks that can't be followed.

This happens with the linux version of FlatOut (the latest giveaway) that includes a wine prefix in the game files and symlinks to drives that are not on all computers.

Without these changes, the game is fully downloaded but it fails to add the game as `installed` to heroic because it fails to calculate the install size:

```
(16:56:58) INFO:    [Gog]:              Got install info from cache for 1207658693 on linux platform
(16:56:59) ERROR:   [DownloadManager]:  Installation of 1207658693 failed with: Error: ENOENT: no such file or directory, stat '/home/ariel/Games/Heroic/FlatOut/prefix/dosdevices/a::'
(16:56:59) WARNING: [DownloadManager]:  Installation of 1207658693 failed!
(16:56:59) INFO:    [DownloadManager]:  1207658693 added to download manager finished.
(16:56:59) INFO:    [DownloadManager]:  1207658693 removed from download manager.
```

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
