### PR TITLE
[FIX]: login flow not working when redirected from store tab

### DIFF
--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -262,7 +262,7 @@ export default function WebView() {
       }
     }
     return
-  }, [webviewRef.current, preloadPath, amazonLoginData])
+  }, [webviewRef.current, preloadPath, amazonLoginData, runner])
 
   useEffect(() => {
     const webview = webviewRef.current


### PR DESCRIPTION
This bug affected only amazon and gog.
The WebView never triggered auth flow when it was required.  


Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
