### PR TITLE
Render SelectFields as MUI Selects

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -4,8 +4,7 @@ import {
   AppSettings,
   GameSettings,
   DiskSpaceData,
-  StatusPromise,
-  GamepadInputEvent
+  StatusPromise
 } from 'common/types'
 import * as path from 'path'
 import {
@@ -1222,7 +1221,11 @@ ipcMain.handle('gamepadAction', async (event, args) => {
   const mainWindow = getMainWindow()!
 
   const { action, metadata } = args
-  const inputEvents: GamepadInputEvent[] = []
+  const inputEvents: (
+    | Electron.MouseInputEvent
+    | Electron.MouseWheelInputEvent
+    | Electron.KeyboardInputEvent
+  )[] = []
 
   /*
    * How to extend:
@@ -1307,6 +1310,32 @@ ipcMain.handle('gamepadAction', async (event, args) => {
         type: 'keyUp',
         keyCode: 'Esc'
       })
+      break
+    case 'tab':
+      inputEvents.push(
+        {
+          type: 'keyDown',
+          keyCode: 'Tab'
+        },
+        {
+          type: 'keyUp',
+          keyCode: 'Tab'
+        }
+      )
+      break
+    case 'shiftTab':
+      inputEvents.push(
+        {
+          type: 'keyDown',
+          keyCode: 'Tab',
+          modifiers: ['shift']
+        },
+        {
+          type: 'keyUp',
+          keyCode: 'Tab',
+          modifiers: ['shift']
+        }
+      )
       break
   }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -366,30 +366,6 @@ export interface GOGImportData {
   dlcs: string[]
 }
 
-export type GamepadInputEvent =
-  | GamepadInputEventKey
-  | GamepadInputEventWheel
-  | GamepadInputEventMouse
-
-interface GamepadInputEventKey {
-  type: 'keyDown' | 'keyUp' | 'char'
-  keyCode: string
-}
-
-interface GamepadInputEventWheel {
-  type: 'mouseWheel'
-  deltaY: number
-  x: number
-  y: number
-}
-
-interface GamepadInputEventMouse {
-  type: 'mouseDown' | 'mouseUp'
-  x: number
-  y: number
-  button: 'left' | 'middle' | 'right'
-}
-
 export interface SteamRuntime {
   path: string
   type: 'sniper' | 'scout' | 'soldier'
@@ -560,6 +536,8 @@ interface GamepadActionArgsWithoutMetadata {
     | 'back'
     | 'altAction'
     | 'esc'
+    | 'tab'
+    | 'shiftTab'
   metadata?: undefined
 }
 

--- a/src/frontend/App.css
+++ b/src/frontend/App.css
@@ -56,7 +56,8 @@ body {
   position: sticky;
   bottom: 0px;
   background: var(--background);
-  z-index: 10;
+  /* MUI Dialogs use a z-index of 1300, make sure this is never less than it */
+  z-index: 1400;
 }
 
 .App .offline-message {

--- a/src/frontend/components/UI/ControllerHints/index.tsx
+++ b/src/frontend/components/UI/ControllerHints/index.tsx
@@ -57,7 +57,7 @@ export default function ControllerHints() {
         'controller.hints.open_virtual_keyboard',
         'Open virtual keyboard'
       )
-    } else if (target.closest('.MuiMenu-list')) {
+    } else if (target.closest('.contextMenu')) {
       // focusing a context menu on a card or list item
       main = t('controller.hints.select', 'Select')
       back = t('controller.hints.back', 'Back')
@@ -70,6 +70,9 @@ export default function ControllerHints() {
       alt2 = t('controller.hints.space', 'Space')
     } else if (installDialog) {
       back = t('controller.hints.close_dialog', 'Close dialog')
+    } else if (target.closest('.MuiList-root')) {
+      main = t('controller.hints.select', 'Select')
+      back = t('controller.hints.close_options', 'Close options')
     }
 
     setMainActionHint(main)

--- a/src/frontend/components/UI/Dialog/components/Dialog.tsx
+++ b/src/frontend/components/UI/Dialog/components/Dialog.tsx
@@ -58,14 +58,16 @@ export const Dialog: React.FC<DialogProps> = ({
   return (
     <MuiDialog
       open={open}
-      onClose={close}
+      onClose={(e, reason) => {
+        if (disableDialogBackdropClose && reason === 'backdropClick') return
+        close()
+      }}
       scroll="paper"
       maxWidth="md"
       PaperComponent={StyledPaper}
       PaperProps={{
         className
       }}
-      disableEscapeKeyDown={disableDialogBackdropClose}
       sx={{
         '& .Dialog__element': {
           maxWidth: 'min(700px, 85vw)',

--- a/src/frontend/components/UI/Dialog/components/Dialog.tsx
+++ b/src/frontend/components/UI/Dialog/components/Dialog.tsx
@@ -39,20 +39,21 @@ export const Dialog: React.FC<DialogProps> = ({
   onClose
 }) => {
   const [open, setOpen] = useState(true)
-  const [focusOnClose, setFocusOnClose] = useState<HTMLElement | null>(null)
   const { disableDialogBackdropClose } = useContext(ContextProvider)
 
   useEffect(() => {
-    setFocusOnClose(document.querySelector<HTMLElement>('*:focus'))
+    // HACK: Focussing the dialog using JS does not seem to work
+    //       Instead, simulate one or two tab presses
+    // One tab to focus the dialog
+    window.api.gamepadAction({ action: 'tab' })
+    // Second tab to skip the close button if it's shown
+    if (showCloseButton) window.api.gamepadAction({ action: 'tab' })
   }, [])
 
   const close = useCallback(() => {
     setOpen(false)
     onClose()
-    if (focusOnClose) {
-      setTimeout(() => focusOnClose.focus(), 200)
-    }
-  }, [onClose, focusOnClose])
+  }, [onClose])
 
   return (
     <MuiDialog

--- a/src/frontend/components/UI/Dialog/components/Dialog.tsx
+++ b/src/frontend/components/UI/Dialog/components/Dialog.tsx
@@ -1,16 +1,20 @@
-import { faXmark } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import ContextProvider from 'frontend/state/ContextProvider'
 import React, {
-  KeyboardEvent,
   ReactNode,
-  SyntheticEvent,
   useCallback,
   useContext,
   useEffect,
-  useRef,
   useState
 } from 'react'
+import {
+  Dialog as MuiDialog,
+  DialogContent,
+  IconButton,
+  Paper,
+  styled
+} from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+
+import ContextProvider from 'frontend/state/ContextProvider'
 
 interface DialogProps {
   className?: string
@@ -19,15 +23,22 @@ interface DialogProps {
   onClose: () => void
 }
 
+const StyledPaper = styled(Paper)(() => ({
+  backgroundColor: 'var(--modal-background)',
+  color: 'var(--text-default)',
+  maxWidth: '100%',
+  '&:has(.settingsDialogContent)': {
+    height: '80%'
+  }
+}))
+
 export const Dialog: React.FC<DialogProps> = ({
   children,
   className,
   showCloseButton = false,
   onClose
 }) => {
-  const dialogRef = useRef<HTMLDialogElement | null>(null)
-  const onCloseRef = useRef(onClose)
-  onCloseRef.current = onClose
+  const [open, setOpen] = useState(true)
   const [focusOnClose, setFocusOnClose] = useState<HTMLElement | null>(null)
   const { disableDialogBackdropClose } = useContext(ContextProvider)
 
@@ -35,84 +46,49 @@ export const Dialog: React.FC<DialogProps> = ({
     setFocusOnClose(document.querySelector<HTMLElement>('*:focus'))
   }, [])
 
-  const close = () => {
-    onCloseRef.current()
+  const close = useCallback(() => {
+    setOpen(false)
+    onClose()
     if (focusOnClose) {
       setTimeout(() => focusOnClose.focus(), 200)
     }
-  }
-
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (dialog) {
-      const cancel = () => {
-        close()
-      }
-      dialog.addEventListener('cancel', cancel)
-
-      if (disableDialogBackdropClose) {
-        dialog['showPopover']()
-
-        return () => {
-          dialog.removeEventListener('cancel', cancel)
-          dialog['hidePopover']()
-        }
-      } else {
-        dialog.showModal()
-
-        return () => {
-          dialog.removeEventListener('cancel', cancel)
-          dialog.close()
-        }
-      }
-    }
-    return
-  }, [dialogRef.current, disableDialogBackdropClose])
-
-  const onDialogClick = useCallback(
-    (e: SyntheticEvent) => {
-      if (e.target === dialogRef.current) {
-        const ev = e.nativeEvent as MouseEvent
-        const tg = e.target as HTMLElement
-        if (
-          ev.offsetX < 0 ||
-          ev.offsetX > tg.offsetWidth ||
-          ev.offsetY < 0 ||
-          ev.offsetY > tg.offsetHeight
-        ) {
-          close()
-        }
-      }
-    },
-    [onClose]
-  )
-
-  const closeIfEsc = (event: KeyboardEvent<HTMLDialogElement>) => {
-    if (event.key === 'Escape') {
-      close()
-    }
-  }
+  }, [onClose, focusOnClose])
 
   return (
-    <div className="Dialog">
-      <dialog
-        className={`Dialog__element ${className}`}
-        ref={dialogRef}
-        onClick={onDialogClick}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore, this feature is new and not yet typed
-        popover="manual"
-        onKeyUp={closeIfEsc}
-      >
+    <MuiDialog
+      open={open}
+      onClose={close}
+      scroll="paper"
+      maxWidth="md"
+      PaperComponent={StyledPaper}
+      PaperProps={{
+        className
+      }}
+      disableEscapeKeyDown={disableDialogBackdropClose}
+      sx={{
+        '& .Dialog__element': {
+          maxWidth: 'min(700px, 85vw)',
+          paddingTop: 'var(--dialog-margin-vertical)'
+        }
+      }}
+    >
+      <>
         {showCloseButton && (
-          <div className="Dialog__Close">
-            <button className="Dialog__CloseButton" onClick={close}>
-              <FontAwesomeIcon className="Dialog__CloseIcon" icon={faXmark} />
-            </button>
-          </div>
+          <IconButton
+            aria-label="close"
+            onClick={close}
+            sx={{
+              position: 'absolute',
+              right: 8,
+              top: 8,
+              color: 'var(--text-default)'
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
         )}
-        {children}
-      </dialog>
-    </div>
+        <DialogContent>{children}</DialogContent>
+      </>
+    </MuiDialog>
   )
 }

--- a/src/frontend/components/UI/Dialog/components/DialogContent.tsx
+++ b/src/frontend/components/UI/Dialog/components/DialogContent.tsx
@@ -9,5 +9,5 @@ export const DialogContent: React.FC<Props> = ({
   children,
   className
 }: Props) => {
-  return <div className={`Dialog__content ${className}`}>{children}</div>
+  return <div className={className}>{children}</div>
 }

--- a/src/frontend/components/UI/Dialog/components/DialogHeader.tsx
+++ b/src/frontend/components/UI/Dialog/components/DialogHeader.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react'
+import { DialogTitle } from '@mui/material'
 
 interface DialogHeaderProps {
   onClose?: () => void
@@ -7,8 +8,15 @@ interface DialogHeaderProps {
 
 export const DialogHeader: React.FC<DialogHeaderProps> = ({ children }) => {
   return (
-    <div className="Dialog__header">
-      <h1 className="Dialog__headerTitle">{children}</h1>
-    </div>
+    <DialogTitle
+      sx={{
+        fontFamily: 'var(--primary-font-family)',
+        fontSize: 'var(--text-xl)',
+        fontWeight: 'var(--bold)',
+        paddingLeft: 0
+      }}
+    >
+      {children}
+    </DialogTitle>
   )
 }

--- a/src/frontend/components/UI/LanguageSelector/index.tsx
+++ b/src/frontend/components/UI/LanguageSelector/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { configStore } from 'frontend/helpers/electronStores'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { SelectField } from '..'
+import { MenuItem } from '@mui/material'
 
 const storage: Storage = window.localStorage
 
@@ -134,9 +135,9 @@ export default function LanguageSelector({
     if (flagPossition === FlagPosition.APPEND) label = `${label} ${flag}`
 
     return (
-      <option key={lang} value={lang}>
+      <MenuItem key={lang} value={lang}>
         {label}
-      </option>
+      </MenuItem>
     )
   }
 

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -44,9 +44,22 @@
   min-width: 100px;
 }
 
+/* hide the second arrow */
+.selectFieldWrapper .MuiOutlinedInput-root .MuiSvgIcon-root {
+  opacity: 0%;
+}
+
+.selectFieldWrapper .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline .css-ihdtdm {
+  width: 0;
+}
+
 .MuiPopover-root .MuiPaper-root {
   color: var(--text-secondary);
   background-color: var(--input-background);
+}
+
+.MuiPopover-root .MuiPaper-root .MuiMenuItem-root {
+  font-family: var(--primary-font-family);
 }
 
 .selectStyle {

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -4,7 +4,8 @@
 }
 
 .selectFieldWrapper select,
-.selectFieldWrapper .MuiOutlinedInput-root {
+.selectFieldWrapper .MuiOutlinedInput-root,
+.selectStyle {
   border-radius: var(--space-3xs);
   grid-area: select;
   width: 100%;

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -4,7 +4,7 @@
 }
 
 .selectFieldWrapper select,
-.selectStyle {
+.selectFieldWrapper .MuiOutlinedInput-root {
   border-radius: var(--space-3xs);
   grid-area: select;
   width: 100%;
@@ -42,6 +42,11 @@
   -webkit-appearance: none;
   -moz-appearance: none;
   min-width: 100px;
+}
+
+.MuiPopover-root .MuiPaper-root {
+  color: var(--text-secondary);
+  background-color: var(--input-background);
 }
 
 .selectStyle {

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -50,7 +50,10 @@
   opacity: 0%;
 }
 
-.selectFieldWrapper .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline .css-ihdtdm {
+.selectFieldWrapper
+  .MuiOutlinedInput-root
+  .MuiOutlinedInput-notchedOutline
+  .css-ihdtdm {
   width: 0;
 }
 

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -44,11 +44,6 @@
   min-width: 100px;
 }
 
-/* hide the second arrow */
-.selectFieldWrapper .MuiOutlinedInput-root .MuiSvgIcon-root {
-  opacity: 0%;
-}
-
 .MuiPopover-root .MuiPaper-root {
   color: var(--text-secondary);
   background-color: var(--input-background);

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -47,10 +47,10 @@
 .MuiPopover-root .MuiPaper-root {
   color: var(--text-secondary);
   background-color: var(--input-background);
-}
 
-.MuiPopover-root .MuiPaper-root .MuiMenuItem-root {
-  font-family: var(--primary-font-family);
+  .MuiMenuItem-root {
+    font-family: var(--primary-font-family);
+  }
 }
 
 .selectStyle {

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -3,7 +3,6 @@
   grid-template-areas: 'label' 'select';
 }
 
-.selectFieldWrapper select,
 .selectStyle,
 .selectFieldWrapper .MuiOutlinedInput-root {
   border-radius: var(--space-3xs);
@@ -57,7 +56,7 @@
   padding-inline-end: 4rem;
 }
 
-.selectFieldWrapper.isRTL select {
+.selectFieldWrapper.isRTL .MuiOutlinedInput-root {
   background-position:
     calc(15px) calc(50% + 1px),
     calc(20px) calc(50% + 1px),

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -14,7 +14,6 @@
   font-family: var(--primary-font-family), 'Noto Color Emoji';
   font-weight: normal;
   font-size: var(--text-md);
-  line-height: 19px;
   color: var(--text-secondary);
   text-indent: 22px;
   border: none;

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -14,7 +14,6 @@
   font-weight: normal;
   font-size: var(--text-md);
   color: var(--text-secondary);
-  text-indent: 22px;
   border: none;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   cursor: pointer;

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -49,13 +49,6 @@
   opacity: 0%;
 }
 
-.selectFieldWrapper
-  .MuiOutlinedInput-root
-  .MuiOutlinedInput-notchedOutline
-  .css-ihdtdm {
-  width: 0;
-}
-
 .MuiPopover-root .MuiPaper-root {
   color: var(--text-secondary);
   background-color: var(--input-background);

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -4,8 +4,8 @@
 }
 
 .selectFieldWrapper select,
-.selectFieldWrapper .MuiOutlinedInput-root,
-.selectStyle {
+.selectStyle,
+.selectFieldWrapper .MuiOutlinedInput-root {
   border-radius: var(--space-3xs);
   grid-area: select;
   width: 100%;

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -52,6 +52,7 @@
 }
 
 .selectStyle {
+  text-indent: 22px;
   padding-inline-end: 4rem;
 }
 

--- a/src/frontend/components/UI/SelectField/index.tsx
+++ b/src/frontend/components/UI/SelectField/index.tsx
@@ -1,12 +1,13 @@
-import React, { ChangeEvent, ReactNode, useContext } from 'react'
+import React, { ReactNode, useContext } from 'react'
 import classnames from 'classnames'
 import ContextProvider from 'frontend/state/ContextProvider'
+import { Select, MenuItem, SelectChangeEvent } from '@mui/material'
 import './index.css'
 
 interface SelectFieldProps {
   htmlId: string
   value: string
-  onChange: (event: ChangeEvent<HTMLSelectElement>) => void
+  onChange: (event: SelectChangeEvent) => void
   children: ReactNode
   afterSelect?: ReactNode
   label?: string
@@ -15,7 +16,7 @@ interface SelectFieldProps {
   extraClass?: string
 }
 
-const SelectField = ({
+export default function SelectField({
   htmlId,
   value,
   onChange,
@@ -25,7 +26,7 @@ const SelectField = ({
   extraClass = '',
   afterSelect,
   children
-}: SelectFieldProps) => {
+}: SelectFieldProps) {
   const { isRTL } = useContext(ContextProvider)
 
   return (
@@ -35,13 +36,11 @@ const SelectField = ({
       })}
     >
       {label && <label htmlFor={htmlId}>{label}</label>}
-      <select id={htmlId} value={value} onChange={onChange} disabled={disabled}>
-        {prompt && <option value="">{prompt}</option>}
+      <Select id={htmlId} value={value} onChange={onChange} disabled={disabled}>
+        {prompt && <MenuItem value="">{prompt}</MenuItem>}
         {children}
-      </select>
+      </Select>
       {afterSelect}
     </div>
   )
 }
-
-export default React.memo(SelectField)

--- a/src/frontend/components/UI/SelectField/index.tsx
+++ b/src/frontend/components/UI/SelectField/index.tsx
@@ -44,6 +44,9 @@ export default function SelectField({
         sx={{
           '& .MuiSelect-icon': { display: 'none' },
           '& .MuiOutlinedInput-notchedOutline legend': { width: 0 },
+          '& .MuiSelect-select': {
+            width: 'auto'
+          }
         }}
       >
         {prompt && <MenuItem value="">{prompt}</MenuItem>}

--- a/src/frontend/components/UI/SelectField/index.tsx
+++ b/src/frontend/components/UI/SelectField/index.tsx
@@ -42,6 +42,7 @@ export default function SelectField({
         onChange={onChange}
         disabled={disabled}
         sx={{
+          '& .MuiSelect-icon': { display: 'none' },
           '& .MuiOutlinedInput-notchedOutline legend': { width: 0 },
         }}
       >

--- a/src/frontend/components/UI/SelectField/index.tsx
+++ b/src/frontend/components/UI/SelectField/index.tsx
@@ -45,8 +45,7 @@ export default function SelectField({
           '& .MuiSelect-icon': { display: 'none' },
           '& .MuiOutlinedInput-notchedOutline legend': { width: 0 },
           '& .MuiSelect-select': {
-            textAlign: isRTL ? 'right' : 'left',
-            paddingLeft: 0
+            textAlign: isRTL ? 'right' : 'left'
           }
         }}
       >

--- a/src/frontend/components/UI/SelectField/index.tsx
+++ b/src/frontend/components/UI/SelectField/index.tsx
@@ -36,7 +36,15 @@ export default function SelectField({
       })}
     >
       {label && <label htmlFor={htmlId}>{label}</label>}
-      <Select id={htmlId} value={value} onChange={onChange} disabled={disabled}>
+      <Select
+        id={htmlId}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        sx={{
+          '& .MuiOutlinedInput-notchedOutline legend': { width: 0 },
+        }}
+      >
         {prompt && <MenuItem value="">{prompt}</MenuItem>}
         {children}
       </Select>

--- a/src/frontend/components/UI/SelectField/index.tsx
+++ b/src/frontend/components/UI/SelectField/index.tsx
@@ -45,7 +45,7 @@ export default function SelectField({
           '& .MuiSelect-icon': { display: 'none' },
           '& .MuiOutlinedInput-notchedOutline legend': { width: 0 },
           '& .MuiSelect-select': {
-            width: 'auto',
+            textAlign: isRTL ? 'right' : 'left',
             paddingLeft: 0
           }
         }}

--- a/src/frontend/components/UI/SelectField/index.tsx
+++ b/src/frontend/components/UI/SelectField/index.tsx
@@ -45,7 +45,8 @@ export default function SelectField({
           '& .MuiSelect-icon': { display: 'none' },
           '& .MuiOutlinedInput-notchedOutline legend': { width: 0 },
           '& .MuiSelect-select': {
-            width: 'auto'
+            width: 'auto',
+            paddingLeft: 0
           }
         }}
       >

--- a/src/frontend/components/UI/ThemeSelector/index.tsx
+++ b/src/frontend/components/UI/ThemeSelector/index.tsx
@@ -5,6 +5,7 @@ import { SelectField, InfoBox, PathSelectionBox } from '..'
 import { AppSettings } from 'common/types'
 import { writeConfig } from 'frontend/helpers'
 import { hasHelp } from 'frontend/hooks/hasHelp'
+import { MenuItem } from '@mui/material'
 
 export const defaultThemes: Record<string, string> = {
   midnightMirage: 'Midnight Mirage',
@@ -75,9 +76,9 @@ export const ThemeSelector = () => {
         value={theme}
       >
         {themes.map((key) => (
-          <option key={key} value={key}>
+          <MenuItem key={key} value={key}>
             {defaultThemes[key] || key}
-          </option>
+          </MenuItem>
         ))}
       </SelectField>
 

--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -57,7 +57,9 @@ export const initGamepad = () => {
     altAction: { triggeredAt: {}, repeatDelay: false },
     rightClick: { triggeredAt: {}, repeatDelay: false },
     leftClick: { triggeredAt: {}, repeatDelay: false },
-    esc: { triggeredAt: {}, repeatDelay: false }
+    esc: { triggeredAt: {}, repeatDelay: false },
+    tab: { triggeredAt: {}, repeatDelay: false },
+    shiftTab: { triggeredAt: {}, repeatDelay: false }
   }
 
   // check if an action should be triggered
@@ -160,6 +162,22 @@ export const initGamepad = () => {
             VirtualKeyboardController.backspace()
             return
           }
+          break
+        case 'padDown':
+        case 'leftStickDown':
+          // MUI Selects open on arrow down, which is usually not your intention
+          // when navigating down with the stick, so we change the action to tab
+          if (isMuiSelect()) {
+            action = 'tab'
+          }
+          break
+        case 'padUp':
+        case 'leftStickUp':
+          // Same as above
+          if (isMuiSelect()) {
+            action = 'shiftTab'
+          }
+          break
       }
 
       if (action === 'mainAction') {
@@ -185,7 +203,7 @@ export const initGamepad = () => {
 
   const currentElement = () => document.querySelector<HTMLElement>(':focus')
 
-  const shouldSimulateClick = isSelect
+  const shouldSimulateClick = () => isSelect() || isMuiSelect()
   function isSelect() {
     const el = currentElement()
     if (!el) return false
@@ -220,6 +238,13 @@ export const initGamepad = () => {
     if (!parent) return false
 
     return parent.classList.contains('MuiMenu-list')
+  }
+
+  function isMuiSelect() {
+    const el = currentElement()
+    if (!el) return false
+
+    return el.classList.contains('MuiSelect-select')
   }
 
   function playable() {

--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -291,18 +291,18 @@ export const initGamepad = () => {
     const el = currentElement()
     if (!el) return false
 
-    return !!el.closest('.Dialog__element')
+    return !!el.closest('.MuiDialog-root')
   }
 
   function closeDialog() {
     const el = currentElement()
     if (!el) return false
 
-    const dialog = el.closest('.Dialog__element')
+    const dialog = el.closest('.MuiDialog-root')
     if (!dialog) return false
 
     const closeButton = dialog.querySelector<HTMLButtonElement>(
-      '.Dialog__CloseButton'
+      '[aria-label="close"]'
     )
     if (!closeButton) return false
 

--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -143,6 +143,8 @@ export const initGamepad = () => {
             el?.blur()
             el?.focus()
             return
+          } else if (isInMuiPopover()) {
+            action = 'tab'
           } else if (isContextMenu()) {
             action = 'rightClick'
           }
@@ -245,6 +247,13 @@ export const initGamepad = () => {
     if (!el) return false
 
     return el.classList.contains('MuiSelect-select')
+  }
+
+  function isInMuiPopover() {
+    const el = currentElement()
+    if (!el) return false
+
+    return !!el.closest('.MuiPopover-root')
   }
 
   function playable() {

--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -172,6 +172,9 @@ export const initGamepad = () => {
           if (isMuiSelect()) {
             action = 'tab'
           }
+          if (isMuiDialogCloseButton()) {
+            action = 'tab'
+          }
           break
         case 'padUp':
         case 'leftStickUp':
@@ -247,6 +250,18 @@ export const initGamepad = () => {
     if (!el) return false
 
     return el.classList.contains('MuiSelect-select')
+  }
+
+  function isMuiDialogCloseButton() {
+    const el = currentElement()
+    if (!el) return false
+
+    const isIconButton = el.classList.contains('MuiIconButton-root')
+    if (!isIconButton) return false
+
+    const parent = el.parentElement
+    if (!parent) return false
+    return parent.classList.contains('MuiDialog-paper')
   }
 
   function isInMuiPopover() {

--- a/src/frontend/screens/Accessibility/index.tsx
+++ b/src/frontend/screens/Accessibility/index.tsx
@@ -19,6 +19,7 @@ import SettingsContext from '../Settings/SettingsContext'
 import useSettingsContext from '../../hooks/useSettingsContext'
 import './index.css'
 import { hasHelp } from 'frontend/hooks/hasHelp'
+import { MenuItem, SelectChangeEvent } from '@mui/material'
 
 const Accessibility = React.memo(function Accessibility() {
   const { t } = useTranslation()
@@ -94,12 +95,12 @@ const Accessibility = React.memo(function Accessibility() {
     setZoomPercent(parseInt(event.target.value))
   }
 
-  const handleContentFontFamily = (event: ChangeEvent<HTMLSelectElement>) => {
+  const handleContentFontFamily = (event: SelectChangeEvent) => {
     setSecondaryFontFamily(event.target.value)
     setContentFont(event.target.value)
   }
 
-  const handleActionsFontFamily = (event: ChangeEvent<HTMLSelectElement>) => {
+  const handleActionsFontFamily = (event: SelectChangeEvent) => {
     setPrimaryFontFamily(event.target.value)
     setActionFont(event.target.value)
   }
@@ -108,9 +109,9 @@ const Accessibility = React.memo(function Accessibility() {
     return fonts.map((font) => {
       const style: CSSProperties = { fontFamily: font }
       return (
-        <option key={font} value={font} style={style}>
+        <MenuItem key={font} value={font} style={style}>
           {font}
-        </option>
+        </MenuItem>
       )
     })
   }, [fonts])

--- a/src/frontend/screens/Game/GamePage/components/LaunchOptions.tsx
+++ b/src/frontend/screens/Game/GamePage/components/LaunchOptions.tsx
@@ -3,6 +3,7 @@ import GameContext from '../../GameContext'
 import { GameInfo, LaunchOption } from 'common/types'
 import { useTranslation } from 'react-i18next'
 import { SelectField } from 'frontend/components/UI'
+import { MenuItem } from '@mui/material'
 
 interface Props {
   gameInfo: GameInfo
@@ -56,9 +57,9 @@ const LaunchOptions = ({ gameInfo, setLaunchArguments }: Props) => {
       prompt={t('launch.options', 'Launch Options...')}
     >
       {launchOptions.map((option, index) => (
-        <option key={index} value={index}>
+        <MenuItem key={index} value={index}>
           {labelForLaunchOption(option)}
-        </option>
+        </MenuItem>
       ))}
     </SelectField>
   )

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/BranchSelector.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/BranchSelector.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { SelectField, TextInputField } from 'frontend/components/UI'
 import { useTranslation } from 'react-i18next'
 import { Dialog, DialogContent } from 'frontend/components/UI/Dialog'
+import { MenuItem } from '@mui/material'
 
 interface BranchSelectorProps {
   appName: string
@@ -94,16 +95,16 @@ export default function BranchSelector({
         }}
       >
         {branches.map((branch) => (
-          <option value={String(branch)} key={String(branch)}>
+          <MenuItem value={String(branch)} key={String(branch)}>
             {branch || t('game.branch.disabled', 'Disabled')}
-          </option>
+          </MenuItem>
         ))}
-        <option value={'heroic-update-passwordOption'}>
+        <MenuItem value={'heroic-update-passwordOption'}>
           {t(
             'game.branch.setPrivateBranchPassword',
             'Set private channel password'
           )}
-        </option>
+        </MenuItem>
       </SelectField>
     </div>
   )

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/BuildSelector.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/BuildSelector.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { SelectField, ToggleSwitch } from 'frontend/components/UI'
 import { useTranslation } from 'react-i18next'
 import { BuildItem } from 'common/types/gog'
+import { MenuItem } from '@mui/material'
 
 interface BuildSelectorProps {
   gameBuilds: BuildItem[]
@@ -49,12 +50,12 @@ export default function BuildSelector({
           onChange={(e) => setSelectedBuild(e.target.value)}
         >
           {gameBuilds.map((build) => (
-            <option key={`build-${build.build_id}`} value={build.build_id}>
+            <MenuItem key={`build-${build.build_id}`} value={build.build_id}>
               <>
                 {t('game.builds.version', 'Version')} {build.version_name} -{' '}
                 {getFormattedDate(build.date_published)}
               </>
-            </option>
+            </MenuItem>
           ))}
         </SelectField>
       )}

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/GameLanguageSelector.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/GameLanguageSelector.tsx
@@ -2,6 +2,7 @@ import { InstallPlatform } from 'common/types'
 import { SelectField } from 'frontend/components/UI'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { MenuItem } from '@mui/material'
 
 interface GameLanguageSelectorProps {
   installLanguages: string[]
@@ -45,9 +46,9 @@ export default function GameLanguageSelector({
     >
       {installLanguages &&
         installLanguages.map((value) => (
-          <option value={value} key={value}>
+          <MenuItem value={value} key={value}>
             {getLanguageName(value)}
-          </option>
+          </MenuItem>
         ))}
     </SelectField>
   )

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -10,6 +10,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { removeSpecialcharacters } from 'frontend/helpers'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faWarning } from '@fortawesome/free-solid-svg-icons'
+import { MenuItem } from '@mui/material'
 
 type Props = {
   setWineVersion: React.Dispatch<
@@ -149,9 +150,9 @@ export default function WineSelector({
           >
             {wineVersionList &&
               wineVersionList.map(({ name }, i) => (
-                <option value={name} key={i}>
+                <MenuItem value={name} key={i}>
                   {name}
-                </option>
+                </MenuItem>
               ))}
           </SelectField>
         </>

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -20,6 +20,7 @@ import WineSelector from './WineSelector'
 import { SelectField } from 'frontend/components/UI'
 import { useTranslation } from 'react-i18next'
 import ThirdPartyDialog from './ThirdPartyDialog'
+import { MenuItem } from '@mui/material'
 
 type Props = {
   appName: string
@@ -144,9 +145,9 @@ export default React.memo(function InstallModal({
         }
       >
         {availablePlatforms.map((p, i) => (
-          <option value={p.value} key={i}>
+          <MenuItem value={p.value} key={i}>
             {p.name}
-          </option>
+          </MenuItem>
         ))}
       </SelectField>
     )

--- a/src/frontend/screens/Settings/components/CustomWineProton.tsx
+++ b/src/frontend/screens/Settings/components/CustomWineProton.tsx
@@ -4,7 +4,7 @@ import { SelectField, SvgButton } from 'frontend/components/UI'
 import ContextProvider from 'frontend/state/ContextProvider'
 import useSetting from 'frontend/hooks/useSetting'
 import SettingsContext from '../SettingsContext'
-import { Tooltip } from '@mui/material'
+import { MenuItem, Tooltip } from '@mui/material'
 import AddBoxIcon from '@mui/icons-material/AddBox'
 import RemoveCircleIcon from '@mui/icons-material/RemoveCircle'
 
@@ -97,7 +97,9 @@ export default function CustomWineProton() {
       }
     >
       {customWinePaths.map((path: string) => (
-        <option key={path}>{path}</option>
+        <MenuItem key={path} value={path}>
+          {path}
+        </MenuItem>
       ))}
     </SelectField>
   )

--- a/src/frontend/screens/Settings/components/EnableFSR.tsx
+++ b/src/frontend/screens/Settings/components/EnableFSR.tsx
@@ -6,6 +6,7 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import SettingsContext from '../SettingsContext'
+import { MenuItem } from '@mui/material'
 
 const EnableFSR = () => {
   const { t } = useTranslation()
@@ -51,7 +52,9 @@ const EnableFSR = () => {
           extraClass="smaller"
         >
           {Array.from(Array(5).keys()).map((n) => (
-            <option key={n + 1}>{n + 1}</option>
+            <MenuItem key={n + 1} value={n + 1}>
+              {n + 1}
+            </MenuItem>
           ))}
         </SelectField>
       )}

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -10,6 +10,7 @@ import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import { MenuItem } from '@mui/material'
 
 const Gamescope = () => {
   const { t } = useTranslation()
@@ -147,18 +148,18 @@ const Gamescope = () => {
                 )}
               />
             }
-            onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+            onChange={(event) =>
               setGamescope({
                 ...gamescope,
-                upscaleMethod: event.currentTarget.value
+                upscaleMethod: event.target.value
               })
             }
             value={gamescope.upscaleMethod}
           >
             {upscaleMethods.map((el) => (
-              <option value={el.value} key={el.value}>
+              <MenuItem value={el.value} key={el.value}>
                 {el.name}
-              </option>
+              </MenuItem>
             ))}
           </SelectField>
           {/* Game Res */}
@@ -273,18 +274,18 @@ const Gamescope = () => {
           <SelectField
             label={'Window Type'}
             htmlId="windowType"
-            onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+            onChange={(event) =>
               setGamescope({
                 ...gamescope,
-                windowType: event.currentTarget.value
+                windowType: event.target.value
               })
             }
             value={gamescope.windowType}
           >
             {windowTypes.map((el) => (
-              <option value={el.value} key={el.value}>
+              <MenuItem value={el.value} key={el.value}>
                 {el.name}
-              </option>
+              </MenuItem>
             ))}
           </SelectField>
         </>

--- a/src/frontend/screens/Settings/components/LibraryTopSection.tsx
+++ b/src/frontend/screens/Settings/components/LibraryTopSection.tsx
@@ -1,9 +1,10 @@
-import React, { ChangeEvent, useContext } from 'react'
+import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SelectField } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { LibraryTopSectionOptions } from 'common/types'
+import { MenuItem, SelectChangeEvent } from '@mui/material'
 
 const LibraryTopSection = () => {
   const { t } = useTranslation()
@@ -13,9 +14,8 @@ const LibraryTopSection = () => {
     'disabled'
   )
 
-  const onSectionChange = (event: ChangeEvent) => {
-    const newValue = (event.target as HTMLSelectElement)
-      .value as LibraryTopSectionOptions
+  const onSectionChange = (event: SelectChangeEvent) => {
+    const newValue = event.target.value as LibraryTopSectionOptions
     handleLibraryTopSection(newValue)
     setLibraryTopSection(newValue)
   }
@@ -27,24 +27,24 @@ const LibraryTopSection = () => {
       onChange={onSectionChange}
       value={libraryTopSection}
     >
-      <option value="recently_played">
+      <MenuItem value="recently_played">
         {t(
           'setting.library_top_option.recently_played',
           'Recently Played Games'
         )}
-      </option>
-      <option value="recently_played_installed">
+      </MenuItem>
+      <MenuItem value="recently_played_installed">
         {t(
           'setting.library_top_option.recently_played_installed',
           'Recently Played Games (Only Installed)'
         )}
-      </option>
-      <option value="favourites">
+      </MenuItem>
+      <MenuItem value="favourites">
         {t('setting.library_top_option.favourites', 'Favourite Games')}
-      </option>
-      <option value="disabled">
+      </MenuItem>
+      <MenuItem value="disabled">
         {t('setting.library_top_option.disabled', 'Disabled')}
-      </option>
+      </MenuItem>
     </SelectField>
   )
 }

--- a/src/frontend/screens/Settings/components/MaxRecentGames.tsx
+++ b/src/frontend/screens/Settings/components/MaxRecentGames.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { SelectField } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import SettingsContext from '../SettingsContext'
+import { MenuItem } from '@mui/material'
 
 const MaxRecentGames = () => {
   const { t } = useTranslation()
@@ -23,7 +24,9 @@ const MaxRecentGames = () => {
       value={maxRecentGames.toString()}
     >
       {Array.from(Array(10).keys()).map((n) => (
-        <option key={n + 1}>{n + 1}</option>
+        <MenuItem key={n + 1} value={n + 1}>
+          {n + 1}
+        </MenuItem>
       ))}
     </SelectField>
   )

--- a/src/frontend/screens/Settings/components/MaxWorkers.tsx
+++ b/src/frontend/screens/Settings/components/MaxWorkers.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SelectField } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
+import { MenuItem } from '@mui/material'
 
 const MaxWorkers = () => {
   const { t } = useTranslation()
@@ -25,11 +26,13 @@ const MaxWorkers = () => {
       extraClass="smaller"
     >
       {Array.from(Array(maxCpus).keys()).map((n) => (
-        <option key={n + 1}>{n + 1}</option>
+        <MenuItem key={n + 1} value={n + 1}>
+          {n + 1}
+        </MenuItem>
       ))}
-      <option key={0} value={0}>
+      <MenuItem key={0} value={0}>
         Max
-      </option>
+      </MenuItem>
     </SelectField>
   )
 }

--- a/src/frontend/screens/Settings/components/SettingsModal/index.scss
+++ b/src/frontend/screens/Settings/components/SettingsModal/index.scss
@@ -10,17 +10,3 @@
     width: 100%;
   }
 }
-
-.InstallModal__dialog:has(.settingsDialogContent) {
-  margin-top: max(2rem, 13vh);
-  @media screen and (max-height: 800px) {
-    margin-top: max(2rem, 8vh);
-    .settingsDialogContent {
-      min-height: 70vh;
-    }
-  }
-
-  @media screen and (max-height: 700px) {
-    margin-top: max(2rem, 6vh);
-  }
-}

--- a/src/frontend/screens/Settings/components/WineVersionSelector.tsx
+++ b/src/frontend/screens/Settings/components/WineVersionSelector.tsx
@@ -25,6 +25,16 @@ export default function WineVersionSelector() {
     const getAltWine = async () => {
       setRefreshing(true)
       const wineList: WineInstallation[] = await window.api.getAlternativeWine()
+
+      // System Wine might change names (version strings) with updates. This
+      // will then lead to it not being found in the alt wine list, as it
+      // is indexed by name. To resolve this, search for the current Wine
+      // version by binary path and update it
+      const currentWine = wineList.find((wine) => wine.bin === wineVersion.bin)
+      if (currentWine) {
+        setWineVersion(currentWine)
+      }
+
       setAltWine(wineList)
       // Avoids not updating wine config when having one wine install only
       if (wineList && wineList.length === 1) {

--- a/src/frontend/screens/Settings/components/WineVersionSelector.tsx
+++ b/src/frontend/screens/Settings/components/WineVersionSelector.tsx
@@ -6,6 +6,7 @@ import { WineInstallation } from 'common/types'
 import useSetting from 'frontend/hooks/useSetting'
 import { defaultWineVersion } from '..'
 import { Link } from 'react-router-dom'
+import { MenuItem } from '@mui/material'
 
 export default function WineVersionSelector() {
   const { t } = useTranslation()
@@ -16,7 +17,7 @@ export default function WineVersionSelector() {
     'wineVersion',
     defaultWineVersion
   )
-  const [altWine, setAltWine] = useState<WineInstallation[]>([])
+  const [altWine, setAltWine] = useState<WineInstallation[]>()
   const [validWine, setValidWine] = useState(true)
   const [refreshing, setRefreshing] = useState(true)
 
@@ -45,6 +46,10 @@ export default function WineVersionSelector() {
     }
     updateWine()
   }, [wineVersion])
+
+  if (!altWine) {
+    return <></>
+  }
 
   return (
     <SelectField
@@ -104,9 +109,9 @@ export default function WineVersionSelector() {
       }
     >
       {altWine.map(({ name }, i) => (
-        <option key={i} value={name}>
+        <MenuItem key={i} value={name}>
           {name.replace(/(Proton-GE-Proton|Proton-GE)/, 'GE-Proton')}
-        </option>
+        </MenuItem>
       ))}
     </SelectField>
   )

--- a/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
@@ -14,6 +14,7 @@ import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 import { ProgressDialog } from 'frontend/components/UI/ProgressDialog'
 import SettingsContext from '../../SettingsContext'
 import TextWithProgress from 'frontend/components/UI/TextWithProgress'
+import { MenuItem } from '@mui/material'
 
 interface Props {
   gogSaves: GOGCloudSavesLocation[]
@@ -205,9 +206,9 @@ export default function GOGSyncSaves({
             }
           >
             {syncCommands.map((el, i) => (
-              <option value={el.value} key={i}>
+              <MenuItem value={el.value} key={i}>
                 {el.name}
-              </option>
+              </MenuItem>
             ))}
           </SelectField>
           <ToggleSwitch

--- a/src/frontend/screens/Settings/sections/SyncSaves/legendary.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/legendary.tsx
@@ -14,6 +14,7 @@ import { SyncType } from 'frontend/types'
 import { ProgressDialog } from 'frontend/components/UI/ProgressDialog'
 import SettingsContext from '../../SettingsContext'
 import TextWithProgress from 'frontend/components/UI/TextWithProgress'
+import { MenuItem } from '@mui/material'
 
 interface Props {
   autoSyncSaves: boolean
@@ -170,9 +171,9 @@ export default function LegendarySyncSaves({
             }
           >
             {syncCommands.map((el, i) => (
-              <option value={el.value} key={i}>
+              <MenuItem value={el.value} key={i}>
                 {el.name}
-              </option>
+              </MenuItem>
             ))}
           </SelectField>
           <ToggleSwitch

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -180,7 +180,7 @@ class GlobalState extends PureComponent<Props> {
     ),
     favouriteGames: configStore.get('games.favourites', []),
     customCategories: configStore.get('games.customCategories', {}),
-    theme: configStore.get('theme', ''),
+    theme: configStore.get('theme', 'midnightMirage'),
     isFullscreen: false,
     isFrameless: false,
     zoomPercent: configStore.get('zoomPercent', 100),


### PR DESCRIPTION
This renders most drop-down selection prompts inside Heroic. In turn, these dropdowns now work inside the Gamescope session.

Current issues:
- [X] Controller navigation does not work, hitting "Down" opens the dropdown, with no way to navigate further down to other components
- [X] There is a black box in the top-left of the component, where the label should be
- [X] The dropdowns do not work while in a Dialog (they're rendered behind the Dialog)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
