### PR TITLE
[UX/Fix] Respect experimental UMU support disabled

### DIFF
--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -275,6 +275,10 @@ class GameConfigV0 extends GameConfig {
       // read game's settings
       const settings = JSON.parse(readFileSync(this.path, 'utf-8'))
       gameSettings = settings[this.appName] || ({} as GameSettings)
+    } else {
+      // only set the `disableUMU` default value when getting settings for a new game
+      // we want it to be `undefined` for games that were installed already
+      defaultSettings.disableUMU = false
     }
 
     if (!isWindows) {

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -559,7 +559,7 @@ export async function isUmuSupported(
 ): Promise<boolean> {
   if (!isLinux) return false
   if (gameSettings.wineVersion.type !== 'proton') return false
-  if (gameSettings.disableUMU === false) return false
+  if (gameSettings.disableUMU === true) return false
   if (gameSettings.disableUMU === undefined) {
     // If the disableUMU setting is undefined it means the game was installed and configured
     // before the introduction of this setting, so the usage of UMU was dictated by the

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -559,7 +559,22 @@ export async function isUmuSupported(
 ): Promise<boolean> {
   if (!isLinux) return false
   if (gameSettings.wineVersion.type !== 'proton') return false
-  if (gameSettings.disableUMU) return false
+  if (gameSettings.disableUMU === false) return false
+  if (gameSettings.disableUMU === undefined) {
+    // If the disableUMU setting is undefined it means the game was installed and configured
+    // before the introduction of this setting, so the usage of UMU was dictated by the
+    // experimental feature configuration.
+    //
+    // We have to check this to not enable UMU incorrectly even if the setting is not editable
+    // anymore.
+    // If we don't, we would end up enabling UMU for games that are already functional with proton
+    // without UMU to not mess their prefix
+    const experimentalFeatures =
+      GlobalConfig.get().getSettings().experimentalFeatures
+
+    // if UMU was never enabled or was enabled and then disabled
+    if (!experimentalFeatures?.umuSupport) return false
+  }
   if (!checkUmuInstalled) return true
   if (!existsSync(await getUmuPath())) return false
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -65,6 +65,7 @@ export type ExperimentalFeatures = {
   enableNewDesign: boolean
   enableHelp: boolean
   cometSupport: boolean
+  umuSupport: boolean
 }
 
 export interface AppSettings extends GameSettings {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -65,7 +65,7 @@ export type ExperimentalFeatures = {
   enableNewDesign: boolean
   enableHelp: boolean
   cometSupport: boolean
-  umuSupport: boolean
+  umuSupport?: boolean
 }
 
 export interface AppSettings extends GameSettings {


### PR DESCRIPTION
A few days ago I made this PR https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4175 making UMU the default when running games with Proton.

There's a problem with that PR: if a game was running with Proton and UMU disabled, updating heroic will make the game run with UMU incorrectly (affecting its prefix irreversibly, maybe breaking it if the game is incompatible with UMU).

To avoid that, we have to also check if UMU was not used before for games that are already installed.

So: for new games, the `disableUMU` setting will be `false` by default or `true` if changed by the user, so it will ignore the old experimental feature value. For games installed before this change, the `disableUMU` setting will be `undefined` so we check the experimental feature value.

How to test:
- revert some commit to have the experimental UMU and disable it
- install a game and run it once using proton without the experimental feature
- update to this commit
- run the game again
- it should NOT use UMU (even though the `Disable UMU` check is disabled in the advanced tab)

- revert some commit to have the experimental UMU and enable it
- install a game and run it once using proton with the experimental feature
- update to this commit
- run the game again
- it should use UMU

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
