### PR TITLE
Feature: support env variables in known fixes

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -682,52 +682,67 @@ async function prepareWineLaunch(
   return { success: true, envVars: envVars }
 }
 
-async function installFixes(appName: string, runner: Runner) {
+function readKnownFixes(appName: string, runner: Runner) {
   const fixPath = join(fixesPath, `${appName}-${storeMap[runner]}.json`)
 
-  if (!existsSync(fixPath)) return
+  if (!existsSync(fixPath)) return null
 
   try {
     const fixesContent = JSON.parse(
       readFileSync(fixPath).toString()
     ) as KnowFixesInfo
 
-    if (fixesContent.winetricks) {
-      sendGameStatusUpdate({
-        appName,
-        runner: runner,
-        status: 'winetricks'
-      })
-
-      for (const winetricksPackage of fixesContent.winetricks) {
-        await Winetricks.install(runner, appName, winetricksPackage)
-      }
-    }
-
-    if (fixesContent.runInPrefix) {
-      const gameInfo = gameManagerMap[runner].getGameInfo(appName)
-
-      sendGameStatusUpdate({
-        appName,
-        runner: runner,
-        status: 'redist',
-        context: 'FIXES'
-      })
-
-      for (const filePath of fixesContent.runInPrefix) {
-        const fullPath = join(gameInfo.install.install_path!, filePath)
-        await runWineCommandOnGame(appName, {
-          commandParts: [fullPath],
-          wait: true,
-          protonVerb: 'run'
-        })
-      }
-    }
+    return fixesContent
   } catch (error) {
     // if we fail to download the json file, it can be malformed causing
     // JSON.parse to throw an exception
     logWarning(`Known fixes could not be applied, ignoring.\n${error}`)
+    return null
   }
+}
+
+async function installFixes(appName: string, runner: Runner) {
+  const knownFixes = readKnownFixes(appName, runner)
+
+  if (!knownFixes) return
+
+  if (knownFixes.winetricks) {
+    sendGameStatusUpdate({
+      appName,
+      runner: runner,
+      status: 'winetricks'
+    })
+
+    for (const winetricksPackage of knownFixes.winetricks) {
+      await Winetricks.install(runner, appName, winetricksPackage)
+    }
+  }
+
+  if (knownFixes.runInPrefix) {
+    const gameInfo = gameManagerMap[runner].getGameInfo(appName)
+
+    sendGameStatusUpdate({
+      appName,
+      runner: runner,
+      status: 'redist',
+      context: 'FIXES'
+    })
+
+    for (const filePath of knownFixes.runInPrefix) {
+      const fullPath = join(gameInfo.install.install_path!, filePath)
+      await runWineCommandOnGame(appName, {
+        commandParts: [fullPath],
+        wait: true,
+        protonVerb: 'run'
+      })
+    }
+  }
+}
+
+function getKnownFixesEnvVariables(appName: string, runner: Runner) {
+  const knownFixes = readKnownFixes(appName, runner)
+
+  return knownFixes?.envVariables || {}
 }
 
 /**
@@ -1135,7 +1150,7 @@ async function runWineCommand({
     return { stdout: '', stderr: '' }
   }
 
-  const env_vars = {
+  const env_vars: Record<string, string> = {
     ...process.env,
     GAMEID: 'umu-0',
     ...setupEnvVars(settings),
@@ -1712,5 +1727,6 @@ export {
   callRunner,
   getRunnerCallWithoutCredentials,
   getWinePath,
-  launchEventCallback
+  launchEventCallback,
+  getKnownFixesEnvVariables
 }

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -68,6 +68,7 @@ import {
 } from '../../logger/logger'
 import { GOGUser } from './user'
 import {
+  getKnownFixesEnvVariables,
   getRunnerCallWithoutCredentials,
   getWinePath,
   launchCleanup,
@@ -536,7 +537,8 @@ export async function launch(
     ...setupWrapperEnvVars({ appName, appRunner: 'gog' }),
     ...(isWindows
       ? {}
-      : setupEnvVars(gameSettings, gameInfo.install.install_path))
+      : setupEnvVars(gameSettings, gameInfo.install.install_path)),
+    ...getKnownFixesEnvVariables(appName, 'gog')
   }
 
   const wrappers = setupWrappers(

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -59,7 +59,8 @@ import {
   setupWrappers,
   launchCleanup,
   getRunnerCallWithoutCredentials,
-  runWineCommand as runWineCommandUtil
+  runWineCommand as runWineCommandUtil,
+  getKnownFixesEnvVariables
 } from '../../launcher'
 import {
   addShortcuts as addShortcutsUtil,
@@ -871,7 +872,8 @@ export async function launch(
     ...setupWrapperEnvVars({ appName, appRunner: 'legendary' }),
     ...(isWindows
       ? {}
-      : setupEnvVars(gameSettings, gameInfo.install.install_path))
+      : setupEnvVars(gameSettings, gameInfo.install.install_path)),
+    ...getKnownFixesEnvVariables(appName, 'legendary')
   }
 
   const wrappers = setupWrappers(

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -31,6 +31,7 @@ import {
 import { isLinux, isWindows } from 'backend/constants'
 import { GameConfig } from 'backend/game_config'
 import {
+  getKnownFixesEnvVariables,
   getRunnerCallWithoutCredentials,
   launchCleanup,
   prepareLaunch,
@@ -344,7 +345,8 @@ export async function launch(
     ...setupWrapperEnvVars({ appName, appRunner: 'nile' }),
     ...(isWindows
       ? {}
-      : setupEnvVars(gameSettings, gameInfo.install.install_path))
+      : setupEnvVars(gameSettings, gameInfo.install.install_path)),
+    ...getKnownFixesEnvVariables(appName, 'nile')
   }
 
   const wrappers = setupWrappers(

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -15,6 +15,7 @@ import { constants as FS_CONSTANTS } from 'graceful-fs'
 import i18next from 'i18next'
 import {
   callRunner,
+  getKnownFixesEnvVariables,
   launchCleanup,
   prepareLaunch,
   prepareWineLaunch,
@@ -219,7 +220,8 @@ export async function launchGame(
       const env = {
         ...process.env,
         ...setupWrapperEnvVars({ appName, appRunner: runner }),
-        ...setupEnvVars(gameSettings, gameInfo.install.install_path)
+        ...setupEnvVars(gameSettings, gameInfo.install.install_path),
+        ...getKnownFixesEnvVariables(appName, runner)
       }
 
       await callRunner(

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -766,6 +766,7 @@ export interface KnowFixesInfo {
   notes?: Record<string, string>
   winetricks?: string[]
   runInPrefix?: string[]
+  envVariables?: Record<string, string>
 }
 
 export interface UploadedLogData {


### PR DESCRIPTION
This PR adds support to define env variables in the `known-fixes` repo https://github.com/Heroic-Games-Launcher/known-fixes/issues/6

The env variables are applied to the launch command if present in the fixes file.

I known that in that issue in the known-fixes repo there's a comment by @imLinguin about adding this information to ULWGL/UMU, but we still need to support Mac games or any env variable that could be specific for Heroic and not generic enough to add to UMU's database.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
