### PR TITLE
[Fix] Account for spaces in GOG game save paths on Windows

### DIFF
--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -212,7 +212,6 @@ async function getDefaultGogSavePaths(
           )
         }
       }
-      absolutePath = absolutePath.replaceAll('"', '')
     }
 
     resolvedLocations.push({

--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -212,6 +212,7 @@ async function getDefaultGogSavePaths(
           )
         }
       }
+      absolutePath = absolutePath.replaceAll('"', '')
     }
 
     resolvedLocations.push({

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -806,7 +806,7 @@ async function shutdownWine(gameSettings: GameSettings) {
 }
 
 const getShellPath = async (path: string): Promise<string> =>
-  normalize((await execAsync(`echo "${path}"`)).stdout.trim())
+  normalize((await execAsync(`echo ${path}`)).stdout.trim())
 
 export const spawnAsync = async (
   command: string,


### PR DESCRIPTION
The way arguments are passed to PowerShell already handles spaces in the path and the additional quotation marks added by `getShellPath()` causes the path to be truncated at the first space (if present).

For example, 'C:\Users\User\Documents\The Witcher 3\' gets interpreted as 'C:\Users\User\Documents\The'.

Using `.replaceAll()` should be safe since files/folders in Windows can't contain quotes anyway.

(Apologies if there's a better way to do this - Most of my experience is in bash and this is the first I've looked at the heroic codebase)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
