### PR TITLE
[FIX] Adtraction fallback

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -9,6 +9,11 @@
         "zoom": "Zoom"
     },
     "add_game": "Add Game",
+    "adtraction-locked": {
+        "description": "It seems the track.adtraction.com domain was unable to load or is blocked. With adtraction, any purchase you make in the GOG store supports Heroic financially. Consider removing the block if you wish to contribute.",
+        "dont-show-again": "Don't show this warning again",
+        "title": "Adtraction is blocked"
+    },
     "Amazon Games": "Amazon Games",
     "anticheat": {
         "anticheats": "Anticheats",

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -8,7 +8,12 @@ import {
   GameMetadataInner,
   LegendaryInstallInfo
 } from './types/legendary'
-import { IpcRendererEvent, TitleBarOverlay } from 'electron'
+import {
+  IpcRendererEvent,
+  TitleBarOverlay,
+  UploadFile,
+  UploadRawData
+} from 'electron'
 import { ChildProcess } from 'child_process'
 import type { HowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
 import { NileInstallInfo, NileInstallPlatform } from './types/nile'
@@ -542,6 +547,16 @@ type ElWebview = {
   reload: () => void
   isLoading: () => boolean
   getURL: () => string
+  loadURL: (
+    url: string,
+    options?: {
+      httpReferer?: string
+      userAgent?: string
+      extraHeaders?: string
+      postData?: (UploadRawData | UploadFile)[]
+      baseURLForDataURL?: string
+    }
+  ) => Promise<void>
   copy: () => string
   selectAll: () => void
   findInPage: (text: string | RegExp) => void

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -8,12 +8,7 @@ import {
   GameMetadataInner,
   LegendaryInstallInfo
 } from './types/legendary'
-import {
-  IpcRendererEvent,
-  TitleBarOverlay,
-  UploadFile,
-  UploadRawData
-} from 'electron'
+import { IpcRendererEvent, TitleBarOverlay } from 'electron'
 import { ChildProcess } from 'child_process'
 import type { HowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
 import { NileInstallInfo, NileInstallPlatform } from './types/nile'
@@ -538,31 +533,6 @@ interface GamepadActionArgsWithoutMetadata {
     | 'esc'
   metadata?: undefined
 }
-
-type ElWebview = {
-  canGoBack: () => boolean
-  canGoForward: () => boolean
-  goBack: () => void
-  goForward: () => void
-  reload: () => void
-  isLoading: () => boolean
-  getURL: () => string
-  loadURL: (
-    url: string,
-    options?: {
-      httpReferer?: string
-      userAgent?: string
-      extraHeaders?: string
-      postData?: (UploadRawData | UploadFile)[]
-      baseURLForDataURL?: string
-    }
-  ) => Promise<void>
-  copy: () => string
-  selectAll: () => void
-  findInPage: (text: string | RegExp) => void
-}
-
-export type WebviewType = HTMLWebViewElement & ElWebview
 
 export type InstallPlatform =
   | LegendaryInstallPlatform

--- a/src/frontend/components/UI/WebviewControls/index.tsx
+++ b/src/frontend/components/UI/WebviewControls/index.tsx
@@ -7,12 +7,11 @@ import {
 import cx from 'classnames'
 import React, { SyntheticEvent, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { WebviewType } from 'common/types'
 import SvgButton from '../SvgButton'
 import './index.css'
 
 interface WebviewControlsProps {
-  webview: WebviewType | null
+  webview: Electron.WebviewTag | null
   initURL: string
   openInBrowser: boolean
 }

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -11,7 +11,7 @@ import { useNavigate, useLocation, useParams } from 'react-router'
 import { UpdateComponent } from 'frontend/components/UI'
 import WebviewControls from 'frontend/components/UI/WebviewControls'
 import ContextProvider from 'frontend/state/ContextProvider'
-import { Runner, WebviewType } from 'common/types'
+import { Runner } from 'common/types'
 import './index.css'
 import LoginWarning from '../Login/components/LoginWarning'
 import { NileLoginData } from 'common/types/nile'
@@ -49,7 +49,7 @@ export default function WebView({ store }: Props) {
     null
   )
   const navigate = useNavigate()
-  const webviewRef = useRef<WebviewType>(null)
+  const webviewRef = useRef<Electron.WebviewTag>(null)
 
   let lang = i18n.language
   if (i18n.language === 'pt') {
@@ -217,7 +217,7 @@ export default function WebView({ store }: Props) {
         }
       }
 
-      const onerror = (error: any) => {
+      const onerror = (error: Electron.DidFailLoadEvent) => {
         const { errorCode, validatedURL } = error
         // Connection refused
         if (

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -217,14 +217,9 @@ export default function WebView({ store }: Props) {
         }
       }
 
-      const onerror = (error: Electron.DidFailLoadEvent) => {
-        const { errorCode, validatedURL } = error
+      const onerror = ({ validatedURL }: Electron.DidFailLoadEvent) => {
         // Connection refused
-        if (
-          errorCode === -102 &&
-          validatedURL &&
-          validatedURL.match(/track\.adtraction\.com/)
-        ) {
+        if (validatedURL && validatedURL.match(/track\.adtraction\.com/)) {
           const parsedUrl = new URL(validatedURL)
           const redirectUrl = parsedUrl.searchParams.get('url')
           if (redirectUrl) {

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -222,9 +222,7 @@ export default function WebView({ store }: Props) {
         if (validatedURL && validatedURL.match(/track\.adtraction\.com/)) {
           const parsedUrl = new URL(validatedURL)
           const redirectUrl = parsedUrl.searchParams.get('url')
-          if (redirectUrl) {
-            webview.loadURL(redirectUrl)
-          }
+          webview.loadURL(redirectUrl || 'https://gog.com')
         }
       }
 


### PR DESCRIPTION
When user has blocked the adtraction we should fallback to load gog url directly  
I also changed types to `Electron.WebviewTag` in places where webview was used, to avoid types issues in the future.

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
