### PR TITLE
[Fix] Prevent empty name category from being added

### DIFF
--- a/e2e/categories.spec.ts
+++ b/e2e/categories.spec.ts
@@ -15,6 +15,9 @@ electronTest('categories', async (app) => {
 
     await expect(dialog.getByText('No categories yet.')).toBeInViewport()
 
+    // add button should be disabled without a name
+    await expect(dialog.getByTitle('Add', { exact: true })).toBeDisabled()
+
     // add new category
     await dialog.getByPlaceholder('Add new category').fill('Great games')
     await dialog.getByTitle('Add', { exact: true }).click()
@@ -23,8 +26,20 @@ electronTest('categories', async (app) => {
       dialog.locator('span', { hasText: 'Great games' })
     ).toBeInViewport()
 
-    // rename category
+    // add button should be disable if trying to rename category to empty name
     await dialog.getByTitle('Rename "Great games"').click()
+    await dialog.getByLabel('Rename "Great games"').fill('Great games')
+    await expect(dialog.getByTitle('Add', { exact: true })).toBeDisabled()
+
+    // add button should be disabled if trying to rename category to empty string
+    await dialog.getByLabel('Rename "Great games"').fill('')
+    await expect(dialog.getByTitle('Add', { exact: true })).toBeDisabled()
+
+    // add button should be disabled if trying to rename category to empty spaces
+    await dialog.getByLabel('Rename "Great games"').fill('   ')
+    await expect(dialog.getByTitle('Add', { exact: true })).toBeDisabled()
+
+    // rename category
     await dialog.getByLabel('Rename "Great games"').fill('Amazing games')
     await dialog
       .getByTitle('Confirm rename of "Great games" as "Amazing games"')

--- a/e2e/categories.spec.ts
+++ b/e2e/categories.spec.ts
@@ -26,7 +26,7 @@ electronTest('categories', async (app) => {
       dialog.locator('span', { hasText: 'Great games' })
     ).toBeInViewport()
 
-    // add button should be disable if trying to rename category to empty name
+    // add button should be disable if trying to rename category to same name
     await dialog.getByTitle('Rename "Great games"').click()
     await dialog.getByLabel('Rename "Great games"').fill('Great games')
     await expect(dialog.getByTitle('Add', { exact: true })).toBeDisabled()

--- a/src/frontend/screens/Library/components/CategoriesManager/index.tsx
+++ b/src/frontend/screens/Library/components/CategoriesManager/index.tsx
@@ -30,7 +30,8 @@ function CategoryItem({
   const [renameMode, setRenameMode] = useState(false)
   const [newName, setNewName] = useState(name)
   const [removeMode, setRemoveMode] = useState(false)
-  const isNewNameEmptyOrEqualsOldName = newName === '' || newName === name
+  const isNewNameEmptyOrEqualsOldName =
+    newName?.trim() === '' || newName === name
 
   const rename = () => {
     renameFunction(name, newName)
@@ -159,7 +160,7 @@ function CategoriesManager() {
 
   const [newCategoryName, setNewCategoryName] = useState('')
 
-  const isCategoryNameEmpty = newCategoryName === ''
+  const isCategoryNameEmpty = newCategoryName?.trim() === ''
 
   const removeCategory = (cat: string) => {
     customCategories.removeCategory(cat)

--- a/src/frontend/screens/Library/components/CategoriesManager/index.tsx
+++ b/src/frontend/screens/Library/components/CategoriesManager/index.tsx
@@ -31,7 +31,7 @@ function CategoryItem({
   const [newName, setNewName] = useState(name)
   const [removeMode, setRemoveMode] = useState(false)
   const isNewNameEmptyOrEqualsOldName =
-    newName?.trim() === '' || newName === name
+    newName.trim() === '' || newName === name
 
   const rename = () => {
     renameFunction(name, newName)
@@ -160,7 +160,7 @@ function CategoriesManager() {
 
   const [newCategoryName, setNewCategoryName] = useState('')
 
-  const isCategoryNameEmpty = newCategoryName?.trim() === ''
+  const isCategoryNameEmpty = newCategoryName.trim() === ''
 
   const removeCategory = (cat: string) => {
     customCategories.removeCategory(cat)

--- a/src/frontend/screens/Library/components/CategoriesManager/index.tsx
+++ b/src/frontend/screens/Library/components/CategoriesManager/index.tsx
@@ -30,6 +30,7 @@ function CategoryItem({
   const [renameMode, setRenameMode] = useState(false)
   const [newName, setNewName] = useState(name)
   const [removeMode, setRemoveMode] = useState(false)
+  const isNewNameEmptyOrEqualsOldName = newName === '' || newName === name
 
   const rename = () => {
     renameFunction(name, newName)
@@ -57,6 +58,7 @@ function CategoryItem({
             'Confirm rename of "{{oldName}}" as "{{newName}}"',
             { oldName: name, newName }
           )}
+          disabled={isNewNameEmptyOrEqualsOldName}
         >
           <FontAwesomeIcon icon={faCheck} />
         </button>
@@ -157,6 +159,8 @@ function CategoriesManager() {
 
   const [newCategoryName, setNewCategoryName] = useState('')
 
+  const isCategoryNameEmpty = newCategoryName === ''
+
   const removeCategory = (cat: string) => {
     customCategories.removeCategory(cat)
   }
@@ -206,6 +210,7 @@ function CategoriesManager() {
               className="button"
               onClick={() => addCategory()}
               title={t('categories-manager.add', 'Add')}
+              disabled={isCategoryNameEmpty}
             >
               <FontAwesomeIcon icon={faAdd} />
             </button>


### PR DESCRIPTION
Currently we can add empty categories and also rename categories for an empty string.
This is just a small fix to prevent those cases.
I also did another one change to disable the "confirm rename button" when the name was not changed.

Before:

https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/33737137/9c392ba2-eadd-4231-9dfc-08d9f00b2a7e

After:

https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/33737137/51b0d6f3-883e-4190-878b-b140fc923e2e

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
