### PR TITLE
[UX] Alt action to launch games with and without logs

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -172,6 +172,7 @@
         "launching": "Launching",
         "playing": {
             "start": "Play Now",
+            "start_with_logs": "Play Now (with logs)",
             "stop": "Playing (Stop)"
         },
         "redist": "Installing Redistributables",

--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import GameContext from '../../GameContext'
 import {
+  ArrowBackIosNew,
   Cancel,
   CloudQueue,
   Download,
@@ -13,6 +14,7 @@ import {
 } from '@mui/icons-material'
 import classNames from 'classnames'
 import { GameInfo } from 'common/types'
+import useSetting from 'frontend/hooks/useSetting'
 
 interface Props {
   gameInfo: GameInfo
@@ -25,6 +27,7 @@ interface Props {
 const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
   const { t } = useTranslation('gamepage')
   const { is } = useContext(GameContext)
+  const [verboseLogs, setVerboseLogs] = useSetting('verboseLogs', false)
 
   function getPlayLabel(): React.ReactNode {
     if (is.syncing) {
@@ -54,10 +57,61 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
       )
     }
 
+    if (verboseLogs) {
+      return (
+        <span className="buttonWithIcon">
+          <PlayArrow data-icon="play" />
+          {t('label.playing.start_with_logs', 'Play (with logs)')}
+        </span>
+      )
+    }
+
     return (
       <span className="buttonWithIcon">
         <PlayArrow data-icon="play" />
         {t('label.playing.start')}
+      </span>
+    )
+  }
+
+  function showAltPlayAction() {
+    if (
+      is.syncing ||
+      is.installingRedist ||
+      is.installingWinetricksPackages ||
+      is.launching ||
+      is.playing
+    ) {
+      return false
+    }
+
+    return true
+  }
+
+  function getAltPlayLabel() {
+    if (
+      is.syncing ||
+      is.installingRedist ||
+      is.installingWinetricksPackages ||
+      is.launching ||
+      is.playing
+    ) {
+      return <></>
+    }
+
+    if (verboseLogs) {
+      return (
+        <span className="buttonWithIcon">
+          <PlayArrow data-icon="play" />
+          {t('label.playing.start')}
+        </span>
+      )
+    }
+
+    return (
+      <span className="buttonWithIcon">
+        <PlayArrow data-icon="play" />
+        {t('label.playing.start_with_logs', 'Play Now (with logs)')}
       </span>
     )
   }
@@ -109,45 +163,60 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
     )
   }
 
+  const handleAltLaunch = async () => {
+    setVerboseLogs(!verboseLogs)
+    await handlePlay(gameInfo)
+  }
+
   const is_installed = gameInfo.is_installed
 
   return (
-    <>
+    <div className="playButtons">
       {is_installed && !is.queued && (
-        <button
-          disabled={
-            is.reparing ||
-            is.moving ||
-            is.updating ||
-            is.uninstalling ||
-            is.syncing ||
-            is.launching ||
-            is.installingWinetricksPackages ||
-            is.installingRedist
-          }
-          autoFocus={true}
-          onClick={async () => handlePlay(gameInfo)}
-          className={classNames(
-            'button',
-            {
-              'is-secondary': !is_installed && !is.queued,
-              'is-success':
-                is.syncing ||
-                (!is.updating &&
-                  !is.playing &&
-                  is_installed &&
-                  !is.notAvailable),
-              'is-tertiary':
-                is.playing ||
-                (!is_installed && is.queued) ||
-                (is_installed && is.notAvailable),
-              'is-disabled': is.updating
-            },
-            'mainBtn'
+        <>
+          <button
+            className={classNames(
+              'button',
+              {
+                'is-secondary': !is_installed && !is.queued,
+                'is-success':
+                  is.syncing ||
+                  (!is.updating &&
+                    !is.playing &&
+                    is_installed &&
+                    !is.notAvailable),
+                'is-tertiary':
+                  is.playing ||
+                  (!is_installed && is.queued) ||
+                  (is_installed && is.notAvailable),
+                'is-disabled': is.updating
+              },
+              'mainBtn'
+            )}
+            disabled={
+              is.reparing ||
+              is.moving ||
+              is.updating ||
+              is.uninstalling ||
+              is.syncing ||
+              is.launching ||
+              is.installingWinetricksPackages ||
+              is.installingRedist
+            }
+            autoFocus={true}
+            onClick={async () => handlePlay(gameInfo)}
+          >
+            {getPlayLabel()}
+          </button>
+          {showAltPlayAction() && (
+            <button className="button altPlay is-success">
+              <ArrowBackIosNew />
+              <a className="button" onClick={handleAltLaunch}>
+                {getAltPlayLabel()}
+              </a>
+            </button>
           )}
-        >
-          {getPlayLabel()}
-        </button>
+        </>
       )}
       {(!is_installed || is.queued) && (
         <button
@@ -179,7 +248,7 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
           {getButtonLabel()}
         </button>
       )}
-    </>
+    </div>
   )
 }
 

--- a/src/frontend/screens/Game/GamePage/index.scss
+++ b/src/frontend/screens/Game/GamePage/index.scss
@@ -274,6 +274,40 @@
       max-width: 560px;
     }
 
+    & .playButtons {
+      display: flex;
+
+      .mainBtn {
+        flex-grow: 1;
+      }
+
+      .altPlay {
+        position: relative;
+        margin-inline-start: 1px;
+        padding-inline: 8px;
+
+        & > svg {
+          rotate: 270deg;
+          font-size: 0.7rem;
+        }
+
+        a {
+          display: none;
+          position: absolute;
+          top: 100%;
+          right: 0px;
+          white-space: nowrap;
+        }
+
+        &:focus,
+        &:hover {
+          a {
+            display: block;
+          }
+        }
+      }
+    }
+
     .summary {
       font-family: var(--primary-font-family);
       font-style: normal;
@@ -653,6 +687,37 @@
           align-self: center;
           max-height: unset;
           padding: var(--space-sm) var(--space-md);
+        }
+
+        & .playButtons {
+          display: flex;
+          justify-content: center;
+
+          .altPlay {
+            position: relative;
+            margin-inline-start: 1px;
+            padding-inline: 8px;
+
+            & > svg {
+              rotate: 270deg;
+              font-size: 0.7rem;
+            }
+
+            a {
+              display: none;
+              position: absolute;
+              top: 100%;
+              right: 0px;
+              white-space: nowrap;
+            }
+
+            &:focus,
+            &:hover {
+              a {
+                display: block;
+              }
+            }
+          }
         }
 
         & .mainBtn {

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -71,6 +71,8 @@ import { hasAnticheatInfo } from 'frontend/hooks/hasAnticheatInfo'
 import { hasHelp } from 'frontend/hooks/hasHelp'
 import Genres from './components/Genres'
 import ReleaseDate from './components/ReleaseDate'
+import useSettingsContext from 'frontend/hooks/useSettingsContext'
+import SettingsContext from 'frontend/screens/Settings/SettingsContext'
 
 export default React.memo(function GamePage(): JSX.Element | null {
   const { appName, runner } = useParams() as { appName: string; runner: Runner }
@@ -265,7 +267,14 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
   let hasUpdate = false
 
-  if (gameInfo && gameInfo.install) {
+  // create setting context functions
+  const settingsContextValues = useSettingsContext({
+    appName,
+    gameInfo,
+    runner
+  })
+
+  if (gameInfo && gameInfo.install && settingsContextValues) {
     const {
       runner,
       title,
@@ -348,144 +357,86 @@ export default React.memo(function GamePage(): JSX.Element | null {
     const hasRequirements = extraInfo ? extraInfo.reqs.length > 0 : false
 
     return (
-      <div className="gameConfigContainer">
-        {!!(art_background ?? art_cover) &&
-          experimentalFeatures.enableNewDesign && (
-            <CachedImage
-              src={art_background || art_cover}
-              className="backgroundImage"
+      <SettingsContext.Provider value={settingsContextValues}>
+        <div className="gameConfigContainer">
+          {!!(art_background ?? art_cover) &&
+            experimentalFeatures.enableNewDesign && (
+              <CachedImage
+                src={art_background || art_cover}
+                className="backgroundImage"
+              />
+            )}
+          {gameInfo.runner !== 'sideload' && showModal.show && (
+            <InstallModal
+              appName={showModal.game}
+              runner={runner}
+              backdropClick={() => setShowModal({ game: '', show: false })}
+              gameInfo={gameInfo}
             />
           )}
-        {gameInfo.runner !== 'sideload' && showModal.show && (
-          <InstallModal
-            appName={showModal.game}
-            runner={runner}
-            backdropClick={() => setShowModal({ game: '', show: false })}
-            gameInfo={gameInfo}
-          />
-        )}
-        {showUninstallModal && (
-          <UninstallModal
-            appName={appName}
-            runner={runner}
-            onClose={() => setShowUninstallModal(false)}
-            isDlc={false}
-          />
-        )}
+          {showUninstallModal && (
+            <UninstallModal
+              appName={appName}
+              runner={runner}
+              onClose={() => setShowUninstallModal(false)}
+              isDlc={false}
+            />
+          )}
 
-        {title ? (
-          <GameContext.Provider value={contextValues}>
-            {/* OLD DESIGN */}
-            {!experimentalFeatures.enableNewDesign && (
-              <>
-                <GamePicture
-                  art_square={art_square}
-                  art_logo={runner === 'nile' ? undefined : art_logo}
-                  store={runner}
-                />
-                <NavLink
-                  className="backButton"
-                  to={backRoute}
-                  title={t2('webview.controls.back', 'Go Back')}
-                >
-                  <ArrowCircleLeft />
-                </NavLink>
-                <div className="store-icon">
-                  <StoreLogos runner={runner} />
-                </div>
-                <div className="gameInfo">
-                  <div className="titleWrapper">
-                    <h1 className="title">{title}</h1>
-                    {!isBrowserGame && <SettingsButton gameInfo={gameInfo} />}
-                    <DotsMenu gameInfo={gameInfo} handleUpdate={handleUpdate} />
-                  </div>
-                  <div className="infoWrapper">
-                    <Genres
-                      genres={
-                        extraInfo?.genres ||
-                        wikiInfo?.pcgamingwiki?.genres ||
-                        []
-                      }
-                    />
-                    <Developer gameInfo={gameInfo} />
-                    <ReleaseDate
-                      runnerDate={extraInfo?.releaseDate}
-                      date={wikiInfo?.pcgamingwiki?.releaseDate}
-                    />
-                    <Description />
-                    <CloudSavesSync gameInfo={gameInfo} />
-                    {!notInstallable && (
-                      <DownloadSizeInfo gameInfo={gameInfo} />
-                    )}
-                    <InstalledInfo gameInfo={gameInfo} />
-                    <Scores gameInfo={gameInfo} />
-                    <HLTB />
-                    <CompatibilityInfo gameInfo={gameInfo} />
-                    <AppleWikiInfo gameInfo={gameInfo} />
-                    <Requirements />
-                  </div>
-                  {!notInstallable && (
-                    <TimeContainer runner={runner} game={appName} />
-                  )}
-                  <GameStatus
-                    gameInfo={gameInfo}
-                    progress={progress}
-                    handleUpdate={handleUpdate}
-                    hasUpdate={hasUpdate}
+          {title ? (
+            <GameContext.Provider value={contextValues}>
+              {/* OLD DESIGN */}
+              {!experimentalFeatures.enableNewDesign && (
+                <>
+                  <GamePicture
+                    art_square={art_square}
+                    art_logo={runner === 'nile' ? undefined : art_logo}
+                    store={runner}
                   />
-                  <LaunchOptions
-                    gameInfo={gameInfo}
-                    setLaunchArguments={setLaunchArguments}
-                  />
-
-                  <Anticheat anticheatInfo={anticheatInfo} />
-                  <MainButton
-                    gameInfo={gameInfo}
-                    handlePlay={handlePlay}
-                    handleInstall={handleInstall}
-                  />
-                  <ReportIssue gameInfo={gameInfo} />
-                </div>
-              </>
-            )}
-            {/* NEW DESIGN */}
-            {experimentalFeatures.enableNewDesign && (
-              <>
-                <div className="topRowWrapper">
                   <NavLink
                     className="backButton"
                     to={backRoute}
                     title={t2('webview.controls.back', 'Go Back')}
                   >
-                    <ArrowBackIosNew />
+                    <ArrowCircleLeft />
                   </NavLink>
-                  {!isBrowserGame && <SettingsButton gameInfo={gameInfo} />}
-                  <DotsMenu gameInfo={gameInfo} handleUpdate={handleUpdate} />
-                </div>
-                <div className="mainInfoWrapper">
-                  <div className="mainInfo">
-                    <GamePicture
-                      art_square={art_cover}
-                      art_logo={art_logo}
-                      store={runner}
-                    />
-                    <div className="store-icon">
-                      <StoreLogos runner={runner} />
+                  <div className="store-icon">
+                    <StoreLogos runner={runner} />
+                  </div>
+                  <div className="gameInfo">
+                    <div className="titleWrapper">
+                      <h1 className="title">{title}</h1>
+                      {!isBrowserGame && <SettingsButton gameInfo={gameInfo} />}
+                      <DotsMenu
+                        gameInfo={gameInfo}
+                        handleUpdate={handleUpdate}
+                      />
                     </div>
-                    <h1 style={{ opacity: art_logo ? 0 : 1 }}>{title}</h1>
-                    <Genres
-                      genres={
-                        gameInfo.extra?.genres ||
-                        wikiInfo?.pcgamingwiki?.genres ||
-                        []
-                      }
-                    />
-                    <Developer gameInfo={gameInfo} />
-                    <ReleaseDate
-                      runnerDate={extraInfo?.releaseDate}
-                      date={wikiInfo?.pcgamingwiki?.releaseDate}
-                    />
-                    <Description />
+                    <div className="infoWrapper">
+                      <Genres
+                        genres={
+                          extraInfo?.genres ||
+                          wikiInfo?.pcgamingwiki?.genres ||
+                          []
+                        }
+                      />
+                      <Developer gameInfo={gameInfo} />
+                      <ReleaseDate
+                        runnerDate={extraInfo?.releaseDate}
+                        date={wikiInfo?.pcgamingwiki?.releaseDate}
+                      />
+                      <Description />
+                      <CloudSavesSync gameInfo={gameInfo} />
+                      {!notInstallable && (
+                        <DownloadSizeInfo gameInfo={gameInfo} />
+                      )}
+                      <InstalledInfo gameInfo={gameInfo} />
+                      <Scores gameInfo={gameInfo} />
+                      <HLTB />
+                      <CompatibilityInfo gameInfo={gameInfo} />
+                      <AppleWikiInfo gameInfo={gameInfo} />
+                      <Requirements />
+                    </div>
                     {!notInstallable && (
                       <TimeContainer runner={runner} game={appName} />
                     )}
@@ -499,97 +450,160 @@ export default React.memo(function GamePage(): JSX.Element | null {
                       gameInfo={gameInfo}
                       setLaunchArguments={setLaunchArguments}
                     />
-                    <div className="buttons">
-                      <MainButton
-                        gameInfo={gameInfo}
-                        handlePlay={handlePlay}
-                        handleInstall={handleInstall}
-                      />
-                      {gameInfo.is_installed && (
-                        <button
-                          className="button is-danger delBtn"
-                          onClick={() => {
-                            setShowUninstallModal(true)
-                          }}
-                        >
-                          <span className="buttonWithIcon">
-                            <DeleteOutline />
-                            {t('button.uninstall', 'Uninstall')}
-                          </span>
-                        </button>
-                      )}
-                    </div>
+
+                    <Anticheat anticheatInfo={anticheatInfo} />
+                    <MainButton
+                      gameInfo={gameInfo}
+                      handlePlay={handlePlay}
+                      handleInstall={handleInstall}
+                    />
+                    <ReportIssue gameInfo={gameInfo} />
                   </div>
-                </div>
-                <div className="extraInfoWrapper">
-                  <div className="extraInfo">
-                    <Tabs
-                      value={currentTab}
-                      onChange={(e, newVal) => setCurrentTab(newVal)}
-                      aria-label="gameinfo tabs"
-                      variant="scrollable"
+                </>
+              )}
+              {/* NEW DESIGN */}
+              {experimentalFeatures.enableNewDesign && (
+                <>
+                  <div className="topRowWrapper">
+                    <NavLink
+                      className="backButton"
+                      to={backRoute}
+                      title={t2('webview.controls.back', 'Go Back')}
                     >
-                      <Tab
-                        value={'info'}
-                        label={t('game.install_info', 'Install info')}
-                        iconPosition="start"
-                        icon={<Info />}
+                      <ArrowBackIosNew />
+                    </NavLink>
+                    {!isBrowserGame && <SettingsButton gameInfo={gameInfo} />}
+                    <DotsMenu gameInfo={gameInfo} handleUpdate={handleUpdate} />
+                  </div>
+                  <div className="mainInfoWrapper">
+                    <div className="mainInfo">
+                      <GamePicture
+                        art_square={art_cover}
+                        art_logo={art_logo}
+                        store={runner}
                       />
-                      {hasWikiInfo && (
-                        <Tab
-                          value={'extra'}
-                          label={t('game.extra_info', 'Extra info')}
-                          iconPosition="start"
-                          icon={<Star />}
-                        />
+                      <div className="store-icon">
+                        <StoreLogos runner={runner} />
+                      </div>
+                      <h1 style={{ opacity: art_logo ? 0 : 1 }}>{title}</h1>
+                      <Genres
+                        genres={
+                          gameInfo.extra?.genres ||
+                          wikiInfo?.pcgamingwiki?.genres ||
+                          []
+                        }
+                      />
+                      <Developer gameInfo={gameInfo} />
+                      <ReleaseDate
+                        runnerDate={extraInfo?.releaseDate}
+                        date={wikiInfo?.pcgamingwiki?.releaseDate}
+                      />
+                      <Description />
+                      {!notInstallable && (
+                        <TimeContainer runner={runner} game={appName} />
                       )}
-                      {hasRequirements && (
-                        <Tab
-                          value={'requirements'}
-                          label={t('game.requirements', 'Requirements')}
-                          iconPosition="start"
-                          icon={<Monitor />}
+                      <GameStatus
+                        gameInfo={gameInfo}
+                        progress={progress}
+                        handleUpdate={handleUpdate}
+                        hasUpdate={hasUpdate}
+                      />
+                      <LaunchOptions
+                        gameInfo={gameInfo}
+                        setLaunchArguments={setLaunchArguments}
+                      />
+                      <div className="buttons">
+                        <MainButton
+                          gameInfo={gameInfo}
+                          handlePlay={handlePlay}
+                          handleInstall={handleInstall}
                         />
-                      )}
-                    </Tabs>
-                    <div>
-                      <TabPanel
-                        value={currentTab}
-                        index="info"
-                        className="infoTab"
-                      >
-                        <DownloadSizeInfo gameInfo={gameInfo} />
-                        <InstalledInfo gameInfo={gameInfo} />
-                        <CloudSavesSync gameInfo={gameInfo} />
-                      </TabPanel>
-
-                      <TabPanel
-                        value={currentTab}
-                        index="extra"
-                        className="extraTab"
-                      >
-                        <Scores gameInfo={gameInfo} />
-                        <HLTB />
-                        <CompatibilityInfo gameInfo={gameInfo} />
-                        <AppleWikiInfo gameInfo={gameInfo} />
-                      </TabPanel>
-
-                      <TabPanel value={currentTab} index="requirements">
-                        <Requirements />
-                      </TabPanel>
+                        {gameInfo.is_installed && (
+                          <button
+                            className="button is-danger delBtn"
+                            onClick={() => {
+                              setShowUninstallModal(true)
+                            }}
+                          >
+                            <span className="buttonWithIcon">
+                              <DeleteOutline />
+                              {t('button.uninstall', 'Uninstall')}
+                            </span>
+                          </button>
+                        )}
+                      </div>
                     </div>
                   </div>
+                  <div className="extraInfoWrapper">
+                    <div className="extraInfo">
+                      <Tabs
+                        value={currentTab}
+                        onChange={(e, newVal) => setCurrentTab(newVal)}
+                        aria-label="gameinfo tabs"
+                        variant="scrollable"
+                      >
+                        <Tab
+                          value={'info'}
+                          label={t('game.install_info', 'Install info')}
+                          iconPosition="start"
+                          icon={<Info />}
+                        />
+                        {hasWikiInfo && (
+                          <Tab
+                            value={'extra'}
+                            label={t('game.extra_info', 'Extra info')}
+                            iconPosition="start"
+                            icon={<Star />}
+                          />
+                        )}
+                        {hasRequirements && (
+                          <Tab
+                            value={'requirements'}
+                            label={t('game.requirements', 'Requirements')}
+                            iconPosition="start"
+                            icon={<Monitor />}
+                          />
+                        )}
+                      </Tabs>
+                      <div>
+                        <TabPanel
+                          value={currentTab}
+                          index="info"
+                          className="infoTab"
+                        >
+                          <DownloadSizeInfo gameInfo={gameInfo} />
+                          <InstalledInfo gameInfo={gameInfo} />
+                          <CloudSavesSync gameInfo={gameInfo} />
+                        </TabPanel>
 
-                  <Anticheat anticheatInfo={anticheatInfo} />
-                </div>
-                <ReportIssue gameInfo={gameInfo} />
-              </>
-            )}
-          </GameContext.Provider>
-        ) : (
-          <UpdateComponent />
-        )}
-      </div>
+                        <TabPanel
+                          value={currentTab}
+                          index="extra"
+                          className="extraTab"
+                        >
+                          <Scores gameInfo={gameInfo} />
+                          <HLTB />
+                          <CompatibilityInfo gameInfo={gameInfo} />
+                          <AppleWikiInfo gameInfo={gameInfo} />
+                        </TabPanel>
+
+                        <TabPanel value={currentTab} index="requirements">
+                          <Requirements />
+                        </TabPanel>
+                      </div>
+                    </div>
+
+                    <Anticheat anticheatInfo={anticheatInfo} />
+                  </div>
+                  <ReportIssue gameInfo={gameInfo} />
+                </>
+              )}
+            </GameContext.Provider>
+          ) : (
+            <UpdateComponent />
+          )}
+        </div>
+      </SettingsContext.Provider>
     )
   }
   return <UpdateComponent />


### PR DESCRIPTION
This PR adds an alternative "Play Now (with logs)" action right next to the normal `Play Now` button in the details page behind a small dropdown.

The idea is that users can easily select to launch a game with and without logs enabled for debugging purposes (and it's easier to instruct to do that and easier to discover).

The main action will be the last one used so users can clearly see if they are running the game with/without logs as a reminder that they can disable them, and both actions will change the game's settings so it's persisted (this way it can be used for things like running as a non-steam game and log things at the same time).

This depends on 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
