### PR TITLE
[FIX] build selector exception on some locales

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/BuildSelector.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/BuildSelector.tsx
@@ -14,10 +14,10 @@ export default function BuildSelector({
   selectedBuild,
   setSelectedBuild
 }: BuildSelectorProps) {
-  const { i18n, t } = useTranslation('gamepage')
+  const { t } = useTranslation('gamepage')
 
   const getFormattedDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleDateString(i18n.languages)
+    return new Date(dateStr).toLocaleDateString(undefined)
   }
 
   return (


### PR DESCRIPTION
Fixes #3668

Turns out passing the locale from i18n isn't that good idea, it's just date formatting so now it will be done based on system locale.

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
