### PR TITLE
[FIX] Disabling DXVK-NVAPI on Proton 9.0

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -575,13 +575,15 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
   if (!gameSettings.enableFsync && wineVersion.type === 'proton') {
     ret.PROTON_NO_FSYNC = '1'
   }
-  if (gameSettings.autoInstallDxvkNvapi && wineVersion.type === 'proton') {
-    ret.PROTON_ENABLE_NVAPI = '1'
-    ret.DXVK_NVAPI_ALLOW_OTHER_DRIVERS = '1'
-  }
-  // proton 9 enabled NVAPI by default
-  else {
-    ret.PROTON_ENABLE_NVAPI = '0'
+  if (wineVersion.type === 'proton') {
+    if (gameSettings.autoInstallDxvkNvapi) {
+      ret.PROTON_ENABLE_NVAPI = '1'
+      ret.DXVK_NVAPI_ALLOW_OTHER_DRIVERS = '1'
+    }
+    // proton 9 enabled NVAPI by default
+    else {
+      ret.PROTON_DISABLE_NVAPI = '1'
+    }
   }
   if (gameSettings.autoInstallDxvkNvapi && wineVersion.type === 'wine') {
     ret.DXVK_ENABLE_NVAPI = '1'

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -579,6 +579,10 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
     ret.PROTON_ENABLE_NVAPI = '1'
     ret.DXVK_NVAPI_ALLOW_OTHER_DRIVERS = '1'
   }
+  // proton 9 enabled NVAPI by default
+  else {
+    ret.PROTON_ENABLE_NVAPI = '0'
+  }
   if (gameSettings.autoInstallDxvkNvapi && wineVersion.type === 'wine') {
     ret.DXVK_ENABLE_NVAPI = '1'
     ret.DXVK_NVAPI_ALLOW_OTHER_DRIVERS = '1'


### PR DESCRIPTION
Proton 9.0 enables NVAPI by default, so we have to set the variable to 0 to disable it

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
