### PR TITLE
[Tech] Patch `@types/node` to restrict our `platform` type to valid platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,5 +157,10 @@
   },
   "resolutions": {
     "ts-morph": "17.0.1"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@types/node": "patches/@types__node.patch"
+    }
   }
 }

--- a/patches/@types__node.patch
+++ b/patches/@types__node.patch
@@ -1,0 +1,45 @@
+diff --git a/process.d.ts b/process.d.ts
+index 5f84863f9b4824dd1bd753726e6cbb3813fe358e..0c8f938a9cb5b807cf7415356ca064495b13cce7 100644
+--- a/process.d.ts
++++ b/process.d.ts
+@@ -66,17 +66,9 @@ declare module "process" {
+                 openssl: string;
+             }
+             type Platform =
+-                | "aix"
+-                | "android"
+                 | "darwin"
+-                | "freebsd"
+-                | "haiku"
+                 | "linux"
+-                | "openbsd"
+-                | "sunos"
+                 | "win32"
+-                | "cygwin"
+-                | "netbsd";
+             type Architecture =
+                 | "arm"
+                 | "arm64"
+@@ -1258,12 +1250,8 @@ declare module "process" {
+                  *
+                  * Currently possible values are:
+                  *
+-                 * * `'aix'`
+                  * * `'darwin'`
+-                 * * `'freebsd'`
+                  * * `'linux'`
+-                 * * `'openbsd'`
+-                 * * `'sunos'`
+                  * * `'win32'`
+                  *
+                  * ```js
+@@ -1271,9 +1259,6 @@ declare module "process" {
+                  *
+                  * console.log(`This platform is ${platform}`);
+                  * ```
+-                 *
+-                 * The value `'android'` may also be returned if the Node.js is built on the
+-                 * Android operating system. However, Android support in Node.js [is experimental](https://github.com/nodejs/node/blob/HEAD/BUILDING.md#androidandroid-based-devices-eg-firefox-os).
+                  * @since v0.1.16
+                  */
+                 readonly platform: Platform;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   ts-morph: 17.0.1
 
+patchedDependencies:
+  '@types/node':
+    hash: fnw5qjd7ourh3kgztkygdc5gdm
+    path: patches/@types__node.patch
+
 importers:
 
   .:
@@ -206,7 +211,7 @@ importers:
         version: 29.4.0
       '@types/node':
         specifier: 20.14.14
-        version: 20.14.14
+        version: 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       '@types/plist':
         specifier: 3.0.2
         version: 3.0.2
@@ -236,7 +241,7 @@ importers:
         version: 0.2.3
       '@vitejs/plugin-react-swc':
         specifier: 3.6.0
-        version: 3.6.0(vite@5.2.8(@types/node@20.14.14)(sass@1.59.2))
+        version: 3.6.0(vite@5.2.8(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(sass@1.59.2))
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
@@ -248,7 +253,7 @@ importers:
         version: 24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       electron-vite:
         specifier: ^2.0.0
-        version: 2.2.0(@swc/core@1.4.11)(vite@5.2.8(@types/node@20.14.14)(sass@1.59.2))
+        version: 2.2.0(@swc/core@1.4.11)(vite@5.2.8(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(sass@1.59.2))
       eslint:
         specifier: 9.7.0
         version: 9.7.0
@@ -272,7 +277,7 @@ importers:
         version: 7.7.0
       jest:
         specifier: 29.5.0
-        version: 29.5.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0)
+        version: 29.5.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0)
       node-gyp:
         specifier: ^10.0.1
         version: 10.1.0
@@ -290,7 +295,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.24.3)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.3))(jest@29.5.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0))(typescript@4.9.4)
+        version: 29.0.5(@babel/core@7.24.3)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.3))(jest@29.5.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0))(typescript@4.9.4)
       ts-prune:
         specifier: 0.10.3
         version: 0.10.3
@@ -311,10 +316,10 @@ importers:
         version: 1.26.0(eslint@9.7.0)
       vite:
         specifier: 5.2.8
-        version: 5.2.8(@types/node@20.14.14)(sass@1.59.2)
+        version: 5.2.8(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(sass@1.59.2)
       vite-plugin-svgr:
         specifier: 4.2.0
-        version: 4.2.0(rollup@4.17.2)(typescript@4.9.4)(vite@5.2.8(@types/node@20.14.14)(sass@1.59.2))
+        version: 4.2.0(rollup@4.17.2)(typescript@4.9.4)(vite@5.2.8(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(sass@1.59.2))
 
 packages:
 
@@ -6537,7 +6542,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -6550,14 +6555,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -6582,7 +6587,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -6600,7 +6605,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -6622,7 +6627,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -6692,7 +6697,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
@@ -7139,7 +7144,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       '@types/responselike': 1.0.3
 
   '@types/d3-array@3.2.1': {}
@@ -7184,15 +7189,15 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
 
   '@types/hast@2.3.10':
     dependencies:
@@ -7232,11 +7237,11 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
 
   '@types/mdast@3.0.15':
     dependencies:
@@ -7246,9 +7251,9 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node@16.18.97': {}
+  '@types/node@16.18.97(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)': {}
 
-  '@types/node@20.14.14':
+  '@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)':
     dependencies:
       undici-types: 5.26.5
 
@@ -7258,7 +7263,7 @@ snapshots:
 
   '@types/plist@3.0.2':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       xmlbuilder: 15.1.1
 
   '@types/prop-types@15.7.12': {}
@@ -7300,7 +7305,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
 
   '@types/sanitize-html@2.9.0':
     dependencies:
@@ -7335,7 +7340,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
     optional: true
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.7.0)(typescript@4.9.4))(eslint@9.7.0)(typescript@4.9.4)':
@@ -7478,10 +7483,10 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
 
-  '@vitejs/plugin-react-swc@3.6.0(vite@5.2.8(@types/node@20.14.14)(sass@1.59.2))':
+  '@vitejs/plugin-react-swc@3.6.0(vite@5.2.8(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(sass@1.59.2))':
     dependencies:
       '@swc/core': 1.4.11
-      vite: 5.2.8(@types/node@20.14.14)(sass@1.59.2)
+      vite: 5.2.8(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(sass@1.59.2)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -8214,13 +8219,13 @@ snapshots:
     dependencies:
       capture-stack-trace: 1.0.2
 
-  create-jest@29.7.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0):
+  create-jest@29.7.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
-      jest-config: 29.7.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -8590,7 +8595,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@2.2.0(@swc/core@1.4.11)(vite@5.2.8(@types/node@20.14.14)(sass@1.59.2)):
+  electron-vite@2.2.0(@swc/core@1.4.11)(vite@5.2.8(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(sass@1.59.2)):
     dependencies:
       '@babel/core': 7.24.3
       '@babel/plugin-transform-arrow-functions': 7.24.1(@babel/core@7.24.3)
@@ -8598,7 +8603,7 @@ snapshots:
       esbuild: 0.19.12
       magic-string: 0.30.10
       picocolors: 1.0.0
-      vite: 5.2.8(@types/node@20.14.14)(sass@1.59.2)
+      vite: 5.2.8(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(sass@1.59.2)
     optionalDependencies:
       '@swc/core': 1.4.11
     transitivePeerDependencies:
@@ -8607,7 +8612,7 @@ snapshots:
   electron@23.3.13:
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 16.18.97
+      '@types/node': 16.18.97(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -8615,7 +8620,7 @@ snapshots:
   electron@31.3.1:
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -9856,7 +9861,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1(babel-plugin-macros@3.1.0)
@@ -9876,16 +9881,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0):
+  jest-cli@29.7.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0)
+      create-jest: 29.7.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -9895,7 +9900,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0):
+  jest-config@29.7.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0):
     dependencies:
       '@babel/core': 7.24.3
       '@jest/test-sequencer': 29.7.0
@@ -9920,7 +9925,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9949,7 +9954,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -9959,7 +9964,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -9998,7 +10003,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -10033,7 +10038,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.10
@@ -10061,7 +10066,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       chalk: 4.1.2
       cjs-module-lexer: 1.2.3
       collect-v8-coverage: 1.0.2
@@ -10107,7 +10112,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.10
@@ -10126,7 +10131,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -10135,17 +10140,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.5.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0):
+  jest@29.5.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0)
+      jest-cli: 29.7.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11832,11 +11837,11 @@ snapshots:
     dependencies:
       typescript: 4.9.4
 
-  ts-jest@29.0.5(@babel/core@7.24.3)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.3))(jest@29.5.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0))(typescript@4.9.4):
+  ts-jest@29.0.5(@babel/core@7.24.3)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.3))(jest@29.5.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0))(typescript@4.9.4):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@20.14.14)(babel-plugin-macros@3.1.0)
+      jest: 29.5.0(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -12189,24 +12194,24 @@ snapshots:
       replace-ext: 2.0.0
       teex: 1.0.1
 
-  vite-plugin-svgr@4.2.0(rollup@4.17.2)(typescript@4.9.4)(vite@5.2.8(@types/node@20.14.14)(sass@1.59.2)):
+  vite-plugin-svgr@4.2.0(rollup@4.17.2)(typescript@4.9.4)(vite@5.2.8(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(sass@1.59.2)):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.17.2)
       '@svgr/core': 8.1.0(typescript@4.9.4)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@4.9.4))
-      vite: 5.2.8(@types/node@20.14.14)(sass@1.59.2)
+      vite: 5.2.8(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(sass@1.59.2)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite@5.2.8(@types/node@20.14.14)(sass@1.59.2):
+  vite@5.2.8(@types/node@20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm))(sass@1.59.2):
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
       rollup: 4.17.2
     optionalDependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.14.14(patch_hash=fnw5qjd7ourh3kgztkygdc5gdm)
       fsevents: 2.3.3
       sass: 1.59.2
 


### PR DESCRIPTION
`process.platform` can, under normal circumstances, only ever be `win32`, `darwin`, or `linux`. `@types/node` can't know this however, so we have to patch it to only make those values possible literal options

Technically this is incorrect (we could have someone run a development version of Heroic on any other platform), but this makes it easier to do checks on the property, or to use it in a switch case / index a Record with it
Somewhat improves the situation of #3908

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
