### PR TITLE
[WORKAROUND]: run physxlegacy setup without user input

### DIFF
--- a/src/backend/storeManagers/gog/setup.ts
+++ b/src/backend/storeManagers/gog/setup.ts
@@ -350,6 +350,14 @@ async function setup(
 
       const commandParts = [exePath, ...exeArguments]
 
+      // HACKS zone
+
+      // Force hands-free setup for PHYSXLEGACY
+      if (dep === 'PHYSXLEGACY') {
+        commandParts.unshift('msiexec', '/i')
+        commandParts.push('/qb')
+      }
+
       logInfo(['SETUP: Installing redist', foundDep.readableName], {
         prefix: LogPrefix.Gog
       })


### PR DESCRIPTION
As we noticed in https://github.com/Heroic-Games-Launcher/known-fixes/pull/7  
the PHYSXLEGACY setup doesn't have a silent switch, or at least it doesn't respect it.

I came up with this simple solution, it should make the experience more hands free.

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
