### PR TITLE
[FIX] Use env for mangohud dlsym hooking

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -129,7 +129,7 @@ async function prepareLaunch(
       }
     }
 
-    mangoHudCommand = [mangoHudBin, '--dlsym']
+    mangoHudCommand = [mangoHudBin]
   }
 
   if (gameSettings.useGameMode) {
@@ -683,6 +683,9 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
   }
   if (isLinux && gameSettings.battlEyeRuntime) {
     ret.PROTON_BATTLEYE_RUNTIME = join(runtimePath, 'battleye_runtime')
+  }
+  if (gameSettings.showMangohud) {
+    ret.MANGOHUD_DLSYM = '1'
   }
   if (wineVersion.type === 'proton') {
     // If we don't set this, GE-Proton tries to guess the AppID from the prefix path, which doesn't work in our case


### PR DESCRIPTION
Mangohud-git removes the --dlsym option

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
