### PR TITLE
[Fix] Make `GamesDBDataInner`'s `square_icon` optional

### DIFF
--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -936,7 +936,7 @@ export async function gogToUnifiedInfo(
       .replace('{ext}', 'jpg') ?? background
 
   const icon = (
-    info.game?.square_icon.url_format || info.game?.icon?.url_format
+    info.game?.square_icon?.url_format || info.game?.icon?.url_format
   )
     ?.replace('{formatter}', '')
     .replace('{ext}', 'jpg')

--- a/src/common/types/gog.ts
+++ b/src/common/types/gog.ts
@@ -276,7 +276,7 @@ interface GamesDBDataInner extends GamesDBDataBase {
   icon?: {
     url_format: string
   }
-  square_icon: {
+  square_icon?: {
     url_format: string
   }
   global_popularity_all_time: number


### PR DESCRIPTION
Apparently some games lack this

Closes #3932

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
