### PR TITLE
[Flatpak] Update manifest for UMU support

### DIFF
--- a/flatpak/templates/com.heroicgameslauncher.hgl.yml.template
+++ b/flatpak/templates/com.heroicgameslauncher.hgl.yml.template
@@ -44,6 +44,9 @@ finish-args:
   - --socket=pulseaudio
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
+  # umu
+  - --filesystem=~/.var/app/org.openwinecomponents.umu.umu-launcher/data/umu
+  - --env=XDG_DATA_DIRS=/app/share
 
 add-extensions:
   org.freedesktop.Platform.Compat.i386:

--- a/flatpak/templates/com.heroicgameslauncher.hgl.yml.template
+++ b/flatpak/templates/com.heroicgameslauncher.hgl.yml.template
@@ -46,7 +46,7 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   # umu
   - --filesystem=~/.var/app/org.openwinecomponents.umu.umu-launcher/data/umu
-  - --env=XDG_DATA_DIRS=/app/share
+  - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share
 
 add-extensions:
   org.freedesktop.Platform.Compat.i386:


### PR DESCRIPTION
Related to https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/3480 and depends on the updated Flatpak support in ULWGL aka umu to be merged/reviewed. After the Flatpak umu is installed in the user's system, the Heroic Games Launcher will need to allow explicit access to umu's `$XDG_DATA_HOME/umu` and the system `/app/share` directory to run games through the launcher. 

The reason is because, without going into the details, umu will currently copy files from `/app/share` to its private Flatpak directory, and Valve's Steam Runtime tools (e.g., Pressure Vessel) are designed to only be executed from the user's home directory. Without explicit visibility to these directories defined in Heroic's manifest, it's likely that umu will fail to launch games successfully due to Flatpak's strict filesystem permissions.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
