### PR TITLE
[Fix] Cache installed wine version on prefix

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -357,7 +357,9 @@ async function prepareWineLaunch(
     writeFileSync(appsNamesPath, JSON.stringify([appName]), 'utf-8')
     hasUpdated = true
   } else {
-    const installedGames : string[] = JSON.parse(readFileSync(appsNamesPath, 'utf-8'))
+    const installedGames: string[] = JSON.parse(
+      readFileSync(appsNamesPath, 'utf-8')
+    )
     if (!installedGames.includes(appName)) {
       installedGames.push(appName)
       writeFileSync(appsNamesPath, JSON.stringify(installedGames), 'utf-8')

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -69,7 +69,7 @@ import { showDialogBoxModalAuto } from './dialog/dialog'
 import { legendarySetup } from './storeManagers/legendary/setup'
 import { gameManagerMap } from 'backend/storeManagers'
 import * as VDF from '@node-steam/vdf'
-import { readFileSync, writeFileSync } from 'fs'
+import { readFileSync } from 'fs'
 import { LegendaryCommand } from './storeManagers/legendary/commands'
 import { commandToArgsArray } from './storeManagers/legendary/library'
 import { searchForExecutableOnPath } from './utils/os/path'
@@ -803,7 +803,8 @@ export async function verifyWinePrefix(
     return { res: { stdout: '', stderr: '' }, updated: false }
   }
 
-  if (!existsSync(winePrefix) && !(await isUmuSupported(wineVersion.type))) {
+  const newPrefix = !existsSync(winePrefix)
+  if (newPrefix && !(await isUmuSupported(wineVersion.type))) {
     mkdirSync(winePrefix, { recursive: true })
   }
 
@@ -826,16 +827,7 @@ export async function verifyWinePrefix(
 
   return command
     .then((result) => {
-      const currentWinePath = join(winePrefix, 'current_wine')
-      if (
-        !existsSync(currentWinePath) ||
-        readFileSync(currentWinePath, 'utf-8') != wineVersion.bin
-      ) {
-        writeFileSync(currentWinePath, wineVersion.bin, 'utf-8')
-        return { res: result, updated: true }
-      } else {
-        return { res: result, updated: false }
-      }
+      return { res: result, updated: newPrefix }
     })
     .catch((error) => {
       logError(['Unable to create Wineprefix: ', error], LogPrefix.Backend)


### PR DESCRIPTION
This caches the used wine version to better detect a wine version change on the prefix. From 9.14 and onward, wineboot does not print the updated message on stdout, which breaks the update detection and eventually causes initial setups to never fire: 
![image](https://github.com/user-attachments/assets/d71ef635-f628-44e2-9c5e-7f83e52f40de)

This will result in what what I reported in discord some time ago: [Missing DOSBox config file for GOG games](https://discord.com/channels/812703221789097985/1283469664902578279)


Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
