### PR TITLE
[Fix] Make the compatibility_layers test work on systems with Wine installed

### DIFF
--- a/src/backend/utils/__tests__/compatibility_layers.test.ts
+++ b/src/backend/utils/__tests__/compatibility_layers.test.ts
@@ -1,4 +1,3 @@
-import { describe } from 'node:test'
 import {
   getDefaultWine,
   getWineExecs,
@@ -7,6 +6,7 @@ import {
 import { mkdirSync } from 'graceful-fs'
 import { dirname, join } from 'path'
 import { tmpdir } from 'os'
+import child_process from 'child_process'
 
 jest.mock('@xhmikosr/decompress')
 jest.mock('../../logger/logfile')
@@ -18,22 +18,16 @@ describe('getDefaultWine', () => {
       name: 'Default Wine - Not Found',
       type: 'wine'
     }
+    jest.spyOn(child_process, 'execSync').mockImplementation(() => {
+      throw new Error()
+    })
     const result = getDefaultWine()
     expect(result).toEqual(expected)
   })
 
   test('return list with one default wine', () => {
-    const expected = {
-      bin: '/usr/bin/wine',
-      name: 'Wine Default - wine-6.0 (Staging)',
-      type: 'wine',
-      wineserver: ''
-    }
-
     // spy on the execSync calling which wine and returning /usr/bin/wine
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const execSync = jest.spyOn(require('child_process'), 'execSync')
-    execSync.mockImplementation((command: any) => {
+    jest.spyOn(child_process, 'execSync').mockImplementation((command) => {
       if (command === 'which wine') {
         return '/usr/bin/wine\n'
       } else if (command === 'wine --version') {
@@ -43,7 +37,9 @@ describe('getDefaultWine', () => {
     })
 
     const result = getDefaultWine()
-    expect(result).toEqual(expected)
+    expect(result.bin).toBe('/usr/bin/wine')
+    expect(result.name).toBe('Wine Default - wine-6.0 (Staging)')
+    expect(result.type).toBe('wine')
   })
 })
 


### PR DESCRIPTION
This test assumed that Wine is not installed, which works fine in CI, but not on most "real" systems

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
