### PR TITLE
Add important warning about wine dependencies to readme description

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ Thanks to the community, Heroic was translated to almost 40 different languages 
 
 Heroic is available on Flathub, so you should be able to easily install it on most distros with Software Centers (Pop!\_Shop, Discover, etc.)
 
+#### Distribution-specific instructions
+
+If you're not using the Flatpak version, make sure you have all Wine dependencies installed:
+[Wine Dependencies](https://github.com/lutris/docs/blob/master/WineDependencies.md).
+
 #### Debian, Ubuntu and Derivatives
 
 Download the file ending in .deb from the [latest release](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/latest).  


### PR DESCRIPTION
README does not provide clear description of how to install and use wine with Heroic for casual users. 

When I first tried to use HGL, I faced the problem that wine installation is not working to launch games. I tried several time to reinstall HGL and different games. This led me to join the discord channel and ask for support. I found out in the topic of *Frequently Asked Questions* (with the help from channel members) that wine dependencies should be installed.

This simple warning in description should save time for casual users, who don't have deep knowledge of wine. Also they won't bother other people with issues that are obviously easy to fix (like in my case described above).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
