### PR TITLE
LoginWarning Popup Automatic Close

### DIFF
--- a/src/frontend/screens/Login/components/LoginWarning/index.tsx
+++ b/src/frontend/screens/Login/components/LoginWarning/index.tsx
@@ -46,10 +46,6 @@ const LoginWarning = function ({
     loginPath = amazonLoginPath
   }
 
-  const closeOnClick = () => {
-    onClose()
-  }
-
   return (
     <Dialog onClose={onClose} className="notLoggedIn" showCloseButton={true}>
       <DialogHeader onClose={onClose}>
@@ -57,7 +53,7 @@ const LoginWarning = function ({
       </DialogHeader>
       <DialogContent>
         <p>{textContent}</p>
-        <NavLink className="button" to={loginPath} onClick={closeOnClick}>
+        <NavLink className="button" to={loginPath} onClick={onClose}>
           <span>{t('not_logged_in.login', 'Log in')}</span>
         </NavLink>
       </DialogContent>

--- a/src/frontend/screens/Login/components/LoginWarning/index.tsx
+++ b/src/frontend/screens/Login/components/LoginWarning/index.tsx
@@ -46,6 +46,10 @@ const LoginWarning = function ({
     loginPath = amazonLoginPath
   }
 
+  const closeOnClick = () => {
+    onClose()
+  }
+
   return (
     <Dialog onClose={onClose} className="notLoggedIn" showCloseButton={true}>
       <DialogHeader onClose={onClose}>
@@ -53,7 +57,7 @@ const LoginWarning = function ({
       </DialogHeader>
       <DialogContent>
         <p>{textContent}</p>
-        <NavLink className="button" to={loginPath}>
+        <NavLink className="button" to={loginPath} onClick={closeOnClick}>
           <span>{t('not_logged_in.login', 'Log in')}</span>
         </NavLink>
       </DialogContent>


### PR DESCRIPTION
Added an onClick handler, called closeOnClick, to close the LoginWarning popup once the login path redirecting button on the popup is clicked so that users don't have to click both the button and the "x" when redirecting to the proper login path.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
