### PR TITLE
[Fix] cleanup discord rpc on launch failures

### DIFF
--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -499,6 +499,7 @@ export async function launch(
   } = await prepareLaunch(gameSettings, gameInfo, isNative(appName))
   if (!launchPrepSuccess) {
     appendGamePlayLog(gameInfo, `Launch aborted: ${launchPrepFailReason}`)
+    launchCleanup()
     showDialogBoxModalAuto({
       title: t('box.error.launchAborted', 'Launch aborted'),
       message: launchPrepFailReason!,
@@ -685,6 +686,8 @@ export async function launch(
     }
   })
 
+  launchCleanup(rpcClient)
+
   if (abort) {
     return true
   }
@@ -692,8 +695,6 @@ export async function launch(
   if (error) {
     logError(['Error launching game:', error], LogPrefix.Gog)
   }
-
-  launchCleanup(rpcClient)
 
   return !error
 }

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -853,6 +853,7 @@ export async function launch(
   } = await prepareLaunch(gameSettings, gameInfo, isNative(appName))
   if (!launchPrepSuccess) {
     appendGamePlayLog(gameInfo, `Launch aborted: ${launchPrepFailReason}`)
+    launchCleanup()
     showDialogBoxModalAuto({
       title: t('box.error.launchAborted', 'Launch aborted'),
       message: launchPrepFailReason!,

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -323,6 +323,7 @@ export async function launch(
 
   if (!launchPrepSuccess) {
     appendGamePlayLog(gameInfo, `Launch aborted: ${launchPrepFailReason}`)
+    launchCleanup()
     showDialogBoxModalAuto({
       title: t('box.error.launchAborted', 'Launch aborted'),
       message: launchPrepFailReason!,

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -179,6 +179,7 @@ export async function launchGame(
 
     if (!launchPrepSuccess) {
       appendGamePlayLog(gameInfo, `Launch aborted: ${launchPrepFailReason}`)
+      launchCleanup()
       showDialogBoxModalAuto({
         title: i18next.t('box.error.launchAborted', 'Launch aborted'),
         message: launchPrepFailReason!,


### PR DESCRIPTION
Fixes issues with hanging rpc client.


Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
