### PR TITLE
[UI/UX] Fix English grammar for launch argument box placeholder

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -502,7 +502,7 @@
                 "command": "The %command% syntax from Steam is not valid as game arguments.",
                 "env": "Environment variables must be configured in the table below."
             },
-            "placeholder": "Put here the Launcher Arguments",
+            "placeholder": "Put the launcher arguments here",
             "title": "Game Arguments (To run after the command):"
         },
         "gamescope": {


### PR DESCRIPTION
This is a slight improvement to the UI, as it's not grammatically correct currently and sticks out.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)

## Before
![image](https://github.com/user-attachments/assets/d5060ef0-9eb3-4fdf-b309-796dbb072acc)

## After
![image](https://github.com/user-attachments/assets/25bcfae1-95bc-4abf-b889-d7fbae4e2e6e)
