### PR TITLE
[UX] Add option to backup saves after closing a game

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -383,7 +383,7 @@
     },
     "infobox": {
         "backupSaves": {
-            "details": "Backups are stored in Heroic's config folder, in `savesBackups/{appName}`.<3></3>To restore a backup, you must do it manually. This is intended as a safety measure and not as a full backup system.<5></5>You may want to delete old backups periodically to free up space.",
+            "details": "Backups are stored in Heroic&apos;s config folder, in `savesBackups/{appName}`.<3></3><4></4>To restore a backup, you must do it manually. This is intended as a safety measure and not as a full backup system.<6></6><7></7>You may want to delete old backups periodically to free up space.",
             "title": "About Heroic backups"
         },
         "help": "Help",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -382,6 +382,10 @@
         "version": "Wine Version"
     },
     "infobox": {
+        "backupSaves": {
+            "details": "Backups are stored in Heroic's config folder, in `savesBackups/{appName}`.<3></3>To restore a backup, you must do it manually. This is intended as a safety measure and not as a full backup system.<5></5>You may want to delete old backups periodically to free up space.",
+            "title": "About Heroic backups"
+        },
         "help": "Help",
         "requirements": "System Requirements",
         "warning": "Warning",
@@ -592,6 +596,7 @@
         "autosync": "Autosync Saves",
         "autoUpdateGames": "Automatically update games",
         "autovkd3d": "Auto Install/Update VKD3D on Prefix",
+        "backupSavesAfterClosingGame": "Backup saves in Heroic's config after closing a game.",
         "before-launch-script-path": "Select a script to run before the game is launched",
         "change-target-exe": "Select an alternative EXE to run",
         "checkForUpdatesOnStartup": "Check for Heroic Updates on Startup",

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -322,7 +322,8 @@ class GlobalConfigV0 extends GlobalConfig {
       framelessWindow: false,
       beforeLaunchScriptPath: '',
       afterLaunchScriptPath: '',
-      disableUMU: false
+      disableUMU: false,
+      backupSavesAfterClosingGame: true
     }
     // @ts-expect-error TODO: We need to settle on *one* place to define settings defaults
     return settings

--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -74,6 +74,7 @@ const defaultWinePrefix = join(defaultWinePrefixDir, 'default')
 const anticheatDataPath = join(appFolder, 'areweanticheatyet.json')
 const imagesCachePath = join(appFolder, 'images-cache')
 const fixesPath = join(appFolder, 'fixes')
+const savesBackupsPath = join(appFolder, 'savesBackups')
 
 const {
   currentLogFile,
@@ -295,5 +296,6 @@ export {
   nileLibrary,
   nileUserData,
   fixesPath,
-  thirdPartyInstalled
+  thirdPartyInstalled,
+  savesBackupsPath
 }

--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -234,6 +234,7 @@ class GameConfigV0 extends GameConfig {
       battlEyeRuntime,
       beforeLaunchScriptPath,
       afterLaunchScriptPath,
+      backupSavesAfterClosingGame,
       gamescope
     } = GlobalConfig.get().getSettings()
 
@@ -266,6 +267,7 @@ class GameConfigV0 extends GameConfig {
       language: '', // we want to fallback to '' always here, fallback lang for games should be ''
       beforeLaunchScriptPath,
       afterLaunchScriptPath,
+      backupSavesAfterClosingGame,
       gamescope
     } as GameSettings
 

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -105,7 +105,12 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
 }) => {
   const game = gameManagerMap[runner].getGameInfo(appName)
   const gameSettings = await gameManagerMap[runner].getSettings(appName)
-  const { autoSyncSaves, savesPath, gogSaves = [] } = gameSettings
+  const {
+    autoSyncSaves,
+    savesPath,
+    gogSaves = [],
+    backupSavesAfterClosingGame
+  } = gameSettings
 
   const { title } = game
 
@@ -258,6 +263,10 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     }
   }
   await addRecentGame(game)
+
+  if (autoSyncSaves && backupSavesAfterClosingGame) {
+    await gameManagerMap[runner].backupSaves(appName, savesPath, gogSaves)
+  }
 
   if (autoSyncSaves && isOnline()) {
     sendGameStatusUpdate({

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -878,7 +878,7 @@ export async function syncSaves(
   return fullOutput
 }
 
-export function backupSaves(
+export async function backupSaves(
   appName: string,
   path: string,
   gogSaves?: GOGCloudSavesLocation[]

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -108,6 +108,7 @@ import ini from 'ini'
 import { getRequiredRedistList, updateRedist } from './redist'
 import { spawn } from 'child_process'
 import { getUmuId } from 'backend/wiki_game_info/umu/utils'
+import { copySavesIntoBackup } from '../storeManagerCommon/games'
 
 export async function getExtraInfo(appName: string): Promise<ExtraInfo> {
   const gameInfo = getGameInfo(appName)
@@ -875,6 +876,31 @@ export async function syncSaves(
   }
 
   return fullOutput
+}
+
+export function backupSaves(
+  appName: string,
+  path: string,
+  gogSaves?: GOGCloudSavesLocation[]
+) {
+  if (!gogSaves) {
+    logError(
+      'No gogSaves paths given, nothing to backup. Check your settings!',
+      LogPrefix.Gog
+    )
+    return
+  }
+
+  for (const savePath of gogSaves) {
+    if (!existsSync(savePath.location)) {
+      logError(
+        `Saves path '${savePath.location}' does no exist, nothing to backup.`,
+        LogPrefix.Gog
+      )
+    } else {
+      copySavesIntoBackup(appName, savePath.location, savePath.name)
+    }
+  }
 }
 
 export async function uninstall({

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -836,7 +836,7 @@ export async function syncSaves(
   return fullOutput
 }
 
-export function backupSaves(appName: string, path: string) {
+export async function backupSaves(appName: string, path: string) {
   if (!path) {
     logError(
       'No path provided for SavesSync, nothing to backup. Check your settings!',

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -91,6 +91,7 @@ import { getUmuId } from 'backend/wiki_game_info/umu/utils'
 import thirdParty from './thirdParty'
 import { Path } from 'backend/schemas'
 import { mkdirSync } from 'fs'
+import { copySavesIntoBackup } from '../storeManagerCommon/games'
 
 /**
  * Alias for `LegendaryLibrary.listUpdateableGames`
@@ -833,6 +834,26 @@ export async function syncSaves(
     )
   }
   return fullOutput
+}
+
+export function backupSaves(appName: string, path: string) {
+  if (!path) {
+    logError(
+      'No path provided for SavesSync, nothing to backup. Check your settings!',
+      LogPrefix.Legendary
+    )
+    return
+  }
+
+  if (!existsSync(path)) {
+    logError(
+      'Saves path does no exist, nothing to backup.',
+      LogPrefix.Legendary
+    )
+    return
+  }
+
+  copySavesIntoBackup(appName, path)
 }
 
 export async function launch(

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -496,9 +496,8 @@ export async function syncSaves(): Promise<string> {
   return ''
 }
 
-export async function backupSaves(): Promise<string> {
+export function backupSaves() {
   // Amazon Games doesn't support cloud saves
-  return ''
 }
 
 export async function uninstall({ appName }: RemoveArgs): Promise<ExecResult> {

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -496,7 +496,7 @@ export async function syncSaves(): Promise<string> {
   return ''
 }
 
-export function backupSaves() {
+export async function backupSaves() {
   // Amazon Games doesn't support cloud saves
 }
 

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -496,6 +496,11 @@ export async function syncSaves(): Promise<string> {
   return ''
 }
 
+export async function backupSaves(): Promise<string> {
+  // Amazon Games doesn't support cloud saves
+  return ''
+}
+
 export async function uninstall({ appName }: RemoveArgs): Promise<ExecResult> {
   const commandParts = ['uninstall', appName]
 

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -221,11 +221,10 @@ export async function syncSaves(
   return ''
 }
 
-export async function backupSaves(appName: string): Promise<string> {
+export async function backupSaves(appName: string) {
   logWarning(
     `backupSaves not implemented on Sideload Game Manager. called for appName = ${appName}`
   )
-  return ''
 }
 
 export async function forceUninstall(appName: string): Promise<void> {

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -221,6 +221,13 @@ export async function syncSaves(
   return ''
 }
 
+export async function backupSaves(appName: string): Promise<string> {
+  logWarning(
+    `backupSaves not implemented on Sideload Game Manager. called for appName = ${appName}`
+  )
+  return ''
+}
+
 export async function forceUninstall(appName: string): Promise<void> {
   logWarning(
     `forceUninstall not implemented on Sideload Game Manager. called for appName = ${appName}`

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -1,17 +1,23 @@
 import { GameInfo, GameSettings, Runner } from 'common/types'
 import { GameConfig } from '../../game_config'
-import { isMac, isLinux, icon } from '../../constants'
+import { isMac, isLinux, icon, savesBackupsPath } from '../../constants'
 import {
   appendGamePlayLog,
   appendWinetricksGamePlayLog,
   lastPlayLogFileLocation,
+  logError,
   logInfo,
   LogPrefix,
   logsDisabled,
   logWarning
 } from '../../logger/logger'
-import { basename, dirname } from 'path'
-import { constants as FS_CONSTANTS } from 'graceful-fs'
+import { basename, dirname, join } from 'path'
+import {
+  cpSync,
+  existsSync,
+  constants as FS_CONSTANTS,
+  mkdirSync
+} from 'graceful-fs'
 import i18next from 'i18next'
 import {
   callRunner,
@@ -272,4 +278,41 @@ export async function launchGame(
     return true
   }
   return false
+}
+
+export function copySavesIntoBackup(
+  appName: string,
+  savesPath: string,
+  subfolder?: string
+) {
+  logInfo(`Creating backup of ${savesPath} for ${appName}`)
+
+  const timeStamp = new Date().toISOString().replace(/\.\d+Z/g, '')
+  let gameBackupsFolder = join(savesBackupsPath, appName)
+
+  // support GOGs multiple save paths for a single game using the save path name as a subfolder
+  if (subfolder) gameBackupsFolder = join(gameBackupsFolder, subfolder)
+
+  if (!existsSync(gameBackupsFolder)) {
+    try {
+      mkdirSync(gameBackupsFolder, { recursive: true })
+    } catch (error) {
+      logError(`Backup folder for ${appName} could not be created.`)
+      logError(error)
+      return
+    }
+  }
+
+  try {
+    cpSync(savesPath, join(gameBackupsFolder, timeStamp.toString()), {
+      recursive: true
+    })
+
+    logInfo(`Backup of ${savesPath} for ${appName} completed.`)
+  } catch (error) {
+    logError(
+      `An error ocurred while creating a backup of the saves of ${appName}.`
+    )
+    logError(error)
+  }
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -203,6 +203,7 @@ export interface GameSettings {
   beforeLaunchScriptPath: string
   afterLaunchScriptPath: string
   disableUMU: boolean
+  backupSavesAfterClosingGame: boolean
 }
 
 export type Status =

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -56,6 +56,11 @@ export interface GameManager {
     path: string,
     gogSaves?: GOGCloudSavesLocation[]
   ) => Promise<string>
+  backupSaves: (
+    appName: string,
+    path: string,
+    gogSaves?: GOGCloudSavesLocation[]
+  ) => Promise<string>
   uninstall: (args: RemoveArgs) => Promise<ExecResult>
   update: (
     appName: string,

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -60,7 +60,7 @@ export interface GameManager {
     appName: string,
     path: string,
     gogSaves?: GOGCloudSavesLocation[]
-  ) => Promise<string>
+  ) => Promise<void>
   uninstall: (args: RemoveArgs) => Promise<ExecResult>
   update: (
     appName: string,

--- a/src/frontend/screens/Settings/components/BackupSavesAfterClosingGame.tsx
+++ b/src/frontend/screens/Settings/components/BackupSavesAfterClosingGame.tsx
@@ -32,11 +32,13 @@ const BackupSavesAfterClosingGame = () => {
 
       <InfoBox text={t('infobox.backupSaves.title', 'About Heroic backups')}>
         <Trans i18n={i18n} key="infobox.backupSaves.details">
-          Backups are stored in Heroic's config folder, in `savesBackups/
+          Backups are stored in Heroic&apos;s config folder, in `savesBackups/
           {appName}`.
+          <br />
           <br />
           To restore a backup, you must do it manually. This is intended as a
           safety measure and not as a full backup system.
+          <br />
           <br />
           You may want to delete old backups periodically to free up space.
         </Trans>

--- a/src/frontend/screens/Settings/components/BackupSavesAfterClosingGame.tsx
+++ b/src/frontend/screens/Settings/components/BackupSavesAfterClosingGame.tsx
@@ -1,0 +1,48 @@
+import React, { useContext } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import { InfoBox, ToggleSwitch } from 'frontend/components/UI'
+import useSetting from 'frontend/hooks/useSetting'
+import SettingsContext from '../SettingsContext'
+
+const BackupSavesAfterClosingGame = () => {
+  const { t, i18n } = useTranslation()
+  const { appName } = useContext(SettingsContext)
+
+  const [backupSavesAfterClosingGame, setBackupSavesAfterClosingGame] =
+    useSetting('backupSavesAfterClosingGame', false)
+  const [autoSyncSaves] = useSetting('autoSyncSaves', false)
+
+  if (!autoSyncSaves) {
+    return <></>
+  }
+
+  return (
+    <div>
+      <ToggleSwitch
+        htmlId="backupSavesAfterClosingGame"
+        value={backupSavesAfterClosingGame}
+        handleChange={() =>
+          setBackupSavesAfterClosingGame(!backupSavesAfterClosingGame)
+        }
+        title={t(
+          'setting.backupSavesAfterClosingGame',
+          "Backup saves in Heroic's config after closing a game."
+        )}
+      />
+
+      <InfoBox text={t('infobox.backupSaves.title', 'About Heroic backups')}>
+        <Trans i18n={i18n} key="infobox.backupSaves.details">
+          Backups are stored in Heroic's config folder, in `savesBackups/
+          {appName}`.
+          <br />
+          To restore a backup, you must do it manually. This is intended as a
+          safety measure and not as a full backup system.
+          <br />
+          You may want to delete old backups periodically to free up space.
+        </Trans>
+      </InfoBox>
+    </div>
+  )
+}
+
+export default BackupSavesAfterClosingGame

--- a/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
@@ -14,6 +14,7 @@ import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 import { ProgressDialog } from 'frontend/components/UI/ProgressDialog'
 import SettingsContext from '../../SettingsContext'
 import TextWithProgress from 'frontend/components/UI/TextWithProgress'
+import BackupSavesAfterClosingGame from '../../components/BackupSavesAfterClosingGame'
 
 interface Props {
   gogSaves: GOGCloudSavesLocation[]
@@ -203,6 +204,8 @@ export default function GOGSyncSaves({
               <li>{t('help.sync.part4')}</li>
             </ul>
           </InfoBox>
+
+          <BackupSavesAfterClosingGame />
         </>
       )}
     </>

--- a/src/frontend/screens/Settings/sections/SyncSaves/legendary.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/legendary.tsx
@@ -14,6 +14,7 @@ import { SyncType } from 'frontend/types'
 import { ProgressDialog } from 'frontend/components/UI/ProgressDialog'
 import SettingsContext from '../../SettingsContext'
 import TextWithProgress from 'frontend/components/UI/TextWithProgress'
+import BackupSavesAfterClosingGame from '../../components/BackupSavesAfterClosingGame'
 
 interface Props {
   autoSyncSaves: boolean
@@ -177,6 +178,8 @@ export default function LegendarySyncSaves({
               <li>{t('help.sync.part4')}</li>
             </ul>
           </InfoBox>
+
+          <BackupSavesAfterClosingGame />
         </>
       )}
     </>


### PR DESCRIPTION
I'm not 100% convinced about this feature as implemented in this PR. I do think that having a way to backup save files before doing some sync is a good idea because I've seen many support tickets of users playing around with cloud saves and ending up losing their saves for different reasons.

This PR adds an option to copy the saves of a game into Heroic's config folder after the game closes if it supports cloud saves and they are enabled.

I think we can only implement this for games with cloud saves since those are the ones we can know the save path from the metadata.

I don't know if the approach here is the best idea so I'm open to any feedback. Other options could be:
- backup BEFORE syncing when launching a game
- backup BEFORE syncing both when launching a game and when running the sync manually (maybe this is safer for what I'm trying to avoid?)
- backup with a button (though users might expect some kind of restore button in that case)

I also don't know how big save files can get (I know GOG added some limits, but I don't know about Epic). Maybe we have to put some limit in the number of backups per game? I'm not sure either

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
