### PR TITLE
[GOG]: ignore port provided in adtraction url

### DIFF
--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -226,7 +226,15 @@ export default function WebView() {
           const parsedUrl = new URL(validatedURL)
           const redirectUrl = parsedUrl.searchParams.get('url')
           const url = new URL(redirectUrl || 'https://gog.com')
-          // Remove any port definitions, they are dumb
+          // Remove any port definitions
+          // Recently GOG made a change where they started to provide a port
+          // in a URL that adtraction is supposed to redirect to.
+          // This leads to urls like https://gog.com:80
+          // That address is unreachable
+          //
+          // Add a entry below if you notice this line of code and cringe
+          // - username - DD/MM/YY
+          // - imLinguin - 01/07/24
           url.port = ''
           webview.loadURL(url.toString())
           if (!localStorage.getItem('adtraction-warning')) {

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -225,7 +225,10 @@ export default function WebView() {
         if (validatedURL && validatedURL.match(/track\.adtraction\.com/)) {
           const parsedUrl = new URL(validatedURL)
           const redirectUrl = parsedUrl.searchParams.get('url')
-          webview.loadURL(redirectUrl || 'https://gog.com')
+          const url = new URL(redirectUrl || 'https://gog.com')
+          // Remove any port definitions, they are dumb
+          url.port = ''
+          webview.loadURL(url.toString())
           if (!localStorage.getItem('adtraction-warning')) {
             setShowAdtractionWarning(true)
           }


### PR DESCRIPTION
Fixes fallback issues introduced after recent changes in how GOG does redirects

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
