### PR TITLE
[FIX] Use mangoapp when using mangohud with gamescope

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -215,6 +215,10 @@ async function prepareLaunch(
         }
       }
 
+      if (gameSettings.showMangohud) {
+        gameScopeCommand.push('--mangoapp')
+      }
+
       gameScopeCommand.push(
         ...shlex.split(gameSettings.gamescope.additionalOptions ?? '')
       )
@@ -687,7 +691,7 @@ function setupWrappers(
       wrappers.push(...shlex.split(wrapperEntry.args ?? ''))
     })
   }
-  if (mangoHudCommand) {
+  if (mangoHudCommand && !gameScopeCommand) {
     wrappers.push(...mangoHudCommand)
   }
   if (gameModeBin) {

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -691,7 +691,7 @@ function setupWrappers(
       wrappers.push(...shlex.split(wrapperEntry.args ?? ''))
     })
   }
-  if (mangoHudCommand && !gameScopeCommand) {
+  if (mangoHudCommand && (!gameScopeCommand || gameScopeCommand.length === 0)) {
     wrappers.push(...mangoHudCommand)
   }
   if (gameModeBin) {

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -691,7 +691,7 @@ function setupWrappers(
       wrappers.push(...shlex.split(wrapperEntry.args ?? ''))
     })
   }
-  if (mangoHudCommand && (!gameScopeCommand || gameScopeCommand.length === 0)) {
+  if (mangoHudCommand && gameScopeCommand?.length === 0) {
     wrappers.push(...mangoHudCommand)
   }
   if (gameModeBin) {


### PR DESCRIPTION
This is how gamescope docs say to use mangohud with gamescope

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
