### PR TITLE
[FIX] Remove isMac check for 32 bit dxvk

### DIFF
--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -304,20 +304,18 @@ export const DXVK = {
     // copy the new dlls to the prefix
     if (is64bitPrefix) {
       dlls32.forEach((dll) => {
-        if (!isMac) {
-          copyFile(
-            `${toolPathx32}/${dll}`,
-            `${winePrefix}/drive_c/windows/syswow64/${dll}`,
-            (err) => {
-              if (err) {
-                logError(
-                  [`Error when copying ${dll}`, err],
-                  LogPrefix.DXVKInstaller
-                )
-              }
+        copyFile(
+          `${toolPathx32}/${dll}`,
+          `${winePrefix}/drive_c/windows/syswow64/${dll}`,
+          (err) => {
+            if (err) {
+              logError(
+                [`Error when copying ${dll}`, err],
+                LogPrefix.DXVKInstaller
+              )
             }
-          )
-        }
+          }
+        )
       })
       dlls64.forEach((dll) => {
         copyFile(
@@ -335,20 +333,18 @@ export const DXVK = {
       })
     } else {
       dlls32.forEach((dll) => {
-        if (!isMac) {
-          copyFile(
-            `${toolPathx32}/${dll}`,
-            `${winePrefix}/drive_c/windows/system32/${dll}`,
-            (err) => {
-              if (err) {
-                logError(
-                  [`Error when copying ${dll}`, err],
-                  LogPrefix.DXVKInstaller
-                )
-              }
+        copyFile(
+          `${toolPathx32}/${dll}`,
+          `${winePrefix}/drive_c/windows/system32/${dll}`,
+          (err) => {
+            if (err) {
+              logError(
+                [`Error when copying ${dll}`, err],
+                LogPrefix.DXVKInstaller
+              )
             }
-          )
-        }
+          }
+        )
       })
     }
 


### PR DESCRIPTION
32 bit dlls can run on mac os thanks to the wow64 implemented in crossover (and upstream wine). 


Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
