### PR TITLE
[Fix] Fix DXVK uninstallation from prefix

### DIFF
--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -295,30 +295,29 @@ export const DXVK = {
       logInfo('Removing DXVK DLLs', LogPrefix.DXVKInstaller)
 
       // removing DXVK dlls
+      let dllsToRemove
       if (is64bitPrefix) {
-        dlls32.forEach((dll) => {
-          rm(`${winePrefix}/drive_c/windows/syswow64/${dll}`, (err) => {
-            if (err) {
-              logError([`Error removing ${dll}`, err], LogPrefix.DXVKInstaller)
-            }
-          })
-        })
-        dlls64.forEach((dll) => {
-          rm(`${winePrefix}/drive_c/windows/system32/${dll}`, (err) => {
-            if (err) {
-              logError([`Error removing ${dll}`, err], LogPrefix.DXVKInstaller)
-            }
-          })
-        })
+        dllsToRemove = dlls64.map(
+          (dll) => `${winePrefix}/drive_c/windows/system32/${dll}`
+        )
+        dllsToRemove.concat(
+          dlls32.map((dll) => `${winePrefix}/drive_c/windows/syswow64/${dll}`)
+        )
       } else {
-        dlls32.forEach((dll) => {
-          rm(`${winePrefix}/drive_c/windows/system32/${dll}`, (err) => {
-            if (err) {
-              logError([`Error removing ${dll}`, err], LogPrefix.DXVKInstaller)
-            }
-          })
-        })
+        dllsToRemove = dlls32.map(
+          (dll) => `${winePrefix}/drive_c/windows/system32/${dll}`
+        )
       }
+      dllsToRemove.forEach((dllFile) => {
+        rm(dllFile, (err) => {
+          if (err) {
+            logError(
+              [`Error removing ${dllFile}`, err],
+              LogPrefix.DXVKInstaller
+            )
+          }
+        })
+      })
 
       // Restore stock Wine libraries
       logInfo('Restoring Wine stock DLLs', LogPrefix.DXVKInstaller)

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -295,75 +295,40 @@ export const DXVK = {
       logInfo('Removing DXVK DLLs', LogPrefix.DXVKInstaller)
 
       // removing DXVK dlls
-      const lib32Path =
-        gameSettings.wineVersion.lib32 === undefined
-          ? ''
-          : gameSettings.wineVersion.lib32
-      const wineLib32Path = lib32Path.replace('~', userHome)
-      if (wineLib32Path === '') {
-        logError(
-          'invalid 32-bit library source directory! Will not remove DXVK DLLs',
-          LogPrefix.DXVKInstaller
-        )
-        return false
-      }
       if (is64bitPrefix) {
-        const libPath =
-          gameSettings.wineVersion.lib === undefined
-            ? ''
-            : gameSettings.wineVersion.lib
-        const wineLibPath = libPath.replace('~', userHome)
-        if (wineLibPath === '') {
-          logError(
-            'invalid 64-bit library source directory! Will not remove DXVK DLLs',
-            LogPrefix.DXVKInstaller
-          )
-          return false
-        }
         dlls32.forEach((dll) => {
-          copyFile(
-            `${wineLib32Path}/wine/i386-windows/${dll}`,
-            `${winePrefix}/drive_c/windows/syswow64/${dll}`,
-            (err) => {
-              if (err) {
-                logError(
-                  [`Error when copying ${dll}`, err],
-                  LogPrefix.DXVKInstaller
-                )
-              }
+          rm(`${winePrefix}/drive_c/windows/syswow64/${dll}`, (err) => {
+            if (err) {
+              logError([`Error removing ${dll}`, err], LogPrefix.DXVKInstaller)
             }
-          )
+          })
         })
         dlls64.forEach((dll) => {
-          copyFile(
-            `${wineLibPath}/wine/x86_64-windows/${dll}`,
-            `${winePrefix}/drive_c/windows/system32/${dll}`,
-            (err) => {
-              if (err) {
-                logError(
-                  [`Error when copying ${dll}`, err],
-                  LogPrefix.DXVKInstaller
-                )
-              }
+          rm(`${winePrefix}/drive_c/windows/system32/${dll}`, (err) => {
+            if (err) {
+              logError([`Error removing ${dll}`, err], LogPrefix.DXVKInstaller)
             }
-          )
+          })
         })
       } else {
         dlls32.forEach((dll) => {
-          copyFile(
-            `${wineLib32Path}/wine/i386-windows/${dll}`,
-            `${winePrefix}/drive_c/windows/system32/${dll}`,
-            (err) => {
-              if (err) {
-                logError(
-                  [`Error when copying ${dll}`, err],
-                  LogPrefix.DXVKInstaller
-                )
-              }
+          rm(`${winePrefix}/drive_c/windows/system32/${dll}`, (err) => {
+            if (err) {
+              logError([`Error removing ${dll}`, err], LogPrefix.DXVKInstaller)
             }
-          )
+          })
         })
       }
+
+      // Restore stock Wine libraries
+      logInfo('Restoring Wine stock DLLs', LogPrefix.DXVKInstaller)
+
+      await runWineCommand({
+        gameSettings,
+        commandParts: ['wineboot', '-u'],
+        wait: true,
+        protonVerb: 'run'
+      })
       return true
     }
 

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -291,6 +291,63 @@ export const DXVK = {
           protonVerb: 'run'
         })
       })
+
+      logInfo('Restoring Wine DLLs', LogPrefix.DXVKInstaller)
+
+      // restore wine dlls
+      const lib32 = gameSettings.wineVersion.lib32
+      const wineLib32 = lib32.replace('~', userHome)
+      if (is64bitPrefix) {
+        dlls32.forEach((dll) => {
+          if (!isMac) {
+            copyFile(
+              `${wineLib32}/wine/i386-windows/${dll}`,
+              `${winePrefix}/drive_c/windows/syswow64/${dll}`,
+              (err) => {
+                if (err) {
+                  logError(
+                    [`Error when copying ${dll}`, err],
+                    LogPrefix.DXVKInstaller
+                  )
+                }
+              }
+            )
+          }
+        })
+        const lib = gameSettings.wineVersion.lib
+        const wineLib = lib.replace('~', userHome)
+        dlls64.forEach((dll) => {
+          copyFile(
+            `${wineLib}/wine/x86_64-windows/${dll}`,
+            `${winePrefix}/drive_c/windows/system32/${dll}`,
+            (err) => {
+              if (err) {
+                logError(
+                  [`Error when copying ${dll}`, err],
+                  LogPrefix.DXVKInstaller
+                )
+              }
+            }
+          )
+        })
+      } else {
+        dlls32.forEach((dll) => {
+          if (!isMac) {
+            copyFile(
+              `${wineLib32}/wine/i386-windows/${dll}`,
+              `${winePrefix}/drive_c/windows/system32/${dll}`,
+              (err) => {
+                if (err) {
+                  logError(
+                    [`Error when copying ${dll}`, err],
+                    LogPrefix.DXVKInstaller
+                  )
+                }
+              }
+            )
+          }
+        })
+      }
       return true
     }
 

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -292,7 +292,7 @@ export const DXVK = {
         })
       })
 
-      logInfo('removing DXVK DLLs', LogPrefix.DXVKInstaller)
+      logInfo('Removing DXVK DLLs', LogPrefix.DXVKInstaller)
 
       // removing DXVK dlls
       const lib32Path =

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -295,13 +295,35 @@ export const DXVK = {
       logInfo('removing DXVK DLLs', LogPrefix.DXVKInstaller)
 
       // removing DXVK dlls
-      const lib32 = gameSettings.wineVersion.lib32
-      const wineLib32 = lib32.replace('~', userHome)
+      const lib32Path =
+        gameSettings.wineVersion.lib32 === undefined
+          ? ''
+          : gameSettings.wineVersion.lib32
+      const wineLib32Path = lib32Path.replace('~', userHome)
+      if (wineLib32Path === '') {
+        logError(
+          'invalid 32-bit library source directory! Will not remove DXVK DLLs',
+          LogPrefix.DXVKInstaller
+        )
+        return false
+      }
       if (is64bitPrefix) {
+        const libPath =
+          gameSettings.wineVersion.lib === undefined
+            ? ''
+            : gameSettings.wineVersion.lib
+        const wineLibPath = libPath.replace('~', userHome)
+        if (wineLibPath === '') {
+          logError(
+            'invalid 64-bit library source directory! Will not remove DXVK DLLs',
+            LogPrefix.DXVKInstaller
+          )
+          return false
+        }
         dlls32.forEach((dll) => {
           if (!isMac) {
             copyFile(
-              `${wineLib32}/wine/i386-windows/${dll}`,
+              `${wineLib32Path}/wine/i386-windows/${dll}`,
               `${winePrefix}/drive_c/windows/syswow64/${dll}`,
               (err) => {
                 if (err) {
@@ -314,11 +336,9 @@ export const DXVK = {
             )
           }
         })
-        const lib = gameSettings.wineVersion.lib
-        const wineLib = lib.replace('~', userHome)
         dlls64.forEach((dll) => {
           copyFile(
-            `${wineLib}/wine/x86_64-windows/${dll}`,
+            `${wineLibPath}/wine/x86_64-windows/${dll}`,
             `${winePrefix}/drive_c/windows/system32/${dll}`,
             (err) => {
               if (err) {
@@ -334,7 +354,7 @@ export const DXVK = {
         dlls32.forEach((dll) => {
           if (!isMac) {
             copyFile(
-              `${wineLib32}/wine/i386-windows/${dll}`,
+              `${wineLib32Path}/wine/i386-windows/${dll}`,
               `${winePrefix}/drive_c/windows/system32/${dll}`,
               (err) => {
                 if (err) {

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -321,20 +321,18 @@ export const DXVK = {
           return false
         }
         dlls32.forEach((dll) => {
-          if (!isMac) {
-            copyFile(
-              `${wineLib32Path}/wine/i386-windows/${dll}`,
-              `${winePrefix}/drive_c/windows/syswow64/${dll}`,
-              (err) => {
-                if (err) {
-                  logError(
-                    [`Error when copying ${dll}`, err],
-                    LogPrefix.DXVKInstaller
-                  )
-                }
+          copyFile(
+            `${wineLib32Path}/wine/i386-windows/${dll}`,
+            `${winePrefix}/drive_c/windows/syswow64/${dll}`,
+            (err) => {
+              if (err) {
+                logError(
+                  [`Error when copying ${dll}`, err],
+                  LogPrefix.DXVKInstaller
+                )
               }
-            )
-          }
+            }
+          )
         })
         dlls64.forEach((dll) => {
           copyFile(
@@ -352,20 +350,18 @@ export const DXVK = {
         })
       } else {
         dlls32.forEach((dll) => {
-          if (!isMac) {
-            copyFile(
-              `${wineLib32Path}/wine/i386-windows/${dll}`,
-              `${winePrefix}/drive_c/windows/system32/${dll}`,
-              (err) => {
-                if (err) {
-                  logError(
-                    [`Error when copying ${dll}`, err],
-                    LogPrefix.DXVKInstaller
-                  )
-                }
+          copyFile(
+            `${wineLib32Path}/wine/i386-windows/${dll}`,
+            `${winePrefix}/drive_c/windows/system32/${dll}`,
+            (err) => {
+              if (err) {
+                logError(
+                  [`Error when copying ${dll}`, err],
+                  LogPrefix.DXVKInstaller
+                )
               }
-            )
-          }
+            }
+          )
         })
       }
       return true

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -212,7 +212,7 @@ export const DXVK = {
     const is64bitPrefix = existsSync(`${winePrefix}/drive_c/windows/syswow64`)
 
     if (!is64bitPrefix) {
-      logWarning('Installing DXVK on a 32-bit prefix!', LogPrefix.DXVKInstaller)
+      logWarning('32-bit prefix detected!', LogPrefix.DXVKInstaller)
     }
 
     if (!existsSync(`${toolsPath}/${tool}/latest_${tool}`)) {
@@ -292,9 +292,9 @@ export const DXVK = {
         })
       })
 
-      logInfo('Restoring Wine DLLs', LogPrefix.DXVKInstaller)
+      logInfo('removing DXVK DLLs', LogPrefix.DXVKInstaller)
 
-      // restore wine dlls
+      // removing DXVK dlls
       const lib32 = gameSettings.wineVersion.lib32
       const wineLib32 = lib32.replace('~', userHome)
       if (is64bitPrefix) {

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -309,14 +309,11 @@ export const DXVK = {
         )
       }
       dllsToRemove.forEach((dllFile) => {
-        rm(dllFile, (err) => {
-          if (err) {
-            logError(
-              [`Error removing ${dllFile}`, err],
-              LogPrefix.DXVKInstaller
-            )
-          }
-        })
+        try {
+          rmSync(dllFile)
+        } catch (err) {
+          logError([`Error removing ${dllFile}`, err], LogPrefix.DXVKInstaller)
+        }
       })
 
       // Restore stock Wine libraries


### PR DESCRIPTION
Fix DXVK uninstallation by restoring Wine/Proton DLLs after DXVK DLL overrides are removed. Otherwise `wineboot -u` will have to be executed to achieve the same result.
Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3707 .
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
