### PR TITLE
[UX] Ignore Proton - Experimental by default, but allow enabling it for advanced usage

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -584,6 +584,14 @@
             },
             "label": "Allow installation of games with broken or denied anticheat"
         },
+        "allow_proton_experimental": {
+            "confirmation": {
+                "message": "'Proton - Experimental' is, by nature, meant for experimentation and not for stable use. Using it as a default for all games can unexpectedly break games previously working during an upgrade. Use it only if you know what you are doing.",
+                "title": "Are you sure?",
+                "understand": "Don't allow it"
+            },
+            "label": "Allow using \"Proton - Experimental\" to run games"
+        },
         "alt-gogdl-bin": "Choose an Alternative GOGDL Binary to use",
         "alt-legendary-bin": "Choose an Alternative Legendary Binary",
         "alt-nile-bin": "Choose an Alternative Nile Binary",

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -169,6 +169,15 @@ export async function getLinuxWineSet(
   protonPaths.forEach((path) => {
     if (existsSync(path)) {
       readdirSync(path).forEach((version) => {
+        if (version.includes('Experimental')) {
+          if (!GlobalConfig.get().getSettings().allowProtonExperimental) {
+            logInfo(
+              'Ignoring "Proton - Experimental". You can change this in Settings > Advanced'
+            )
+            return
+          }
+        }
+
         // Only relevant to Lutris
         if (version.startsWith('UMU-Latest')) {
           return

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -102,6 +102,7 @@ export interface AppSettings extends GameSettings {
   startInTray: boolean
   allowInstallationBrokenAnticheat: boolean
   disableUMU: boolean
+  allowProtonExperimental: boolean
 }
 
 export type LibraryTopSectionOptions =

--- a/src/frontend/screens/Settings/components/AllowProtonExperimental.tsx
+++ b/src/frontend/screens/Settings/components/AllowProtonExperimental.tsx
@@ -1,0 +1,63 @@
+import React, { useContext } from 'react'
+import { useTranslation } from 'react-i18next'
+import useSetting from 'frontend/hooks/useSetting'
+import { ToggleSwitch } from 'frontend/components/UI'
+import ContextProvider from 'frontend/state/ContextProvider'
+
+const AllowProtonExperimental = () => {
+  const { t } = useTranslation()
+  const { showDialogModal } = useContext(ContextProvider)
+  const [allowProtonExperimental, setAllowProtonExperimental] = useSetting(
+    'allowProtonExperimental',
+    false
+  )
+
+  const toggleConfig = () => {
+    if (allowProtonExperimental) {
+      setAllowProtonExperimental(false)
+    } else {
+      showDialogModal({
+        title: t(
+          'setting.allow_proton_experimental.confirmation.title',
+          'Are you sure?'
+        ),
+        message: t(
+          'setting.allow_proton_experimental.confirmation.message',
+          "'Proton - Experimental' is, by nature, meant for experimentation and not for stable use. Using it as a default for all games can unexpectedly break games previously working during an upgrade. Use it only if you know what you are doing."
+        ),
+        buttons: [
+          {
+            text: t(
+              'setting.allow_proton_experimental.confirmation.understand',
+              'I understand, allow it'
+            ),
+            onClick: () => setAllowProtonExperimental(true)
+          },
+          {
+            text: t(
+              'setting.allow_proton_experimental.confirmation.understand',
+              "Don't allow it"
+            )
+          }
+        ],
+        type: 'MESSAGE'
+      })
+    }
+  }
+
+  return (
+    <div className="toggleRow">
+      <ToggleSwitch
+        htmlId="allowProtonExperimental"
+        value={allowProtonExperimental}
+        handleChange={() => toggleConfig()}
+        title={t(
+          'setting.allow_proton_experimental.label',
+          'Allow using "Proton - Experimental" to run games'
+        )}
+      />
+    </div>
+  )
+}
+
+export default AllowProtonExperimental

--- a/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
@@ -25,6 +25,7 @@ import {
   ExperimentalFeatures,
   ResetHeroic
 } from '../../components'
+import AllowProtonExperimental from '../../components/AllowProtonExperimental'
 
 export default function AdvancedSetting() {
   const { config } = useContext(SettingsContext)
@@ -177,6 +178,8 @@ export default function AdvancedSetting() {
       <DisableLogs />
 
       <AllowInstallationBrokenAnticheat />
+
+      <AllowProtonExperimental />
 
       <hr />
 


### PR DESCRIPTION
This PR changes how we handle the `Proton - Experimental` option to run games.

We currently have a problem, that, for some users, `Proton - Experimental` might be the only wine/proton they have when they use Heroic for the first time and it gets assigned as a default game setting. From there, all their games ends up using `Proton - Experimental` with the risks that creates: it's experimental and not tested as much as stable versions, so an updated in steam without the user noticing it can break games in Heroic and it's hard to know what changed (users usually think nothing changed).

With this change, `Proton - Experimental` won't show up by default in the `Wine Version` selectors throughout the app, so inexperienced users can't select it by mistake and shouldn't be automatically selected by Heroic either (there's also this idea that, because it fixes many games, it's always better, so checking the option shows a warning for the user with some information about what experimental means).

For users that know what they are doing and want to be intentional about using `Proton - Experimental`, there's now a checkbox in Settings > Advances to stop ignoring it.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
