### PR TITLE
Check prefix folder is correct before deleting it

### DIFF
--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -23,6 +23,7 @@ import { notify } from '../../dialog/dialog'
 import { launchGame } from 'backend/storeManagers/storeManagerCommon/games'
 import { GOGCloudSavesLocation } from 'common/types/gog'
 import { InstallResult, RemoveArgs } from 'common/types/game_manager'
+import { removePrefix } from 'backend/utils/uninstaller'
 
 export function getGameInfo(appName: string): GameInfo {
   const store = libraryStore.get('games', [])
@@ -110,14 +111,9 @@ export async function uninstall({
     title,
     install: { executable }
   } = gameInfo
-  const { winePrefix } = await getSettings(appName)
 
   if (shouldRemovePrefix) {
-    logInfo(`Removing prefix ${winePrefix}`, LogPrefix.Backend)
-    if (existsSync(winePrefix)) {
-      // remove prefix if exists
-      rmSync(winePrefix, { recursive: true })
-    }
+    removePrefix(appName, 'sideload')
   }
   libraryStore.set('games', current)
 

--- a/src/backend/utils/uninstaller.ts
+++ b/src/backend/utils/uninstaller.ts
@@ -1,0 +1,125 @@
+import { GlobalConfig } from 'backend/config'
+import { fixesPath, gamesConfigPath } from 'backend/constants'
+import { notify } from 'backend/dialog/dialog'
+import { logError, logInfo, LogPrefix } from 'backend/logger/logger'
+import { gameManagerMap } from 'backend/storeManagers'
+import { sendGameStatusUpdate } from 'backend/utils'
+import { Runner } from 'common/types'
+import { storeMap } from 'common/utils'
+import { Event } from 'electron'
+import { existsSync, readdirSync, rmSync } from 'graceful-fs'
+import i18next from 'i18next'
+import { join } from 'path'
+
+export const removePrefix = async (appName: string, runner: Runner) => {
+  const { winePrefix } = await gameManagerMap[runner].getSettings(appName)
+  logInfo(`Removing prefix ${winePrefix}`, LogPrefix.Backend)
+
+  if (!existsSync(winePrefix)) {
+    logInfo(`Prefix folder ${winePrefix} doesn't exist, ignoring removal`)
+    return
+  }
+
+  // folder exists, do some sanity checks before deleting it
+  const { defaultInstallPath, defaultWinePrefix } =
+    GlobalConfig.get().getSettings()
+
+  if (winePrefix === defaultInstallPath) {
+    logInfo(
+      `Can't delete folder ${winePrefix}, prefix folder is the default install directory ${defaultInstallPath}`
+    )
+    return
+  }
+
+  if (winePrefix === defaultWinePrefix) {
+    logInfo(
+      `Can't delete folder ${winePrefix}, prefix folder is the default prefix directory ${defaultWinePrefix}`
+    )
+    return
+  }
+
+  const dirContent = readdirSync(winePrefix)
+
+  if (dirContent.length > 0) {
+    const driveCPath = join(winePrefix, 'drive_c')
+
+    if (!existsSync(driveCPath)) {
+      logInfo(
+        `Can't delete folder ${winePrefix}, folder does not contain a drive_c folder. If this is the correct prefix folder, delete it manually.`
+      )
+      return
+    }
+  }
+
+  // if we got here, we are safe to delete this folder
+  rmSync(winePrefix, { recursive: true })
+}
+
+export const removeFixFile = (appName: string, runner: Runner) => {
+  const fixFilePath = join(fixesPath, `${appName}-${storeMap[runner]}.json`)
+  if (existsSync(fixFilePath)) {
+    rmSync(fixFilePath)
+  }
+}
+
+export const removeSettingsAndLogs = (appName: string) => {
+  const removeIfExists = (filename: string) => {
+    logInfo(`Removing ${filename}`, LogPrefix.Backend)
+    const gameSettingsFile = join(gamesConfigPath, filename)
+    if (existsSync(gameSettingsFile)) {
+      rmSync(gameSettingsFile)
+    }
+  }
+
+  removeIfExists(appName.concat('.json'))
+  removeIfExists(appName.concat('.log'))
+  removeIfExists(appName.concat('-lastPlay.log'))
+}
+
+export const uninstallGameCallback = async (
+  event: Event,
+  appName: string,
+  runner: Runner,
+  shouldRemovePrefix: boolean,
+  shouldRemoveSetting: boolean
+) => {
+  sendGameStatusUpdate({
+    appName,
+    runner,
+    status: 'uninstalling'
+  })
+
+  const { title } = gameManagerMap[runner].getGameInfo(appName)
+
+  let uninstalled = false
+
+  try {
+    await gameManagerMap[runner].uninstall({ appName, shouldRemovePrefix })
+    uninstalled = true
+  } catch (error) {
+    notify({
+      title,
+      body: i18next.t('notify.uninstalled.error', 'Error uninstalling')
+    })
+    logError(error, LogPrefix.Backend)
+  }
+
+  if (uninstalled) {
+    if (shouldRemovePrefix) {
+      removePrefix(appName, runner)
+    }
+    if (shouldRemoveSetting) {
+      removeSettingsAndLogs(appName)
+    }
+    removeFixFile(appName, runner)
+
+    notify({ title, body: i18next.t('notify.uninstalled') })
+    logInfo('Finished uninstalling', LogPrefix.Backend)
+  }
+
+  sendGameStatusUpdate({
+    appName,
+    runner,
+    status: 'done'
+  })
+}


### PR DESCRIPTION
This PR adds a few checks before deleting the prefix of a game to check that we don't delete the wrong thing:

- if the path is the same as the game installation path, we don't delete it (would delete all games)
- if the path is the same as the default/shared prefix path, we don't delete it (would delete all prefixes)
- if the path does NOT contain a `drive_c` folder, we don't delete it (it either not a prefix or there's something off in it)

I also used the opportunity to move some code into a new `utils/uninstaller.ts` file to make `main.ts` a bit smaller.



---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
