### PR TITLE
[UX] Ignore error message fetching non-existent known-fix json

### DIFF
--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -185,7 +185,7 @@ async function downloadFixesFor(appName: string, runner: Runner) {
   if (!existsSync(fixesPath)) {
     mkdirSync(fixesPath, { recursive: true })
   }
-  downloadFile({ url, dest })
+  downloadFile({ url, dest, ignoreFailure: false })
 }
 
 export { installQueueElement, updateQueueElement }

--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -185,7 +185,7 @@ async function downloadFixesFor(appName: string, runner: Runner) {
   if (!existsSync(fixesPath)) {
     mkdirSync(fixesPath, { recursive: true })
   }
-  downloadFile({ url, dest, ignoreFailure: false })
+  downloadFile({ url, dest, ignoreFailure: true })
 }
 
 export { installQueueElement, updateQueueElement }


### PR DESCRIPTION
When trying to download the `known-fix` file for a game that has no known fixes file, an error is printed in the logs:

```
(22:28:24) ERROR:   [DownloadManager]:  Downloader: Failed to get headers for https://raw.githubusercontent.com/Heroic-Games-Launcher/known-fixes/main/epic/4656facc740742a39e265b026e13d075-epic.json. 
Error: Error: Request failed with status code 404
(node:184327) UnhandledPromiseRejectionWarning: Error: Failed to get headers
    at downloadFile (/home/ariel/dev/oss/HeroicGamesLauncher/build/electron/main.565caa16.js:21710:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
(Use `electron --trace-warnings ...` to show where the warning was created)
```

Not finding a fixes file is totally harmless and in the majority of cases it is actually expected (there's only like... 50 files in the repo), and the error in the logs confuses users when they are trying to debug an issue with a game not working (they think something was wrong with the game download).

This PR adds a flag to the downloadFile function to allow us to ignore the failure and avoid confusing users.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
