### PR TITLE
[Fix] Add missing input text fields in advanced game default settings for scripts

### DIFF
--- a/src/frontend/screens/Settings/components/AfterLaunchScriptPath.tsx
+++ b/src/frontend/screens/Settings/components/AfterLaunchScriptPath.tsx
@@ -6,13 +6,9 @@ import { PathSelectionBox } from 'frontend/components/UI'
 
 const AfterLaunchScriptPath = () => {
   const { t } = useTranslation()
-  const { isDefault, gameInfo } = useContext(SettingsContext)
+  const { gameInfo } = useContext(SettingsContext)
 
   const [scriptPath, setScriptPath] = useSetting('afterLaunchScriptPath', '')
-
-  if (isDefault) {
-    return <></>
-  }
 
   return (
     <PathSelectionBox

--- a/src/frontend/screens/Settings/components/BeforeLaunchScriptPath.tsx
+++ b/src/frontend/screens/Settings/components/BeforeLaunchScriptPath.tsx
@@ -6,13 +6,9 @@ import { PathSelectionBox } from 'frontend/components/UI'
 
 const BeforeLaunchScriptPath = () => {
   const { t } = useTranslation()
-  const { isDefault, gameInfo } = useContext(SettingsContext)
+  const { gameInfo } = useContext(SettingsContext)
 
   const [scriptPath, setScriptPath] = useSetting('beforeLaunchScriptPath', '')
-
-  if (isDefault) {
-    return <></>
-  }
 
   return (
     <PathSelectionBox

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.scss
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.scss
@@ -86,3 +86,7 @@ details {
     gap: 10px;
   }
 }
+
+.Field label {
+  float: left;
+}

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.scss
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.scss
@@ -87,6 +87,6 @@ details {
   }
 }
 
-.Field label {
-  float: left;
+.Field {
+  text-align: left;
 }


### PR DESCRIPTION
Adds missing input text fields in advanced game default settings for scripts to run before and after a game is launched feature.
Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4044.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
