### PR TITLE
[Fix] Hide UMU-Latest from dropdown menu

### DIFF
--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -168,6 +168,10 @@ export async function getLinuxWineSet(
   protonPaths.forEach((path) => {
     if (existsSync(path)) {
       readdirSync(path).forEach((version) => {
+        // Only relevant to Lutris
+        if (version.startsWith('UMU-Latest')) {
+          return
+        }
         const protonBin = join(path, version, 'proton')
         // check if bin exists to avoid false positives
         if (existsSync(protonBin)) {


### PR DESCRIPTION
Overview:
- This PR hides the `UMU-Latest` symbolic link from the wine version dropdown menu to prevent users from intentionally selecting it and to avoid unexpectedly upgrading the game's wine prefix. 

Context:
- This file is intended to be used for clients like Lutris, who use umu as a wine manager, so that they can find the wine binaries associated with the current running Proton build and it's only created when either `PROTONPATH=GE-Proton` is set or `PROTONPATH` is unset. It is completely useless for Heroic's use case, as they only use umu for its runtime. At best, it will only cause confusion or mislead users when displayed in the dropdown menu as it gives the impression that an up-to-date Proton build will be used. At worst, when selecting `UMU-Latest`, it may even trigger Proton to upgrade the user's wine prefix, potentially breaking any fixes that were applied (e.g., winetricks wmp11 verb).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
