### PR TITLE
Fix: Do not check Epic server status if not an Epic game

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -91,8 +91,11 @@ async function prepareLaunch(
 ): Promise<LaunchPreperationResult> {
   const globalSettings = GlobalConfig.get().getSettings()
 
-  const offlineMode =
-    gameSettings.offlineMode || !isOnline() || (await isEpicServiceOffline())
+  let offlineMode = gameSettings.offlineMode || !isOnline()
+
+  if (!offlineMode && gameInfo.runner === 'legendary') {
+    offlineMode = await isEpicServiceOffline()
+  }
 
   // Check if the game needs an internet connection
   if (!gameInfo.canRunOffline && offlineMode) {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1327,18 +1327,20 @@ ipcMain.handle(
 ipcMain.handle(
   'importGame',
   async (event, { appName, path, runner, platform }): StatusPromise => {
-    const epicOffline = await isEpicServiceOffline()
-    if (epicOffline && runner === 'legendary') {
-      showDialogBoxModalAuto({
-        event,
-        title: i18next.t('box.warning.title', 'Warning'),
-        message: i18next.t(
-          'box.warning.epic.import',
-          'Epic Servers are having major outage right now, the game cannot be imported!'
-        ),
-        type: 'ERROR'
-      })
-      return { status: 'error' }
+    if (runner === 'legendary') {
+      const epicOffline = await isEpicServiceOffline()
+      if (epicOffline) {
+        showDialogBoxModalAuto({
+          event,
+          title: i18next.t('box.warning.title', 'Warning'),
+          message: i18next.t(
+            'box.warning.epic.import',
+            'Epic Servers are having major outage right now, the game cannot be imported!'
+          ),
+          type: 'ERROR'
+        })
+        return { status: 'error' }
+      }
     }
 
     const title = gameManagerMap[runner].getGameInfo(appName).title
@@ -1401,18 +1403,20 @@ ipcMain.handle('updateGame', async (event, appName, runner): StatusPromise => {
     return { status: 'error' }
   }
 
-  const epicOffline = await isEpicServiceOffline()
-  if (epicOffline && runner === 'legendary') {
-    showDialogBoxModalAuto({
-      event,
-      title: i18next.t('box.warning.title', 'Warning'),
-      message: i18next.t(
-        'box.warning.epic.update',
-        'Epic Servers are having major outage right now, the game cannot be updated!'
-      ),
-      type: 'ERROR'
-    })
-    return { status: 'error' }
+  if (runner === 'legendary') {
+    const epicOffline = await isEpicServiceOffline()
+    if (epicOffline) {
+      showDialogBoxModalAuto({
+        event,
+        title: i18next.t('box.warning.title', 'Warning'),
+        message: i18next.t(
+          'box.warning.epic.update',
+          'Epic Servers are having major outage right now, the game cannot be updated!'
+        ),
+        type: 'ERROR'
+      })
+      return { status: 'error' }
+    }
   }
 
   const { title } = gameManagerMap[runner].getGameInfo(appName)


### PR DESCRIPTION
We were checking if the Epic server was offline for some actions when the game was not an Epic game (when importing, updating, and to check if we should add the `--offline` flag). This PR fixes that.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
