### PR TITLE
Fix UI bugs in search bar

### DIFF
--- a/src/frontend/components/UI/SearchBar/index.scss
+++ b/src/frontend/components/UI/SearchBar/index.scss
@@ -47,6 +47,10 @@
     display: block;
   }
 
+  ul.autoComplete:empty {
+    display: none;
+  }
+
   .searchButton {
     padding: var(--space-2xs) var(--space-2xs) 0 var(--space-2xs);
   }

--- a/src/frontend/components/UI/SearchBar/index.scss
+++ b/src/frontend/components/UI/SearchBar/index.scss
@@ -61,6 +61,10 @@
     background: transparent;
     border: none;
     color: var(--text-secondary);
+
+    svg {
+      cursor: pointer;
+    }
   }
 
   .searchBarInput {


### PR DESCRIPTION
While using Heroic, I noticed two small UI bugs (or what I believe to be bugs). 

1. The "x" button to clear the search bar didn't set the cursor to a pointer on hover, so I added that.
2. The autocomplete dropdown underneath the search bar would still be present when there were no results, which looked kind of strange. Here's before and after photos of this:

![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/58576759/512e51a5-3e5e-41c0-bef4-fe36f14d86ce)
![image](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/assets/58576759/ae625fe2-67c7-40df-89f1-0bc982534f32)

Let me know if anything needs to be changed, but I thought I'd just do this really quick in case it was something you guys could benefit from. Thanks!

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
