### PR TITLE
Disable Snap for now

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     uses: ./.github/workflows/build-base.yml
     with:
-      publish-snap: true
+      publish-snap: false
     secrets:
       snapcraftIdEdge: ${{ secrets.SNAPCRAFT_ID_EDGE }}
       workflowToken: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
Our Snap credentials need renewing, and I don't know whether we even want to continue publishing Snaps (they never really worked 100%, and no-one in the core team uses them AFAIK)

I've kept most of the infrastructure in-place, in case we do decide on enabling it again in the future

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
