### PR TITLE
[FIX]: gog setup regression for v1 games

### DIFF
--- a/src/backend/storeManagers/gog/setup.ts
+++ b/src/backend/storeManagers/gog/setup.ts
@@ -173,11 +173,11 @@ async function setup(
     context: 'GOG'
   })
   if (manifestData.version === 1) {
-    if (existsSync(gameSupportDir)) {
+    if (existsSync(path.join(gogSupportPath, appName))) {
       for (const supportCommand of manifestData.product?.support_commands ||
         []) {
         if (
-          !supportCommand.languages.includes(
+          supportCommand.languages.includes(
             gameInfo.install.language ?? 'English'
           ) ||
           supportCommand.languages.includes('Neutral')


### PR DESCRIPTION
On Linux we were looking at the windows version of the path which was always false.


Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
