### PR TITLE
[Fix] Sideload: Don't update game settings if we're in editMode

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -114,25 +114,14 @@ export default function SideloadDialog({
     }
   }, [])
 
+  // Suggest default Wine prefix if we're adding a new app
   useEffect(() => {
-    const setWine = async () => {
-      if (editMode && appName) {
-        const appSettings = await window.api.getGameSettings(
-          appName,
-          'sideload'
-        )
-        if (appSettings?.winePrefix) {
-          setWinePrefix(appSettings.winePrefix)
-        }
-        return
-      } else {
-        const { defaultWinePrefix } = await window.api.requestAppSettings()
-        const sugestedWinePrefix = `${defaultWinePrefix}/${title}`
-        setWinePrefix(sugestedWinePrefix)
-      }
-    }
-    setWine()
-  }, [title])
+    if (editMode) return
+    window.api.requestAppSettings().then(({ defaultWinePrefix }) => {
+      const suggestedWinePrefix = `${defaultWinePrefix}/${title}`
+      setWinePrefix(suggestedWinePrefix)
+    })
+  }, [title, editMode])
 
   async function searchImage() {
     setSearching(true)
@@ -181,15 +170,16 @@ export default function SideloadDialog({
     if (!gameSettings) {
       return
     }
-    await writeConfig({
-      appName: app_name,
-      config: {
-        ...gameSettings,
-        winePrefix,
-        wineVersion,
-        wineCrossoverBottle: crossoverBottle
-      }
-    })
+    if (!editMode)
+      window.api.writeConfig({
+        appName: app_name,
+        config: {
+          ...gameSettings,
+          winePrefix,
+          wineVersion,
+          wineCrossoverBottle: crossoverBottle
+        }
+      })
 
     await refreshLibrary({
       library: 'sideload',


### PR DESCRIPTION
Clicking "Finish" in the "Edit App/Game" dialog made Heroic "forget" the Wine Version associated with that game. That's now fixed.

The problem here is that the configured Wine version is initially undefined, only being updated by the version selector. That's not rendered in editMode, so we're just always saving undefined.
It seems this issue was thought about for the Wine prefix, as *it* is set by an effect above (so the whole spiel ends up doing nothing). This is no longer needed now, so I've removed that part of the effect's functionality.

To test: Edit a sideloaded game (making sure to click "Finish" to save your changes), head to the game settings. Before, notice your Wine Version being reset to the first one in the list. Now, notice your Wine Version is not altered.

Note: The configured CrossOver bottle should also be affected by this change, although I don't have an Apple device to test this on.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
