### PR TITLE
Show Amazon Games for users with empty username

### DIFF
--- a/src/frontend/components/UI/LibraryFilters/index.tsx
+++ b/src/frontend/components/UI/LibraryFilters/index.tsx
@@ -159,7 +159,7 @@ export default function LibraryFilters() {
       <div className="dropdown">
         {epic.username && storeToggle('legendary')}
         {gog.username && storeToggle('gog')}
-        {amazon.username && storeToggle('nile')}
+        {amazon.user_id && storeToggle('nile')}
         {storeToggle('sideload')}
 
         <hr />


### PR DESCRIPTION
For some users, Amazon Games  returns an empty string for `username`, so checking whether a user is logged in has to be done on `user_id` instead. This commit will allow 'Unknown' users to see their Amazon Games in library. Discovered in https://discord.com/channels/812703221789097985/1210941204716331018/1210941204716331018

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
