### PR TITLE
[Feat-macOS] Download GPTK from Wine Manager

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -24,9 +24,9 @@ import { logError, logInfo, LogPrefix } from './logger/logger'
 import {
   getCrossover,
   getDefaultWine,
-  getGamingPortingToolkitWine,
+  getGamePortingToolkitWine,
   getLinuxWineSet,
-  getSystemGamingPortingToolkitWine,
+  getSystemGamePortingToolkitWine,
   getWhisky,
   getWineOnMac,
   getWineskinWine
@@ -135,8 +135,8 @@ abstract class GlobalConfig {
       return new Set<WineInstallation>()
     }
 
-    const getGPTKWine = await getGamingPortingToolkitWine()
-    const getSystemGPTK = await getSystemGamingPortingToolkitWine()
+    const getGPTKWine = await getGamePortingToolkitWine()
+    const getSystemGPTK = await getSystemGamePortingToolkitWine()
     const crossover = await getCrossover()
     const wineOnMac = await getWineOnMac()
     const wineskinWine = await getWineskinWine()

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -26,6 +26,7 @@ import {
   getDefaultWine,
   getGamingPortingToolkitWine,
   getLinuxWineSet,
+  getSystemGamingPortingToolkitWine,
   getWhisky,
   getWineOnMac,
   getWineskinWine
@@ -134,14 +135,16 @@ abstract class GlobalConfig {
       return new Set<WineInstallation>()
     }
 
+    const getGPTKWine = await getGamingPortingToolkitWine()
+    const getSystemGPTK = await getSystemGamingPortingToolkitWine()
     const crossover = await getCrossover()
     const wineOnMac = await getWineOnMac()
     const wineskinWine = await getWineskinWine()
-    const gamingPortingToolkitWine = await getGamingPortingToolkitWine()
     const whiskyWine = await getWhisky()
 
     return new Set([
-      ...gamingPortingToolkitWine,
+      ...getGPTKWine,
+      ...getSystemGPTK,
       ...crossover,
       ...wineOnMac,
       ...wineskinWine,

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -886,7 +886,7 @@ export async function downloadDefaultWine() {
         !version.version.endsWith('-LoL')
       )
     } else if (isMac) {
-      return version.version.includes('Wine-Crossover')
+      return version.version.includes('Game-Porting-Toolkit')
     }
     return false
   })[0]

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -353,7 +353,7 @@ export async function getGamePortingToolkitWine(): Promise<
 
   wineGPTKPaths.forEach((winePath) => {
     const infoFilePath = join(winePath, 'Contents/Info.plist')
-    if (winePath && existsSync(infoFilePath)) {
+    if (existsSync(infoFilePath)) {
       const wineBin = join(winePath, '/Contents/Resources/wine/bin/wine64')
       try {
         const name = winePath.split('/').pop() || ''

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -334,12 +334,12 @@ export async function getCrossover(): Promise<Set<WineInstallation>> {
  * Detects Gaming Porting Toolkit Wine installs on Mac
  * @returns Promise<Set<WineInstallation>>
  **/
-export async function getGamingPortingToolkitWine(): Promise<
+export async function getGamePortingToolkitWine(): Promise<
   Set<WineInstallation>
 > {
-  const gamingPortingToolkitWine = new Set<WineInstallation>()
+  const gamePortingToolkitWine = new Set<WineInstallation>()
   if (!isMac) {
-    return gamingPortingToolkitWine
+    return gamePortingToolkitWine
   }
 
   const GPTK_ToolPath = join(toolsPath, 'game-porting-toolkit')
@@ -358,7 +358,7 @@ export async function getGamingPortingToolkitWine(): Promise<
       try {
         const name = winePath.split('/').pop() || ''
         if (existsSync(wineBin)) {
-          gamingPortingToolkitWine.add({
+          gamePortingToolkitWine.add({
             ...getWineExecs(wineBin),
             lib: `${winePath}/Contents/Resources/wine/lib`,
             lib32: `${winePath}/Contents/Resources/wine/lib`,
@@ -377,14 +377,14 @@ export async function getGamingPortingToolkitWine(): Promise<
     }
   })
 
-  return gamingPortingToolkitWine
+  return gamePortingToolkitWine
 }
 
 /**
  * Detects Gaming Porting Toolkit Wine installs on Mac
  * @returns Promise<Set<WineInstallation>>
  **/
-export async function getSystemGamingPortingToolkitWine(): Promise<
+export async function getSystemGamePortingToolkitWine(): Promise<
   Set<WineInstallation>
 > {
   const systemGPTK = new Set<WineInstallation>()
@@ -400,7 +400,7 @@ export async function getSystemGamingPortingToolkitWine(): Promise<
 
   if (existsSync(wineBin)) {
     logInfo(
-      `Found Gaming Porting Toolkit Wine at ${dirname(wineBin)}`,
+      `Found Game Porting Toolkit Wine at ${dirname(wineBin)}`,
       LogPrefix.GlobalConfig
     )
     try {

--- a/src/backend/wine/manager/downloader/constants.ts
+++ b/src/backend/wine/manager/downloader/constants.ts
@@ -21,3 +21,7 @@ export const WINECROSSOVER_URL =
 /// Url to Wine Staging for macOS github release page
 export const WINESTAGINGMACOS_URL =
   'https://api.github.com/repos/Gcenx/macOS_Wine_builds/releases'
+
+/// Url to Game Porting Toolkit from Gcenx github release page
+export const GPTK_URL =
+  'https://api.github.com/repos/Gcenx/game-porting-toolkit/releases'

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -145,7 +145,7 @@ async function getAvailableVersions({
             releases.push(...fetchedReleases)
           })
           .catch((error: Error) => {
-            throw error
+            logError(error, LogPrefix.WineDownloader)
           })
         break
       }

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -15,7 +15,8 @@ import {
   PROTON_URL,
   WINELUTRIS_URL,
   WINECROSSOVER_URL,
-  WINESTAGINGMACOS_URL
+  WINESTAGINGMACOS_URL,
+  GPTK_URL
 } from './constants'
 import { VersionInfo, Repositorys } from 'common/types'
 import {
@@ -131,6 +132,20 @@ async function getAvailableVersions({
           })
           .catch((error: Error) => {
             logError(error, LogPrefix.WineDownloader)
+          })
+        break
+      }
+      case Repositorys.GPTK: {
+        await fetchReleases({
+          url: GPTK_URL,
+          type: 'Game-Porting-Toolkit',
+          count: count
+        })
+          .then((fetchedReleases: VersionInfo[]) => {
+            releases.push(...fetchedReleases)
+          })
+          .catch((error: Error) => {
+            throw error
           })
         break
       }

--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -11,6 +11,16 @@ interface fetchProps {
   count: number
 }
 
+function getVersionName(type: string, tag_name: string): string {
+  if (type.includes('Wine')) {
+    return `Wine-${tag_name}`
+  } else if (type.includes('Toolkit')) {
+    return `${tag_name}`
+  } else {
+    return `Proton-${tag_name}`
+  }
+}
+
 /**
  * Helper to fetch releases from given url.
  *
@@ -32,9 +42,7 @@ async function fetchReleases({
       .then((data) => {
         for (const release of data.data) {
           const release_data = {} as VersionInfo
-          release_data.version = type.includes('Wine')
-            ? `Wine-${release.tag_name}`
-            : `Proton-${release.tag_name}`
+          release_data.version = getVersionName(type, release.tag_name)
           release_data.type = type
           release_data.date = release.published_at.split('T')[0]
           release_data.disksize = 0

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -40,7 +40,11 @@ async function updateWineVersionInfos(
     logInfo('Fetching upstream information...', LogPrefix.WineDownloader)
 
     const repositorys = isMac
-      ? [Repositorys.WINECROSSOVER, Repositorys.WINESTAGINGMACOS]
+      ? [
+          Repositorys.WINECROSSOVER,
+          Repositorys.WINESTAGINGMACOS,
+          Repositorys.GPTK
+        ]
       : [Repositorys.WINEGE, Repositorys.PROTONGE]
 
     await getAvailableVersions({
@@ -86,6 +90,16 @@ async function updateWineVersionInfos(
   return releases
 }
 
+function getInstallDir(release: WineVersionInfo): string {
+  if (release?.type?.includes('Wine')) {
+    return `${toolsPath}/wine`
+  } else if (release.type.includes('Toolkit')) {
+    return `${toolsPath}/game-porting-toolkit`
+  } else {
+    return `${toolsPath}/proton`
+  }
+}
+
 async function installWineVersion(
   release: WineVersionInfo,
   onProgress: (status: WineManagerStatus) => void
@@ -97,6 +111,10 @@ async function installWineVersion(
     mkdirSync(`${toolsPath}/wine`, { recursive: true })
   }
 
+  if (isMac && !existsSync(`${toolsPath}/game-porting-toolkit`)) {
+    mkdirSync(`${toolsPath}/game-porting-toolkit`, { recursive: true })
+  }
+
   if (!existsSync(`${toolsPath}/proton`)) {
     mkdirSync(`${toolsPath}/proton`, { recursive: true })
   }
@@ -106,9 +124,7 @@ async function installWineVersion(
     LogPrefix.WineDownloader
   )
 
-  const installDir = release?.type?.includes('Wine')
-    ? `${toolsPath}/wine`
-    : `${toolsPath}/proton`
+  const installDir = getInstallDir(release)
 
   const abortController = createAbortController(release.version)
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -684,6 +684,7 @@ export type Type =
   | 'Wine-Kron4ek'
   | 'Wine-Crossover'
   | 'Wine-Staging-macOS'
+  | 'Game-Porting-Toolkit'
 
 /**
  * Interface contains information about a version
@@ -713,7 +714,8 @@ export enum Repositorys {
   PROTON,
   WINELUTRIS,
   WINECROSSOVER,
-  WINESTAGINGMACOS
+  WINESTAGINGMACOS,
+  GPTK
 }
 
 export type WineManagerStatus =

--- a/src/frontend/screens/Settings/components/WineVersionSelector.tsx
+++ b/src/frontend/screens/Settings/components/WineVersionSelector.tsx
@@ -31,6 +31,7 @@ export default function WineVersionSelector() {
       }
       setRefreshing(false)
     }
+    window.api.handleWineVersionsUpdated(getAltWine)
     getAltWine()
   }, [])
 

--- a/src/frontend/screens/Settings/components/WineVersionSelector.tsx
+++ b/src/frontend/screens/Settings/components/WineVersionSelector.tsx
@@ -31,8 +31,8 @@ export default function WineVersionSelector() {
       }
       setRefreshing(false)
     }
-    window.api.handleWineVersionsUpdated(getAltWine)
     getAltWine()
+    return window.api.handleWineVersionsUpdated(getAltWine)
   }, [])
 
   useEffect(() => {

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -50,22 +50,22 @@ export default function WineManager(): JSX.Element | null {
     value: 'winege',
     enabled: isLinux
   }
-  const winecrossover: WineManagerUISettings = {
-    type: 'Wine-Crossover',
-    value: 'winecrossover',
+  const gamePortingToolkit: WineManagerUISettings = {
+    type: 'Game-Porting-Toolkit',
+    value: 'gpt',
     enabled: !isLinux
   }
 
   const [repository, setRepository] = useState<WineManagerUISettings>(
-    isLinux ? winege : winecrossover
+    isLinux ? winege : gamePortingToolkit
   )
   const [wineManagerSettings, setWineManagerSettings] = useState<
     WineManagerUISettings[]
   >([
     { type: 'Wine-GE', value: 'winege', enabled: isLinux },
     { type: 'Proton-GE', value: 'protonge', enabled: isLinux },
-    { type: 'Wine-Crossover', value: 'winecrossover', enabled: !isLinux },
-    { type: 'Wine-Staging-macOS', value: 'winestagingmacos', enabled: !isLinux }
+    { type: 'Game-Porting-Toolkit', value: 'gpt', enabled: !isLinux },
+    { type: 'Wine-Crossover', value: 'winecrossover', enabled: !isLinux }
   ])
 
   const getWineVersions = (repo: Type) => {


### PR DESCRIPTION
This adds Apple's Gaming porting toolkit download support from the Wine Manager.

The GTPK build is hosted by Gcenx on Github and should contain all the necessary file to be able to run the games.

![image](https://github.com/user-attachments/assets/656f116b-19b0-4026-8a83-81940db4c2e0)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
