### PR TITLE
[EPIC]: Support third-party managed applications

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -140,6 +140,7 @@
         "size": "Size",
         "steamdeck-compatibility-info": "SteamDeck Compatibility",
         "syncsaves": "Sync Saves",
+        "third-party-app": "Third-Party Manager",
         "version": "Version"
     },
     "install": {
@@ -271,5 +272,10 @@
         "settings": "Settings",
         "store": "Store Page",
         "verify": "Verify and Repair"
+    },
+    "third-party-managed": {
+        "header": "This game is managed by a third-party application",
+        "notice1": "This game is managed by a third-party application: \"{{application_name}}\"",
+        "notice2": "After clicking Install, Heroic will run the application in order to complete the installation process"
     }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -287,6 +287,7 @@
         "show_hidden": "Show Hidden",
         "show_installed_only": "Show Installed only",
         "show_support_offline_only": "Show offline-supported only",
+        "show_third_party_managed_only": "Show third-party managed only",
         "uncategorized": "Uncategorized"
     },
     "help": {

--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -62,6 +62,7 @@ const nileConfigPath = join(appFolder, 'nile_config', 'nile')
 const configPath = join(appFolder, 'config.json')
 const gamesConfigPath = join(appFolder, 'GamesConfig')
 const toolsPath = join(appFolder, 'tools')
+const epicRedistPath = join(toolsPath, 'redist', 'legendary')
 const gogRedistPath = join(toolsPath, 'redist', 'gog')
 const heroicIconFolder = join(appFolder, 'icons')
 const runtimePath = join(toolsPath, 'runtimes')
@@ -90,6 +91,10 @@ const icon = fixAsarPath(join(publicDir, 'icon.png'))
 const iconDark = fixAsarPath(join(publicDir, 'icon-dark.png'))
 const iconLight = fixAsarPath(join(publicDir, 'icon-light.png'))
 const installed = join(legendaryConfigPath, 'installed.json')
+const thirdPartyInstalled = join(
+  legendaryConfigPath,
+  'third-party-installed.json'
+)
 const legendaryMetadata = join(legendaryConfigPath, 'metadata')
 const nileInstalled = join(nileConfigPath, 'installed.json')
 const nileLibrary = join(nileConfigPath, 'library.json')
@@ -279,10 +284,12 @@ export {
   gogdlConfigPath,
   gogSupportPath,
   gogRedistPath,
+  epicRedistPath,
   vulkanHelperBin,
   nileConfigPath,
   nileInstalled,
   nileLibrary,
   nileUserData,
-  fixesPath
+  fixesPath,
+  thirdPartyInstalled
 }

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -23,13 +23,15 @@ import {
 } from './library'
 import { LegendaryUser } from './user'
 import {
+  downloadFile,
   getLegendaryBin,
   killPattern,
   moveOnUnix,
   moveOnWindows,
   sendGameStatusUpdate,
   sendProgressUpdate,
-  shutdownWine
+  shutdownWine,
+  spawnAsync
 } from '../../utils'
 import {
   isMac,
@@ -37,7 +39,8 @@ import {
   installed,
   configStore,
   isCLINoGui,
-  isLinux
+  isLinux,
+  epicRedistPath
 } from '../../constants'
 import {
   appendGamePlayLog,
@@ -83,7 +86,9 @@ import {
   PositiveInteger
 } from './commands/base'
 import { LegendaryCommand } from './commands'
+import thirdParty from './thirdParty'
 import { Path } from 'backend/schemas'
+import { mkdirSync } from 'fs'
 
 /**
  * Alias for `LegendaryLibrary.listUpdateableGames`
@@ -144,9 +149,13 @@ async function getProductSlug(namespace: string, title: string) {
   }
 
   try {
-    const result = await axios('https://www.epicgames.com/graphql', {
+    const result = await axios('https://launcher.store.epicgames.com/graphql', {
       data: graphql,
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) EpicGamesLauncher'
+      },
       method: 'POST'
     })
 
@@ -233,9 +242,13 @@ async function getExtraFromGraphql(
   }
 
   try {
-    const result = await axios('https://www.epicgames.com/graphql', {
+    const result = await axios('https://launcher.store.epicgames.com/graphql', {
       data: graphql,
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) EpicGamesLauncher'
+      },
       method: 'POST'
     })
 
@@ -289,6 +302,7 @@ const emptyExtraInfo = {
 export async function getExtraInfo(appName: string): Promise<ExtraInfo> {
   const { namespace, title } = getGameInfo(appName)
   if (namespace === undefined) return emptyExtraInfo
+
   const cachedExtraInfo = gameInfoStore.get(namespace)
   if (cachedExtraInfo) {
     return cachedExtraInfo
@@ -571,6 +585,22 @@ export async function install(
   status: 'done' | 'error' | 'abort'
   error?: string
 }> {
+  const gameInfo = getGameInfo(appName)
+  if (gameInfo.thirdPartyManagedApp) {
+    if (
+      !['origin', 'the ea app'].includes(
+        gameInfo.thirdPartyManagedApp.toLowerCase()
+      )
+    ) {
+      logError(
+        ['Third party app', gameInfo.thirdPartyManagedApp, 'not supported'],
+        LogPrefix.Legendary
+      )
+      return { status: 'error' }
+    }
+
+    return installEA(gameInfo, platformToInstall)
+  }
   const { maxWorkers, downloadNoHttps } = GlobalConfig.get().getSettings()
   const info = await getInstallInfo(appName, platformToInstall)
 
@@ -634,7 +664,54 @@ export async function install(
   return { status: 'done' }
 }
 
+async function installEA(
+  gameInfo: GameInfo,
+  platformToInstall: string
+): Promise<{
+  status: 'done' | 'error' | 'abort'
+  error?: string
+}> {
+  logInfo('Getting EA App installer', LogPrefix.Legendary)
+  const installerPath = join(epicRedistPath, 'EAappInstaller.exe')
+
+  if (!existsSync(epicRedistPath)) {
+    mkdirSync(epicRedistPath, { recursive: true })
+  }
+
+  if (!existsSync(installerPath)) {
+    try {
+      await downloadFile({
+        url: 'https://origin-a.akamaihd.net/EA-Desktop-Client-Download/installer-releases/EAappInstaller.exe',
+        dest: installerPath
+      })
+    } catch (e) {
+      return { status: 'error', error: `${e}` }
+    }
+  }
+
+  if (isWindows) {
+    const process = await spawnAsync(installerPath, [
+      'EAX_LAUNCH_CLIENT=0',
+      'IGNORE_INSTALLED=1'
+    ])
+
+    if (process.code !== null && process.code === 3) {
+      return { status: 'abort' }
+    }
+  }
+
+  await thirdParty.addInstalledGame(gameInfo.app_name, platformToInstall)
+
+  return { status: 'done' }
+}
+
 export async function uninstall({ appName }: RemoveArgs): Promise<ExecResult> {
+  const gameInfo = getGameInfo(appName)
+  if (gameInfo.thirdPartyManagedApp) {
+    await thirdParty.removeInstalledGame(appName)
+    return { stdout: '', stderr: '' }
+  }
+
   const command: LegendaryCommand = {
     subcommand: 'uninstall',
     appName: LegendaryAppName.parse(appName),
@@ -867,6 +944,13 @@ export async function launch(
     command['--override-exe'] = Path.parse(gameSettings.targetExe)
   if (offlineMode) command['--offline'] = true
   if (isCLINoGui) command['--skip-version-check'] = true
+  if (
+    gameInfo.thirdPartyManagedApp &&
+    ['origin', 'the ea app'].includes(
+      gameInfo.thirdPartyManagedApp.toLowerCase()
+    )
+  )
+    command['--origin'] = true
 
   const fullCommand = getRunnerCallWithoutCredentials(
     command,

--- a/src/backend/storeManagers/legendary/setup.ts
+++ b/src/backend/storeManagers/legendary/setup.ts
@@ -4,9 +4,10 @@ import { getInstallInfo } from './library'
 import { sendGameStatusUpdate } from 'backend/utils'
 import { enable, getStatus, isEnabled } from './eos_overlay/eos_overlay'
 import { split } from 'shlex'
-import { logError } from 'backend/logger/logger'
+import { logError, logInfo, LogPrefix } from 'backend/logger/logger'
 import { runWineCommand } from 'backend/launcher'
 import { GameConfig } from 'backend/game_config'
+import { epicRedistPath } from 'backend/constants'
 
 export const legendarySetup = async (appName: string) => {
   const gameInfo = getGameInfo(appName)
@@ -37,9 +38,15 @@ export const legendarySetup = async (appName: string) => {
   })
 
   const winPlatforms = ['Windows', 'Win32', 'windows']
+  const isEAManaged =
+    gameInfo.thirdPartyManagedApp &&
+    ['origin', 'the ea app'].includes(
+      gameInfo.thirdPartyManagedApp.toLowerCase()
+    )
   if (
     gameInfo.install.platform &&
-    winPlatforms.includes(gameInfo.install.platform)
+    winPlatforms.includes(gameInfo.install.platform) &&
+    !isEAManaged
   ) {
     try {
       const info = await getInstallInfo(appName, gameInfo.install.platform)
@@ -62,6 +69,24 @@ export const legendarySetup = async (appName: string) => {
       }
     } catch (error) {
       logError(`getInstallInfo failed with ${error}`)
+    }
+  }
+
+  if (isEAManaged) {
+    const installerPath = join(epicRedistPath, 'EAappInstaller.exe')
+    try {
+      await runWineCommand({
+        gameSettings,
+        commandParts: [
+          installerPath,
+          'EAX_LAUNCH_CLIENT=0',
+          'IGNORE_INSTALLED=1'
+        ],
+        wait: true,
+        protonVerb: 'run'
+      })
+    } catch (e) {
+      logError(`Failed to run EA App installer ${e}`, LogPrefix.Legendary)
     }
   }
 

--- a/src/backend/storeManagers/legendary/thirdParty.ts
+++ b/src/backend/storeManagers/legendary/thirdParty.ts
@@ -1,0 +1,83 @@
+import { thirdPartyInstalled } from 'backend/constants'
+import { LogPrefix, logWarning, logError } from 'backend/logger/logger'
+import { InstalledJsonMetadata } from 'common/types/legendary'
+import { existsSync, readFileSync } from 'fs'
+import { readFile, writeFile } from 'fs/promises'
+
+const getInstalledGames = (): [string, InstalledJsonMetadata][] => {
+  if (existsSync(thirdPartyInstalled)) {
+    try {
+      const thirdPartyData = JSON.parse(
+        readFileSync(thirdPartyInstalled, 'utf-8')
+      ) as [string, string][]
+
+      const installObjects: [string, InstalledJsonMetadata][] =
+        thirdPartyData.map(([app_name, platform]) => [
+          app_name,
+          { app_name, platform } as InstalledJsonMetadata
+        ])
+
+      return installObjects
+    } catch (error) {
+      logWarning(
+        ['Failed to read third-party-installed.json', error],
+        LogPrefix.Legendary
+      )
+    }
+  }
+  return []
+}
+
+const addInstalledGame = async (appName: string, platform: string) => {
+  const installedAppNames = []
+
+  if (existsSync(thirdPartyInstalled)) {
+    try {
+      const buffer = await readFile(thirdPartyInstalled, 'utf-8')
+      installedAppNames.push(...(JSON.parse(buffer) as [string, string][]))
+    } catch (err) {
+      logWarning(
+        `Failed to read third-party-installed.json ${err}`,
+        LogPrefix.Legendary
+      )
+    }
+  }
+  installedAppNames.push([appName, platform])
+
+  try {
+    await writeFile(
+      thirdPartyInstalled,
+      JSON.stringify(installedAppNames),
+      'utf-8'
+    )
+  } catch (err) {
+    logError(
+      `Failed to write third-party-installed.json ${err}`,
+      LogPrefix.Legendary
+    )
+  }
+}
+
+const removeInstalledGame = async (appName: string) => {
+  const installedAppNames = []
+  try {
+    const buffer = await readFile(thirdPartyInstalled, 'utf-8')
+    installedAppNames.push(...(JSON.parse(buffer) as [string, string][]))
+  } catch (err) {
+    logWarning('Failed to read third-party-installed.json', LogPrefix.Legendary)
+  }
+  const index = installedAppNames.findIndex((a) => a[0] === appName)
+  installedAppNames.splice(index, 1)
+
+  try {
+    await writeFile(
+      thirdPartyInstalled,
+      JSON.stringify(installedAppNames),
+      'utf-8'
+    )
+  } catch (e) {
+    logError('Failed to write third-party-installed.json', LogPrefix.Legendary)
+  }
+}
+
+export default { getInstalledGames, addInstalledGame, removeInstalledGame }

--- a/src/frontend/components/UI/Anticheat/index.scss
+++ b/src/frontend/components/UI/Anticheat/index.scss
@@ -11,7 +11,7 @@
   .statusInfo {
     flex-direction: column;
     display: flex;
-    margin-inline: auto;
+    margin-inline: var(--space-lg);
     text-align: start;
   }
 }

--- a/src/frontend/components/UI/LibraryFilters/index.tsx
+++ b/src/frontend/components/UI/LibraryFilters/index.tsx
@@ -30,7 +30,9 @@ export default function LibraryFilters() {
     platformsFilters,
     setPlatformsFilters,
     showSupportOfflineOnly,
-    setShowSupportOfflineOnly
+    setShowSupportOfflineOnly,
+    showThirdPartyManagedOnly,
+    setShowThirdPartyManagedOnly
   } = useContext(LibraryContext)
 
   const toggleShowHidden = () => {
@@ -51,6 +53,10 @@ export default function LibraryFilters() {
 
   const toggleOnlySupportOffline = () => {
     setShowSupportOfflineOnly(!showSupportOfflineOnly)
+  }
+
+  const toggleThirdParty = () => {
+    setShowThirdPartyManagedOnly(!showThirdPartyManagedOnly)
   }
 
   const toggleStoreFilter = (store: Category) => {
@@ -207,6 +213,16 @@ export default function LibraryFilters() {
           title={t(
             'header.show_support_offline_only',
             'Show offline-supported only'
+          )}
+        />
+        <ToggleSwitch
+          key="only-third-party-managed"
+          htmlId="only-third-party-managed"
+          handleChange={() => toggleThirdParty()}
+          value={showThirdPartyManagedOnly}
+          title={t(
+            'header.show_third_party_managed_only',
+            'Show third-party managed only'
           )}
         />
         <hr />

--- a/src/frontend/hooks/hasStatus.ts
+++ b/src/frontend/hooks/hasStatus.ts
@@ -48,7 +48,10 @@ export function hasStatus(
         return setGameStatus({ status, folder, label, statusContext })
       }
 
-      if (thirdPartyManagedApp === 'Origin') {
+      if (
+        thirdPartyManagedApp &&
+        !['origin', 'the ea app'].includes(thirdPartyManagedApp.toLowerCase())
+      ) {
         const label = getStatusLabel({
           status: 'notSupportedGame',
           t,
@@ -61,7 +64,7 @@ export function hasStatus(
         })
       }
 
-      if (is_installed) {
+      if (is_installed && !thirdPartyManagedApp) {
         const gameAvailable = await handleNonAvailableGames(appName, runner)
         if (!gameAvailable) {
           const label = getStatusLabel({

--- a/src/frontend/screens/Game/GamePage/components/DownloadSizeInfo.tsx
+++ b/src/frontend/screens/Game/GamePage/components/DownloadSizeInfo.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import GameContext from '../../GameContext'
-import { CloudDownload, Storage } from '@mui/icons-material'
+import { CloudDownload, Storage, Assignment } from '@mui/icons-material'
 import { size } from 'frontend/helpers'
 import { GameInfo } from 'common/types'
 import ContextProvider from 'frontend/state/ContextProvider'
@@ -28,7 +28,13 @@ const DownloadSizeInfo = ({ gameInfo }: Props) => {
   }
 
   if (gameInfo.thirdPartyManagedApp) {
-    return null
+    return (
+      <div className="iconWithText">
+        <Assignment />
+        <b>{t('info.third-party-app', 'Third-Party Manager')}</b>
+        {gameInfo.thirdPartyManagedApp}
+      </div>
+    )
   }
 
   const downloadSize =

--- a/src/frontend/screens/Game/GamePage/components/InstalledInfo.tsx
+++ b/src/frontend/screens/Game/GamePage/components/InstalledInfo.tsx
@@ -25,6 +25,7 @@ const InstalledInfo = ({ gameInfo }: Props) => {
   }
 
   const isSideloaded = runner === 'sideload'
+  const isThirdParty = !!gameInfo.thirdPartyManagedApp
 
   const {
     install: { platform: installPlatform },
@@ -70,7 +71,7 @@ const InstalledInfo = ({ gameInfo }: Props) => {
 
   const info = (
     <>
-      {!isSideloaded && (
+      {!isSideloaded && !isThirdParty && (
         <div>
           <b>{t('info.size')}:</b> {install_size}
         </div>
@@ -79,7 +80,7 @@ const InstalledInfo = ({ gameInfo }: Props) => {
         <b>{t('info.installedPlatform', 'Installed Platform')}:</b>{' '}
         {installPlatform === 'osx' ? 'MacOS' : installPlatform}
       </div>
-      {!isSideloaded && (
+      {!isSideloaded && !isThirdParty && (
         <div>
           <b>{t('info.version')}:</b> {version}
         </div>
@@ -88,15 +89,23 @@ const InstalledInfo = ({ gameInfo }: Props) => {
         <b>{t('info.canRunOffline', 'Online Required')}:</b>{' '}
         {t(canRunOffline ? 'box.no' : 'box.yes')}
       </div>
-      <div
-        className="clickable"
-        onClick={() =>
-          appLocation !== undefined ? window.api.openFolder(appLocation) : {}
-        }
-      >
-        <b>{t('info.path')}:</b>{' '}
-        <div className="truncatedPath">{appLocation}</div>
-      </div>
+      {isThirdParty && (
+        <div>
+          <b>{t('info.third-party-app', 'Third-Party Manager')}</b>{' '}
+          {gameInfo.thirdPartyManagedApp}
+        </div>
+      )}
+      {!isThirdParty && (
+        <div
+          className="clickable"
+          onClick={() =>
+            appLocation !== undefined ? window.api.openFolder(appLocation) : {}
+          }
+        >
+          <b>{t('info.path')}:</b>{' '}
+          <div className="truncatedPath">{appLocation}</div>
+        </div>
+      )}
       {!is.win && !is.native && (
         <>
           <div>

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -144,7 +144,11 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const isInstallingRedist = status === 'redist'
   const notAvailable = !gameAvailable && gameInfo.is_installed
   const notSupportedGame =
-    gameInfo.runner !== 'sideload' && gameInfo.thirdPartyManagedApp === 'Origin'
+    gameInfo.runner !== 'sideload' &&
+    !!gameInfo.thirdPartyManagedApp &&
+    !['origin', 'the ea app'].includes(
+      gameInfo.thirdPartyManagedApp.toLowerCase()
+    )
   const isOffline = connectivity.status !== 'online'
 
   const backRoute = location.state?.fromDM ? '/download-manager' : '/library'
@@ -172,6 +176,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
         const {
           install,
           is_installed,
+          thirdPartyManagedApp,
           is_linux_native = undefined,
           is_mac_native = undefined
         } = { ...gameInfo }
@@ -189,6 +194,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
           !is_installed &&
           !notSupportedGame &&
           !notInstallable &&
+          !thirdPartyManagedApp &&
           !isOffline
         ) {
           getInstallInfo(appName, runner, installPlatform)

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -67,6 +67,7 @@ export default function GamesSubmenu({
   )
   const { t } = useTranslation('gamepage')
   const isSideloaded = runner === 'sideload'
+  const isThirdPartyManaged = !!gameInfo.thirdPartyManagedApp
 
   async function onMoveInstallYesClick() {
     const { defaultInstallPath } = await window.api.requestAppSettings()
@@ -232,6 +233,7 @@ export default function GamesSubmenu({
     onShowModifyInstall &&
     ['legendary', 'gog'].includes(runner) &&
     isInstalled &&
+    !isThirdPartyManaged &&
     installPlatform !== 'linux'
 
   return (
@@ -282,7 +284,7 @@ export default function GamesSubmenu({
               >
                 {t('button.uninstall', 'Uninstall')}
               </button>{' '}
-              {!isSideloaded && (
+              {!isSideloaded && !isThirdPartyManaged && (
                 <button
                   onClick={async () => handleUpdate()}
                   className="link button is-text is-link"
@@ -291,7 +293,7 @@ export default function GamesSubmenu({
                   {t('button.force_update', 'Force Update if Available')}
                 </button>
               )}{' '}
-              {!isSideloaded && (
+              {!isSideloaded && !isThirdPartyManaged && (
                 <button
                   onClick={async () => handleMoveInstall()}
                   className="link button is-text is-link"
@@ -299,7 +301,7 @@ export default function GamesSubmenu({
                   {t('submenu.move', 'Move Game')}
                 </button>
               )}{' '}
-              {!isSideloaded && (
+              {!isSideloaded && !isThirdPartyManaged && (
                 <button
                   onClick={async () => handleChangeInstall()}
                   className="link button is-text is-link"
@@ -307,7 +309,7 @@ export default function GamesSubmenu({
                   {t('submenu.change', 'Change Install Location')}
                 </button>
               )}{' '}
-              {!isSideloaded && (
+              {!isSideloaded && !isThirdPartyManaged && (
                 <button
                   onClick={async () => handleRepair(appName)}
                   className="link button is-text is-link"

--- a/src/frontend/screens/Library/LibraryContext.tsx
+++ b/src/frontend/screens/Library/LibraryContext.tsx
@@ -25,6 +25,8 @@ const initialContext: LibraryContextType = {
   setSortInstalled: () => null,
   showSupportOfflineOnly: false,
   setShowSupportOfflineOnly: () => null,
+  showThirdPartyManagedOnly: false,
+  setShowThirdPartyManagedOnly: () => null,
   handleAddGameButtonClick: () => null,
   setShowCategories: () => null
 }

--- a/src/frontend/screens/Library/components/InstallModal/ThirdPartyDialog/index.scss
+++ b/src/frontend/screens/Library/components/InstallModal/ThirdPartyDialog/index.scss
@@ -1,0 +1,25 @@
+.thirdPartyNotice {
+  display: flex;
+  max-width: 560px;
+  gap: 0.4rem;
+  padding: var(--space-md);
+  border-radius: 20px;
+  background-color: var(--current-background);
+  margin-bottom: var(--space-lg);
+  border: 2px solid var(--anticheat-supported);
+  & > div.noticeInfo {
+    margin: 0 var(--space-lg);
+    display: flex;
+    flex-direction: column;
+    text-align: start;
+  }
+  & .noticeIcon path {
+    fill: var(--anticheat-supported);
+  }
+  & h4 {
+    margin: 0 0 var(--space-md);
+  }
+  & p {
+    margin: 0 0 var(--space-md);
+  }
+}

--- a/src/frontend/screens/Library/components/InstallModal/ThirdPartyDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/ThirdPartyDialog/index.tsx
@@ -1,0 +1,141 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+  GameInfo,
+  InstallPlatform,
+  Runner,
+  WineInstallation
+} from 'common/types'
+import Anticheat from 'frontend/components/UI/Anticheat'
+import {
+  DialogFooter,
+  DialogHeader,
+  DialogContent
+} from 'frontend/components/UI/Dialog'
+import { install, writeConfig } from 'frontend/helpers'
+import { hasAnticheatInfo } from 'frontend/hooks/hasAnticheatInfo'
+import ContextProvider from 'frontend/state/ContextProvider'
+import { InstallProgress } from 'frontend/types'
+import React, { useCallback, useContext } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ReactComponent as AllowedIcon } from 'frontend/assets/rounded_checkmark_icon.svg'
+import { AvailablePlatforms } from '..'
+import './index.scss'
+
+interface Props {
+  backdropClick: () => void
+  appName: string
+  runner: Runner
+  platformToInstall: InstallPlatform
+  availablePlatforms: AvailablePlatforms
+  winePrefix: string
+  crossoverBottle: string
+  wineVersion: WineInstallation | undefined
+  children: React.ReactNode
+  gameInfo: GameInfo
+}
+
+export default function ThirdPartyDialog({
+  appName,
+  runner,
+  backdropClick,
+  gameInfo,
+  availablePlatforms,
+  wineVersion,
+  children,
+  crossoverBottle,
+  winePrefix,
+  platformToInstall
+}: Props) {
+  const { t } = useTranslation('gamepage')
+  const { platform } = useContext(ContextProvider)
+  const isWin = platform === 'win32'
+  const progress = {} as InstallProgress
+
+  const anticheatInfo = hasAnticheatInfo(gameInfo)
+
+  const handleInstall = useCallback(async () => {
+    // Write Default game config with prefix on linux
+    if (!isWin) {
+      const gameSettings = await window.api.requestGameSettings(appName)
+
+      if (wineVersion) {
+        writeConfig({
+          appName,
+          config: {
+            ...gameSettings,
+            winePrefix,
+            wineVersion,
+            wineCrossoverBottle: crossoverBottle
+          }
+        })
+      }
+    }
+
+    backdropClick()
+
+    return install({
+      gameInfo,
+      previousProgress: progress,
+      progress,
+      installPath: 'thirdParty',
+      isInstalling: false,
+      t,
+      platformToInstall,
+      showDialogModal: () => backdropClick()
+    })
+  }, [appName, t, winePrefix, wineVersion, crossoverBottle, platformToInstall])
+
+  return (
+    <>
+      <DialogHeader onClose={backdropClick}>
+        {gameInfo.title}
+        {availablePlatforms.map((p) => (
+          <FontAwesomeIcon
+            className="InstallModal__platformIcon"
+            icon={p.icon}
+            key={p.value}
+          />
+        ))}
+      </DialogHeader>
+      <DialogContent>
+        <div className="thirdPartyNotice">
+          <div className="noticeIcon">
+            <AllowedIcon />
+          </div>
+          <div className="noticeInfo">
+            <h4>
+              {t(
+                'third-party-managed.header',
+                'This game is managed by a third-party application'
+              )}
+            </h4>
+            <p>
+              {t(
+                'third-party-managed.notice1',
+                'This game is managed by a third-party application: "{{application_name}}"',
+                { application_name: gameInfo.thirdPartyManagedApp }
+              )}
+            </p>
+            <p>
+              {t(
+                'third-party-managed.notice2',
+                'After clicking Install, Heroic will run the application in order to complete the installation process'
+              )}
+            </p>
+          </div>
+        </div>
+        <Anticheat anticheatInfo={anticheatInfo} />
+        {children}
+      </DialogContent>
+      <DialogFooter>
+        <button
+          className={`button is-secondary`}
+          onClick={handleInstall}
+          disabled={runner !== 'legendary'}
+        >
+          {t('button.install')}
+        </button>
+      </DialogFooter>
+    </>
+  )
+}

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -23,6 +23,7 @@ type Props = {
   wineVersion: WineInstallation | undefined
   title?: string
   appName: string
+  initiallyOpen?: boolean
 }
 
 export default function WineSelector({
@@ -34,10 +35,12 @@ export default function WineSelector({
   title = 'sideload',
   crossoverBottle,
   setCrossoverBottle,
+  initiallyOpen,
   appName
 }: Props) {
   const { t, i18n } = useTranslation('gamepage')
 
+  const [detailsOpen, setDetailsOpen] = React.useState(!!initiallyOpen)
   const [useDefaultSettings, setUseDefaultSettings] = React.useState(false)
   const [description, setDescription] = React.useState('')
 
@@ -79,7 +82,7 @@ export default function WineSelector({
 
   return (
     <>
-      <details>
+      <details open={detailsOpen} onChange={() => setDetailsOpen(detailsOpen)}>
         <summary>
           {t('setting.show-wine-settings', 'Show Wine settings')}
         </summary>

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -19,6 +19,7 @@ import SideloadDialog from './SideloadDialog'
 import WineSelector from './WineSelector'
 import { SelectField } from 'frontend/components/UI'
 import { useTranslation } from 'react-i18next'
+import ThirdPartyDialog from './ThirdPartyDialog'
 
 type Props = {
   appName: string
@@ -152,6 +153,7 @@ export default React.memo(function InstallModal({
   }
 
   const showDownloadDialog = !isSideload && gameInfo
+  const isThirdPartyManagedApp = gameInfo && !!gameInfo.thirdPartyManagedApp
 
   return (
     <div className="InstallModal">
@@ -160,7 +162,35 @@ export default React.memo(function InstallModal({
         showCloseButton
         className="InstallModal__dialog"
       >
-        {showDownloadDialog ? (
+        {isThirdPartyManagedApp ? (
+          <ThirdPartyDialog
+            appName={appName}
+            runner={runner}
+            winePrefix={winePrefix}
+            wineVersion={wineVersion}
+            availablePlatforms={availablePlatforms}
+            backdropClick={backdropClick}
+            platformToInstall={platformToInstall}
+            gameInfo={gameInfo}
+            crossoverBottle={crossoverBottle}
+          >
+            {platformSelection()}
+            {hasWine ? (
+              <WineSelector
+                appName={appName}
+                winePrefix={winePrefix}
+                wineVersion={wineVersion}
+                wineVersionList={wineVersionList}
+                title={gameInfo?.title}
+                setWinePrefix={setWinePrefix}
+                setWineVersion={setWineVersion}
+                crossoverBottle={crossoverBottle}
+                setCrossoverBottle={setCrossoverBottle}
+                initiallyOpen
+              />
+            ) : null}
+          </ThirdPartyDialog>
+        ) : showDownloadDialog ? (
           <DownloadDialog
             appName={appName}
             runner={runner}

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -169,6 +169,15 @@ export default React.memo(function Library(): JSX.Element {
     setSupportOfflineOnly(value)
   }
 
+  const [showThirdPartyManagedOnly, setShowThirdPartyManagedOnly] = useState(
+    JSON.parse(storage.getItem('show_third_party_managed_only') || 'false')
+  )
+
+  const handleShowThirdPartyOnly = (value: boolean) => {
+    storage.setItem('show_third_party_managed_only', JSON.stringify(value))
+    setShowThirdPartyManagedOnly(value)
+  }
+
   const [showCategories, setShowCategories] = useState(false)
 
   const [showModal, setShowModal] = useState<ModalState>({
@@ -436,6 +445,10 @@ export default React.memo(function Library(): JSX.Element {
         library = library.filter((game) => game.canRunOffline)
       }
 
+      if (showThirdPartyManagedOnly) {
+        library = library.filter((game) => !!game.thirdPartyManagedApp)
+      }
+
       if (!showNonAvailable) {
         const nonAvailbleGames = storage.getItem('nonAvailableGames') || '[]'
         const nonAvailbleGamesArray = JSON.parse(nonAvailbleGames)
@@ -525,7 +538,8 @@ export default React.memo(function Library(): JSX.Element {
     showFavouritesLibrary,
     showInstalledOnly,
     showNonAvailable,
-    showSupportOfflineOnly
+    showSupportOfflineOnly,
+    showThirdPartyManagedOnly
   ])
 
   // we need this to do proper `position: sticky` of the Add Game area
@@ -597,6 +611,8 @@ export default React.memo(function Library(): JSX.Element {
         setSortInstalled: handleSortInstalled,
         showSupportOfflineOnly,
         setShowSupportOfflineOnly: handleShowSupportOfflineOnly,
+        showThirdPartyManagedOnly,
+        setShowThirdPartyManagedOnly: handleShowThirdPartyOnly,
         sortDescending,
         sortInstalled,
         handleAddGameButtonClick: () => handleModal('', 'sideload', null),

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -231,6 +231,8 @@ export interface LibraryContextType {
   setSortInstalled: (value: boolean) => void
   showSupportOfflineOnly: boolean
   setShowSupportOfflineOnly: (value: boolean) => void
+  showThirdPartyManagedOnly: boolean
+  setShowThirdPartyManagedOnly: (value: boolean) => void
   handleAddGameButtonClick: () => void
   setShowCategories: (value: boolean) => void
 }


### PR DESCRIPTION
This enables support for EA games in Heroic by installing EA App in wine prefix when needed.  

We still need to see how this all behaves with Mac native games. At the moment only Windows titles are taken care of


Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
