### PR TITLE
[Fix] Show Crossover bottle in installed info details

### DIFF
--- a/src/frontend/screens/Game/GamePage/components/InstalledInfo.tsx
+++ b/src/frontend/screens/Game/GamePage/components/InstalledInfo.tsx
@@ -65,8 +65,7 @@ const InstalledInfo = ({ gameInfo }: Props) => {
       wine = wine.split('-')[0]
     }
     wineName = wine
-    wineType =
-      wineVersion.type === 'crossover' ? wineCrossoverBottle : winePrefix
+    wineType = wineVersion.type
   }
 
   const info = (
@@ -111,10 +110,10 @@ const InstalledInfo = ({ gameInfo }: Props) => {
           <div>
             <b>Wine:</b> {wineName}
           </div>
-          {wineVersion && wineType === 'crossover' ? (
+          {wineType === 'crossover' ? (
             <div>
               <b>{t2('setting.winecrossoverbottle', 'Bottle')}:</b>{' '}
-              <div className="truncatedPath">{winePrefix}</div>
+              <div>{wineCrossoverBottle}</div>
             </div>
           ) : (
             <div


### PR DESCRIPTION
We have a bug on Mac, when using Crossover, the game details page shows the wineprefix instead of the bottle name in the Installed Info area, when wine prefix makes no sense in that case.

There was code already for that but it was bugged.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
