### PR TITLE
[UX/Tech] Use Proton-GE instead of Wine-GE as default and as recommended

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -911,8 +911,8 @@
         "size": "Size"
     },
     "wineExplanation": {
-        "proton-ge": "Proton-GE-Proton is a Proton variant created by Glorious Eggroll. It is meant to be used in Steam, but some games outside Steam may work better with this variant. It provides mostly useless logs for troubleshooting.",
-        "wine-ge": "Wine-GE-Proton is a Wine variant created by Glorious Eggroll. It is the recommended Wine to be used outside Steam. This provides useful logs when troubleshooting."
+        "proton-ge": "Proton-GE-Proton is a Proton variant created by Glorious Eggroll. It is meant to be used along with the UMU launcher (default in Heroic).",
+        "wine-ge": "Wine-GE-Proton is a Wine variant created by Glorious Eggroll. It has been deprecated in favor of Proton-GE with the UMU launcher."
     },
     "winetricks": {
         "install": "Install",

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -917,13 +917,10 @@ export async function downloadDefaultWine() {
   await updateWineVersionInfos(true)
   // get list of wines on wineDownloaderInfoStore
   const availableWine = wineDownloaderInfoStore.get('wine-releases', [])
-  // use Wine-GE type if on Linux and Wine-Crossover if on Mac
+  // use Proton-GE type if on Linux and GamePortingToolkit if on Mac
   const release = availableWine.filter((version) => {
     if (isLinux) {
-      return (
-        version.version.includes('Wine-GE-Proton') &&
-        !version.version.endsWith('-LoL')
-      )
+      return version.version.includes('Proton-GE-Proton')
     } else if (isMac) {
       return version.version.includes('Game-Porting-Toolkit')
     }

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -45,9 +45,9 @@ export default function WineManager(): JSX.Element | null {
     useContext(ContextProvider)
   const isLinux = platform === 'linux'
 
-  const winege: WineManagerUISettings = {
-    type: 'Wine-GE',
-    value: 'winege',
+  const protonge: WineManagerUISettings = {
+    type: 'Proton-GE',
+    value: 'protonge',
     enabled: isLinux
   }
   const gamePortingToolkit: WineManagerUISettings = {
@@ -57,14 +57,14 @@ export default function WineManager(): JSX.Element | null {
   }
 
   const [repository, setRepository] = useState<WineManagerUISettings>(
-    isLinux ? winege : gamePortingToolkit
+    isLinux ? protonge : gamePortingToolkit
   )
   const [wineManagerSettings, setWineManagerSettings] = useState<
     WineManagerUISettings[]
   >([
+    protonge,
     { type: 'Wine-GE', value: 'winege', enabled: isLinux },
-    { type: 'Proton-GE', value: 'protonge', enabled: isLinux },
-    { type: 'Game-Porting-Toolkit', value: 'gpt', enabled: !isLinux },
+    gamePortingToolkit,
     { type: 'Wine-Crossover', value: 'winecrossover', enabled: !isLinux }
   ])
 
@@ -114,20 +114,20 @@ export default function WineManager(): JSX.Element | null {
       case 'Wine-GE':
         return (
           <div className="infoBox">
-            <FontAwesomeIcon icon={faCheck} color={'green'} />
+            <FontAwesomeIcon icon={faWarning} color={'orange'} />
             {t(
               'wineExplanation.wine-ge',
-              'Wine-GE-Proton is a Wine variant created by Glorious Eggroll. It is the recommended Wine to be used outside Steam. This provides useful logs when troubleshooting.'
+              'Wine-GE-Proton is a Wine variant created by Glorious Eggroll. It has been deprecated in favor of Proton-GE with the UMU launcher.'
             )}
           </div>
         )
       case 'Proton-GE':
         return (
           <div className="infoBox">
-            <FontAwesomeIcon icon={faWarning} color={'orange'} />
+            <FontAwesomeIcon icon={faCheck} color={'green'} />
             {t(
               'wineExplanation.proton-ge',
-              'Proton-GE-Proton is a Proton variant created by Glorious Eggroll. It is meant to be used in Steam, but some games outside Steam may work better with this variant. It provides mostly useless logs for troubleshooting.'
+              'Proton-GE-Proton is a Proton variant created by Glorious Eggroll. It is meant to be used along with the UMU launcher (default in Heroic).'
             )}
           </div>
         )


### PR DESCRIPTION
The other day I made a PR enabling UMU by default.

With that in place we can now make Proton-GE the recommended/preferred compatibility layer to be used.

I updated:
- the default if no wine is present
- updated the wine manager to make it the first tab
- changed the copy at the top of that page to reflect the new recommendation

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
