### PR TITLE
Enable macOS universal build

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Upload macOS Universal version
         uses: actions/upload-artifact@v4
         with:
-          name: mac-arm64
+          name: mac-universal
           path: dist/Heroic*universal.dmg
           retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -26,7 +26,7 @@ jobs:
         run: pnpm dist:win portable
         if: runner.os == 'Windows'
       - name: Build macOS x64 & arm64 versions
-        run: pnpm dist:mac --x64 --arm64 --publish=never
+        run: pnpm dist:mac --x64 --arm64  --universal --publish=never
         env:
           GITHUB_TOKEN: ${{ secrets.workflowToken }}
           GH_TOKEN: ${{ secrets.workflowToken }}

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -72,3 +72,12 @@ jobs:
           if-no-files-found: error
           compression-level: 3
         if: runner.os == 'macOS'
+      - name: Upload macOS Universal version
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-arm64
+          path: dist/Heroic*universal.dmg
+          retention-days: 14
+          if-no-files-found: error
+          compression-level: 3
+        if: runner.os == 'macOS'

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:ci": "jest --runInBand --silent",
     "test:e2e": "electron-vite build && cross-env CI=e2e xvfb-maybe -- playwright test",
     "release:linux": "electron-vite build && electron-builder -p always --linux deb AppImage rpm pacman tar.xz",
-    "release:mac": "electron-vite build && electron-builder -p always --mac --x64 --arm64",
+    "release:mac": "electron-vite build && electron-builder -p always --mac --x64 --arm64 --universal",
     "release:win": "electron-vite build && electron-builder -p always --win portable --x64",
     "release:updateFlathub:ci": "tsc flathub/update-flathub.ts --skipLibCheck --target es2015 --moduleResolution node --module commonjs && node flathub/update-flathub.js",
     "sign:win": "electron-vite build && electron-builder -p never --win nsis --x64",
@@ -51,6 +51,7 @@
     "download-helper-binaries": "esbuild --bundle --platform=node --target=node21 meta/downloadHelperBinaries.ts | node"
   },
   "dependencies": {
+    "@electron/universal": "^2.0.1",
     "@emotion/react": "11.10.6",
     "@emotion/styled": "11.10.6",
     "@fontsource/cabin": "4.5.10",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "download-helper-binaries": "esbuild --bundle --platform=node --target=node21 meta/downloadHelperBinaries.ts | node"
   },
   "dependencies": {
-    "@electron/universal": "^2.0.1",
     "@emotion/react": "11.10.6",
     "@emotion/styled": "11.10.6",
     "@fontsource/cabin": "4.5.10",


### PR DESCRIPTION
Creates a build that runs on both architectures.

I feel like this should break things but small tests I did it seems to work?

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
