### PR TITLE
[FIX] Wine/Proton-GE-latest not updatable after Heroic relaunch or Wine manager refresh

### DIFF
--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -290,19 +290,19 @@ async function installVersion({
     )
   }
 
-  if (!overwrite) {
-    // Unzip
-    try {
-      mkdirSync(installSubDir)
-    } catch (error) {
-      unlinkFile(tarFile)
-      throw new Error(`Failed to make folder ${installSubDir} with:\n ${error}`)
-    }
-  } else {
-    // backup old folder
+  // backup old folder
+  if (overwrite) {
     renameSync(installSubDir, `${installSubDir}_backup`)
   }
 
+  try {
+    mkdirSync(installSubDir)
+  } catch (error) {
+    unlinkFile(tarFile)
+    throw new Error(`Failed to make folder ${installSubDir} with:\n ${error}`)
+  }
+
+  // Unzip
   await unzipFile({
     filePath: tarFile,
     unzipDir: installSubDir,

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -62,7 +62,7 @@ async function updateWineVersionInfos(
             releases[index].installDir = old.installDir
             releases[index].isInstalled = old.isInstalled
             releases[index].disksize = old.disksize
-            if (releases[index].checksum !== old.checksum) {
+            if (releases[index].checksum !== old.checksum || old.hasUpdate) {
               releases[index].hasUpdate = true
             }
           } else {


### PR DESCRIPTION
Wine-GE-latest or Proton-GE-latest updates do not work because of two problems:

1. When Heroic starts up, new Wine/Proton updates are checked in background but the user is not notified, you have to go to "Wine Manager" screen to see them, unfortunately the update button disappears the next time you restart Heroic or if you reload the versions list and so they go unnoticed.
2. The update fails because the Wine installation folder is renamed with "_backup" suffix (to restore it in case of problems) and the unzip does not find the original folder where to install the new version.

I fixed it by preventing the override of "hasUpdate" field in the wine-downloader-info.json file until Wine is updated and recreating the Wine folder after the backup.
For me I would show somewhere an indicator for new Wine updates at Heroic startup.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
