### PR TITLE
[Fix] Maintain proper cursor over SVGs on Game page

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.scss
+++ b/src/frontend/screens/Game/GamePage/index.scss
@@ -218,7 +218,7 @@
       margin-bottom: 0;
     }
 
-    svg {
+    svg:not(:is(button > svg)) {
       cursor: text;
     }
 

--- a/src/frontend/screens/Game/GamePage/index.scss
+++ b/src/frontend/screens/Game/GamePage/index.scss
@@ -218,10 +218,6 @@
       margin-bottom: 0;
     }
 
-    svg:not(:is(button > svg)) {
-      cursor: text;
-    }
-
     & > .selectFieldWrapper.Field {
       margin-bottom: var(--space-md);
     }


### PR DESCRIPTION
Fixes #4212 

## Issue

On Game Info SVG tags, we are currently applying a cursor `text` style, which is a bit jarring on SVGs inside button tags.


### Before

https://github.com/user-attachments/assets/3b2b4b0e-b839-4646-bdcc-a78907cb4895

### After

https://github.com/user-attachments/assets/4b207baf-a92c-4800-bd54-a4208e336272




---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
