### PR TITLE
[Fix] Cloud save path input field can't be manually edited

### DIFF
--- a/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
@@ -124,7 +124,7 @@ export default function GOGSyncSaves({
                 htmlId="inputSavePath"
                 placeholder={t('setting.savefolder.placeholder')}
                 path={value.location}
-                canEditPath={isSyncing}
+                canEditPath={!isSyncing}
                 onPathChange={(path) => {
                   const saves = [...gogSaves]
                   saves[index] = {

--- a/src/frontend/screens/Settings/sections/SyncSaves/legendary.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/legendary.tsx
@@ -111,7 +111,7 @@ export default function LegendarySyncSaves({
             path={savesPath}
             placeholder={t('setting.savefolder.placeholder')}
             pathDialogTitle={t('box.sync.title')}
-            canEditPath={isSyncing}
+            canEditPath={!isSyncing}
             afterInput={
               <span
                 role={'button'}


### PR DESCRIPTION
We have a bug in the logic, we are disabling the input when we are NOT syncing and we are enabling the field while we ARE syncing. This prevents fixing the path if it's wrong.

This PR fixes that by toggling the condition

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
