### PR TITLE
[Fix] Delete runner configurations when resetting heroic

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -111,7 +111,7 @@
         },
         "reset-heroic": {
             "question": {
-                "message": "Are you sure you want to reset Heroic? This will remove all Settings and Caching but won't remove your Installed games or your Epic credentials. Portable versions (AppImage, WinPortable, ...) of heroic needs to be restarted manually afterwards.",
+                "message": "Are you sure you want to reset Heroic? This will remove all Settings and Caching. Portable versions (AppImage, WinPortable, ...) of heroic needs to be restarted manually afterwards.",
                 "title": "Reset Heroic"
             }
         },
@@ -765,7 +765,7 @@
             },
             "details": "Details",
             "resetHeroic": {
-                "help": "This will remove all Settings and Caching but won't remove your Installed games or your Epic credentials. Portable versions (AppImage, WinPortable, ...) of heroic needs to be restarted manually afterwards."
+                "help": "This will remove all Settings and Caching. Portable versions (AppImage, WinPortable, ...) of heroic needs to be restarted manually afterwards."
             },
             "title": {
                 "clearCache": "Clear Cache",

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -34,7 +34,10 @@ import {
   GITHUB_API,
   isMac,
   configStore,
-  isLinux
+  isLinux,
+  legendaryConfigPath,
+  gogdlConfigPath,
+  nileConfigPath
 } from './constants'
 import {
   appendGamePlayLog,
@@ -414,7 +417,13 @@ function clearCache(
 }
 
 function resetHeroic() {
-  const appFolders = [gamesConfigPath, configPath]
+  const appFolders = [
+    gamesConfigPath,
+    configPath,
+    legendaryConfigPath,
+    gogdlConfigPath,
+    nileConfigPath
+  ]
   appFolders.forEach((folder) => {
     rmSync(folder, { recursive: true, force: true })
   })

--- a/src/frontend/screens/Settings/components/ResetHeroic.tsx
+++ b/src/frontend/screens/Settings/components/ResetHeroic.tsx
@@ -16,7 +16,7 @@ const ResetHeroic = () => {
       <InfoBox text={t('settings.advanced.details', 'Details')}>
         {t(
           'settings.advanced.resetHeroic.help',
-          "This will remove all Settings and Caching but won't remove your Installed games or your Epic credentials. Portable versions (AppImage, WinPortable, ...) of heroic needs to be restarted manually afterwards."
+          "This will remove all Settings and Caching. Portable versions (AppImage, WinPortable, ...) of heroic needs to be restarted manually afterwards."
         )}
       </InfoBox>
       <button className="button is-footer is-danger" onClick={showResetDialog}>

--- a/src/frontend/screens/Settings/components/ResetHeroic.tsx
+++ b/src/frontend/screens/Settings/components/ResetHeroic.tsx
@@ -16,7 +16,7 @@ const ResetHeroic = () => {
       <InfoBox text={t('settings.advanced.details', 'Details')}>
         {t(
           'settings.advanced.resetHeroic.help',
-          "This will remove all Settings and Caching. Portable versions (AppImage, WinPortable, ...) of heroic needs to be restarted manually afterwards."
+          'This will remove all Settings and Caching. Portable versions (AppImage, WinPortable, ...) of heroic needs to be restarted manually afterwards.'
         )}
       </InfoBox>
       <button className="button is-footer is-danger" onClick={showResetDialog}>

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -432,7 +432,7 @@ class GlobalState extends PureComponent<Props> {
       title: t('box.reset-heroic.question.title', 'Reset Heroic'),
       message: t(
         'box.reset-heroic.question.message',
-        "Are you sure you want to reset Heroic? This will remove all Settings and Caching but won't remove your Installed games or your Epic credentials. Portable versions (AppImage, WinPortable, ...) of heroic needs to be restarted manually afterwards."
+        'Are you sure you want to reset Heroic? This will remove all Settings and Caching. Portable versions (AppImage, WinPortable, ...) of heroic needs to be restarted manually afterwards.'
       ),
       buttons: [
         { text: t('box.yes'), onClick: window.api.resetHeroic },


### PR DESCRIPTION
Some people are having issues with nile, and have to manually delete these files, so I propose making heroic do this automatically when it is reset

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
