### PR TITLE
chore: improve whisky discoverability on mac

### DIFF
--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -387,9 +387,12 @@ export async function getWhisky(): Promise<Set<WineInstallation>> {
     return whisky
   }
 
-  const whiskyWinePath = `${userHome}/Library/Application Support/com.isaacmarovitz.Whisky/Libraries`
-  const whiskyVersionPlist = `${whiskyWinePath}/WhiskyWineVersion.plist`
-  const whiskyWineBin = `${whiskyWinePath}/Wine/bin/wine64`
+  const whiskyWinePath = join(
+    userHome,
+    'Library/Application Support/com.isaacmarovitz.Whisky/Libraries'
+  )
+  const whiskyVersionPlist = join(whiskyWinePath, 'WhiskyWineVersion.plist')
+  const whiskyWineBin = join(whiskyWinePath, 'Wine/bin/wine64')
 
   if (existsSync(whiskyVersionPlist) && existsSync(whiskyWineBin)) {
     try {
@@ -401,9 +404,9 @@ export async function getWhisky(): Promise<Set<WineInstallation>> {
       whisky.add({
         bin: whiskyWineBin,
         name: `Whisky - ${versionString}`,
-        type: `toolkit`,
-        lib: `${dirname(whiskyWineBin)}/../lib`,
-        lib32: `${dirname(whiskyWineBin)}/../lib`,
+        type: 'toolkit',
+        lib: join(whiskyWinePath, 'Wine/lib'),
+        lib32: join(whiskyWinePath, 'Wine/lib'),
         ...getWineExecs(whiskyWineBin)
       })
     } catch (error) {

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -387,29 +387,32 @@ export async function getWhisky(): Promise<Set<WineInstallation>> {
     return whisky
   }
 
-  await execAsync(
-    'mdfind kMDItemCFBundleIdentifier = "com.isaacmarovitz.Whisky"'
-  ).then(async ({ stdout }) => {
-    stdout.split('\n').forEach((whiskyMacPath) => {
-      const infoFilePath = join(whiskyMacPath, 'Contents/Info.plist')
-      if (whiskyMacPath && existsSync(infoFilePath)) {
-        const info = plistParse(
-          readFileSync(infoFilePath, 'utf-8')
-        ) as PlistObject
-        const version = info['CFBundleShortVersionString'] || ''
-        const whiskyWineBin = `${userHome}/Library/Application Support/com.isaacmarovitz.Whisky/Libraries/Wine/bin/wine64`
+  const whiskyWinePath = `${userHome}/Library/Application Support/com.isaacmarovitz.Whisky/Libraries`
+  const whiskyVersionPlist = `${whiskyWinePath}/WhiskyWineVersion.plist`
+  const whiskyWineBin = `${whiskyWinePath}/Wine/bin/wine64`
 
-        whisky.add({
-          bin: whiskyWineBin,
-          name: `Whisky - ${version}`,
-          type: `toolkit`,
-          lib: `${dirname(whiskyWineBin)}/../lib`,
-          lib32: `${dirname(whiskyWineBin)}/../lib`,
-          ...getWineExecs(whiskyWineBin)
-        })
-      }
-    })
-  })
+  if (existsSync(whiskyVersionPlist) && existsSync(whiskyWineBin)) {
+    try {
+      const info = plistParse(
+        readFileSync(whiskyVersionPlist, 'utf-8')
+      ) as PlistObject
+      const version = info['version']
+      const versionString = `${version['major']}.${version['minor']}.${version['patch']}-${version['build']}`
+      whisky.add({
+        bin: whiskyWineBin,
+        name: `Whisky - ${versionString}`,
+        type: `toolkit`,
+        lib: `${dirname(whiskyWineBin)}/../lib`,
+        lib32: `${dirname(whiskyWineBin)}/../lib`,
+        ...getWineExecs(whiskyWineBin)
+      })
+    } catch (error) {
+      logError(
+        `Error getting wine version for ${whiskyWineBin}`,
+        LogPrefix.GlobalConfig
+      )
+    }
+  }
 
   return whisky
 }


### PR DESCRIPTION
https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/3728#issuecomment-2105946706
Use the same version detection method as [Whisky](https://github.com/Whisky-App/Whisky/blob/57082e3187a4b4481f1c80c85506f939e41bbded/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift)

Ping @ahmed2m. I do not have Whisky installed. Please download the [CI build](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/actions/runs/9049401139) to see if this works.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
