### PR TITLE
[Fix] Print sideload game install dir in logs

### DIFF
--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -450,11 +450,17 @@ class GameLogWriter extends LogWriter {
     // init log file and then append message if any
     try {
       // log game title and install directory
+
+      const installPath =
+        this.gameInfo.runner === 'sideload'
+          ? this.gameInfo.folder_name
+          : this.gameInfo.install.install_path
+
       await writeFile(
         this.filePath,
         `Launching "${this.gameInfo.title}" (${runner})\n` +
           `Native? ${notNative ? 'No' : 'Yes'}\n` +
-          `Installed in: ${this.gameInfo.install.install_path}\n\n`
+          `Installed in: ${installPath}\n\n`
       )
 
       try {


### PR DESCRIPTION
This PR fixes an issue with sideloaded games printing `Installed in: undefined` instead of the real app folder.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
