### PR TITLE
fix: add default path for crossover on macOS

### DIFF
--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -302,11 +302,16 @@ export async function getCrossover(): Promise<Set<WineInstallation>> {
 
   const crossoverMacPath = new Set<string>()
 
-  // search for crossover installed on /Applications/CrossOver.app
-  const crossoverAppPath = '/Applications/CrossOver.app'
-  if (existsSync(crossoverAppPath)) {
-    crossoverMacPath.add(crossoverAppPath)
-  }
+  // search for crossover installed on default path
+  const crossoverDefaultPath = [
+    '/Applications/CrossOver.app',
+    '/Applications/CrossOver Preview.app'
+  ]
+  crossoverDefaultPath.forEach((crossoverAppPath) => {
+    if (existsSync(crossoverAppPath)) {
+      crossoverMacPath.add(crossoverAppPath)
+    }
+  })
 
   // search for crossover installed around the system
   await execAsync(

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -300,33 +300,42 @@ export async function getCrossover(): Promise<Set<WineInstallation>> {
     return crossover
   }
 
+  const crossoverMacPath = new Set<string>()
+
+  // search for crossover installed on /Applications/CrossOver.app
+  const crossoverAppPath = '/Applications/CrossOver.app'
+  if (existsSync(crossoverAppPath)) {
+    crossoverMacPath.add(crossoverAppPath)
+  }
+
+  // search for crossover installed around the system
   await execAsync(
     'mdfind kMDItemCFBundleIdentifier = "com.codeweavers.CrossOver"'
-  )
-    .then(async ({ stdout }) => {
-      stdout.split('\n').forEach((crossoverMacPath) => {
-        const infoFilePath = join(crossoverMacPath, 'Contents/Info.plist')
-        if (crossoverMacPath && existsSync(infoFilePath)) {
-          const info = plistParse(
-            readFileSync(infoFilePath, 'utf-8')
-          ) as PlistObject
-          const version = info['CFBundleShortVersionString'] || ''
-          const crossoverWineBin = join(
-            crossoverMacPath,
-            'Contents/SharedSupport/CrossOver/bin/wine'
-          )
-          crossover.add({
-            bin: crossoverWineBin,
-            name: `CrossOver - ${version}`,
-            type: 'crossover',
-            ...getWineExecs(crossoverWineBin)
-          })
-        }
+  ).then(async ({ stdout }) => {
+    stdout.split('\n').forEach((crossoverPath) => {
+      crossoverMacPath.add(crossoverPath)
+    })
+  })
+
+  crossoverMacPath.forEach((crossoverPath) => {
+    const infoFilePath = join(crossoverPath, 'Contents/Info.plist')
+    if (crossoverPath && existsSync(infoFilePath)) {
+      const info = plistParse(
+        readFileSync(infoFilePath, 'utf-8')
+      ) as PlistObject
+      const version = info['CFBundleShortVersionString'] || ''
+      const crossoverWineBin = join(
+        crossoverPath,
+        'Contents/SharedSupport/CrossOver/bin/wine'
+      )
+      crossover.add({
+        bin: crossoverWineBin,
+        name: `CrossOver - ${version}`,
+        type: 'crossover',
+        ...getWineExecs(crossoverWineBin)
       })
-    })
-    .catch(() => {
-      logInfo('CrossOver not found', LogPrefix.GlobalConfig)
-    })
+    }
+  })
   return crossover
 }
 

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -309,7 +309,7 @@ export async function getCrossover(): Promise<Set<WineInstallation>> {
   ]
   crossoverDefaultPath.forEach((crossoverAppPath) => {
     if (existsSync(crossoverAppPath)) {
-      crossoverMacPath.add(crossoverAppPath)
+      crossoverPaths.add(crossoverAppPath)
     }
   })
 

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -318,7 +318,7 @@ export async function getCrossover(): Promise<Set<WineInstallation>> {
     'mdfind kMDItemCFBundleIdentifier = "com.codeweavers.CrossOver"'
   ).then(async ({ stdout }) => {
     stdout.split('\n').forEach((crossoverPath) => {
-      crossoverMacPath.add(crossoverPath)
+      crossoverPaths.add(crossoverPath)
     })
   })
 

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -300,7 +300,7 @@ export async function getCrossover(): Promise<Set<WineInstallation>> {
     return crossover
   }
 
-  const crossoverMacPath = new Set<string>()
+  const crossoverPaths = new Set<string>()
 
   // search for crossover installed on default path
   const crossoverDefaultPath = [

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -322,7 +322,7 @@ export async function getCrossover(): Promise<Set<WineInstallation>> {
     })
   })
 
-  crossoverMacPath.forEach((crossoverPath) => {
+  crossoverPaths.forEach((crossoverPath) => {
     const infoFilePath = join(crossoverPath, 'Contents/Info.plist')
     if (crossoverPath && existsSync(infoFilePath)) {
       const info = plistParse(


### PR DESCRIPTION
If user disabled Spotlight, `mdfind` will not work. `/Applications/CrossOver.app` is the default install location for `CrossOver`, therefore adding it here as a backup.

Fixes #3025

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
