### PR TITLE
[Test] Add a small timeout to fix flaky webview e2e spec

### DIFF
--- a/e2e/webview_controls.spec.ts
+++ b/e2e/webview_controls.spec.ts
@@ -45,6 +45,7 @@ electronTest('webview', async (app) => {
       'value',
       'https://www.google.com/'
     )
+    await page.waitForTimeout(200)
 
     // go back twice to end up in the library
     await page.getByTitle('Go back').click()


### PR DESCRIPTION
The test seems to be flaky (I guess moving between webview pages is not consistent in speed). There are many PRs failing in this test and re-running the e2e tests sometimes solves the problem.

This adds a small timeout before pressing `Go back` that seems to solve the flakyness, I tested locally and it's green consistently with this.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
