### PR TITLE
[Fix] Make checkDiskSpace look at the correct drive again

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -563,16 +563,10 @@ ipcMain.on('unlock', () => {
 })
 
 ipcMain.handle('checkDiskSpace', async (_e, folder): Promise<DiskSpaceData> => {
-  // We only need to look at the root directory for used/free space
-  // Trying to query this for a directory that doesn't exist (which `folder`
-  // might be) will not work
-  const { root } = path.parse(folder)
-
   // FIXME: Propagate errors
   const parsedPath = Path.parse(folder)
-  const parsedRootPath = Path.parse(root)
 
-  const { freeSpace, totalSpace } = await getDiskInfo(parsedRootPath)
+  const { freeSpace, totalSpace } = await getDiskInfo(parsedPath)
   const pathIsWritable = await isWritable(parsedPath)
   const pathIsFlatpakAccessible = isAccessibleWithinFlatpakSandbox(parsedPath)
 

--- a/src/backend/utils/filesystem/__tests__/unix.test.ts
+++ b/src/backend/utils/filesystem/__tests__/unix.test.ts
@@ -1,0 +1,59 @@
+import fs from 'fs'
+import * as util_os_processes from '../../os/processes'
+import { getDiskInfo_unix } from '../unix'
+import type { Path } from 'backend/schemas'
+
+describe('getDiskInfo_unix', () => {
+  it('Works with root path', async () => {
+    const accessSyp = jest
+      .spyOn(fs.promises, 'access')
+      .mockImplementation(async () => Promise.resolve())
+    const spawnWrapperSpy = jest
+      .spyOn(util_os_processes, 'genericSpawnWrapper')
+      .mockImplementation(async () => {
+        return Promise.resolve({
+          stdout:
+            'Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 100 90 10 90% /',
+          stderr: '',
+          exitCode: null,
+          signalName: null
+        })
+      })
+
+    const ret = await getDiskInfo_unix('/' as Path)
+    expect(ret.totalSpace).toBe(100 * 1024)
+    expect(ret.freeSpace).toBe(10 * 1024)
+    expect(accessSyp).toHaveBeenCalledTimes(1)
+    expect(spawnWrapperSpy).toHaveBeenCalledWith('df', ['-P', '-k', '/'])
+    expect(spawnWrapperSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('Works with nested path', async () => {
+    const accessSyp = jest
+      .spyOn(fs.promises, 'access')
+      .mockImplementation(async (path) => {
+        if (path === '/foo/bar/baz') {
+          return Promise.reject()
+        }
+        return Promise.resolve()
+      })
+    const spawnWrapperSpy = jest
+      .spyOn(util_os_processes, 'genericSpawnWrapper')
+      .mockImplementation(async () => {
+        return Promise.resolve({
+          stdout:
+            'Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 100 90 10 90% /foo/bar',
+          stderr: '',
+          exitCode: null,
+          signalName: null
+        })
+      })
+
+    const ret = await getDiskInfo_unix('/foo/bar/baz' as Path)
+    expect(ret.totalSpace).toBe(100 * 1024)
+    expect(ret.freeSpace).toBe(10 * 1024)
+    expect(accessSyp).toHaveBeenCalledTimes(2)
+    expect(spawnWrapperSpy).toHaveBeenCalledWith('df', ['-P', '-k', '/foo/bar'])
+    expect(spawnWrapperSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/backend/utils/filesystem/__tests__/windows.test.ts
+++ b/src/backend/utils/filesystem/__tests__/windows.test.ts
@@ -1,0 +1,67 @@
+import * as util_os_processes from '../../os/processes'
+import { getDiskInfo_windows } from '../windows'
+import type { Path } from 'backend/schemas'
+
+describe('getDiskInfo_windows', () => {
+  it('Works with root path', async () => {
+    const spawnWrapperSpy = jest
+      .spyOn(util_os_processes, 'genericSpawnWrapper')
+      .mockImplementation(async () => {
+        return Promise.resolve({
+          stdout: JSON.stringify([{ Caption: 'C:', FreeSpace: 10, Size: 100 }]),
+          stderr: '',
+          exitCode: null,
+          signalName: null
+        })
+      })
+
+    const ret = await getDiskInfo_windows('C:' as Path)
+    expect(ret.totalSpace).toBe(100)
+    expect(ret.freeSpace).toBe(10)
+    expect(spawnWrapperSpy).toHaveBeenCalledWith('powershell', [
+      'Get-CimInstance',
+      '-Class',
+      'Win32_LogicalDisk',
+      '-Property',
+      'Caption,FreeSpace,Size',
+      '|',
+      'Select-Object',
+      'Caption,FreeSpace,Size',
+      '|',
+      'ConvertTo-Json',
+      '-Compress'
+    ])
+    expect(spawnWrapperSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('Works with nested path', async () => {
+    const spawnWrapperSpy = jest
+      .spyOn(util_os_processes, 'genericSpawnWrapper')
+      .mockImplementation(async () => {
+        return Promise.resolve({
+          stdout: JSON.stringify([{ Caption: 'C:', FreeSpace: 10, Size: 100 }]),
+          stderr: '',
+          exitCode: null,
+          signalName: null
+        })
+      })
+
+    const ret = await getDiskInfo_windows('C:/foo/bar/baz' as Path)
+    expect(ret.totalSpace).toBe(100)
+    expect(ret.freeSpace).toBe(10)
+    expect(spawnWrapperSpy).toHaveBeenCalledWith('powershell', [
+      'Get-CimInstance',
+      '-Class',
+      'Win32_LogicalDisk',
+      '-Property',
+      'Caption,FreeSpace,Size',
+      '|',
+      'Select-Object',
+      'Caption,FreeSpace,Size',
+      '|',
+      'ConvertTo-Json',
+      '-Compress'
+    ])
+    expect(spawnWrapperSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/backend/utils/filesystem/index.ts
+++ b/src/backend/utils/filesystem/index.ts
@@ -6,6 +6,10 @@ interface DiskInfo {
   totalSpace: number
 }
 
+/**
+ * Gathers information about the disk `path` is on.
+ * `path` does not have to exist.
+ */
 async function getDiskInfo(path: Path): Promise<DiskInfo> {
   switch (process.platform) {
     case 'linux':

--- a/src/backend/utils/filesystem/unix.ts
+++ b/src/backend/utils/filesystem/unix.ts
@@ -1,17 +1,34 @@
 import { genericSpawnWrapper } from '../os/processes'
 import { access } from 'fs/promises'
+import { join } from 'path'
 
 import type { Path } from 'backend/schemas'
 import type { DiskInfo } from './index'
 
 async function getDiskInfo_unix(path: Path): Promise<DiskInfo> {
-  const { stdout } = await genericSpawnWrapper('df', ['-P', '-k', path])
+  const rootPath = await findFirstExistingPath(path)
+
+  const { stdout } = await genericSpawnWrapper('df', ['-P', '-k', rootPath])
   const lineSplit = stdout.split('\n')[1].split(/\s+/)
   const [, totalSpaceKiBStr, , freeSpaceKiBStr] = lineSplit
   return {
     totalSpace: Number(totalSpaceKiBStr ?? 0) * 1024,
     freeSpace: Number(freeSpaceKiBStr ?? 0) * 1024
   }
+}
+
+/**
+ * Finds the first existing path in the path's hierarchy
+ * @example
+ * findFirstExistingPath('/foo/bar/baz')
+ * // => '/foo/bar/baz' if it exists, otherwise '/foo/bar', otherwise '/foo', otherwise '/'
+ */
+async function findFirstExistingPath(path: Path): Promise<Path> {
+  let maybeExistingPath = path
+  while (!(await isWritable_unix(maybeExistingPath))) {
+    maybeExistingPath = join(maybeExistingPath, '..') as Path
+  }
+  return maybeExistingPath
 }
 
 async function isWritable_unix(path: Path): Promise<boolean> {


### PR DESCRIPTION
In my checkDiskSpace refactor (#3440), I used the `root` property of the object returned by Node's [`path.parse`](https://nodejs.org/api/path.html#pathparsepath), thinking that it'd, logically, give me the root folder (or in other words the mount point) of the disk the path is on. This is not the case on Linux/macOS, it's just simply always `/` there.
This issue would manifest itself in the wrong disk space info being displayed when installing a game onto a drive other than the primary one.

Resolving this was somewhat tricky. Since this function runs on both macOS and Linux, we can't use commandline tools like `findmnt` to help us here, so I went back to what we did before the refactor: Going up the directory tree and using the first path that exists. This works just fine on Unix, since there will always be a `/` path (as opposed to Windows, where entire drive letters can be missing)

I've also added a test for these functions now, so this issue can't happen again.

To test this:
1. Install a game onto another hard drive on the current main branch, see that the total/free disk space is reported incorrectly
2. Try the same thing with this PR, info will now be correct

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [X] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
