### PR TITLE
macOS Dock Menu support

### DIFF
--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -20,6 +20,9 @@ export const initTrayIcon = async (mainWindow: BrowserWindow) => {
     }
 
     appIcon.setContextMenu(contextMenu(mainWindow, recentGames))
+    //terrible two liner to make the tray icon menu appear in the dock too on macOS
+    if (process.platform === 'darwin')
+      require('electron').app.dock.setMenu(contextMenu(mainWindow, recentGames))
   }
   await loadContextMenu()
 

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain, Menu, nativeImage, Tray } from 'electron'
+import { app, BrowserWindow, ipcMain, Menu, nativeImage, Tray } from 'electron'
 import i18next from 'i18next'
 import { RecentGame } from 'common/types'
 import { logInfo, LogPrefix } from '../logger/logger'
@@ -22,7 +22,7 @@ export const initTrayIcon = async (mainWindow: BrowserWindow) => {
     appIcon.setContextMenu(contextMenu(mainWindow, recentGames))
     //terrible two liner to make the tray icon menu appear in the dock too on macOS
     if (process.platform === 'darwin')
-      require('electron').app.dock.setMenu(contextMenu(mainWindow, recentGames))
+      app.dock.setMenu(contextMenu(mainWindow, recentGames))
   }
   await loadContextMenu()
 

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -16,10 +16,10 @@ export const initTrayIcon = async (mainWindow: BrowserWindow) => {
   // helper function to set/update the context menu
   const loadContextMenu = async (recentGames?: RecentGame[]) => {
     recentGames ??= await getRecentGames({ limited: true })
-    const currentContextMenu = contextMenu(mainWindow, recentGames)
-    appIcon.setContextMenu(currentContextMenu)
+    const newContextMenu = contextMenu(mainWindow, recentGames)
+    appIcon.setContextMenu(newContextMenu)
     // makes the tray icon menu appear in the dock too on macOS
-    if (isMac) app.dock.setMenu(currentContextMenu)
+    if (isMac) app.dock.setMenu(newContextMenu)
   }
   await loadContextMenu()
 

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -13,12 +13,11 @@ export const initTrayIcon = async (mainWindow: BrowserWindow) => {
   // create icon
   const appIcon = new Tray(getIcon(process.platform))
 
-  // helper function to set/update the context menu
+  // helper function to set/update the context menu and on macOS the dock menu
   const loadContextMenu = async (recentGames?: RecentGame[]) => {
     recentGames ??= await getRecentGames({ limited: true })
     const newContextMenu = contextMenu(mainWindow, recentGames)
     appIcon.setContextMenu(newContextMenu)
-    // makes the tray icon menu appear in the dock too on macOS
     if (isMac) app.dock.setMenu(newContextMenu)
   }
   await loadContextMenu()

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -79,11 +79,7 @@ const getIcon = (platform = process.platform) => {
 }
 
 // generate the context menu
-const contextMenu = (
-  mainWindow: BrowserWindow,
-  recentGames: RecentGame[],
-  platform = process.platform
-) => {
+const contextMenu = (mainWindow: BrowserWindow, recentGames: RecentGame[]) => {
   const recentsMenu = recentGames.map((game) => {
     return {
       click: function () {

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -6,7 +6,7 @@ import { handleProtocol } from '../protocol'
 import { getRecentGames, maxRecentGames } from '../recent_games/recent_games'
 import { handleExit, showAboutWindow } from '../utils'
 import { GlobalConfig } from '../config'
-import { iconDark, iconLight } from '../constants'
+import { iconDark, iconLight, isMac } from '../constants'
 import { backendEvents } from '../backend_events'
 
 export const initTrayIcon = async (mainWindow: BrowserWindow) => {
@@ -15,14 +15,11 @@ export const initTrayIcon = async (mainWindow: BrowserWindow) => {
 
   // helper function to set/update the context menu
   const loadContextMenu = async (recentGames?: RecentGame[]) => {
-    if (!recentGames) {
-      recentGames = await getRecentGames({ limited: true })
-    }
-
-    appIcon.setContextMenu(contextMenu(mainWindow, recentGames))
-    //terrible two liner to make the tray icon menu appear in the dock too on macOS
-    if (process.platform === 'darwin')
-      app.dock.setMenu(contextMenu(mainWindow, recentGames))
+    recentGames ??= await getRecentGames({ limited: true })
+    const currentContextMenu = contextMenu(mainWindow, recentGames)
+    appIcon.setContextMenu(currentContextMenu)
+    // makes the tray icon menu appear in the dock too on macOS
+    if (isMac) app.dock.setMenu(currentContextMenu)
   }
   await loadContextMenu()
 
@@ -112,7 +109,7 @@ const contextMenu = (
       label: i18next.t('tray.about', 'About')
     },
     {
-      accelerator: platform === 'darwin' ? 'Cmd+R' : 'Ctrl+R',
+      accelerator: isMac ? 'Cmd+R' : 'Ctrl+R',
       click: function () {
         mainWindow.reload()
       },
@@ -120,7 +117,7 @@ const contextMenu = (
     },
     {
       label: 'Debug',
-      accelerator: platform === 'darwin' ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
+      accelerator: isMac ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
       click: () => {
         mainWindow.webContents.openDevTools()
       }
@@ -130,7 +127,7 @@ const contextMenu = (
         handleExit()
       },
       label: i18next.t('tray.quit', 'Quit'),
-      accelerator: platform === 'darwin' ? 'Cmd+Q' : 'Ctrl+Q'
+      accelerator: isMac ? 'Cmd+Q' : 'Ctrl+Q'
     }
   ])
 }

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -79,7 +79,11 @@ const getIcon = (platform = process.platform) => {
 }
 
 // generate the context menu
-const contextMenu = (mainWindow: BrowserWindow, recentGames: RecentGame[]) => {
+const contextMenu = (
+  mainWindow: BrowserWindow,
+  recentGames: RecentGame[],
+  platform = process.platform
+) => {
   const recentsMenu = recentGames.map((game) => {
     return {
       click: function () {
@@ -105,7 +109,7 @@ const contextMenu = (mainWindow: BrowserWindow, recentGames: RecentGame[]) => {
       label: i18next.t('tray.about', 'About')
     },
     {
-      accelerator: isMac ? 'Cmd+R' : 'Ctrl+R',
+      accelerator: platform === 'darwin' ? 'Cmd+R' : 'Ctrl+R',
       click: function () {
         mainWindow.reload()
       },
@@ -113,7 +117,7 @@ const contextMenu = (mainWindow: BrowserWindow, recentGames: RecentGame[]) => {
     },
     {
       label: 'Debug',
-      accelerator: isMac ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
+      accelerator: platform === 'darwin' ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
       click: () => {
         mainWindow.webContents.openDevTools()
       }
@@ -123,7 +127,7 @@ const contextMenu = (mainWindow: BrowserWindow, recentGames: RecentGame[]) => {
         handleExit()
       },
       label: i18next.t('tray.quit', 'Quit'),
-      accelerator: isMac ? 'Cmd+Q' : 'Ctrl+Q'
+      accelerator: platform === 'darwin' ? 'Cmd+Q' : 'Ctrl+Q'
     }
   ])
 }


### PR DESCRIPTION
Implements support for macOS Dock Menus.

Original text:
A terrible two liner that I didn’t put through the linter to show that support for Dock Menu’s would be easy to implement.

I should probably improve it, but I first wanted to know if the devs are open to this at all before I actually spend time on this.

Closes #4156.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
