### PR TITLE
[UX] Enable/disable logs game-by-game instead of globally

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -744,6 +744,9 @@
         "showMetalOverlay": "Show Stats Overlay",
         "start-in-tray": "Start Minimized",
         "steamruntime": "Use Steam Runtime",
+        "verboseLogs": {
+            "description": "Enable verbose logs"
+        },
         "winecrossoverbottle": "CrossOver Bottle",
         "wineprefix": "WinePrefix folder",
         "wineversion": "Wine Version"

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -322,7 +322,8 @@ class GlobalConfigV0 extends GlobalConfig {
       framelessWindow: false,
       beforeLaunchScriptPath: '',
       afterLaunchScriptPath: '',
-      disableUMU: false
+      disableUMU: false,
+      verboseLogs: false
     }
     // @ts-expect-error TODO: We need to settle on *one* place to define settings defaults
     return settings

--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -234,7 +234,8 @@ class GameConfigV0 extends GameConfig {
       battlEyeRuntime,
       beforeLaunchScriptPath,
       afterLaunchScriptPath,
-      gamescope
+      gamescope,
+      verboseLogs
     } = GlobalConfig.get().getSettings()
 
     // initialize generic defaults
@@ -266,7 +267,8 @@ class GameConfigV0 extends GameConfig {
       language: '', // we want to fallback to '' always here, fallback lang for games should be ''
       beforeLaunchScriptPath,
       afterLaunchScriptPath,
-      gamescope
+      gamescope,
+      verboseLogs
     } as GameSettings
 
     let gameSettings = {} as GameSettings

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -63,7 +63,6 @@ import {
   logFileLocation,
   logInfo,
   LogPrefix,
-  logsDisabled,
   logWarning
 } from '../../logger/logger'
 import { GOGUser } from './user'
@@ -690,6 +689,13 @@ export async function launch(
   )
   appendGamePlayLog(gameInfo, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
 
+  if (!gameSettings.verboseLogs) {
+    appendGamePlayLog(
+      gameInfo,
+      'IMPORTANT: Logs are disabled. Enable verbose logs before reporting an issue.'
+    )
+  }
+
   const userData: UserData | undefined = configStore.get_nodefault('userData')
 
   sendGameStatusUpdate({ appName, runner: 'gog', status: 'playing' })
@@ -724,7 +730,7 @@ export async function launch(
     wrappers,
     logMessagePrefix: `Launching ${gameInfo.title}`,
     onOutput: (output: string) => {
-      if (!logsDisabled) appendGamePlayLog(gameInfo, output)
+      if (gameSettings.verboseLogs) appendGamePlayLog(gameInfo, output)
     }
   })
 

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -48,8 +48,7 @@ import {
   logError,
   logFileLocation,
   logInfo,
-  LogPrefix,
-  logsDisabled
+  LogPrefix
 } from '../../logger/logger'
 import {
   prepareLaunch,
@@ -955,6 +954,13 @@ export async function launch(
   )
   appendGamePlayLog(gameInfo, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
 
+  if (!gameSettings.verboseLogs) {
+    appendGamePlayLog(
+      gameInfo,
+      'IMPORTANT: Logs are disabled. Enable verbose logs before reporting an issue.'
+    )
+  }
+
   sendGameStatusUpdate({ appName, runner: 'legendary', status: 'playing' })
 
   const { error } = await runLegendaryCommand(command, {
@@ -963,7 +969,7 @@ export async function launch(
     wrappers: wrappers,
     logMessagePrefix: `Launching ${gameInfo.title}`,
     onOutput: (output) => {
-      if (!logsDisabled) appendGamePlayLog(gameInfo, output)
+      if (gameSettings.verboseLogs) appendGamePlayLog(gameInfo, output)
     }
   })
 

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -25,8 +25,7 @@ import {
   logDebug,
   logError,
   logFileLocation,
-  logInfo,
-  logsDisabled
+  logInfo
 } from 'backend/logger/logger'
 import { isLinux, isWindows } from 'backend/constants'
 import { GameConfig } from 'backend/game_config'
@@ -420,6 +419,13 @@ export async function launch(
   )
   appendGamePlayLog(gameInfo, `Launch Command: ${fullCommand}\n\nGame Log:\n`)
 
+  if (!gameSettings.verboseLogs) {
+    appendGamePlayLog(
+      gameInfo,
+      'IMPORTANT: Logs are disabled. Enable verbose logs before reporting an issue.'
+    )
+  }
+
   sendGameStatusUpdate({ appName, runner: 'nile', status: 'playing' })
 
   const { error } = await runNileCommand(commandParts, {
@@ -428,7 +434,7 @@ export async function launch(
     wrappers,
     logMessagePrefix: `Launching ${gameInfo.title}`,
     onOutput(output) {
-      if (!logsDisabled) appendGamePlayLog(gameInfo, output)
+      if (gameSettings.verboseLogs) appendGamePlayLog(gameInfo, output)
     }
   })
 

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -7,7 +7,6 @@ import {
   lastPlayLogFileLocation,
   logInfo,
   LogPrefix,
-  logsDisabled,
   logWarning
 } from '../../logger/logger'
 import { basename, dirname } from 'path'
@@ -265,7 +264,7 @@ export async function launchGame(
         logFile: lastPlayLogFileLocation(appName),
         logMessagePrefix: LogPrefix.Backend,
         onOutput: (output) => {
-          if (!logsDisabled) appendGamePlayLog(gameInfo, output)
+          if (gameSettings.verboseLogs) appendGamePlayLog(gameInfo, output)
         }
       }
     })

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -971,7 +971,9 @@ export async function checkWineBeforeLaunch(
         `Wine version ${gameSettings.wineVersion.name} is not valid, trying another one.`,
         LogPrefix.Backend
       )
+    }
 
+    if (gameSettings.verboseLogs) {
       appendGamePlayLog(
         gameInfo,
         `Wine version ${gameSettings.wineVersion.name} is not valid, trying another one.\n`
@@ -989,10 +991,12 @@ export async function checkWineBeforeLaunch(
 
       if (response === 0) {
         logInfo(`Changing wine version to ${defaultwine.name}`)
-        appendGamePlayLog(
-          gameInfo,
-          `Changing wine version to ${defaultwine.name}\n`
-        )
+        if (gameSettings.verboseLogs) {
+          appendGamePlayLog(
+            gameInfo,
+            `Changing wine version to ${defaultwine.name}\n`
+          )
+        }
         gameSettings.wineVersion = defaultwine
         GameConfig.get(gameInfo.app_name).setSetting('wineVersion', defaultwine)
         return true

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -103,6 +103,7 @@ export interface AppSettings extends GameSettings {
   startInTray: boolean
   allowInstallationBrokenAnticheat: boolean
   disableUMU: boolean
+  verboseLogs: boolean
 }
 
 export type LibraryTopSectionOptions =
@@ -204,6 +205,7 @@ export interface GameSettings {
   beforeLaunchScriptPath: string
   afterLaunchScriptPath: string
   disableUMU: boolean
+  verboseLogs: boolean
 }
 
 export type Status =

--- a/src/frontend/screens/Settings/components/VerboseLogs.tsx
+++ b/src/frontend/screens/Settings/components/VerboseLogs.tsx
@@ -1,0 +1,30 @@
+import React, { useContext } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ToggleSwitch } from 'frontend/components/UI'
+import useSetting from 'frontend/hooks/useSetting'
+import SettingsContext from '../SettingsContext'
+
+const VerboseLogs = () => {
+  const { t } = useTranslation()
+
+  const { isDefault } = useContext(SettingsContext)
+
+  const [verboseLogs, setVerboseLogs] = useSetting('verboseLogs', false)
+
+  if (isDefault) {
+    return <></>
+  }
+
+  return (
+    <div className="toggleRow">
+      <ToggleSwitch
+        htmlId="verboseLogs"
+        value={verboseLogs}
+        handleChange={() => setVerboseLogs(!verboseLogs)}
+        title={t('setting.verboseLogs.description', 'Enable verbose logs')}
+      />
+    </div>
+  )
+}
+
+export default VerboseLogs

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -47,6 +47,7 @@ import FooterInfo from '../FooterInfo'
 import { Tabs, Tab } from '@mui/material'
 import { GameInfo } from 'common/types'
 import DisableUMU from '../../components/DisableUMU'
+import VerboseLogs from '../../components/VerboseLogs'
 
 const windowsPlatforms = ['Win32', 'Windows', 'windows']
 function getStartingTab(platform: string, gameInfo?: GameInfo | null): string {
@@ -215,6 +216,7 @@ export default function GamesSettings() {
             <OfflineMode />
           </>
         )}
+        <VerboseLogs />
         <DisableUMU />
         <AlternativeExe />
         <LauncherArgs />


### PR DESCRIPTION
Currently, we can only enable/disable logs globally to log game output.

This has some issues:
- the setting to disable all logs is not next to the game's settings, so it's not easy to find for users
- logs can impact performance (specially for games with a lot of output) and disk usage, having to enable logs for all games to debug one game means a user can forget to disable it after debugging one game and it will silently apply to all games, logging unnecessary information for games that are already working
- we were enabling all logs by default, which meant users had to know they can disable them

This PR changes that so we can enable `verbose logs` in a game-by-game basis. Some benefits:
- If I forget the logs "on" for a game, it won't affect the other games
- The setting is now in the Advanced tab in the game's settings, so it's easier to find
- Now the log file shows a message telling the user that logs are disabled, and tells them to enable verbose logs before reporting a problem

This also enables me to do another change I want to do related to logs and UX, but I'll keep that in another PR to keep this one smaller.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
