### PR TITLE
[FIX] amazon filters not displaying when username is empty

### DIFF
--- a/src/frontend/components/UI/LibraryFilters/index.tsx
+++ b/src/frontend/components/UI/LibraryFilters/index.tsx
@@ -159,7 +159,7 @@ export default function LibraryFilters() {
       <div className="dropdown">
         {epic.username && storeToggle('legendary')}
         {gog.username && storeToggle('gog')}
-        {amazon.username && storeToggle('nile')}
+        {amazon.user_id && storeToggle('nile')}
         {storeToggle('sideload')}
 
         <hr />


### PR DESCRIPTION
Username might be empty for amazon, we handle it everywhere by using user_id but for some reason not here

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
