### PR TITLE
[FIX] don't run getWinePath on windows

### DIFF
--- a/src/backend/storeManagers/gog/setup.ts
+++ b/src/backend/storeManagers/gog/setup.ts
@@ -132,11 +132,13 @@ async function setup(
   const lang: string | undefined = languages.of(installLanguage!)
 
   const dependencies: string[] = []
-  const gameDirectoryPath = await getWinePath({
-    path: gameInfo.install.install_path!,
-    variant: 'win',
-    gameSettings
-  })
+  const gameDirectoryPath = isWindows
+    ? gameInfo.install.install_path!
+    : await getWinePath({
+        path: gameInfo.install.install_path!,
+        variant: 'win',
+        gameSettings
+      })
 
   sendGameStatusUpdate({
     appName,
@@ -193,11 +195,13 @@ async function setup(
   } else {
     // check if scriptinterpreter is required based on manifest
     if (manifestData.scriptInterpreter) {
-      const wineGameSupportDir = await getWinePath({
-        path: gameSupportDir,
-        variant: 'win',
-        gameSettings
-      })
+      const wineGameSupportDir = isWindows
+        ? gameSupportDir
+        : await getWinePath({
+            path: gameSupportDir,
+            variant: 'win',
+            gameSettings
+          })
       const isiPath = path.join(
         gogRedistPath,
         '__redist/ISI/scriptinterpreter.exe'


### PR DESCRIPTION
I think we should QA things more on Windows. Basically gog setup was trying to get paths from wine.... this PR fixes that


Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
