### PR TITLE
Fix legendary download progress bar percentage for updates

### DIFF
--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -467,8 +467,14 @@ export function onInstallOrUpdateOutput(
     const downloaded = parseFloat(progress.bytes)
     const downloadCache = totalDownloadSize - currentDownloadSize[appName]
     const totalDownloaded = downloaded + downloadCache
-    const newPercent =
-      Math.round((totalDownloaded / totalDownloadSize) * 10000) / 100
+    let newPercent: number
+    if (action === 'installing') {
+      newPercent =
+        Math.round((totalDownloaded / totalDownloadSize) * 10000) / 100
+    } else {
+      newPercent =
+        Math.round((downloaded / currentDownloadSize[appName]) * 10000) / 100
+    }
     progress.percent = newPercent >= 0 ? newPercent : undefined
   }
 


### PR DESCRIPTION
closes #4190 

### Issue:
as discussed in #4190, the current method of calculating progress percentage for updates provides a misleading output. 

This PR attempts to fix this by:
- preserving the existing functionality of using already downloaded files into progress bar calculation for installs
- and ignoring download cache for updates to better represent the game update progress.

For more context and clarity, a detailed discussion is present in the linked issue

### Testing:
I am using Rocket League as an example here. I redownloaded the game from an old manifest that legendary had saved locally, then triggered an update from Heroic.



#### Before (Heroic 2.15.2)
- ![image_2025-01-05_01-14-15](https://github.com/user-attachments/assets/f7b9a2ad-ed71-415b-9a5b-c8ae0b69913e)

logs: 
  - ![image_2025-01-05_01-16-52](https://github.com/user-attachments/assets/5c0374f7-5f61-415e-a97d-16d879472d27)

#### After (my dev branch)

- ![image_2025-01-05_01-25-34](https://github.com/user-attachments/assets/f6fc1c66-b44d-4538-9d0a-932cf8961f0c)

logs:
  - ![image_2025-01-05_01-25-52](https://github.com/user-attachments/assets/09d41474-faad-4445-bf2a-10f740f8c398)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)

