### PR TITLE
[UX] Make auto install of known fixes not experimental anymore

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -633,7 +633,6 @@
         "esync": "Enable Esync",
         "exit-to-tray": "Exit to System Tray",
         "experimental_features": {
-            "automaticWinetricksFixes": "Apply known fixes automatically",
             "cometSupport": "Comet support",
             "enableHelp": "Help component",
             "enableNewDesign": "New design",

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -369,9 +369,8 @@ async function prepareWineLaunch(
     if (runner === 'legendary') {
       await legendarySetup(appName)
     }
-    if (experimentalFeatures?.automaticWinetricksFixes !== false) {
-      await installFixes(appName, runner)
-    }
+
+    await installFixes(appName, runner)
   }
 
   try {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -64,7 +64,6 @@ export type Release = {
 export type ExperimentalFeatures = {
   enableNewDesign: boolean
   enableHelp: boolean
-  automaticWinetricksFixes: boolean
   cometSupport: boolean
   umuSupport: boolean
 }

--- a/src/frontend/screens/Settings/components/ExperimentalFeatures.tsx
+++ b/src/frontend/screens/Settings/components/ExperimentalFeatures.tsx
@@ -9,10 +9,6 @@ const ExperimentalFeatures = () => {
 
   const FEATURES = ['enableNewDesign', 'enableHelp', 'cometSupport']
 
-  if (platform !== 'win32') {
-    FEATURES.push('automaticWinetricksFixes')
-  }
-
   if (platform === 'linux') {
     FEATURES.push('umuSupport')
   }
@@ -23,7 +19,6 @@ const ExperimentalFeatures = () => {
     {
       enableNewDesign: false,
       enableHelp: false,
-      automaticWinetricksFixes: true,
       cometSupport: true,
       umuSupport: false
     }
@@ -43,7 +38,6 @@ const ExperimentalFeatures = () => {
     Translations:
     t('setting.experimental_features.enableNewDesign', 'New design')
     t('setting.experimental_features.enableHelp', 'Help component')
-    t('setting.experimental_features.automaticWinetricksFixes', 'Apply known fixes automatically')
     t('setting.experimental_features.cometSupport', 'Comet support')
     t('setting.experimental_features.umuSupport', 'Use UMU as Proton runtime')
   */

--- a/src/frontend/state/ContextProvider.tsx
+++ b/src/frontend/state/ContextProvider.tsx
@@ -97,7 +97,6 @@ const initialContext: ContextType = {
   experimentalFeatures: {
     enableNewDesign: false,
     enableHelp: false,
-    automaticWinetricksFixes: true,
     cometSupport: true,
     umuSupport: false
   },

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -211,7 +211,6 @@ class GlobalState extends PureComponent<Props> {
     experimentalFeatures: {
       enableNewDesign: false,
       enableHelp: false,
-      automaticWinetricksFixes: true,
       cometSupport: true,
       umuSupport: false,
       ...(globalSettings?.experimentalFeatures || {})


### PR DESCRIPTION
We've had the auto installation of known winetricks fixes as an experimental feature enabled by default for a long time and there has not been any big issue reported. I think it's about time for that to be not experimental anymore.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
