### PR TITLE
Fix: egs-sync path field is always disabled

### DIFF
--- a/src/frontend/screens/Settings/components/EgsSettings.tsx
+++ b/src/frontend/screens/Settings/components/EgsSettings.tsx
@@ -73,7 +73,7 @@ const EgsSettings = () => {
         path={egsPath}
         placeholder={t('placeholder.egs-prefix')}
         pathDialogTitle={t('box.choose-egs-prefix')}
-        canEditPath={isSyncing}
+        canEditPath={!isSyncing}
         label={t('setting.egs-sync')}
         htmlId="set_epic_sync_path"
       />


### PR DESCRIPTION
We have the logic backwards, it should be editable when NOT `isSyncing` (current logic makes it always disabled cause isSyncing starts as false)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
