### PR TITLE
Automatically update runtimes

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -374,14 +374,18 @@ async function prepareWineLaunch(
     }
   }
 
-  if (gameSettings.eacRuntime && !isInstalled('eac_runtime') && isOnline()) {
+  if (
+    gameSettings.eacRuntime &&
+    isOnline() &&
+    !(await isInstalled('eac_runtime'))
+  ) {
     await download('eac_runtime')
   }
 
   if (
     gameSettings.battlEyeRuntime &&
-    !isInstalled('battleye_runtime') &&
-    isOnline()
+    isOnline() &&
+    !(await isInstalled('battleye_runtime'))
   ) {
     await download('battleye_runtime')
   }

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -232,7 +232,7 @@ export async function install(
   args: InstallArgs
 ): Promise<InstallResult> {
   logWarning(
-    `install not implemented on Sideload Game Manager. called for appName = ${appName}`
+    `forceUninstall not implemented on Sideload Game Manager. called for appName = ${appName}`
   )
   return { status: 'error' }
 }

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -232,7 +232,7 @@ export async function install(
   args: InstallArgs
 ): Promise<InstallResult> {
   logWarning(
-    `forceUninstall not implemented on Sideload Game Manager. called for appName = ${appName}`
+    `install not implemented on Sideload Game Manager. called for appName = ${appName}`
   )
   return { status: 'error' }
 }

--- a/src/backend/wine/runtimes/ipc_handler.ts
+++ b/src/backend/wine/runtimes/ipc_handler.ts
@@ -5,6 +5,6 @@ ipcMain.handle('downloadRuntime', async (e, runtime_name) =>
   download(runtime_name)
 )
 
-ipcMain.handle('isRuntimeInstalled', (e, runtime_name) =>
+ipcMain.handle('isRuntimeInstalled', async (e, runtime_name) =>
   isInstalled(runtime_name)
 )

--- a/src/backend/wine/runtimes/runtimes.ts
+++ b/src/backend/wine/runtimes/runtimes.ts
@@ -1,10 +1,17 @@
-import { existsSync, mkdirSync, unlinkSync } from 'graceful-fs'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync
+} from 'graceful-fs'
 import { join } from 'path'
 import { runtimePath } from './../../constants'
 import { logError, logInfo, LogPrefix } from './../../logger/logger'
 import { Runtime, RuntimeName } from 'common/types'
 import { downloadFile, extractTarFile, getAssetDataFromDownload } from './util'
 import { axiosClient } from 'backend/utils'
+import { rmSync } from 'fs'
 
 async function _get(): Promise<Runtime[]> {
   mkdirSync(runtimePath, { recursive: true })
@@ -36,10 +43,20 @@ async function download(name: RuntimeName): Promise<boolean> {
     await downloadFile(runtime.url, tarFilePath)
 
     const extractedFolderPath = join(runtimePath, name)
+
+    if (existsSync(extractedFolderPath)) {
+      rmSync(extractedFolderPath, { recursive: true })
+    }
+
     await extractTarFile(tarFilePath, content_type, {
       extractedPath: extractedFolderPath,
       strip: 1
     })
+
+    writeFileSync(
+      join(extractedFolderPath, 'current_version'),
+      runtime.created_at
+    )
 
     unlinkSync(tarFilePath)
 
@@ -53,8 +70,27 @@ async function download(name: RuntimeName): Promise<boolean> {
   }
 }
 
-function isInstalled(name: RuntimeName) {
-  return existsSync(join(runtimePath, name))
+async function isInstalled(name: RuntimeName) {
+  if (!existsSync(join(runtimePath, name))) return false
+
+  const runtimes = await _get()
+  const runtime = runtimes.find((inst) => {
+    return inst.name === name
+  })
+
+  // this should be impossible, so prevent redownload by faking it's installed
+  if (!runtime) {
+    logError('Runtime not found in runtime list', LogPrefix.Runtime)
+    return true
+  }
+
+  const version_path = join(runtimePath, name, 'current_version')
+
+  if (!existsSync(version_path)) return false
+
+  const current_version = readFileSync(version_path)
+
+  return runtime.created_at === current_version.toString()
 }
 
 export { download, isInstalled }

--- a/src/backend/wine/runtimes/runtimes.ts
+++ b/src/backend/wine/runtimes/runtimes.ts
@@ -3,7 +3,8 @@ import {
   mkdirSync,
   readFileSync,
   unlinkSync,
-  writeFileSync
+  writeFileSync,
+  rmSync
 } from 'graceful-fs'
 import { join } from 'path'
 import { runtimePath } from './../../constants'
@@ -11,7 +12,6 @@ import { logError, logInfo, LogPrefix } from './../../logger/logger'
 import { Runtime, RuntimeName } from 'common/types'
 import { downloadFile, extractTarFile, getAssetDataFromDownload } from './util'
 import { axiosClient } from 'backend/utils'
-import { rmSync } from 'fs'
 
 async function _get(): Promise<Runtime[]> {
   mkdirSync(runtimePath, { recursive: true })
@@ -74,9 +74,7 @@ async function isInstalled(name: RuntimeName) {
   if (!existsSync(join(runtimePath, name))) return false
 
   const runtimes = await _get()
-  const runtime = runtimes.find((inst) => {
-    return inst.name === name
-  })
+  const runtime = runtimes.find((inst) => inst.name === name)
 
   // this should be impossible, so prevent redownload by faking it's installed
   if (!runtime) {

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -247,7 +247,7 @@ interface AsyncIPCFunctions {
   disableEosOverlay: (appName: string) => Promise<void>
   isEosOverlayEnabled: (appName?: string) => Promise<boolean>
   downloadRuntime: (runtime_name: RuntimeName) => Promise<boolean>
-  isRuntimeInstalled: (runtime_name: RuntimeName) => boolean
+  isRuntimeInstalled: (runtime_name: RuntimeName) => Promise<boolean>
   getDMQueueInformation: () => {
     elements: DMQueueElement[]
     finished: DMQueueElement[]


### PR DESCRIPTION
IsInstalled now returns false when the runtime is outdated, which then will cause a redownload the next time a game is launched

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
