### PR TITLE
[Fix] Prevent uninstalling a game while it's running

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -36,6 +36,7 @@
             "cannotUninstallEpic": "Epic games cannot be uninstalled while another Epic game is being installed.",
             "checkbox": "Remove prefix: {{prefix}}{{newLine}}Note: This can't be undone and will also remove not backed up save files.",
             "dlc": "Do you want to uninstall \"{{title}}\" (DLC)?",
+            "gameIsRunning": "{{title}} is running. Close the game to uninstall it.",
             "message": "Do you want to uninstall \"{{title}}\"?",
             "prefix_warning": "The Wine prefix for this game is the default prefix. If you really want to delete it, you have to do it manually.",
             "settingcheckbox": "Erase settings and remove log{{newLine}}Note: This can't be undone. Any modified settings will be forgotten and log will be deleted.",

--- a/src/frontend/components/UI/UninstallModal/index.tsx
+++ b/src/frontend/components/UI/UninstallModal/index.tsx
@@ -34,8 +34,13 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
   const [showUninstallModal, setShowUninstallModal] = useState(false)
   const navigate = useNavigate()
   const location = useLocation()
-  const { installingEpicGame } = useContext(ContextProvider)
+  const { installingEpicGame, libraryStatus } = useContext(ContextProvider)
   const [gameTitle, setGameTitle] = useState('')
+
+  const isGameRunning = libraryStatus.find(
+    (st) =>
+      st.appName === appName && st.runner === runner && st.status === 'playing'
+  )
 
   const checkIfIsNative = async () => {
     // This assumes native games are installed should be changed in the future
@@ -113,6 +118,32 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
                 'gamepage:box.uninstall.cannotUninstallEpic',
                 'Epic games cannot be uninstalled while another Epic game is being installed.'
               )}
+            </DialogContent>
+            <DialogFooter>
+              <button onClick={onClose} className={`button outline`}>
+                {t('box.close', 'Close')}
+              </button>
+            </DialogFooter>
+          </Dialog>
+        )}
+      </>
+    )
+  }
+
+  if (isGameRunning) {
+    return (
+      <>
+        {showUninstallModal && (
+          <Dialog onClose={onClose} showCloseButton className="uninstall-modal">
+            <DialogHeader onClose={onClose}>
+              {t('gamepage:box.uninstall.title')}
+            </DialogHeader>
+            <DialogContent>
+              {t('gamepage:box.uninstall.gameIsRunning', {
+                defaultValue:
+                  '{{title}} is running. Close the game to uninstall it.',
+                title: gameTitle
+              })}
             </DialogContent>
             <DialogFooter>
               <button onClick={onClose} className={`button outline`}>

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -12,6 +12,7 @@ import { NavLink } from 'react-router-dom'
 import { InstallModal } from 'frontend/screens/Library/components'
 import { CircularProgress } from '@mui/material'
 import UninstallModal from 'frontend/components/UI/UninstallModal'
+import GameContext from '../GameContext'
 
 interface Props {
   appName: string
@@ -51,11 +52,9 @@ export default function GamesSubmenu({
     showDialogModal,
     setIsSettingsModalOpen
   } = useContext(ContextProvider)
+  const { is } = useContext(GameContext)
   const isWin = platform === 'win32'
   const isLinux = platform === 'linux'
-  const gameStatus = libraryStatus.find(
-    (st) => st.appName === appName && st.runner === runner
-  )
 
   const [steamRefresh, setSteamRefresh] = useState<boolean>(false)
   const [addedToSteam, setAddedToSteam] = useState<boolean>(false)
@@ -284,7 +283,7 @@ export default function GamesSubmenu({
               <button
                 onClick={async () => setShowUninstallModal(true)}
                 className="link button is-text is-link"
-                disabled={gameStatus?.status === 'playing'}
+                disabled={is.playing}
               >
                 {t('button.uninstall', 'Uninstall')}
               </button>{' '}

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -53,6 +53,9 @@ export default function GamesSubmenu({
   } = useContext(ContextProvider)
   const isWin = platform === 'win32'
   const isLinux = platform === 'linux'
+  const gameStatus = libraryStatus.find(
+    (st) => st.appName === appName && st.runner === runner
+  )
 
   const [steamRefresh, setSteamRefresh] = useState<boolean>(false)
   const [addedToSteam, setAddedToSteam] = useState<boolean>(false)
@@ -281,6 +284,7 @@ export default function GamesSubmenu({
               <button
                 onClick={async () => setShowUninstallModal(true)}
                 className="link button is-text is-link"
+                disabled={gameStatus?.status === 'playing'}
               >
                 {t('button.uninstall', 'Uninstall')}
               </button>{' '}

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -358,7 +358,7 @@ const GameCard = ({
       // uninstall
       label: t('button.uninstall'),
       onclick: onUninstallClick,
-      show: isInstalled && !isUpdating
+      show: isInstalled && !isUpdating && !isPlaying
     }
   ]
 


### PR DESCRIPTION
This PR disables the "Uninstall" button while a game is running so it cannot be uninstalled by mistake.

Other games can be uninstalled (though we still have the limitation if not uninstalling an Epic game while another Epic game is being installed, but that's unrelated to this fix).

Apart from disabling the buttons, I also made the Uninstall dialog no-op when the game is playing, so if we add an uninstall button and we forget to disable it, it still won't allow the user to uninstall the game while it's running.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
