### PR TITLE
Fix: Remove sideloaded games from recent list when uninstalled

### DIFF
--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -24,6 +24,7 @@ import { launchGame } from 'backend/storeManagers/storeManagerCommon/games'
 import { GOGCloudSavesLocation } from 'common/types/gog'
 import { InstallResult, RemoveArgs } from 'common/types/game_manager'
 import { removePrefix } from 'backend/utils/uninstaller'
+import { removeRecentGame } from 'backend/recent_games/recent_games'
 
 export function getGameInfo(appName: string): GameInfo {
   const store = libraryStore.get('games', [])
@@ -124,6 +125,7 @@ export async function uninstall({
   notify({ title, body: i18next.t('notify.uninstalled') })
 
   removeShortcutsUtil(gameInfo)
+  removeRecentGame(appName)
 
   sendGameStatusUpdate({
     appName,


### PR DESCRIPTION
We have an issue that we can only manually remove elements from the recent list in the tray icon when they are either installed or part of the games in the library, but uninstalled sideloaded games disappear completely.

This PR doesn't fix the full problem but I think it's good enough for most use cases:
- It does remove the item when uninstalled
- It does NOT cleanup the list if it has old items (I don't think it's worth including code to check the list and remove entries, we can handle those cases manually)

To clean the list with already old elements, we can instruct users to edit the file at `~/.config/heroic/store/config.json` and remove elements they don't want from the `"recent"` key.

Fixes #4170 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
