### PR TITLE
Fix chrome-sandbox ownership/mode so e2e tests can run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,7 @@ jobs:
       - name: Checkout repository.
         uses: actions/checkout@v3
       - uses: ./.github/actions/install-deps
+      - name: Fix ownership and mode
+        run: sudo chown root /home/runner/work/HeroicGamesLauncher/HeroicGamesLauncher/node_modules/electron/dist/chrome-sandbox && sudo chmod 4755 /home/runner/work/HeroicGamesLauncher/HeroicGamesLauncher/node_modules/electron/dist/chrome-sandbox
       - name: Test E2E
         run: pnpm test:e2e


### PR DESCRIPTION
So... e2e tests have been failing consistently for the last week or so in CI but they work just fine locally.

I added some debugging code in this test branch/PR https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4256 and the output shows this weird sandbox issue:

```
[pid=2422][err] [2422:0110/021426.940726:FATAL:setuid_sandbox_host.cc(158)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /home/runner/work/HeroicGamesLauncher/HeroicGamesLauncher/node_modules/electron/dist/chrome-sandbox is owned by root and has mode 4755.
```

So this PR is changing the ownership and mode of the chrome-sanbox binary so it doesn't exit and now tests are working.

I really don't know what changed (I think we didn't update electron, and nothing changed in the CI config, so I'm guessing electron does _some magic_ during the download and something changed there?). Or maybe something changed in GitHub's side with the image that runs the tests?

I haven't seen a proper fix or what changed, but people in the electron repo suggest doing that so the binary doesn't complain https://github.com/electron/electron/issues/42510

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
