### PR TITLE
Make actions_font_family_no_default and content_font_family_no_default more translation-friendly

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,8 +1,8 @@
 {
     "accessibility": {
-        "actions_font_family_no_default": "Actions Font Family (Default: {{fontFamily}})",
+        "actions_font_family_default": "Actions Font Family (Default: {{fontFamily}})",
         "all_tiles_in_color": "Show all game tiles in color",
-        "content_font_family_no_default": "Content Font Family (Default: {{fontFamily}})",
+        "content_font_family_default": "Content Font Family (Default: {{fontFamily}})",
         "disable_dialog_backdrop_close": "Disable closing dialogs by clicking outside",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,8 +1,8 @@
 {
     "accessibility": {
-        "actions_font_family_no_default": "Actions Font Family (Default):",
+        "actions_font_family_no_default": "Actions Font Family (Default: {{fontFamily}})",
         "all_tiles_in_color": "Show all game tiles in color",
-        "content_font_family_no_default": "Content Font Family (Default: ",
+        "content_font_family_no_default": "Content Font Family (Default: {{fontFamily}})",
         "disable_dialog_backdrop_close": "Disable closing dialogs by clicking outside",
         "fonts": "Fonts",
         "title": "Accessibility",

--- a/src/frontend/screens/Accessibility/index.tsx
+++ b/src/frontend/screens/Accessibility/index.tsx
@@ -164,7 +164,7 @@ export default React.memo(function Accessibility() {
           value={contentFont}
           onChange={handleContentFontFamily}
           label={t(
-            'accessibility.content_font_family_no_default',
+            'accessibility.content_font_family_default',
             'Content Font Family (Default: {{fontFamily}})',
             { fontFamily: defaultSecondaryFont.split(',')[0].trim() }
           )}
@@ -177,7 +177,7 @@ export default React.memo(function Accessibility() {
           value={actionFont}
           onChange={handleActionsFontFamily}
           label={t(
-            'accessibility.actions_font_family_no_default',
+            'accessibility.actions_font_family_default',
             'Actions Font Family (Default: {{fontFamily}})',
             { fontFamily: defaultPrimaryFont.split(',')[0].trim() }
           )}

--- a/src/frontend/screens/Accessibility/index.tsx
+++ b/src/frontend/screens/Accessibility/index.tsx
@@ -163,14 +163,11 @@ export default React.memo(function Accessibility() {
           htmlId="content-font-family"
           value={contentFont}
           onChange={handleContentFontFamily}
-          label={
-            t(
-              'accessibility.content_font_family_no_default',
-              'Content Font Family (Default: '
-            ) +
-            defaultSecondaryFont.split(',')[0].trim() +
-            ')'
-          }
+          label={t(
+            'accessibility.content_font_family_no_default',
+            'Content Font Family (Default: {{fontFamily}})',
+            { fontFamily: defaultSecondaryFont.split(',')[0].trim() }
+          )}
         >
           {options}
         </SelectField>
@@ -179,14 +176,11 @@ export default React.memo(function Accessibility() {
           htmlId="actions-font-family"
           value={actionFont}
           onChange={handleActionsFontFamily}
-          label={
-            t(
-              'accessibility.actions_font_family_no_default',
-              'Actions Font Family (Default: '
-            ) +
-            defaultPrimaryFont.split(',')[0].trim() +
-            ')'
-          }
+          label={t(
+            'accessibility.actions_font_family_no_default',
+            'Actions Font Family (Default: {{fontFamily}})',
+            { fontFamily: defaultPrimaryFont.split(',')[0].trim() }
+          )}
         >
           {options}
         </SelectField>


### PR DESCRIPTION
Replace string concatenation with i18n interpolation in `actions_font_family_no_default` and `content_font_family_no_default` keys.

This should help eliminate translation errors, as currently many languages have incorrect translation for those keys, even `en` has an incorrectly placed parenthesis there, resulting in this displayed in UI: `Actions Font Family (Default): "Rubik")`.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
