### PR TITLE
[Tech] Type-check Backend & Frontend events

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "ts-jest": "29.0.5",
     "ts-prune": "0.10.3",
     "type-fest": "3.6.1",
+    "typed-emitter": "^2.1.0",
     "typescript": "4.9.4",
     "unimported": "1.26.0",
     "vite": "3.2.8",

--- a/src/backend/api/helpers.ts
+++ b/src/backend/api/helpers.ts
@@ -3,7 +3,6 @@ import {
   Runner,
   InstallPlatform,
   WineCommandArgs,
-  ConnectivityChangedCallback,
   ConnectivityStatus,
   AppSettings,
   GameSettings,
@@ -115,7 +114,13 @@ export const runWineCommandForGame = async (args: RunWineCommandArgs) =>
   ipcRenderer.invoke('runWineCommandForGame', args)
 
 export const onConnectivityChanged = async (
-  callback: ConnectivityChangedCallback
+  callback: (
+    event: Electron.IpcRendererEvent,
+    status: {
+      status: ConnectivityStatus
+      retryIn: number
+    }
+  ) => void
 ) => ipcRenderer.on('connectivity-changed', callback)
 
 export const getConnectivityStatus = async () =>

--- a/src/backend/api/library.ts
+++ b/src/backend/api/library.ts
@@ -1,7 +1,6 @@
 import { ipcRenderer } from 'electron'
 import {
   Runner,
-  InstallParams,
   LaunchParams,
   ImportGameArgs,
   GameStatus,
@@ -74,11 +73,15 @@ export const handleLaunchGame = (
 ) => ipcRenderer.on('launchGame', callback)
 
 export const handleInstallGame = (
-  callback: (event: Electron.IpcRendererEvent, args: InstallParams) => void
+  callback: (
+    event: Electron.IpcRendererEvent,
+    appName: string,
+    runner: Runner
+  ) => void
 ) => ipcRenderer.on('installGame', callback)
 
 export const handleRefreshLibrary = (
-  callback: (event: Electron.IpcRendererEvent, runner: Runner) => void
+  callback: (event: Electron.IpcRendererEvent, runner?: Runner) => void
 ) => ipcRenderer.on('refreshLibrary', callback)
 
 export const handleGamePush = (

--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -127,8 +127,9 @@ export const pathExists = async (path: string) =>
 export const processShortcut = async (combination: string) =>
   ipcRenderer.send('processShortcut', combination)
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const handleGoToScreen = (callback: any) => {
+export const handleGoToScreen = (
+  callback: (e: Electron.IpcRendererEvent, screen: string) => void
+) => {
   ipcRenderer.on('openScreen', callback)
   return () => {
     ipcRenderer.removeListener('openScreen', callback)

--- a/src/backend/api/wine.ts
+++ b/src/backend/api/wine.ts
@@ -38,7 +38,7 @@ export const refreshWineVersionInfo = async (fetch?: boolean): Promise<void> =>
 export const handleProgressOfWinetricks = (
   onProgress: (
     e: Electron.IpcRendererEvent,
-    payload: { messages: string[]; installingComponent: '' }
+    payload: { messages: string[]; installingComponent: string }
   ) => void
 ): (() => void) => {
   ipcRenderer.on('progressOfWinetricks', onProgress)

--- a/src/backend/backend_events.ts
+++ b/src/backend/backend_events.ts
@@ -1,5 +1,19 @@
 import EventEmitter from 'events'
 
+import type TypedEventEmitter from 'typed-emitter'
+import type { GameStatus, RecentGame } from 'common/types'
+
+type BackendEvents = {
+  gameStatusUpdate: (payload: GameStatus) => void
+  recentGamesChanged: (recentGames: RecentGame[]) => void
+  settingChanged: (obj: {
+    key: string
+    oldValue: unknown
+    newValue: unknown
+  }) => void
+  [key: `progressUpdate-${string}`]: (progress: GameStatus) => void
+}
+
 // This can be used to emit/listen to events to decouple components
 // For example:
 //   When the list of recent games changes, a `recentGamesChanged` event is emitted.
@@ -9,4 +23,5 @@ import EventEmitter from 'events'
 // Usage:
 //   Emit events with `backendEvents.emit("eventName", arg1, arg2)
 //   Listen to events with `backendEvents.on("eventName", (arg1, arg2) => { ... })
-export const backendEvents = new EventEmitter()
+export const backendEvents =
+  new EventEmitter() as TypedEventEmitter<BackendEvents>

--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -121,7 +121,7 @@ export function initLogger() {
     )
 
     if (key === 'disableLogs') {
-      logsDisabled = newValue
+      logsDisabled = newValue as boolean
     }
   })
 }

--- a/src/backend/main_window.ts
+++ b/src/backend/main_window.ts
@@ -2,6 +2,7 @@ import { AppSettings, WindowProps } from 'common/types'
 import { BrowserWindow, screen } from 'electron'
 import path from 'path'
 import { configStore } from './constants'
+import type { FrontendMessages } from 'common/types/frontend_messages'
 
 let mainWindow: BrowserWindow | null = null
 
@@ -18,7 +19,10 @@ export const isFrameless = () => {
 // send a message to the main window's webContents if available
 // returns `false` if no mainWindow or no webContents
 // returns `true` if the message was sent to the webContents
-export const sendFrontendMessage = (message: string, ...payload: unknown[]) => {
+export const sendFrontendMessage = <MessageName extends keyof FrontendMessages>(
+  message: MessageName,
+  ...payload: Parameters<FrontendMessages[MessageName]>
+) => {
   // get the first BrowserWindow if for some reason we don't have a webContents
   if (!mainWindow?.webContents) {
     mainWindow = BrowserWindow.getAllWindows()[0]

--- a/src/backend/progress_bar.ts
+++ b/src/backend/progress_bar.ts
@@ -1,9 +1,9 @@
-import { InstallProgress } from 'common/types'
+import { GameStatus } from 'common/types'
 import { backendEvents } from './backend_events'
 import { getMainWindow } from './main_window'
 
-const handleProgressUpdate = ({ progress }: { progress: InstallProgress }) => {
-  if (progress.percent) {
+const handleProgressUpdate = ({ progress }: GameStatus) => {
+  if (progress?.percent) {
     getMainWindow()?.setProgressBar(progress.percent / 100)
   }
 }

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -135,10 +135,7 @@ async function handleLaunch(
       icon: icon
     })
     if (response === 0) {
-      return sendFrontendMessage('installGame', {
-        appName: app_name,
-        runner: gameRunner
-      })
+      return sendFrontendMessage('installGame', app_name, gameRunner)
     }
     if (response === 1) {
       return logInfo('Not installing game', LogPrefix.ProtocolHandler)
@@ -146,7 +143,7 @@ async function handleLaunch(
   }
 
   mainWindow?.hide()
-  sendFrontendMessage('launchGame', arg, gameRunner)
+  sendFrontendMessage('launchGame', app_name, gameRunner)
 }
 
 /**

--- a/src/backend/tools/ipc_handler.ts
+++ b/src/backend/tools/ipc_handler.ts
@@ -53,10 +53,9 @@ ipcMain.handle('callTool', async (event, { tool, exe, appName, runner }) => {
   if (runner === 'gog') {
     // Check if game was modified by offline installer / wine uninstaller
     await GOGLibraryManager.checkForOfflineInstallerChanges(appName)
-    sendFrontendMessage(
-      'pushGameToLibrary',
-      GOGLibraryManager.getGameInfo(appName)
-    )
+    const maybeNewGameInfo = GOGLibraryManager.getGameInfo(appName)
+    if (maybeNewGameInfo)
+      sendFrontendMessage('pushGameToLibrary', maybeNewGameInfo)
   }
 
   sendGameStatusUpdate({ appName, runner, status: 'done' })

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -870,7 +870,7 @@ export async function downloadDefaultWine() {
 
   // download the latest version
   const onProgress = (state: State, progress?: ProgressInfo) => {
-    sendFrontendMessage('progressOfWineManager' + release.version, {
+    sendFrontendMessage(`progressOfWineManager${release.version}`, {
       state,
       progress
     })

--- a/src/backend/wine/manager/ipc_handler.ts
+++ b/src/backend/wine/manager/ipc_handler.ts
@@ -10,7 +10,7 @@ import { sendFrontendMessage } from '../../main_window'
 
 ipcMain.handle('installWineVersion', async (e, release) => {
   const onProgress = (state: State, progress?: ProgressInfo) => {
-    sendFrontendMessage('progressOfWineManager' + release.version, {
+    sendFrontendMessage(`progressOfWineManager${release.version}`, {
       state,
       progress
     })

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -8,7 +8,7 @@ import {
   GameMetadataInner,
   LegendaryInstallInfo
 } from './types/legendary'
-import { IpcRendererEvent, TitleBarOverlay } from 'electron'
+import { TitleBarOverlay } from 'electron'
 import { ChildProcess } from 'child_process'
 import type { HowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
 import { NileInstallInfo, NileInstallPlatform } from './types/nile'
@@ -540,11 +540,6 @@ export type InstallPlatform =
   | GogInstallPlatform
   | NileInstallPlatform
   | 'Browser'
-
-export type ConnectivityChangedCallback = (
-  event: IpcRendererEvent,
-  status: ConnectivityStatus
-) => void
 
 export type ConnectivityStatus = 'offline' | 'check-online' | 'online'
 

--- a/src/common/types/frontend_messages.ts
+++ b/src/common/types/frontend_messages.ts
@@ -1,0 +1,57 @@
+import type {
+  ButtonOptions,
+  ConnectivityStatus,
+  DialogType,
+  DMQueueElement,
+  DownloadManagerState,
+  GameInfo,
+  GameStatus,
+  ProgressInfo,
+  RecentGame,
+  Runner,
+  State
+} from 'common/types'
+
+type FrontendMessages = {
+  gameStatusUpdate: (status: GameStatus) => void
+  wineVersionsUpdated: () => void
+  showDialog: (
+    title: string,
+    message: string,
+    type: DialogType,
+    buttons?: Array<ButtonOptions>
+  ) => void
+  changedDMQueueInformation: (
+    elements: DMQueueElement[],
+    state: DownloadManagerState
+  ) => void
+  maximized: () => void
+  unmaximized: () => void
+  fullscreen: (status: boolean) => void
+  refreshLibrary: (runner?: Runner) => void
+  openScreen: (screen: string) => void
+  'connectivity-changed': (status: {
+    status: ConnectivityStatus
+    retryIn: number
+  }) => void
+  launchGame: (appName: string, runner: Runner) => void
+  installGame: (appName: string, runner: Runner) => void
+  recentGamesChanged: (newRecentGames: RecentGame[]) => void
+  pushGameToLibrary: (info: GameInfo) => void
+  progressOfWinetricks: (payload: {
+    messages: string[]
+    installingComponent: string
+  }) => void
+  'installing-winetricks-component': (component: string) => void
+
+  [key: `progressUpdate${string}`]: (progress: GameStatus) => void
+  [key: `progressOfWineManager${string}`]: (progress: {
+    state: State
+    progress?: ProgressInfo
+  }) => void
+
+  // Used inside tests, so we can be a bit lenient with the type checking here
+  message: (...params: unknown[]) => void
+}
+
+export type { FrontendMessages }

--- a/src/frontend/components/UI/Sidebar/index.tsx
+++ b/src/frontend/components/UI/Sidebar/index.tsx
@@ -49,7 +49,7 @@ export default React.memo(function Sidebar() {
   }, [sidebarEl])
 
   useEffect(() => {
-    window.api.handleGoToScreen((e: Event, screen: string) => {
+    window.api.handleGoToScreen((e, screen) => {
       // handle navigate to screen
       navigate(screen, { state: { fromGameCard: false } })
     })

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -9,7 +9,6 @@ import {
   RefreshOptions,
   Runner,
   WineVersionInfo,
-  InstallParams,
   LibraryTopSectionOptions,
   ExperimentalFeatures
 } from 'common/types'
@@ -773,44 +772,37 @@ class GlobalState extends PureComponent<Props> {
       }
     )
 
-    window.api.handleInstallGame(
-      async (e: IpcRendererEvent, args: InstallParams) => {
-        const currentApp = libraryStatus.filter(
-          (game) => game.appName === appName
-        )[0]
-        const { appName, runner } = args
-        if (!currentApp || (currentApp && currentApp.status !== 'installing')) {
-          const gameInfo = await getGameInfo(appName, runner)
-          if (!gameInfo || gameInfo.runner === 'sideload') {
-            return
-          }
-          return this.setState({
-            showInstallModal: {
-              show: true,
-              appName,
-              runner,
-              gameInfo
-            }
-          })
+    window.api.handleInstallGame(async (e, appName, runner) => {
+      const currentApp = libraryStatus.filter(
+        (game) => game.appName === appName
+      )[0]
+      if (!currentApp || (currentApp && currentApp.status !== 'installing')) {
+        const gameInfo = await getGameInfo(appName, runner)
+        if (!gameInfo || gameInfo.runner === 'sideload') {
+          return
         }
-      }
-    )
-
-    window.api.handleGameStatus(
-      async (e: IpcRendererEvent, args: GameStatus) => {
-        return this.handleGameStatus({ ...args })
-      }
-    )
-
-    window.api.handleRefreshLibrary(
-      async (e: IpcRendererEvent, runner: Runner) => {
-        this.refreshLibrary({
-          checkForUpdates: false,
-          runInBackground: true,
-          library: runner
+        return this.setState({
+          showInstallModal: {
+            show: true,
+            appName,
+            runner,
+            gameInfo
+          }
         })
       }
-    )
+    })
+
+    window.api.handleGameStatus((e, args) => {
+      this.handleGameStatus({ ...args })
+    })
+
+    window.api.handleRefreshLibrary((e, runner) => {
+      this.refreshLibrary({
+        checkForUpdates: false,
+        runInBackground: true,
+        library: runner
+      })
+    })
 
     window.api.handleGamePush((e: IpcRendererEvent, args: GameInfo) => {
       if (!args.app_name) return

--- a/yarn.lock
+++ b/yarn.lock
@@ -7800,6 +7800,13 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rxjs@^7.5.2:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
+
 sade@^1.7.3:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
@@ -8736,6 +8743,13 @@ typed-array-length@^1.0.4:
     call-bind "^1.0.2"
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
+
+typed-emitter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/typed-emitter/-/typed-emitter-2.1.0.tgz#ca78e3d8ef1476f228f548d62e04e3d4d3fd77fb"
+  integrity sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==
+  optionalDependencies:
+    rxjs "^7.5.2"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
This adds typechecking for `backendEvents` and `sendFrontendMessage`. I've already caught a few issues with this (see #3648, some smaller issues are also corrected here)  
Typechecking is done with the usual pattern of an interface holding all possible events/messages, and their corresponding function definitions (similarly to how IPC works, for example)

This is entirely a dev change, no actual code is altered

Requires #3648 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
