### PR TITLE
[FIX] Broken behavior of webview back arrow

### DIFF
--- a/e2e/webview_controls.spec.ts
+++ b/e2e/webview_controls.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test'
+import { electronTest } from './helpers'
+import { WebviewTag } from 'electron'
+
+electronTest('webview', async (app) => {
+  const page = await app.firstWindow()
+
+  await test.step('goes back and forth inside webview and also to heroic screens', async () => {
+    // we have to do this or it fails, the icon also has the same text
+    await page.locator('span').filter({ hasText: 'Documentation' }).click()
+
+    // we have to wait a bit for the webview to properly load these urls
+    // it's not great to force a sleep, but without these it's too flaky
+    await page.waitForTimeout(300)
+
+    await expect(page.locator('.WebviewControls__urlInput')).toHaveAttribute(
+      'value',
+      'https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki'
+    )
+    await page.waitForTimeout(300)
+
+    // we have to force a src change since we can't really click something reliably
+    // inside the webview programatically
+    await page.$eval(
+      'webview',
+      (el: WebviewTag) => (el.src = 'https://www.google.com/')
+    )
+    await page.waitForTimeout(300)
+
+    await expect(page.locator('.WebviewControls__urlInput')).toHaveAttribute(
+      'value',
+      'https://www.google.com/'
+    )
+
+    // go back to previous page in webview's history
+    await page.getByTitle('Go back').click()
+    await expect(page.locator('.WebviewControls__urlInput')).toHaveAttribute(
+      'value',
+      'https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki'
+    )
+
+    // go forward again to google.com
+    await page.getByTitle('Go forward').click()
+    await expect(page.locator('.WebviewControls__urlInput')).toHaveAttribute(
+      'value',
+      'https://www.google.com/'
+    )
+
+    // go back twice to end up in the library
+    await page.getByTitle('Go back').click()
+    await page.getByTitle('Go back').click()
+    await expect(page.getByText('All Games')).toBeVisible()
+  })
+})

--- a/src/frontend/components/UI/WebviewControls/index.tsx
+++ b/src/frontend/components/UI/WebviewControls/index.tsx
@@ -79,7 +79,7 @@ export default function WebviewControls({
         console.error(error)
       }
     },
-    [webview]
+    [webview, webviewGoBack]
   )
 
   return (


### PR DESCRIPTION
After this https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/3426, the back arrow for the webview was actually broken to process the webview's history.

This PR fixes that by adding the `webviewGoBack` dependency to `useCallback` so the function gets updated (honestly I don't see the point of using `useCallback` here, seems like an over-optimization).

Without this fix, the back arrow always takes you to the last heroic screen instead of navigating back inside the webview

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
