### PR TITLE
[Fix] Run `pnpm download-helper-binaries` in the AppVeyor setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ install:
   - corepack enable
   - corepack prepare pnpm@latest-8 --activate
   - pnpm install
+  - pnpm download-helper-binaries
 
 environment:
   GH_TOKEN:


### PR DESCRIPTION
AppVeyor script was missing this instruction, meaning our release builds lacked helper binaries

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
