### PR TITLE
[Fix] Escape backslashes in PowerShell ArgumentList

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1021,7 +1021,10 @@ async function callRunner(
       isWindows && !!(await searchForExecutableOnPath('powershell'))
 
   if (shouldUsePowerShell) {
-    const argsAsString = commandParts.map((part) => `"\`"${part}\`""`).join(',')
+    const argsAsString = commandParts
+      .map((part) => part.replaceAll('\\', '\\\\'))
+      .map((part) => `"\`"${part}\`""`)
+      .join(',')
     commandParts = [
       'Start-Process',
       `"\`"${fullRunnerPath}\`""`,


### PR DESCRIPTION
Backslashes are *mostly* fine to just include without escaping, but there are certain cases where they can cause issues. One of those would be when specifying just a drive letter (`X:\`) as one argument (for example as the install path for a game). In that case, when adding the necessary escape characters around the argument, we'd end up with ```"`"X:\`""```. PS would then see that the backtick is escaped by a \\ (even though it's not supposed to be), and the whole thing would fall apart

Resolving this is luckily rather easy, we can simply replace every one \\ with two \\ to end up with one escaped \\, which can then no longer break anything around it

To test:
- Be on Windows
- Try to install a game onto a "bare" drive letter (for example `D:\`)
- Won't work on main, will work here

~~This still needs a bit more testing with uncommon arguments, PS is pretty unpredictable after all~~

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
