### PR TITLE
[Feat] Improve the "Move Game" experience a bit

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -238,7 +238,7 @@
         "installing": "Installing",
         "launching": "Launching",
         "moving": "Moving Installation, please wait",
-        "moving-files": "Moving file '{{file}}': {{percent}} ",
+        "moving-files": "Moving file '{{file}}': {{percent}}%",
         "notinstalled": "This game is not installed",
         "notSupported": "Not supported",
         "notSupportedGame": "Not Supported",

--- a/src/frontend/screens/Game/GamePage/components/GameStatus.tsx
+++ b/src/frontend/screens/Game/GamePage/components/GameStatus.tsx
@@ -56,13 +56,12 @@ const GameStatus = ({ gameInfo, progress, handleUpdate, hasUpdate }: Props) => {
     }
 
     if (is.moving) {
-      if (file && percent) {
-        return `${t(
+      if (file && percent !== undefined) {
+        return t(
           'status.moving-files',
-          `Moving file '{{file}}': {{percent}} `,
-          { file, percent }
-        )}  
-        `
+          `Moving file '{{file}}': {{percent}}%`,
+          { file, percent: percent.toFixed(0) }
+        )
       }
 
       return `${t('status.moving', 'Moving Installation, please wait')} ...`


### PR DESCRIPTION
Nothing too significant, just 3 quick improvements to the "Move Game" functionality:
- Progress reports are dispatched to the Frontend more frequently
  - There were multiple `if (percent)` checks, which erroneously filtered out the case where percent might be 0 (aka we just started copying a new file)
- On Linux, we now tell `rsync` to delete source/old files after they're copied to the new location
  - This should help in scenarios with very little disk space being available. Before, we first copy and then delete, now we delete files while copying, and then the entire directory (which should be using virtually no space anymore) at the end
- The types for the `progress` property of the progress update are now correct (`percent` should be a number instead of a string, and `eta` and `bytes` were missing entirely)
  - Note that `eta` and `bytes` still aren't populated on Windows (`robocopy` simply doesn't give us this info), so I've not displayed them anywhere yet
   - This issue was found by type-checking `sendFrontendMessage`, a PR for that should land alongside this one

I'm still not entirely happy with this function (from a user's point of view I'd expect it to give me a progress bar for the entire move operation, knowing that one specific file is being moved is not too helpful), but that'd be a more complex refactor

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
