### PR TITLE
[UX] Wait until winetricks lists before allowing the user to search

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -919,6 +919,8 @@
         "installed": "Installed components:",
         "installing": "Installation in progress: {{component}}",
         "loading": "Loading",
+        "loading-available": "Loading available components ...",
+        "no-components": "No available components",
         "nothingYet": "Nothing was installed by Winetricks yet",
         "openGUI": "Open Winetricks GUI",
         "search": "Search fonts or components"

--- a/src/frontend/components/UI/Winetricks/index.tsx
+++ b/src/frontend/components/UI/Winetricks/index.tsx
@@ -15,12 +15,13 @@ export default function Winetricks({ onClose, runner }: Props) {
   const { appName } = useContext(SettingsContext)
   const { t } = useTranslation()
 
-  const [loading, setLoading] = useState(true)
+  const [loadingInstalled, setLoadingInstalled] = useState(true)
+  const [loadingAvailable, setLoadingAvailable] = useState(true)
 
   // keep track of all installed components for a game/app
   const [installed, setInstalled] = useState<string[]>([])
   async function listInstalled() {
-    setLoading(true)
+    setLoadingInstalled(true)
     try {
       const components = await window.api.winetricksListInstalled(
         runner,
@@ -30,7 +31,7 @@ export default function Winetricks({ onClose, runner }: Props) {
     } catch {
       setInstalled([])
     }
-    setLoading(false)
+    setLoadingInstalled(false)
   }
   useEffect(() => {
     listInstalled()
@@ -39,6 +40,7 @@ export default function Winetricks({ onClose, runner }: Props) {
   const [allComponents, setAllComponents] = useState<string[]>([])
   useEffect(() => {
     async function listComponents() {
+      setLoadingAvailable(true)
       try {
         const components = await window.api.winetricksListAvailable(
           runner,
@@ -48,7 +50,9 @@ export default function Winetricks({ onClose, runner }: Props) {
       } catch {
         setAllComponents([])
       }
+      setLoadingAvailable(false)
     }
+
     listComponents()
   }, [])
 
@@ -108,9 +112,9 @@ export default function Winetricks({ onClose, runner }: Props) {
 
   const dialogContent = (
     <>
-      {!loading && (
+      {!loadingInstalled && (
         <div className="installWrapper">
-          {!installing && (
+          {!installing && allComponents.length !== 0 && (
             <div className="actions">
               <WinetricksSearchBar
                 allComponents={allComponents}
@@ -126,6 +130,19 @@ export default function Winetricks({ onClose, runner }: Props) {
               </button>
             </div>
           )}
+          {loadingAvailable && (
+            <span>
+              {t(
+                'winetricks.loading-available',
+                'Loading available components ...'
+              )}
+            </span>
+          )}
+          {!loadingAvailable && allComponents.length === 0 && (
+            <span>
+              {t('winetricks.no-components', 'No available components')}
+            </span>
+          )}
           {installing && (
             <p>
               {t(
@@ -140,8 +157,8 @@ export default function Winetricks({ onClose, runner }: Props) {
 
       <div className="installedWrapper">
         <b>{t('winetricks.installed', 'Installed components:')}</b>
-        {loading && <span>{t('winetricks.loading', 'Loading')}</span>}
-        {!loading && installed.length === 0 && (
+        {loadingInstalled && <span>{t('winetricks.loading', 'Loading')}</span>}
+        {!loadingInstalled && installed.length === 0 && (
           <span>
             {t(
               'winetricks.nothingYet',
@@ -149,7 +166,7 @@ export default function Winetricks({ onClose, runner }: Props) {
             )}
           </span>
         )}
-        {!loading && <span>{installed.join(', ')}</span>}
+        {!loadingInstalled && <span>{installed.join(', ')}</span>}
       </div>
     </>
   )


### PR DESCRIPTION
When opening the Winetricks dialog, if a user starts typing too fast in the input field before we get the list of valid components/fonts then it will look like nothing is found. Many users reported that in discord.

This PR changes the dialog to show a message while we are loading the list of things available so users can't type while it's loading, and then we allow searching only once it's ready.

This should make it less confusing for users.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
