### PR TITLE
[Feat] Offer option to upload logs to a pastebin

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -665,12 +665,47 @@
         },
         "library_top_section": "Library Top Section",
         "log": {
-            "copy-to-clipboard": "Copy log content to clipboard",
+            "descriptiveNames": {
+                "game-log": "Game log of {{gameTitle}}",
+                "gog": "GOG log",
+                "heroic": "General Heroic log",
+                "legendary": "Epic Games / Legendary log",
+                "nile": "Amazon / Nile log"
+            },
             "instructions": "Join our Discord and look for the \"#-support\" section. Read the pinned \"Read Me First | Frequently Asked Questions\" thread and follow the instructions to share these logs and any relevant information about your problem.",
             "instructions_title": "How to report a problem?",
             "join-heroic-discord": "Join our Discord",
             "no-file": "No log file found",
-            "show-in-folder": "Show log file in folder"
+            "show-in-folder": "Show log file in folder",
+            "show-uploads": "Show uploaded log files",
+            "upload": {
+                "actions": "Actions",
+                "button": "Upload log file",
+                "confirm": {
+                    "content": "Do you really want to upload \"{{name}}\"?",
+                    "title": "Upload log file?"
+                },
+                "delete": "Request log file deletion",
+                "done": {
+                    "content": "Uploaded to {{url}} (URL copied to your clipboard)",
+                    "title": "Upload complete"
+                },
+                "error": {
+                    "content": "Failed to upload log file. Check Heroic's general log for details",
+                    "title": "Upload failed"
+                },
+                "header": "Uploaded log files",
+                "hours-ago": "Uploaded {{hoursAgo, relativetime(hours)}}",
+                "minutes-ago": "Uploaded {{minutesAgo, relativetime(minutes)}}",
+                "no-files": "No log files were uploaded",
+                "open": "Open log file upload",
+                "title": "Log title",
+                "upload-date": "Upload date",
+                "uploading": {
+                    "content": "Uploading log file...",
+                    "title": "Uploading"
+                }
+            }
         },
         "mangohud": "Enable Mangohud (Mangohud needs to be installed)",
         "manualsync": {

--- a/src/backend/api/misc.ts
+++ b/src/backend/api/misc.ts
@@ -5,7 +5,8 @@ import {
   Tools,
   DialogType,
   ButtonOptions,
-  GamepadActionArgs
+  GamepadActionArgs,
+  type UploadedLogData
 } from 'common/types'
 import { NileRegisterData } from 'common/types/nile'
 
@@ -208,3 +209,26 @@ export const fetchPlaytimeFromServer = async (
   runner: Runner,
   appName: string
 ) => ipcRenderer.invoke('getPlaytimeFromRunner', runner, appName)
+
+export const getUploadedLogFiles = async () =>
+  ipcRenderer.invoke('getUploadedLogFiles')
+export const uploadLogFile = async (name: string, appNameOrRunner: string) =>
+  ipcRenderer.invoke('uploadLogFile', name, appNameOrRunner)
+export const deleteUploadedLogFile = async (url: string) =>
+  ipcRenderer.invoke('deleteUploadedLogFile', url)
+
+export const logFileUploadedSlot = (
+  callback: (
+    e: Electron.IpcRendererEvent,
+    url: string,
+    data: UploadedLogData
+  ) => void
+) => {
+  ipcRenderer.on('logFileUploaded', callback)
+}
+
+export const logFileUploadDeletedSlot = (
+  callback: (e: Electron.IpcRendererEvent, url: string) => void
+) => {
+  ipcRenderer.on('logFileUploadDeleted', callback)
+}

--- a/src/backend/electron_store.ts
+++ b/src/backend/electron_store.ts
@@ -53,4 +53,8 @@ export class TypeCheckedStoreBackend<
   public clear() {
     this.store.clear()
   }
+
+  public get raw_store() {
+    return this.store.store as StoreStructure[Name]
+  }
 }

--- a/src/backend/logger/__tests__/uploader.test.ts
+++ b/src/backend/logger/__tests__/uploader.test.ts
@@ -1,0 +1,177 @@
+import * as logfile from '../logfile'
+import { TypeCheckedStoreBackend } from '../../electron_store'
+
+import { dirSync } from 'tmp'
+import { join } from 'path'
+import { writeFileSync } from 'fs'
+import {
+  deleteUploadedLogFile,
+  getUploadedLogFiles,
+  uploadLogFile
+} from '../uploader'
+
+jest.mock('electron-store')
+jest.mock('../logfile')
+
+describe('logger/uploader', () => {
+  let fetchSpy: jest.SpyInstance<
+    ReturnType<typeof fetch>,
+    Parameters<typeof fetch>
+  >
+  const fixedTime = new Date()
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(fixedTime)
+    fetchSpy = jest.spyOn(global, 'fetch')
+  })
+  beforeEach(() => {
+    fetchSpy.mockReset()
+  })
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  const uploadedLogFileStore = new TypeCheckedStoreBackend('uploadedLogs', {
+    cwd: 'store',
+    name: 'uploadedLogs',
+    accessPropertiesByDotNotation: false
+  })
+
+  describe('uploadLogFile', () => {
+    const tmpDir = dirSync({ unsafeCleanup: true })
+    const testLogPath = join(tmpDir.name, 'test.txt')
+    writeFileSync(testLogPath, 'Test log content')
+
+    test('Works normally', async () => {
+      fetchSpy.mockImplementationOnce(
+        async () =>
+          new Response('https://0x0.st/test\n', {
+            status: 200,
+            headers: {
+              'X-Token': 'test-token'
+            }
+          })
+      )
+
+      const getLogFileMock = jest
+        .spyOn(logfile, 'getLogFile')
+        .mockImplementationOnce((appNameOrRunner) =>
+          join(tmpDir.name, appNameOrRunner + '.txt')
+        )
+
+      await expect(
+        uploadLogFile('Test log file', 'test')
+      ).resolves.toMatchObject([
+        'https://0x0.st/test',
+        {
+          name: 'Test log file',
+          token: 'test-token',
+          uploadedAt: fixedTime.valueOf()
+        }
+      ])
+      expect(fetchSpy).toBeCalledTimes(1)
+      const expectedFormData = new FormData()
+      expectedFormData.set('file', new Blob(['Test log content']), 'test.txt')
+      expectedFormData.set('expires', '24')
+      expect(fetchSpy).toBeCalledWith('https://0x0.st', {
+        body: expectedFormData,
+        method: 'post',
+        headers: { 'User-Agent': 'HeroicGamesLauncher/1.0.0' }
+      })
+      expect(getLogFileMock).toBeCalledWith('test')
+    })
+
+    test('fetch fails', async () => {
+      fetchSpy.mockImplementation(async () => {
+        throw new Error()
+      })
+
+      jest
+        .spyOn(logfile, 'getLogFile')
+        .mockImplementationOnce((appNameOrRunner) =>
+          join(tmpDir.name, appNameOrRunner + '.txt')
+        )
+
+      await expect(uploadLogFile('Test log file', 'test')).resolves.toBe(false)
+      expect(fetchSpy).toBeCalledTimes(1)
+    })
+  })
+
+  describe('deleteUploadedLogFile', () => {
+    test('Works normally', async () => {
+      uploadedLogFileStore.set('https://0x0.st/test' as string, {
+        token: 'test-token',
+        name: 'Test Name',
+        uploadedAt: fixedTime.valueOf()
+      })
+
+      fetchSpy.mockImplementation(
+        async () => new Response(null, { status: 200 })
+      )
+
+      await expect(deleteUploadedLogFile('https://0x0.st/test')).resolves.toBe(
+        true
+      )
+      expect(fetchSpy).toBeCalledTimes(1)
+
+      const expectedFormData = new FormData()
+      expectedFormData.set('token', 'test-token')
+      expectedFormData.set('delete', '')
+      expect(fetchSpy).toBeCalledWith('https://0x0.st/test', {
+        body: expectedFormData,
+        method: 'post',
+        headers: { 'User-Agent': 'HeroicGamesLauncher/1.0.0' }
+      })
+
+      expect(uploadedLogFileStore.raw_store).toMatchObject({})
+    })
+
+    test('fetch fails', async () => {
+      uploadedLogFileStore.set('https://0x0.st/test' as string, {
+        token: 'test-token',
+        name: 'Test Name',
+        uploadedAt: fixedTime.valueOf()
+      })
+
+      fetchSpy.mockImplementation(async () => {
+        throw new Error()
+      })
+      await expect(deleteUploadedLogFile('https://0x0.st/test')).resolves.toBe(
+        false
+      )
+      expect(uploadedLogFileStore.raw_store).toMatchObject({
+        'https://0x0.st/test': {
+          token: 'test-token',
+          name: 'Test Name',
+          uploadedAt: fixedTime.valueOf()
+        }
+      })
+    })
+  })
+
+  describe('getUploadedLogFiles', () => {
+    test('Works normally', async () => {
+      uploadedLogFileStore.set('https://0x0.st/test' as string, {
+        token: 'test-token',
+        name: 'Test Name',
+        uploadedAt: fixedTime.valueOf()
+      })
+      await expect(getUploadedLogFiles()).resolves.toMatchObject({
+        'https://0x0.st/test': {
+          token: 'test-token',
+          name: 'Test Name',
+          uploadedAt: fixedTime.valueOf()
+        }
+      })
+    })
+
+    test('Old logs get deleted', async () => {
+      uploadedLogFileStore.set('https://0x0.st/test' as string, {
+        token: 'test-token',
+        name: 'Test Name',
+        uploadedAt: new Date(fixedTime).setDate(fixedTime.getDate() - 1)
+      })
+      await expect(getUploadedLogFiles()).resolves.toMatchObject({})
+      expect(uploadedLogFileStore.raw_store).toMatchObject({})
+    })
+  })
+})

--- a/src/backend/logger/ipc_handler.ts
+++ b/src/backend/logger/ipc_handler.ts
@@ -2,6 +2,11 @@ import { ipcMain } from 'electron'
 import { existsSync, readFileSync } from 'graceful-fs'
 import { showItemInFolder } from '../utils'
 import { getLogFile } from './logfile'
+import {
+  uploadLogFile,
+  deleteUploadedLogFile,
+  getUploadedLogFiles
+} from './uploader'
 
 ipcMain.handle('getLogContent', (event, appNameOrRunner) => {
   const logPath = getLogFile(appNameOrRunner)
@@ -11,3 +16,11 @@ ipcMain.handle('getLogContent', (event, appNameOrRunner) => {
 ipcMain.on('showLogFileInFolder', async (e, appNameOrRunner) =>
   showItemInFolder(getLogFile(appNameOrRunner))
 )
+
+ipcMain.handle('uploadLogFile', async (e, name, appNameOrRunner) =>
+  uploadLogFile(name, appNameOrRunner)
+)
+ipcMain.handle('deleteUploadedLogFile', async (e, url) =>
+  deleteUploadedLogFile(url)
+)
+ipcMain.handle('getUploadedLogFiles', async () => getUploadedLogFiles())

--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -36,7 +36,8 @@ export enum LogPrefix {
   Connection = 'Connection',
   DownloadManager = 'DownloadManager',
   ExtraGameInfo = 'ExtraGameInfo',
-  Sideload = 'Sideload'
+  Sideload = 'Sideload',
+  LogUploader = 'LogUploader'
 }
 
 export const RunnerToLogPrefixMap = {

--- a/src/backend/logger/uploader.ts
+++ b/src/backend/logger/uploader.ts
@@ -1,0 +1,135 @@
+import { app } from 'electron'
+import { readFile } from 'fs/promises'
+import path from 'path'
+import { z } from 'zod'
+
+import { TypeCheckedStoreBackend } from '../electron_store'
+import { getLogFile } from './logfile'
+import { logError, logInfo, LogPrefix } from './logger'
+import { sendFrontendMessage } from '../main_window'
+
+import type { UploadedLogData } from 'common/types'
+
+const uploadedLogFileStore = new TypeCheckedStoreBackend('uploadedLogs', {
+  cwd: 'store',
+  name: 'uploadedLogs',
+  accessPropertiesByDotNotation: false
+})
+
+async function sendRequestToApi(formData: FormData, url = 'https://0x0.st') {
+  return fetch(url, {
+    body: formData,
+    method: 'post',
+    headers: {
+      'User-Agent': `HeroicGamesLauncher/${app.getVersion()}`
+    }
+  }).catch((err) => {
+    logError([`Failed to send data to 0x0.st:`, err], LogPrefix.LogUploader)
+    return null
+  })
+}
+
+/**
+ * Uploads the log file of a game / runner / Heroic to https://0x0.st
+ * @param name See {@link UploadedLogData.name}
+ * @param appNameOrRunner Used to get the log file path. See {@link getLogFile}
+ * @returns `false` if an error occurred, otherwise the URL to the uploaded file and {@link UploadedLogData}
+ */
+async function uploadLogFile(
+  name: string,
+  appNameOrRunner: string
+): Promise<false | [string, UploadedLogData]> {
+  const fileLocation = getLogFile(appNameOrRunner)
+  const filename = path.basename(fileLocation)
+
+  const fileContents = await readFile(fileLocation)
+  const fileBlob = new Blob([fileContents])
+
+  const formData = new FormData()
+  formData.set('file', fileBlob, filename)
+  formData.set('expires', '24')
+
+  const response = await sendRequestToApi(formData)
+  if (!response) return false
+
+  const token = response.headers.get('X-Token')
+  const responseText = (await response.text()).trim()
+  const maybeUrl = z.string().url().safeParse(responseText)
+  if (!response.ok || !token || !maybeUrl.success) {
+    logError(
+      [
+        `Failed to upload log file, response error code ${response.status} ${response.statusText}, text:`,
+        responseText
+      ],
+      LogPrefix.LogUploader
+    )
+    return false
+  }
+
+  const url = maybeUrl.data
+  const uploadData: UploadedLogData = {
+    name,
+    token,
+    uploadedAt: Date.now()
+  }
+  uploadedLogFileStore.set(url, uploadData)
+  sendFrontendMessage('logFileUploaded', url, uploadData)
+  logInfo(`Uploaded log file ${name} to ${url}`, LogPrefix.LogUploader)
+  return [url, uploadData]
+}
+
+/**
+ * Deletes a log file previously uploaded using {@link uploadLogFile}
+ * @param url The URL to the uploaded log file
+ * @returns Whether the file was deleted
+ */
+async function deleteUploadedLogFile(url: string): Promise<boolean> {
+  const logData = uploadedLogFileStore.get_nodefault(url)
+  if (!logData) return false
+
+  const formData = new FormData()
+  formData.set('token', logData.token)
+  formData.set('delete', '')
+
+  const response = await sendRequestToApi(formData, url)
+  if (!response) return false
+
+  if (!response.ok) {
+    logError(
+      [
+        `Failed to delete log file upload, response error code ${response.status} ${response.statusText}, text:`,
+        await response.text()
+      ],
+      LogPrefix.LogUploader
+    )
+    return false
+  }
+
+  uploadedLogFileStore.delete(url)
+  sendFrontendMessage('logFileUploadDeleted', url)
+  logInfo([`Deleted log file ${logData.name} (${url})`], LogPrefix.LogUploader)
+
+  return true
+}
+
+/**
+ * Returns all log files which are still valid. Also deletes expired
+ * ones from {@link uploadedLogFileStore}
+ */
+async function getUploadedLogFiles(): Promise<Record<string, UploadedLogData>> {
+  const allStoredLogs = uploadedLogFileStore.raw_store
+  const validUploadedLogs: Record<string, UploadedLogData> = {}
+  // Filter and delete expired logs
+  for (const [key, value] of Object.entries(allStoredLogs)) {
+    const timeDifferenceMs = Date.now() - value.uploadedAt
+    const timeDifferenceHours = timeDifferenceMs / 1000 / 60 / 60
+    if (timeDifferenceHours >= 24) {
+      uploadedLogFileStore.delete(key)
+    } else {
+      validUploadedLogs[key] = value
+    }
+  }
+  return validUploadedLogs
+}
+
+export { uploadLogFile, deleteUploadedLogFile, getUploadedLogFiles }

--- a/src/common/typedefs/ipcBridge.d.ts
+++ b/src/common/typedefs/ipcBridge.d.ts
@@ -32,7 +32,8 @@ import {
   LaunchOption,
   DownloadManagerState,
   InstallInfo,
-  WikiInfo
+  WikiInfo,
+  UploadedLogData
 } from 'common/types'
 import { GameOverride, SelectiveDownload } from 'common/types/legendary'
 import { GOGCloudSavesLocation } from 'common/types/gog'
@@ -297,6 +298,13 @@ interface AsyncIPCFunctions {
     enabled: boolean
     modsToLoad: string[]
   }) => Promise<void>
+
+  uploadLogFile: (
+    name: string,
+    appNameOrRunner: string
+  ) => Promise<false | [string, UploadedLogData]>
+  deleteUploadedLogFile: (url: string) => Promise<boolean>
+  getUploadedLogFiles: () => Promise<Record<string, UploadedLogData>>
 }
 
 // This is quite ugly & throws a lot of errors in a regular .ts file

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -767,3 +767,12 @@ export interface KnowFixesInfo {
   winetricks?: string[]
   runInPrefix?: string[]
 }
+
+export interface UploadedLogData {
+  // Descriptive name of the log file (e.g. "Game log of ...")
+  name: string
+  // Token to modify the file (used to delete the log file on the server)
+  token: string
+  // Time the log file was uploaded (used to know whether it expired)
+  uploadedAt: number
+}

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -14,7 +14,8 @@ import {
   AppSettings,
   WikiInfo,
   GameInfo,
-  WindowProps
+  WindowProps,
+  UploadedLogData
 } from 'common/types'
 import { UserData } from 'common/types/gog'
 import { NileUserData } from './nile'
@@ -97,6 +98,7 @@ export interface StoreStructure {
   wikigameinfo: {
     [title: string]: WikiInfo
   }
+  uploadedLogs: Record<string, UploadedLogData>
 }
 
 export type StoreOptions<T extends Record<string, unknown>> = Store.Options<T>

--- a/src/common/types/frontend_messages.ts
+++ b/src/common/types/frontend_messages.ts
@@ -8,6 +8,7 @@ import type {
   GameStatus,
   RecentGame,
   Runner,
+  UploadedLogData,
   WineManagerStatus
 } from 'common/types'
 
@@ -43,6 +44,8 @@ type FrontendMessages = {
   }) => void
   progressOfWineManager: (version: string, progress: WineManagerStatus) => void
   'installing-winetricks-component': (component: string) => void
+  logFileUploaded: (url: string, data: UploadedLogData) => void
+  logFileUploadDeleted: (url: string) => void
 
   [key: `progressUpdate${string}`]: (progress: GameStatus) => void
 

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -16,6 +16,8 @@ import ExternalLinkDialog from './components/UI/ExternalLinkDialog'
 import WindowControls from './components/UI/WindowControls'
 import classNames from 'classnames'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
+import LogFileUploadDialog from './components/UI/LogFileUploadDialog'
+import UploadedLogFilesList from './screens/Settings/sections/LogSettings/components/UploadedLogFilesList'
 
 function Root() {
   const {
@@ -58,6 +60,8 @@ function Root() {
             />
           )}
           <ExternalLinkDialog />
+          <LogFileUploadDialog />
+          <UploadedLogFilesList />
           <Outlet />
         </main>
         <div className="controller">

--- a/src/frontend/components/UI/Dialog/components/DialogHeader.tsx
+++ b/src/frontend/components/UI/Dialog/components/DialogHeader.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react'
 
 interface DialogHeaderProps {
-  onClose: () => void
+  onClose?: () => void
   children: ReactNode
 }
 

--- a/src/frontend/components/UI/LogFileUploadDialog/index.tsx
+++ b/src/frontend/components/UI/LogFileUploadDialog/index.tsx
@@ -1,0 +1,115 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { CircularProgress } from '@mui/material'
+
+import { Dialog, DialogContent, DialogFooter, DialogHeader } from '../Dialog'
+import { useShallowGlobalState } from 'frontend/state/GlobalStateV2'
+
+export default function LogUploadDialog() {
+  const { t } = useTranslation()
+  const { uploadLogFileProps, setUploadLogFileProps } = useShallowGlobalState(
+    'uploadLogFileProps',
+    'setUploadLogFileProps'
+  )
+
+  const [confirmed, setConfirmed] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState(false)
+  const [uploadUrl, setUploadUrl] = useState<string | null>(null)
+
+  const onClose = useCallback(() => {
+    setConfirmed(false)
+    setUploading(false)
+    setUploadLogFileProps(false)
+  }, [setConfirmed, setUploading, setUploadLogFileProps])
+
+  const doUpload = useCallback(async () => {
+    if (!uploadLogFileProps) return
+
+    setConfirmed(true)
+    setUploading(true)
+
+    const result = await window.api.uploadLogFile(
+      uploadLogFileProps.name,
+      uploadLogFileProps.appNameOrRunner
+    )
+
+    setUploading(false)
+    if (!result) {
+      setError(true)
+      return
+    }
+    const [url] = result
+    await navigator.clipboard.writeText(url)
+    setUploadUrl(url)
+  }, [uploadLogFileProps])
+
+  const [dialogTitle, dialogContent, dialogFooter] = useMemo(() => {
+    if (!uploadLogFileProps) return ['', '', '']
+    if (!confirmed)
+      return [
+        t('setting.log.upload.confirm.title', 'Upload log file?'),
+        t(
+          'setting.log.upload.confirm.content',
+          'Do you really want to upload "{{name}}"?',
+          { name: uploadLogFileProps.name }
+        ),
+        <>
+          <button onClick={doUpload} className={'button is-primary'}>
+            {t('box.yes')}
+          </button>
+          <button onClick={onClose} className={'button is-danger'}>
+            {t('box.no')}
+          </button>
+        </>
+      ]
+    if (uploading)
+      return [
+        t('setting.log.upload.uploading.title', 'Uploading'),
+        <>
+          <CircularProgress />
+          <br />
+          {t('setting.log.upload.uploading.content', 'Uploading log file...')}
+        </>,
+        <></>
+      ]
+    if (error)
+      return [
+        t('setting.log.upload.error.title', 'Upload failed'),
+        t(
+          'setting.log.upload.error.content',
+          "Failed to upload log file. Check Heroic's general log for details"
+        ),
+        <>
+          <button onClick={onClose} className={'button is-secondary'}>
+            {t('box.ok')}
+          </button>
+        </>
+      ]
+    return [
+      t('setting.log.upload.done.title', 'Upload complete'),
+      t(
+        'setting.log.upload.done.content',
+        'Uploaded to {{url}} (URL copied to your clipboard)',
+        {
+          url: uploadUrl
+        }
+      ),
+      <>
+        <button onClick={onClose} className={'button is-secondary'}>
+          {t('box.ok')}
+        </button>
+      </>
+    ]
+  }, [uploadLogFileProps, confirmed, uploading, error, uploadUrl])
+
+  if (!uploadLogFileProps) return <></>
+
+  return (
+    <Dialog onClose={onClose} showCloseButton={false}>
+      <DialogHeader>{dialogTitle}</DialogHeader>
+      <DialogContent>{dialogContent}</DialogContent>
+      <DialogFooter>{dialogFooter}</DialogFooter>
+    </Dialog>
+  )
+}

--- a/src/frontend/screens/Settings/sections/LogSettings/components/UploadedLogFilesList/index.css
+++ b/src/frontend/screens/Settings/sections/LogSettings/components/UploadedLogFilesList/index.css
@@ -1,0 +1,6 @@
+.uploadedLogFilesTable {
+  th,
+  td {
+    padding: 0 0.5rem;
+  }
+}

--- a/src/frontend/screens/Settings/sections/LogSettings/components/UploadedLogFilesList/index.tsx
+++ b/src/frontend/screens/Settings/sections/LogSettings/components/UploadedLogFilesList/index.tsx
@@ -1,0 +1,121 @@
+import React, { memo, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Launch, Delete } from '@mui/icons-material'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader
+} from 'frontend/components/UI/Dialog'
+import SvgButton from 'frontend/components/UI/SvgButton'
+
+import useUploadedLogFiles from 'frontend/state/UploadedLogFiles'
+import type { UploadedLogData } from 'common/types'
+import {
+  useGlobalState,
+  useShallowGlobalState
+} from 'frontend/state/GlobalStateV2'
+
+import './index.css'
+
+interface UploadedLogFileItemProps extends UploadedLogData {
+  url: string
+}
+const UploadedLogFileItem = memo(function UploadedLogFileItem(
+  props: UploadedLogFileItemProps
+) {
+  const { url, name, uploadedAt } = props
+  const { t } = useTranslation()
+
+  const uploadedAgoText = useMemo(() => {
+    const minutesAgo = Math.round((Date.now() - uploadedAt) / 1000 / 60)
+    const showHours = minutesAgo > 60
+    if (showHours) {
+      return t(
+        'setting.log.upload.hours-ago',
+        'Uploaded {{hoursAgo, relativetime(hours)}}',
+        { hoursAgo: -Math.round(minutesAgo / 60) }
+      )
+    }
+    return t(
+      'setting.log.upload.minutes-ago',
+      'Uploaded {{minutesAgo, relativetime(minutes)}}',
+      {
+        minutesAgo: -minutesAgo
+      }
+    )
+  }, [(Date.now() - uploadedAt) / 1000 / 60 > 60])
+
+  return (
+    <tr>
+      <td>{name}</td>
+      <td>{uploadedAgoText}</td>
+      <td>
+        <SvgButton
+          onClick={() => window.api.openExternalUrl(url)}
+          title={t('setting.log.upload.open', 'Open log file upload')}
+        >
+          <Launch color="primary" />
+        </SvgButton>
+        <SvgButton
+          onClick={async () => window.api.deleteUploadedLogFile(url)}
+          title={t('setting.log.upload.delete', 'Request log file deletion')}
+        >
+          <Delete color="error" />
+        </SvgButton>
+      </td>
+    </tr>
+  )
+})
+
+export default function UploadedLogFilesList() {
+  const { showUploadedLogFileList } = useShallowGlobalState(
+    'showUploadedLogFileList'
+  )
+  const uploadedLogFiles = useUploadedLogFiles()
+  const { t } = useTranslation()
+
+  const logsSortedByMostRecentlyUploaded = useMemo(() => {
+    const logsArr = Object.entries(uploadedLogFiles).map(([url, data]) => ({
+      ...data,
+      url
+    }))
+    logsArr.sort((a, b) => b.uploadedAt - a.uploadedAt)
+    return logsArr
+  }, [uploadedLogFiles])
+
+  if (!showUploadedLogFileList) return <></>
+
+  return (
+    <Dialog
+      onClose={() =>
+        useGlobalState.setState({ showUploadedLogFileList: false })
+      }
+      showCloseButton={true}
+    >
+      <DialogHeader>
+        {t('setting.log.upload.header', 'Uploaded log files')}
+      </DialogHeader>
+      <DialogContent>
+        {logsSortedByMostRecentlyUploaded.length ? (
+          <table className="uploadedLogFilesTable">
+            <thead>
+              <tr>
+                <th>{t('setting.log.upload.title', 'Log title')}</th>
+                <th>{t('setting.log.upload.upload-date', 'Upload date')}</th>
+                <th>{t('setting.log.upload.actions', 'Actions')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logsSortedByMostRecentlyUploaded.map((logData) => (
+                <UploadedLogFileItem key={logData.url} {...logData} />
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          t('setting.log.upload.no-files', 'No log files were uploaded')
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/frontend/state/GlobalStateV2.ts
+++ b/src/frontend/state/GlobalStateV2.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand'
+import { useShallow } from 'zustand/react/shallow'
+
+interface GlobalStateV2 {
+  uploadLogFileProps:
+    | false
+    | {
+        appNameOrRunner: string
+        name: string
+      }
+  setUploadLogFileProps: (props: GlobalStateV2['uploadLogFileProps']) => void
+
+  showUploadedLogFileList: boolean
+}
+
+const useGlobalState = create<GlobalStateV2>()((set) => ({
+  uploadLogFileProps: false,
+  setUploadLogFileProps: (uploadLogFileProps) => {
+    set({ uploadLogFileProps })
+  },
+
+  showUploadedLogFileList: false
+}))
+
+function useShallowGlobalState<Keys extends (keyof GlobalStateV2)[]>(
+  ...keys: Keys
+): Pick<GlobalStateV2, Keys[number]> {
+  return useGlobalState(
+    useShallow(
+      (state) =>
+        Object.fromEntries(keys.map((key) => [key, state[key]])) as {
+          [key in Keys[number]]: GlobalStateV2[key]
+        }
+    )
+  )
+}
+
+export { useGlobalState, useShallowGlobalState }

--- a/src/frontend/state/UploadedLogFiles.ts
+++ b/src/frontend/state/UploadedLogFiles.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+
+import type { UploadedLogData } from 'common/types'
+
+const useUploadedLogFiles = create<Record<string, UploadedLogData>>()(
+  () => ({})
+)
+
+window.api
+  .getUploadedLogFiles()
+  .then((logFiles) => useUploadedLogFiles.setState(logFiles))
+
+window.api.logFileUploadedSlot((e, url, data) =>
+  useUploadedLogFiles.setState({ [url]: data })
+)
+
+window.api.logFileUploadDeletedSlot((e, url) => {
+  const currentLogFiles = useUploadedLogFiles.getState()
+  delete currentLogFiles[url]
+  useUploadedLogFiles.setState({ ...currentLogFiles }, true)
+})
+
+export default useUploadedLogFiles


### PR DESCRIPTION
When displaying a game log, a new button to directly upload the log file to a pastebin service is now presented. This button will upload the log file to `https://0x0.st` and copy the resulting sharable URL into the user's clipboard.

To alleviate privacy concerns, logs are (1) only kept valid for 24 hours and (2) can be deleted from within Heroic:
In the "Settings" -> "Logs" tab specifically, a new button to view uploaded logs was added. It lists all logs which are still valid, the user can then open the sharable URL again or request file deletion

Behind the scenes, two new Zustand states have been added:
- `useGlobalState`, which is my attempt at slowly migrating the current Global State to Zustand. It holds global information (specifically, whether the log file upload dialog or the upload list dialog are open)
- `useUploadedLogFiles`, holding data on uploaded log files. The Backend pushes updates to this using two new Frontend messages

Closes #3863 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [X] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
