### PR TITLE
[Fix] Log the full error in the uncaughtException handler

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -518,11 +518,13 @@ ipcMain.once('frontendReady', () => {
 
 // Maybe this can help with white screens
 process.on('uncaughtException', async (err) => {
-  logError(`${err.name}: ${err.message}`, LogPrefix.Backend)
+  logError(err, LogPrefix.Backend)
+
   // We might get "object has been destroyed" exceptions in CI, since we start
   // and close Heroic quickly there. Displaying an error box would lock up
   // the test (until the timeout is reached), so let's not do that
   if (process.env.CI === 'e2e') return
+
   showDialogBoxModalAuto({
     title: i18next.t(
       'box.error.uncaught-exception.title',


### PR DESCRIPTION
`logError` can handle `Error` objects just fine, and will give us more information than just the name & message (which can be crucial to debug exceptions caught by this handler)

No need to review this before the release, mainly just creating this to help users with unexplained uncaught exceptions

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
