### PR TITLE
[UX] Show 'import game' hint/instructions in 'add game' dialog

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -213,6 +213,10 @@
         "field": {
             "title": "Title"
         },
+        "import-hint": {
+            "content": "Do NOT use this feature for that.<1></1>Instead, <3>log into</3> the store, look for the game in your library, open the installation dialog, and click the &quot;Import Game&quot; button",
+            "title": "Important! Are you adding a game from Epic/GOG/Amazon? Click here!"
+        },
         "info": {
             "broser": "BrowserURL",
             "exe": "Select Executable",

--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -7,7 +7,8 @@ import {
   CachedImage,
   TextInputField,
   PathSelectionBox,
-  ToggleSwitch
+  ToggleSwitch,
+  InfoBox
 } from 'frontend/components/UI'
 import { DialogContent, DialogFooter } from 'frontend/components/UI/Dialog'
 import {
@@ -17,12 +18,13 @@ import {
   writeConfig
 } from 'frontend/helpers'
 import React, { useContext, useEffect, useState } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { AvailablePlatforms } from '..'
 import fallbackImage from 'frontend/assets/heroic_card.jpg'
 import ContextProvider from 'frontend/state/ContextProvider'
 import classNames from 'classnames'
 import axios from 'axios'
+import { NavLink } from 'react-router-dom'
 
 type Props = {
   availablePlatforms: AvailablePlatforms
@@ -289,6 +291,22 @@ export default function SideloadDialog({
             </span>
           </div>
           <div className="sideloadForm">
+            <InfoBox
+              text={t(
+                'sideload.import-hint.title',
+                'Important! Are you adding a game from Epic/GOG/Amazon? Click here!'
+              )}
+            >
+              <div className="sideloadImportHint">
+                <Trans key="sideload.import-hint.content">
+                  Do NOT use this feature for that.
+                  <br />
+                  Instead, <NavLink to={'/login'}>log into</NavLink> the store,
+                  look for the game in your library, open the installation
+                  dialog, and click the &quot;Import Game&quot; button
+                </Trans>
+              </div>
+            </InfoBox>
             <TextInputField
               label={t('sideload.info.title', 'Game/App Title')}
               placeholder={t(

--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -49,7 +49,7 @@ export default function SideloadDialog({
   children,
   appName
 }: Props) {
-  const { t } = useTranslation('gamepage')
+  const { t, i18n } = useTranslation('gamepage')
   const [title, setTitle] = useState<string>(t('sideload.field.title', 'Title'))
   const [selectedExe, setSelectedExe] = useState('')
   const [gameUrl, setGameUrl] = useState('')
@@ -298,7 +298,7 @@ export default function SideloadDialog({
               )}
             >
               <div className="sideloadImportHint">
-                <Trans key="sideload.import-hint.content">
+                <Trans i18n={i18n} key="sideload.import-hint.content">
                   Do NOT use this feature for that.
                   <br />
                   Instead, <NavLink to={'/login'}>log into</NavLink> the store,

--- a/src/frontend/screens/Library/components/InstallModal/index.scss
+++ b/src/frontend/screens/Library/components/InstallModal/index.scss
@@ -103,3 +103,9 @@
 .sideloadForm {
   padding-inline-start: var(--space-xs);
 }
+
+.sideloadImportHint {
+  a {
+    text-decoration: underline;
+  }
+}


### PR DESCRIPTION
This PR adds a small InfoBox at the top of the `Add Game` dialog to tell the users that if they are trying to add an Epic/GOG/Amazon game they own from a store, they should actually use the Import Game feature.

![image](https://github.com/user-attachments/assets/dbd2c23c-3da8-44cf-8c1e-02606c751d41)

![image](https://github.com/user-attachments/assets/7a77c358-8494-4b17-b661-b1cc0e85612d)

it's small so it's not too invasive for the people that understand the difference, but hopefully it gets the attention of new users and prevents them from using Add Game when they actually want to import.

Closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3902

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
