### PR TITLE
[UX] Be more explicit about broken anticheat affecting multiplayer in copy

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -145,8 +145,8 @@
     "install": {
         "anticheat-warning": {
             "cancel": "No",
-            "install": "Yes (I understand it will not work)",
-            "message": "The anticheat support is broken or denied. The game will not work. Do you want to install it anyway?",
+            "install_anyway": "Yes (I understand the multiplayer features will not work)",
+            "multiplayer_message": "The anticheat support is broken or denied. The game may open but the multiplayer features will not work. Do you want to install it anyway?",
             "title": "Anticheat Broken/Denied"
         },
         "disk-space-left": "Space Available",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -17,7 +17,7 @@
     "Amazon Games": "Amazon Games",
     "anticheat": {
         "anticheats": "Anticheats",
-        "may_not_work": "It may not work due to denied or broken anticheat support.",
+        "multiplayer_may_not_work": "Multiplayer features may not work due to denied or broken anticheat support.",
         "reference": "Reference",
         "source": "Source",
         "status": "Status",

--- a/src/frontend/components/UI/Anticheat/index.tsx
+++ b/src/frontend/components/UI/Anticheat/index.tsx
@@ -65,8 +65,8 @@ export default function Anticheat({ anticheatInfo }: Props) {
         {mayNotWork && (
           <p>
             {t(
-              'anticheat.may_not_work',
-              'It may not work due to denied or broken anticheat support.'
+              'anticheat.multiplayer_may_not_work',
+              'Multiplayer features may not work due to denied or broken anticheat support.'
             )}
           </p>
         )}

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -195,14 +195,14 @@ export default function DownloadDialog({
     showDialogModal({
       title: t('install.anticheat-warning.title', 'Anticheat Broken/Denied'),
       message: t(
-        'install.anticheat-warning.message',
-        'The anticheat support is broken or denied. The game will not work. Do you want to install it anyway?'
+        'install.anticheat-warning.multiplayer_message',
+        'The anticheat support is broken or denied. The game may open but the multiplayer features will not work. Do you want to install it anyway?'
       ),
       buttons: [
         {
           text: t(
-            'install.anticheat-warning.install',
-            'Yes (I understand it will not work)'
+            'install.anticheat-warning.install_anyway',
+            'Yes (I understand the multiplayer features will not work)'
           ),
           onClick: async () => handleInstall(path, true)
         },


### PR DESCRIPTION
It's really common for users to install games like Fortnite with broken anticheat and they see the game opens after the installation even with Heroic saying "I understand it will not work". After that they think the game actually works and ask for help getting the game to be playable.

This PR updates the copy of the 2 messages to be more clear that the game will open, but the multiplayer features are what won't work.

This should also help to avoid confusion when a game works for single player and has denied/broken anticheat and only the multiplayer part won't work.

I changed the translation keys to required them to be all updated so we don't have old outdated strings.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
