### PR TITLE
[Fix] Hand `null` to the Frontend if we can't fetch a game's info

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -708,7 +708,14 @@ ipcMain.handle('getGameInfo', async (event, appName, runner) => {
   if (runner === 'legendary' && !LegendaryLibraryManager.hasGame(appName)) {
     return null
   }
-  return gameManagerMap[runner].getGameInfo(appName)
+  const tempGameInfo = gameManagerMap[runner].getGameInfo(appName)
+  // The game managers return an empty object if they couldn't fetch the game
+  // info, since most of the backend assumes getting it can never fail (and
+  // an empty object is a little easier to work with than `null`)
+  // The frontend can however handle being passed an explicit `null` value, so
+  // we return that here instead if the game info is empty
+  if (!Object.keys(tempGameInfo).length) return null
+  return tempGameInfo
 })
 
 ipcMain.handle('getExtraInfo', async (event, appName, runner) => {


### PR DESCRIPTION
See comment message

This resolves a race condition when uninstalling sideloaded games. After clicking the button, if the rendering order of library and game card is just right, the game card for the just-uninstalled game still tries to request & use that game's info, which fails (since the game is uninstalled), but isn't caught (since the returned GameInfo is an empty object, which isn't falsy). The game card then tries to access `gameInfo.install.platform`, which raises an exception and leads to React Router's "Unexpected Application Error" screen.
This issue is very hard to reproduce, as the library rendering before the game card in question avoids it, which seems to be the case most of the time.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
