### PR TITLE
[Fix] Proton with ESYNC/FSYNC

### DIFF
--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -489,7 +489,7 @@ export const Winetricks = {
       // might need to set some environment variables differently than normal
       // (e.g. `WINEESYNC=1` vs `PROTON_NO_ESYNC=0`).
       // These settings will be a copy of the normal game settings, but with
-      // their wineVersion set to one always of the tyoe `wine`
+      // their wineVersion set to one always of the type `wine`
       const settingsWithWineVersion = {
         ...gameSettings,
         wineVersion: alwaysWine_wineVersion

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -499,24 +499,24 @@ export const Winetricks = {
 
       const linuxEnvs = {
         ...process.env,
-        WINEPREFIX: winePrefix,
-        PATH: `${winepath}:${process.env.PATH}`,
         ...setupEnvVars(settingsWithWineVersion),
-        ...setupWineEnvVars(settingsWithWineVersion, appName)
+        ...setupWineEnvVars(settingsWithWineVersion, appName),
+        WINEPREFIX: winePrefix,
+        PATH: `${winepath}:${process.env.PATH}`
       }
 
       const wineServer = join(winepath, 'wineserver')
 
       const macEnvs = {
         ...process.env,
+        // FIXME: Do we want to use `settingsWithWineVersion` here?
+        ...setupEnvVars(gameSettings),
+        ...setupWineEnvVars(gameSettings, appName),
         WINEPREFIX: winePrefix,
         WINESERVER: wineServer,
         WINE: wineBin,
         WINE64: wineBin,
-        PATH: `/opt/homebrew/bin:${process.env.PATH}`,
-        // FIXME: Do we want to use `settingsWithWineVersion` here?
-        ...setupEnvVars(gameSettings),
-        ...setupWineEnvVars(gameSettings, appName)
+        PATH: `/opt/homebrew/bin:${process.env.PATH}`
       }
 
       const envs = isMac ? macEnvs : linuxEnvs

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -146,9 +146,9 @@ const getFileSize = fileSize.partial({ base: 2 }) as (arg: unknown) => string
 function getWineFromProton(
   wineVersion: WineInstallation,
   winePrefix: string
-): { winePrefix: string; wineBin: string } {
+): { winePrefix: string; wineVersion: WineInstallation } {
   if (wineVersion.type !== 'proton') {
-    return { winePrefix, wineBin: wineVersion.bin }
+    return { winePrefix, wineVersion }
   }
 
   winePrefix = join(winePrefix, 'pfx')
@@ -157,8 +157,17 @@ function getWineFromProton(
   for (const distPath of ['dist', 'files']) {
     const protonBaseDir = dirname(wineVersion.bin)
     const wineBin = join(protonBaseDir, distPath, 'bin', 'wine')
-    if (existsSync(wineBin)) {
-      return { wineBin, winePrefix }
+    if (!existsSync(wineBin)) continue
+
+    const wineserverBin = join(protonBaseDir, distPath, 'bin', 'wineserver')
+    return {
+      winePrefix,
+      wineVersion: {
+        ...wineVersion,
+        type: 'wine',
+        bin: wineBin,
+        wineserver: existsSync(wineserverBin) ? wineserverBin : undefined
+      }
     }
   }
 
@@ -171,7 +180,7 @@ function getWineFromProton(
     LogPrefix.Backend
   )
 
-  return { wineBin: '', winePrefix }
+  return { wineVersion, winePrefix }
 }
 
 async function isEpicServiceOffline(


### PR DESCRIPTION
Multiple little things amounted to Proton no longer being usable while ESYNC/FSYNC were turned on. This resolves those little things by (1) setting the correct env vars when launching Winetricks and (2) no longer launching Winetricks on game launch

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
