### PR TITLE
[Feat] Pass additional game information to the pre-post launch script using environment variables

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1368,7 +1368,7 @@ async function runScriptForGame(
   scriptPath: string
 ): Promise<boolean | string> {
   return new Promise((resolve, reject) => {
-    var scriptEnv = { GAMEINFO_TITLE: gameInfo.title , GAMEINFO_EXEC: gameInfo.install.executable };
+    let scriptEnv = { GAMEINFO_TITLE: gameInfo.title , GAMEINFO_EXEC: gameInfo.install.executable };
     Object.assign(scriptEnv, process.env);
     const child = spawn(scriptPath, { cwd: gameInfo.install.install_path , env: scriptEnv })
 

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1370,6 +1370,7 @@ async function runScriptForGame(
   return new Promise((resolve, reject) => {
     const scriptEnv = {
       HEROIC_GAMEINFO_EXEC: gameInfo.install.executable,
+      HEROIC_GAMEINFO_RUNNER: gameInfo.runner,
       HEROIC_GAMEINFO_TITLE: gameInfo.title
     }
     Object.assign(scriptEnv, process.env)

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1368,9 +1368,15 @@ async function runScriptForGame(
   scriptPath: string
 ): Promise<boolean | string> {
   return new Promise((resolve, reject) => {
-    const scriptEnv = { GAMEINFO_TITLE: gameInfo.title , GAMEINFO_EXEC: gameInfo.install.executable };
-    Object.assign(scriptEnv, process.env);
-    const child = spawn(scriptPath, { cwd: gameInfo.install.install_path , env: scriptEnv })
+    const scriptEnv = {
+      GAMEINFO_TITLE: gameInfo.title,
+      GAMEINFO_EXEC: gameInfo.install.executable
+    }
+    Object.assign(scriptEnv, process.env)
+    const child = spawn(scriptPath, {
+      cwd: gameInfo.install.install_path,
+      env: scriptEnv
+    })
 
     child.stdout.on('data', (data) => {
       appendGamePlayLog(gameInfo, data.toString())

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1368,7 +1368,9 @@ async function runScriptForGame(
   scriptPath: string
 ): Promise<boolean | string> {
   return new Promise((resolve, reject) => {
-    const child = spawn(scriptPath, { cwd: gameInfo.install.install_path })
+    var scriptEnv = { GAMEINFO_TITLE: gameInfo.title , GAMEINFO_EXEC: gameInfo.install.executable };
+    Object.assign(scriptEnv, process.env);
+    const child = spawn(scriptPath, { cwd: gameInfo.install.install_path , env: scriptEnv })
 
     child.stdout.on('data', (data) => {
       appendGamePlayLog(gameInfo, data.toString())

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1369,8 +1369,8 @@ async function runScriptForGame(
 ): Promise<boolean | string> {
   return new Promise((resolve, reject) => {
     const scriptEnv = {
-      GAMEINFO_TITLE: gameInfo.title,
-      GAMEINFO_EXEC: gameInfo.install.executable
+      HEROIC_GAMEINFO_EXEC: gameInfo.install.executable,
+      HEROIC_GAMEINFO_TITLE: gameInfo.title
     }
     Object.assign(scriptEnv, process.env)
     const child = spawn(scriptPath, {

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1323,7 +1323,7 @@ async function runBeforeLaunchScript(
     `Running script before ${gameInfo.title} (${gameSettings.beforeLaunchScriptPath})\n`
   )
 
-  return runScriptForGame(gameInfo, gameSettings.beforeLaunchScriptPath)
+  return runScriptForGame(gameInfo, gameSettings, 'before')
 }
 
 async function runAfterLaunchScript(
@@ -1338,7 +1338,7 @@ async function runAfterLaunchScript(
     gameInfo,
     `Running script after ${gameInfo.title} (${gameSettings.afterLaunchScriptPath})\n`
   )
-  return runScriptForGame(gameInfo, gameSettings.afterLaunchScriptPath)
+  return runScriptForGame(gameInfo, gameSettings, 'after')
 }
 
 /* Execute script before launch/after exit, wait until the script
@@ -1365,13 +1365,21 @@ async function runAfterLaunchScript(
  */
 async function runScriptForGame(
   gameInfo: GameInfo,
-  scriptPath: string
+  gameSettings: GameSettings,
+  scriptStage: string
 ): Promise<boolean | string> {
   return new Promise((resolve, reject) => {
+    const scriptPath =
+      scriptStage === 'before'
+        ? gameSettings.beforeLaunchScriptPath
+        : gameSettings.afterLaunchScriptPath
     const scriptEnv = {
-      HEROIC_GAMEINFO_EXEC: gameInfo.install.executable,
-      HEROIC_GAMEINFO_RUNNER: gameInfo.runner,
-      HEROIC_GAMEINFO_TITLE: gameInfo.title
+      HEROIC_GAME_APP_NAME: gameInfo.app_name,
+      HEROIC_GAME_EXEC: gameInfo.install.executable,
+      HEROIC_GAME_PREFIX: gameSettings.winePrefix,
+      HEROIC_GAME_RUNNER: gameInfo.runner,
+      HEROIC_GAME_SCRIPT_STAGE: scriptStage,
+      HEROIC_GAME_TITLE: gameInfo.title
     }
     Object.assign(scriptEnv, process.env)
     const child = spawn(scriptPath, {

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1376,9 +1376,9 @@ async function runScriptForGame(
       HEROIC_GAME_PREFIX: gameSettings.winePrefix,
       HEROIC_GAME_RUNNER: gameInfo.runner,
       HEROIC_GAME_SCRIPT_STAGE: scriptStage,
-      HEROIC_GAME_TITLE: gameInfo.title
+      HEROIC_GAME_TITLE: gameInfo.title,
+      ...process.env
     }
-    Object.assign(scriptEnv, process.env)
     const child = spawn(scriptPath, {
       cwd: gameInfo.install.install_path,
       env: scriptEnv

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1366,13 +1366,10 @@ async function runAfterLaunchScript(
 async function runScriptForGame(
   gameInfo: GameInfo,
   gameSettings: GameSettings,
-  scriptStage: string
+  scriptStage: 'before' | 'after'
 ): Promise<boolean | string> {
   return new Promise((resolve, reject) => {
-    const scriptPath =
-      scriptStage === 'before'
-        ? gameSettings.beforeLaunchScriptPath
-        : gameSettings.afterLaunchScriptPath
+    const scriptPath = gameSettings[`${scriptStage}LaunchScriptPath`]
     const scriptEnv = {
       HEROIC_GAME_APP_NAME: gameInfo.app_name,
       HEROIC_GAME_EXEC: gameInfo.install.executable,

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1368,7 +1368,7 @@ async function runScriptForGame(
   scriptPath: string
 ): Promise<boolean | string> {
   return new Promise((resolve, reject) => {
-    let scriptEnv = { GAMEINFO_TITLE: gameInfo.title , GAMEINFO_EXEC: gameInfo.install.executable };
+    const scriptEnv = { GAMEINFO_TITLE: gameInfo.title , GAMEINFO_EXEC: gameInfo.install.executable };
     Object.assign(scriptEnv, process.env);
     const child = spawn(scriptPath, { cwd: gameInfo.install.install_path , env: scriptEnv })
 


### PR DESCRIPTION
This PR goal is to pass additional game information (title and executable path) to the pre-post launch script using environment variables. This would allow to use the same script with different games, taking actions based on the game title value or executable path.
Tries to fulfill the alternative solution proposed in https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3691.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
