### PR TITLE
Add scroll to categories dropdown when too many categories

### DIFF
--- a/src/frontend/components/UI/LibraryFilters/index.css
+++ b/src/frontend/components/UI/LibraryFilters/index.css
@@ -55,7 +55,8 @@
     .dropdown {
       pointer-events: all;
       opacity: 1;
-      max-height: 100vh;
+      max-height: 70vh;
+      overflow-y: auto;
       box-shadow: 4px 5px 5px 7px rgba(0, 0, 0, 0.2);
     }
   }


### PR DESCRIPTION
This PR fixes this issue reported in Discord https://discord.com/channels/812703221789097985/1253620445224112159/1253620445224112159

when adding categories, a user can add many categories and not fit the screen when opening the dropdown. This adds a scroll and a height limit.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
