### PR TITLE
[GOG]: use native builds of ScummVM and DOSBox when available

### DIFF
--- a/src/backend/storeManagers/gog/setup.ts
+++ b/src/backend/storeManagers/gog/setup.ts
@@ -14,7 +14,7 @@ import {
   gogSupportPath,
   isWindows
 } from '../../constants'
-import { getWinePath, runWineCommand, verifyWinePrefix } from '../../launcher'
+import { runWineCommand, verifyWinePrefix } from '../../launcher'
 import { getGameInfo as getGogLibraryGameInfo } from 'backend/storeManagers/gog/library'
 import { readFile } from 'node:fs/promises'
 import shlex from 'shlex'
@@ -132,13 +132,7 @@ async function setup(
   const lang: string | undefined = languages.of(installLanguage!)
 
   const dependencies: string[] = []
-  const gameDirectoryPath = isWindows
-    ? gameInfo.install.install_path!
-    : await getWinePath({
-        path: gameInfo.install.install_path!,
-        variant: 'win',
-        gameSettings
-      })
+  const gameDirectoryPath = gameInfo.install.install_path!
 
   sendGameStatusUpdate({
     appName,
@@ -195,13 +189,6 @@ async function setup(
   } else {
     // check if scriptinterpreter is required based on manifest
     if (manifestData.scriptInterpreter) {
-      const wineGameSupportDir = isWindows
-        ? gameSupportDir
-        : await getWinePath({
-            path: gameSupportDir,
-            variant: 'win',
-            gameSettings
-          })
       const isiPath = path.join(
         gogRedistPath,
         '__redist/ISI/scriptinterpreter.exe'
@@ -240,7 +227,8 @@ async function setup(
             `/galaxyclient`,
             `/buildId=${gameInfo.install.buildId}`,
             `/versionName=${gameInfo.install.version}`,
-            `/supportDir=${wineGameSupportDir}`,
+            `/lang-code=${gameInfo.install.language || 'en-US'}`,
+            `/supportDir=${gameSupportDir}`,
             '/nodesktopshorctut',
             '/nodesktopshortcut'
           ]


### PR DESCRIPTION
Tested with `Alone in the Dark 1` (dosbox) and `Beneath the Steel Sky` (scummvm)

gogdl will pick available versions with following conditions

- alternative executable isn't set (Game Settings -> Advanced)
- executable is either dosbox.exe or scummvm.exe

possible executables gogdl will look for

|  | Flatpak | PATH |
|--------|--------|--------|
| DOSBox | `io.github.dosbox-staging` | `dosbox` |
| ScummVM | `org.scummvm.ScummVM` | `scummvm` |

when gogdl is in flatpak container it will attempt to call `flatpak-spawn` available through `org.freedesktop.Flatpak` session bus.

If none of the above are available default wine runner will be called

updated to gogdl 1.1.0 that includes this change


Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
