### PR TITLE
[Fix] "Wine version is not valid" clarifications

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -942,7 +942,7 @@ export async function checkWineBeforeLaunch(
 
       appendGamePlayLog(
         gameInfo,
-        `Wine version ${gameSettings.wineVersion.name} is not valid, trying another one.`
+        `Wine version ${gameSettings.wineVersion.name} is not valid, trying another one.\n`
       )
     }
 

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -957,6 +957,10 @@ export async function checkWineBeforeLaunch(
 
       if (response === 0) {
         logInfo(`Changing wine version to ${defaultwine.name}`)
+        appendGamePlayLog(
+          gameInfo,
+          `Changing wine version to ${defaultwine.name}\n`
+        )
         gameSettings.wineVersion = defaultwine
         GameConfig.get(gameInfo.app_name).setSetting('wineVersion', defaultwine)
         return true


### PR DESCRIPTION
Trying to launch a game with an invalid Wine version presents the user with an option to choose the default version instead, if that's valid. This is also logged in the game log, but had two issues:
- A missing newline character caused the message to be on the same line as the next log messages (currently a Winetricks package listing)
- We would log that we're changing the version, but wouldn't log the version that we changed to

Both of those issues are now resolved

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
