### PR TITLE
[UX] Filter settings that don't apply to current platform and game

### DIFF
--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -585,6 +585,7 @@ class GameLogWriter extends LogWriter {
       delete gameSettings.enableFSR
       delete gameSettings.showMangohud
       delete gameSettings.showFps
+      delete gameSettings.disableUMU
 
       if (notNative) {
         const wineType = gameSettings.wineVersion
@@ -639,6 +640,7 @@ class GameLogWriter extends LogWriter {
       delete gameSettings.battlEyeRuntime
       delete gameSettings.eacRuntime
       delete gameSettings.nvidiaPrime
+      delete gameSettings.disableUMU
     }
 
     return gameSettings

--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -4,7 +4,13 @@
  *        Note that with console.log and console.warn everything will be saved too.
  *        error equals console.error
  */
-import { AppSettings, GameInfo, GameSettings, Runner } from 'common/types'
+import {
+  AppSettings,
+  GameInfo,
+  GameScopeSettings,
+  GameSettings,
+  Runner
+} from 'common/types'
 import { showDialogBoxModalAuto } from '../dialog/dialog'
 import {
   appendMessageToLogFile,
@@ -26,7 +32,7 @@ import { existsSync, mkdirSync, openSync } from 'graceful-fs'
 import { Winetricks } from 'backend/tools'
 import { gameAnticheatInfo } from 'backend/anticheat/utils'
 import { isUmuSupported } from 'backend/utils/compatibility_layers'
-import { isWindows } from 'backend/constants/environment'
+import { isLinux, isMac, isWindows } from 'backend/constants/environment'
 import { gamesConfigPath } from 'backend/constants/paths'
 
 export enum LogPrefix {
@@ -515,6 +521,128 @@ class GameLogWriter extends LogWriter {
     this.filePath = lastPlayLogFileLocation(gameInfo.app_name)
   }
 
+  // cleanup settings for logs to avoid confusions during support requests
+  filterGameSettingsForLog(
+    gameSettings: Partial<GameSettings>,
+    notNative: boolean
+  ): Partial<GameSettings> {
+    // remove gamescope settings if it's disabled
+    const gscope = gameSettings['gamescope'] as Partial<GameScopeSettings>
+    if (gscope) {
+      if (!gscope['enableLimiter']) {
+        delete gscope['fpsLimiter']
+        delete gscope['fpsLimiterNoFocus']
+      }
+      if (!gscope['enableUpscaling']) {
+        delete gscope['upscaleMethod']
+        delete gscope['upscaleHeight']
+        delete gscope['upscaleWidth']
+        delete gscope['gameHeight']
+        delete gscope['gameWidth']
+        delete gscope['windowType']
+      }
+    }
+
+    // remove settings that are not used on Linux
+    if (isLinux) {
+      delete gameSettings['enableMsync']
+      delete gameSettings['wineCrossoverBottle']
+
+      if (notNative) {
+        const wineType = gameSettings['wineVersion']
+        if (wineType) {
+          if (wineType['type'] === 'proton') {
+            delete gameSettings['autoInstallDxvk']
+            delete gameSettings['autoInstallVkd3d']
+          }
+        }
+      } else {
+        // remove settings that are not used on native Linux games
+        delete gameSettings['wineVersion']
+        delete gameSettings['winePrefix']
+        delete gameSettings['autoInstallDxvk']
+        delete gameSettings['autoInstallDxvkNvapi']
+        delete gameSettings['autoInstallVkd3d']
+        delete gameSettings['enableFsync']
+        delete gameSettings['enableEsync']
+        delete gameSettings['enableFSR']
+        delete gameSettings['showFps']
+        delete gameSettings['enableDXVKFpsLimit']
+        delete gameSettings['eacRuntime']
+        delete gameSettings['battlEyeRuntime']
+        delete gameSettings['useGameMode']
+      }
+    }
+
+    // remove settings that are not used on Mac
+    if (isMac) {
+      delete gameSettings['useGameMode']
+      delete gameSettings['gamescope']
+      delete gameSettings['nvidiaPrime']
+      delete gameSettings['battlEyeRuntime']
+      delete gameSettings['eacRuntime']
+      delete gameSettings['enableFSR']
+      delete gameSettings['showMangohud']
+      delete gameSettings['showFps']
+
+      if (notNative) {
+        const wineType = gameSettings['wineVersion']
+        if (wineType) {
+          if (wineType['type'] === 'wine') {
+            delete gameSettings['wineCrossoverBottle']
+          }
+
+          if (wineType['type'] === 'toolkit') {
+            delete gameSettings['autoInstallDxvk']
+            delete gameSettings['autoInstallDxvkNvapi']
+            delete gameSettings['autoInstallVkd3d']
+          }
+
+          if (wineType['type'] === 'crossover') {
+            delete gameSettings['autoInstallDxvk']
+            delete gameSettings['autoInstallDxvkNvapi']
+            delete gameSettings['autoInstallVkd3d']
+          }
+        }
+
+        delete gameSettings['wineVersion']
+        delete gameSettings['winePrefix']
+      } else {
+        // remove settings that are not used on native Mac games
+        delete gameSettings['enableDXVKFpsLimit']
+        delete gameSettings['wineVersion']
+        delete gameSettings['winePrefix']
+        delete gameSettings['wineCrossoverBottle']
+      }
+    }
+
+    // remove settings that are not used on Windows
+    if (isWindows) {
+      delete gameSettings['enableMsync']
+      delete gameSettings['enableFSR']
+      delete gameSettings['enableEsync']
+      delete gameSettings['enableFsync']
+      delete gameSettings['enableDXVKFpsLimit']
+      delete gameSettings['DXVKFpsCap']
+      delete gameSettings['autoInstallDxvk']
+      delete gameSettings['autoInstallDxvkNvapi']
+      delete gameSettings['autoInstallVkd3d']
+      delete gameSettings['gamescope']
+      delete gameSettings['useGameMode']
+      delete gameSettings['showMangohud']
+      delete gameSettings['showFps']
+      delete gameSettings['preferSystemLibs']
+      delete gameSettings['wineCrossoverBottle']
+      delete gameSettings['winePrefix']
+      delete gameSettings['wineVersion']
+      delete gameSettings['battlEyeRuntime']
+      delete gameSettings['eacRuntime']
+      delete gameSettings['nvidiaPrime']
+    }
+
+    return gameSettings
+  }
+
   async initLog() {
     const { app_name, runner } = this.gameInfo
 
@@ -555,7 +683,11 @@ class GameLogWriter extends LogWriter {
 
       // log game settings
       const gameSettings = await gameManagerMap[runner].getSettings(app_name)
-      const gameSettingsString = JSON.stringify(gameSettings, null, '\t')
+      const gameSettingsString = JSON.stringify(
+        this.filterGameSettingsForLog({ ...gameSettings }, notNative),
+        null,
+        '\t'
+      )
       const startPlayingDate = new Date()
       // log anticheat info
       const antiCheatInfo = gameAnticheatInfo(this.gameInfo.namespace)

--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -527,117 +527,118 @@ class GameLogWriter extends LogWriter {
     notNative: boolean
   ): Partial<GameSettings> {
     // remove gamescope settings if it's disabled
-    const gscope = gameSettings['gamescope'] as Partial<GameScopeSettings>
+    const gscope: Partial<GameScopeSettings> | undefined =
+      gameSettings.gamescope
     if (gscope) {
-      if (!gscope['enableLimiter']) {
-        delete gscope['fpsLimiter']
-        delete gscope['fpsLimiterNoFocus']
+      if (!gscope.enableLimiter) {
+        delete gscope.fpsLimiter
+        delete gscope.fpsLimiterNoFocus
       }
-      if (!gscope['enableUpscaling']) {
-        delete gscope['upscaleMethod']
-        delete gscope['upscaleHeight']
-        delete gscope['upscaleWidth']
-        delete gscope['gameHeight']
-        delete gscope['gameWidth']
-        delete gscope['windowType']
+      if (!gscope.enableUpscaling) {
+        delete gscope.upscaleMethod
+        delete gscope.upscaleHeight
+        delete gscope.upscaleWidth
+        delete gscope.gameHeight
+        delete gscope.gameWidth
+        delete gscope.windowType
       }
     }
 
     // remove settings that are not used on Linux
     if (isLinux) {
-      delete gameSettings['enableMsync']
-      delete gameSettings['wineCrossoverBottle']
+      delete gameSettings.enableMsync
+      delete gameSettings.wineCrossoverBottle
 
       if (notNative) {
-        const wineType = gameSettings['wineVersion']
-        if (wineType) {
-          if (wineType['type'] === 'proton') {
-            delete gameSettings['autoInstallDxvk']
-            delete gameSettings['autoInstallVkd3d']
+        const wineVersion = gameSettings.wineVersion
+        if (wineVersion) {
+          if (wineVersion.type === 'proton') {
+            delete gameSettings.autoInstallDxvk
+            delete gameSettings.autoInstallVkd3d
           }
         }
       } else {
         // remove settings that are not used on native Linux games
-        delete gameSettings['wineVersion']
-        delete gameSettings['winePrefix']
-        delete gameSettings['autoInstallDxvk']
-        delete gameSettings['autoInstallDxvkNvapi']
-        delete gameSettings['autoInstallVkd3d']
-        delete gameSettings['enableFsync']
-        delete gameSettings['enableEsync']
-        delete gameSettings['enableFSR']
-        delete gameSettings['showFps']
-        delete gameSettings['enableDXVKFpsLimit']
-        delete gameSettings['eacRuntime']
-        delete gameSettings['battlEyeRuntime']
-        delete gameSettings['useGameMode']
+        delete gameSettings.wineVersion
+        delete gameSettings.winePrefix
+        delete gameSettings.autoInstallDxvk
+        delete gameSettings.autoInstallDxvkNvapi
+        delete gameSettings.autoInstallVkd3d
+        delete gameSettings.enableFsync
+        delete gameSettings.enableEsync
+        delete gameSettings.enableFSR
+        delete gameSettings.showFps
+        delete gameSettings.enableDXVKFpsLimit
+        delete gameSettings.eacRuntime
+        delete gameSettings.battlEyeRuntime
+        delete gameSettings.useGameMode
       }
     }
 
     // remove settings that are not used on Mac
     if (isMac) {
-      delete gameSettings['useGameMode']
-      delete gameSettings['gamescope']
-      delete gameSettings['nvidiaPrime']
-      delete gameSettings['battlEyeRuntime']
-      delete gameSettings['eacRuntime']
-      delete gameSettings['enableFSR']
-      delete gameSettings['showMangohud']
-      delete gameSettings['showFps']
+      delete gameSettings.useGameMode
+      delete gameSettings.gamescope
+      delete gameSettings.nvidiaPrime
+      delete gameSettings.battlEyeRuntime
+      delete gameSettings.eacRuntime
+      delete gameSettings.enableFSR
+      delete gameSettings.showMangohud
+      delete gameSettings.showFps
 
       if (notNative) {
-        const wineType = gameSettings['wineVersion']
+        const wineType = gameSettings.wineVersion
         if (wineType) {
-          if (wineType['type'] === 'wine') {
-            delete gameSettings['wineCrossoverBottle']
+          if (wineType.type === 'wine') {
+            delete gameSettings.wineCrossoverBottle
           }
 
-          if (wineType['type'] === 'toolkit') {
-            delete gameSettings['autoInstallDxvk']
-            delete gameSettings['autoInstallDxvkNvapi']
-            delete gameSettings['autoInstallVkd3d']
+          if (wineType.type === 'toolkit') {
+            delete gameSettings.autoInstallDxvk
+            delete gameSettings.autoInstallDxvkNvapi
+            delete gameSettings.autoInstallVkd3d
           }
 
-          if (wineType['type'] === 'crossover') {
-            delete gameSettings['autoInstallDxvk']
-            delete gameSettings['autoInstallDxvkNvapi']
-            delete gameSettings['autoInstallVkd3d']
+          if (wineType.type === 'crossover') {
+            delete gameSettings.autoInstallDxvk
+            delete gameSettings.autoInstallDxvkNvapi
+            delete gameSettings.autoInstallVkd3d
           }
         }
 
-        delete gameSettings['wineVersion']
-        delete gameSettings['winePrefix']
+        delete gameSettings.wineVersion
+        delete gameSettings.winePrefix
       } else {
         // remove settings that are not used on native Mac games
-        delete gameSettings['enableDXVKFpsLimit']
-        delete gameSettings['wineVersion']
-        delete gameSettings['winePrefix']
-        delete gameSettings['wineCrossoverBottle']
+        delete gameSettings.enableDXVKFpsLimit
+        delete gameSettings.wineVersion
+        delete gameSettings.winePrefix
+        delete gameSettings.wineCrossoverBottle
       }
     }
 
     // remove settings that are not used on Windows
     if (isWindows) {
-      delete gameSettings['enableMsync']
-      delete gameSettings['enableFSR']
-      delete gameSettings['enableEsync']
-      delete gameSettings['enableFsync']
-      delete gameSettings['enableDXVKFpsLimit']
-      delete gameSettings['DXVKFpsCap']
-      delete gameSettings['autoInstallDxvk']
-      delete gameSettings['autoInstallDxvkNvapi']
-      delete gameSettings['autoInstallVkd3d']
-      delete gameSettings['gamescope']
-      delete gameSettings['useGameMode']
-      delete gameSettings['showMangohud']
-      delete gameSettings['showFps']
-      delete gameSettings['preferSystemLibs']
-      delete gameSettings['wineCrossoverBottle']
-      delete gameSettings['winePrefix']
-      delete gameSettings['wineVersion']
-      delete gameSettings['battlEyeRuntime']
-      delete gameSettings['eacRuntime']
-      delete gameSettings['nvidiaPrime']
+      delete gameSettings.enableMsync
+      delete gameSettings.enableFSR
+      delete gameSettings.enableEsync
+      delete gameSettings.enableFsync
+      delete gameSettings.enableDXVKFpsLimit
+      delete gameSettings.DXVKFpsCap
+      delete gameSettings.autoInstallDxvk
+      delete gameSettings.autoInstallDxvkNvapi
+      delete gameSettings.autoInstallVkd3d
+      delete gameSettings.gamescope
+      delete gameSettings.useGameMode
+      delete gameSettings.showMangohud
+      delete gameSettings.showFps
+      delete gameSettings.preferSystemLibs
+      delete gameSettings.wineCrossoverBottle
+      delete gameSettings.winePrefix
+      delete gameSettings.wineVersion
+      delete gameSettings.battlEyeRuntime
+      delete gameSettings.eacRuntime
+      delete gameSettings.nvidiaPrime
     }
 
     return gameSettings
@@ -684,7 +685,7 @@ class GameLogWriter extends LogWriter {
       // log game settings
       const gameSettings = await gameManagerMap[runner].getSettings(app_name)
       const gameSettingsString = JSON.stringify(
-        this.filterGameSettingsForLog({ ...gameSettings }, notNative),
+        this.filterGameSettingsForLog(structuredClone(gameSettings), notNative),
         null,
         '\t'
       )

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -738,7 +738,7 @@ export interface WindowProps extends Electron.Rectangle {
   titleBarOverlay?: TitleBarOverlay | boolean
 }
 
-interface GameScopeSettings {
+export interface GameScopeSettings {
   enableUpscaling: boolean
   enableLimiter: boolean
   enableForceGrabCursor: boolean


### PR DESCRIPTION
This PR changes the behavior of the Game logger to remove settings from the output when the settings don't make sense for a given game and platform.

For example: it will filter out all the wine-related settings for native games, or hide the gamescope settings when the parent gamescope setting is disabled.

The idea behind this is that these settings that don't make any sense for a given situation are still displayed in the logs, adding noise and confusing the users and during support.

I think this is a good enough first iteration, I think there are probably more settings that can be removed specially on windows, but I don't have a machine with windows to verify (I was looking at the code of the different settings only).

Note: I know the code is kinda verbose, but it was intentional to make it super clear which elements are being removed an in which conditions. I could refactor this to set settings in an array and looping but I kinda felt this was better. I can change this if we don't agree.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
