### PR TITLE
[Tech] Don't compute log file locations when importing `constants.ts`

### DIFF
--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -5,7 +5,6 @@ import { parse } from '@node-steam/vdf'
 
 import { GameConfigVersion, GlobalConfigVersion } from 'common/types'
 import { logDebug, LogPrefix } from './logger/logger'
-import { createNewLogFileAndClearOldOnes } from './logger/logfile'
 import { env } from 'process'
 import { app } from 'electron'
 import { existsSync, mkdirSync, readFileSync } from 'graceful-fs'
@@ -74,14 +73,6 @@ const defaultWinePrefix = join(defaultWinePrefixDir, 'default')
 const anticheatDataPath = join(appFolder, 'areweanticheatyet.json')
 const imagesCachePath = join(appFolder, 'images-cache')
 const fixesPath = join(appFolder, 'fixes')
-
-const {
-  currentLogFile,
-  lastLogFile,
-  legendaryLogFile,
-  gogdlLogFile,
-  nileLogFile
-} = createNewLogFileAndClearOldOnes()
 
 const publicDir = resolve(
   __dirname,
@@ -234,11 +225,6 @@ export function createNecessaryFolders() {
 export {
   currentGameConfigVersion,
   currentGlobalConfigVersion,
-  currentLogFile,
-  lastLogFile,
-  legendaryLogFile,
-  gogdlLogFile,
-  nileLogFile,
   discordLink,
   execOptions,
   fixAsarPath,

--- a/src/backend/logger/__mocks__/logfile.ts
+++ b/src/backend/logger/__mocks__/logfile.ts
@@ -1,7 +1,14 @@
-const logfile = jest.requireActual('../logfile')
+import tmp from 'tmp'
+import { join } from 'path'
 
-logfile.createNewLogFileAndClearOldOnes = jest.fn().mockReturnValue('')
+const logfile = jest.requireActual<typeof import('../logfile')>('../logfile')
+
+const tmpLogDir = tmp.dirSync({ unsafeCleanup: true }).name
+
 logfile.appendMessageToLogFile = jest.fn()
+logfile.initLogfile = jest.fn()
+logfile.getLogFile = (appNameOrRunner) =>
+  join(tmpLogDir, appNameOrRunner + '.log')
 
 module.exports = logfile
 export {}

--- a/src/backend/logger/__tests__/logfile.test.ts
+++ b/src/backend/logger/__tests__/logfile.test.ts
@@ -31,7 +31,7 @@ describeSkipOnWindows('logger/logfile.ts', () => {
     })
     const consoleSpy = jest.spyOn(console, 'log')
 
-    const logs = logfile.createNewLogFileAndClearOldOnes()
+    const logs = logfile.testingExports.createNewLogFileAndClearOldOnes()
 
     expect(logs.currentLogFile).toBe('')
     expect(logs.gogdlLogFile).toBe('')
@@ -53,7 +53,7 @@ describeSkipOnWindows('logger/logfile.ts', () => {
       nileLogFile: ''
     })
 
-    const data = logfile.createNewLogFileAndClearOldOnes()
+    const data = logfile.testingExports.createNewLogFileAndClearOldOnes()
 
     expect(logger.logError).not.toBeCalled()
     expect(data).toStrictEqual({
@@ -81,7 +81,7 @@ describeSkipOnWindows('logger/logfile.ts', () => {
 
     expect(graceful_fs.existsSync(monthOutdatedLogFile)).toBeTruthy()
 
-    logfile.createNewLogFileAndClearOldOnes()
+    logfile.testingExports.createNewLogFileAndClearOldOnes()
 
     expect(logger.logError).toBeCalledWith(
       [
@@ -113,7 +113,7 @@ describeSkipOnWindows('logger/logfile.ts', () => {
     expect(graceful_fs.existsSync(monthOutdatedLogFile)).toBeTruthy()
     expect(graceful_fs.existsSync(yearOutdatedLogFile)).toBeTruthy()
 
-    logfile.createNewLogFileAndClearOldOnes()
+    logfile.testingExports.createNewLogFileAndClearOldOnes()
 
     expect(logger.logError).not.toBeCalled()
     expect(graceful_fs.existsSync(monthOutdatedLogFile)).toBeFalsy()

--- a/src/backend/logger/logfile.ts
+++ b/src/backend/logger/logfile.ts
@@ -29,7 +29,7 @@ export const getLongestPrefix = (): number => longestPrefix
  * It also removes old logs every new month.
  * @returns path to current log file
  */
-export function createNewLogFileAndClearOldOnes(): createLogFileReturn {
+function createNewLogFileAndClearOldOnes(): createLogFileReturn {
   const date = new Date()
   let logDir = ''
   try {
@@ -158,4 +158,13 @@ export function appendMessageToLogFile(message: string) {
       skipLogToFile: true
     })
   }
+}
+
+export function initLogfile() {
+  createNewLogFileAndClearOldOnes()
+}
+
+// ts-prune-ignore-next
+export const testingExports = {
+  createNewLogFileAndClearOldOnes
 }

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -157,6 +157,7 @@ import {
   getGameSdl
 } from 'backend/storeManagers/legendary/library'
 import { storeMap } from 'common/utils'
+import { initLogfile } from './logger/logfile'
 
 app.commandLine?.appendSwitch('ozone-platform-hint', 'auto')
 
@@ -300,6 +301,7 @@ if (!gotTheLock) {
   })
   app.whenReady().then(async () => {
     initLogger()
+    initLogfile()
     initOnlineMonitor()
     initStoreManagers()
     initImagesCache()

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -36,8 +36,9 @@ import {
   LogPrefix,
   logWarning
 } from '../../logger/logger'
+import { getLogFile } from '../../logger/logfile'
 import { getGOGdlBin, getFileSize, axiosClient } from '../../utils'
-import { gogdlConfigPath, gogdlLogFile } from '../../constants'
+import { gogdlConfigPath } from '../../constants'
 import {
   libraryStore,
   installedGamesStore,
@@ -1333,7 +1334,7 @@ export async function runRunnerCommand(
     { name: 'gog', logPrefix: LogPrefix.Gog, bin, dir },
     {
       ...options,
-      verboseLogFile: gogdlLogFile
+      verboseLogFile: getLogFile('gogdl')
     }
   )
 }

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -28,7 +28,6 @@ import {
 import {
   fallBackImage,
   legendaryConfigPath,
-  legendaryLogFile,
   legendaryMetadata,
   isLinux,
   userHome,
@@ -41,6 +40,7 @@ import {
   LogPrefix,
   logWarning
 } from '../../logger/logger'
+import { getLogFile } from '../../logger/logfile'
 import {
   gamesOverrideStore,
   installStore,
@@ -695,7 +695,7 @@ export async function runRunnerCommand(
     { name: 'legendary', logPrefix: LogPrefix.Legendary, bin, dir },
     {
       ...options,
-      verboseLogFile: legendaryLogFile
+      verboseLogFile: getLogFile('legendary')
     }
   )
 }

--- a/src/backend/storeManagers/nile/library.ts
+++ b/src/backend/storeManagers/nile/library.ts
@@ -1,10 +1,5 @@
 import JSON5 from 'json5'
-import {
-  nileConfigPath,
-  nileInstalled,
-  nileLibrary,
-  nileLogFile
-} from 'backend/constants'
+import { nileConfigPath, nileInstalled, nileLibrary } from 'backend/constants'
 import {
   LogPrefix,
   logDebug,
@@ -28,6 +23,7 @@ import { dirname, join } from 'path'
 import { app } from 'electron'
 import { copySync } from 'fs-extra'
 import { NileUser } from './user'
+import { getLogFile } from '../../logger/logfile'
 
 const installedGames: Map<string, NileInstallMetadataInfo> = new Map()
 const library: Map<string, GameInfo> = new Map()
@@ -483,7 +479,7 @@ export async function runRunnerCommand(
     { name: 'nile', logPrefix: LogPrefix.Nile, bin, dir },
     {
       ...options,
-      verboseLogFile: nileLogFile
+      verboseLogFile: getLogFile('nile')
     }
   )
 }


### PR DESCRIPTION
Log file locations (`currentLogFile`, `lastLogFile`, `legendaryLogFile`, etc.) were computed when importing the `constants.ts` file, which in turn lead to a lot of code being ran & modules being imported, even if those values are never actually read.
We can instead just use the common `initXXX` pattern to set the log file paths, and `getLogFile` to get them where they're needed.

This doesn't have an immediate benefit, but makes testing slightly easier in the future. Instead of having to mock a lot of modules just to get a non-crashing test setup, you now need *slightly less*

I've tested all aspects of the app relating to log files. Code itself was not touched, so I only tested on Linux (since the only thing required to test was whether the functions actually ran at the correct time)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [X] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
