### PR TITLE
Added dbug option for vscode to be able to set breakpoints in the frontend and backend at the same time

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,40 @@
       "cwd": "${workspaceFolder}",
       "runtimeExecutable": "pnpm",
       "args": ["start"]
+    },
+    {
+      "name": "Debug Main Process",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron-vite",
+      "windows": {
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron-vite.cmd"
+      },
+      "runtimeArgs": ["--sourcemap"],
+      "env": {
+        "REMOTE_DEBUGGING_PORT": "9222"
+      }
+    },
+    {
+      "name": "Debug Renderer Process",
+      "port": 9222,
+      "request": "attach",
+      "type": "chrome",
+      "webRoot": "${workspaceFolder}/src/frontend",
+      "timeout": 60000,
+      "presentation": {
+        "hidden": true
+      }
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug All",
+      "configurations": ["Debug Main Process", "Debug Renderer Process"],
+      "presentation": {
+        "order": 1
+      }
     }
   ]
 }


### PR DESCRIPTION
Using vscode breakpoints in /src/frontend weren't stoping. 
Added 'Debug All' option 

![image](https://github.com/user-attachments/assets/5c1f44ff-720a-4687-beac-e43a922e10d5)
