### PR TITLE
[GOG]: don't check for notInstallable during library sync

### DIFF
--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -119,19 +119,22 @@ export async function getExtraInfo(appName: string): Promise<ExtraInfo> {
 
   const gamesData = await getGamesData(appName)
 
-  const gogStoreUrl = gamesData?._links?.store.href
+  let gogStoreUrl = gamesData?._links?.store.href
   const releaseDate =
     gamesData?._embedded.product?.globalReleaseDate?.substring(0, 19)
 
-  const storeUrl = new URL(gogStoreUrl)
-  storeUrl.hostname = 'af.gog.com'
-  storeUrl.searchParams.set('as', '1838482841')
+  if (gogStoreUrl) {
+    const storeUrl = new URL(gogStoreUrl)
+    storeUrl.hostname = 'af.gog.com'
+    storeUrl.searchParams.set('as', '1838482841')
+    gogStoreUrl = storeUrl.toString()
+  }
 
   const extra: ExtraInfo = {
     about: gameInfo.extra?.about,
     reqs,
     releaseDate,
-    storeUrl: storeUrl.toString(),
+    storeUrl: gogStoreUrl,
     changelog: productInfo?.data.changelog
   }
   return extra

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -52,7 +52,6 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { unzipSync } from 'node:zlib'
 import { readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { checkForRedistUpdates } from './redist'
-import { version } from 'node:os'
 
 const library: Map<string, GameInfo> = new Map()
 const installedGames: Map<string, InstalledInfo> = new Map()

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -971,7 +971,7 @@ export async function gogToUnifiedInfo(
     },
     is_installed: false,
     save_folder: '',
-    title: (info.game.title['en-US'] ?? '').trim(),
+    title: ((info.title['*'] || info.game.title['*']) ?? '').trim(),
     canRunOffline: true,
     is_mac_native: Boolean(
       info.supported_operating_systems.find((os) => os.slug === 'osx')

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -52,6 +52,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { unzipSync } from 'node:zlib'
 import { readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { checkForRedistUpdates } from './redist'
+import { version } from 'node:os'
 
 const library: Map<string, GameInfo> = new Map()
 const installedGames: Map<string, InstalledInfo> = new Map()
@@ -575,6 +576,28 @@ export async function getInstallInfo(
       `stdout = ${!!res.stdout} and res.abort = ${!!res.abort} in getInstallInfo`,
       LogPrefix.Gog
     )
+    if (res.stderr.includes("Game doesn't support content system api")) {
+      return {
+        game: {
+          app_name: appName,
+          title: gameData.title,
+          launch_options: [],
+          owned_dlc: [],
+          version: '',
+          branches: [],
+          buildId: ''
+        },
+        manifest: {
+          app_name: appName,
+          disk_size: 0,
+          download_size: 0,
+          languages: [],
+          versionEtag: '',
+          dependencies: [],
+          perLangSize: { '*': { download_size: 0, disk_size: 0 } }
+        }
+      }
+    }
     return
   }
 
@@ -964,11 +987,6 @@ export async function gogToUnifiedInfo(
     install: {
       is_dlc: false
     },
-    installable:
-      (galaxyProductInfo?.content_system_compatibility.osx ||
-        galaxyProductInfo?.content_system_compatibility.windows ||
-        galaxyProductInfo?.content_system_compatibility.linux) ??
-      false,
     is_installed: false,
     namespace: galaxyProductInfo?.slug,
     save_folder: '',

--- a/src/frontend/screens/Game/GamePage/components/DownloadSizeInfo.tsx
+++ b/src/frontend/screens/Game/GamePage/components/DownloadSizeInfo.tsx
@@ -31,10 +31,6 @@ const DownloadSizeInfo = ({ gameInfo }: Props) => {
     return null
   }
 
-  if (gameInfo.installable !== undefined && !gameInfo.installable) {
-    return null
-  }
-
   const downloadSize =
     gameInstallInfo?.manifest?.download_size &&
     size(Number(gameInstallInfo?.manifest?.download_size))

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -197,8 +197,8 @@ export default React.memo(function GamePage(): JSX.Element | null {
                 throw 'Cannot get game info'
               }
               if (
-                info.manifest.disk_size == 0 &&
-                info.manifest.download_size == 0
+                info.manifest.disk_size === 0 &&
+                info.manifest.download_size === 0
               ) {
                 setNotInstallable(true)
                 return

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -111,6 +111,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const [progress, previousProgress] = hasProgress(appName)
 
   const [extraInfo, setExtraInfo] = useState<ExtraInfo | null>(null)
+  const [notInstallable, setNotInstallable] = useState<boolean>(false)
   const [gameInstallInfo, setGameInstallInfo] = useState<InstallInfo | null>(
     null
   )
@@ -142,8 +143,6 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const isInstallingWinetricksPackages = status === 'winetricks'
   const isInstallingRedist = status === 'redist'
   const notAvailable = !gameAvailable && gameInfo.is_installed
-  const notInstallable =
-    gameInfo.installable !== undefined && !gameInfo.installable
   const notSupportedGame =
     gameInfo.runner !== 'sideload' && gameInfo.thirdPartyManagedApp === 'Origin'
   const isOffline = connectivity.status !== 'online'
@@ -172,6 +171,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       if (gameInfo && status) {
         const {
           install,
+          is_installed,
           is_linux_native = undefined,
           is_mac_native = undefined
         } = { ...gameInfo }
@@ -186,6 +186,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
         if (
           runner !== 'sideload' &&
+          !is_installed &&
           !notSupportedGame &&
           !notInstallable &&
           !isOffline
@@ -194,6 +195,13 @@ export default React.memo(function GamePage(): JSX.Element | null {
             .then((info) => {
               if (!info) {
                 throw 'Cannot get game info'
+              }
+              if (
+                info.manifest.disk_size == 0 &&
+                info.manifest.download_size == 0
+              ) {
+                setNotInstallable(true)
+                return
               }
               setGameInstallInfo(info)
             })
@@ -381,7 +389,9 @@ export default React.memo(function GamePage(): JSX.Element | null {
                     />
                     <Description />
                     <CloudSavesSync gameInfo={gameInfo} />
-                    <DownloadSizeInfo gameInfo={gameInfo} />
+                    {!notInstallable && (
+                      <DownloadSizeInfo gameInfo={gameInfo} />
+                    )}
                     <InstalledInfo gameInfo={gameInfo} />
                     <Scores gameInfo={gameInfo} />
                     <HLTB />

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -39,6 +39,7 @@ import StoreLogos from 'frontend/components/UI/StoreLogos'
 import UninstallModal from 'frontend/components/UI/UninstallModal'
 import { getCardStatus, getImageFormatting } from './constants'
 import { hasStatus } from 'frontend/hooks/hasStatus'
+import fallBackImage from 'frontend/assets/heroic_card.jpg'
 import LibraryContext from '../../LibraryContext'
 
 interface Card {
@@ -416,7 +417,7 @@ const GameCard = ({
             <StoreLogos runner={runner} />
             {justPlayed ? (
               <CachedImage
-                src={art_cover}
+                src={art_cover || fallBackImage}
                 className="justPlayedImg"
                 alt={title}
               />

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -274,6 +274,32 @@ export default function DownloadDialog({
           selectedBuild,
           branch
         )
+
+        if (
+          gameInstallInfo?.manifest.disk_size === 0 &&
+          gameInstallInfo.manifest.download_size === 0
+        ) {
+          showDialogModal({
+            showDialog: true,
+            title: t(
+              'label.game.not-installable-game',
+              'Game is NOT Installable'
+            ),
+            message: t(
+              'status.gog-goodie',
+              "This game doesn't appear to be installable. Check downloadable content on https://gog.com/account"
+            ),
+            buttons: [
+              {
+                text: tr('box.ok')
+              }
+            ],
+            type: 'MESSAGE'
+          })
+          backdropClick()
+          return
+        }
+
         setGameInstallInfo(gameInstallInfo)
         setGettingInstallInfo(false)
 


### PR DESCRIPTION
This should resolve number of issues, but also allow players with pre-release access to actually download their games.


Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
