### PR TITLE
[Fix] Allow unselecting Launch Options. Show selector after a game finishes installation

### DIFF
--- a/src/frontend/screens/Game/GamePage/components/LaunchOptions.tsx
+++ b/src/frontend/screens/Game/GamePage/components/LaunchOptions.tsx
@@ -6,7 +6,7 @@ import { SelectField } from 'frontend/components/UI'
 
 interface Props {
   gameInfo: GameInfo
-  setLaunchArguments: (selected_option: LaunchOption) => void
+  setLaunchArguments: (selected_option: LaunchOption | undefined) => void
 }
 
 const LaunchOptions = ({ gameInfo, setLaunchArguments }: Props) => {
@@ -17,7 +17,7 @@ const LaunchOptions = ({ gameInfo, setLaunchArguments }: Props) => {
 
   useEffect(() => {
     window.api.getLaunchOptions(appName, runner).then(setLaunchOptions)
-  }, [])
+  }, [gameInfo])
 
   if (!gameInfo.is_installed) {
     return null
@@ -31,9 +31,14 @@ const LaunchOptions = ({ gameInfo, setLaunchArguments }: Props) => {
     <SelectField
       htmlId="launch_options"
       onChange={({ target: { value } }) => {
-        const selectedIndex = Number(value)
-        setSelectedLaunchOptionIndex(selectedIndex)
-        setLaunchArguments(launchOptions[selectedIndex])
+        if (value === '') {
+          setSelectedLaunchOptionIndex(-1)
+          setLaunchArguments(undefined)
+        } else {
+          const selectedIndex = Number(value)
+          setSelectedLaunchOptionIndex(selectedIndex)
+          setLaunchArguments(launchOptions[selectedIndex])
+        }
       }}
       value={selectedLaunchOptionIndex.toString()}
       prompt={t('launch.options', 'Launch Options...')}


### PR DESCRIPTION
This PR fixes 2 issues with the `Launch Options` selector in the game page:
- it was not possible to unselect options once something was selected (apart from going out and back to the game page)
- the select was not showing up if the installation of a game finished while in the game page screen

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
