### PR TITLE
improv: use empty parameter for initializing the umu prefix

### DIFF
--- a/flatpak/templates/com.heroicgameslauncher.hgl.yml.template
+++ b/flatpak/templates/com.heroicgameslauncher.hgl.yml.template
@@ -45,7 +45,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   # umu
-  - --filesystem=~/.var/app/org.openwinecomponents.umu.umu-launcher/data/umu
+  - --filesystem=xdg-data/umu:create
   - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share
 
 add-extensions:

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -816,7 +816,7 @@ export async function verifyWinePrefix(
 
   const command = runWineCommand({
     commandParts: (await isUmuSupported(wineVersion.type))
-      ? ['createprefix']
+      ? ['']
       : ['wineboot', '--init'],
     wait: haveToWait,
     gameSettings: settings,


### PR DESCRIPTION
createprefix isn't a valid command in proton, umu will handlle an empty parameter gracefully.  
This PR also updates the template for new umu permission 

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
