### PR TITLE
[Fix] Epic: Hide UE-related items from the user's library

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -510,7 +510,14 @@ function loadFile(app_name: string): boolean {
   }
   const { namespace } = metadata
 
-  if (namespace === 'ue') {
+  const ueCategories = ['assets', 'asset-format', 'plugins', 'projects']
+  const isUeTitle =
+    namespace === 'ue' ||
+    !!metadata.categories.find((category) =>
+      ueCategories.includes(category.path)
+    )
+
+  if (isUeTitle) {
     return false
   }
 


### PR DESCRIPTION
Resolves this issue reported on Discord: https://discord.com/channels/812703221789097985/1308977164619747429

We are already checking for the `namespace` property being `ue`, but it seems this is not actually set for some UE items (specifically assets, plugins, and projects)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
