### PR TITLE
[Fix] Epic login prompt empty when navigating to it from store

### DIFF
--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -298,6 +298,8 @@ export default function WebView() {
       setShowLoginWarningFor('gog')
     } else if (startUrl.match(/gaming\.amazon\.com/) && !amazon.user_id) {
       setShowLoginWarningFor('amazon')
+    } else {
+      setShowLoginWarningFor(null)
     }
   }, [startUrl])
 

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -122,7 +122,7 @@ export default function WebView() {
     return () => {
       mounted = false
     }
-  }, [])
+  }, [isEpicLogin])
 
   useEffect(() => {
     if (pathname !== '/loginweb/nile') return

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -109,9 +109,9 @@ export default function WebView() {
   useEffect(() => {
     let mounted = true
     const fetchLocalPreloadPath = async () => {
-      const path = (await window.api.getLocalPeloadPath()) as unknown
+      const path = await window.api.getLocalPeloadPath()
       if (mounted) {
-        setPreloadPath(path as string)
+        setPreloadPath(path)
       }
     }
 


### PR DESCRIPTION
When opening the Epic Games Store while not being logged in and clicking the "Go to Login" button, the login webview was never displayed. Additionally, doing the same thing with the GOG/Amazon stores would lead to the login warning being displayed twice.

This was, I believe, caused by #3540. When changing locations that point to the same element (in this case from WebView to WebView), instead of throwing away the old element and re-rendering a completely new one, React Router now re-renders the current one (at least it seems like that's how it works)

This exposed a couple issues with the state handling on that component:
- The `useEffect` fetching the Epic Preload path did not rely on `isEpicLogin`, even though `isEpicLogin` being true without a preload path being set results in us rendering an empty element
- The login warning would not get reset if none of the regexes applied anymore

Closes #3682

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
