### PR TITLE
[Refactor] Make InstallModal global with state moved to zustand

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -18,6 +18,7 @@ import classNames from 'classnames'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import LogFileUploadDialog from './components/UI/LogFileUploadDialog'
 import UploadedLogFilesList from './screens/Settings/sections/LogSettings/components/UploadedLogFilesList'
+import { InstallGameWrapper } from './screens/Library/components/InstallModal'
 
 function Root() {
   const {
@@ -59,6 +60,7 @@ function Root() {
               type={isSettingsModalOpen.type}
             />
           )}
+          <InstallGameWrapper />
           <ExternalLinkDialog />
           <LogFileUploadDialog />
           <UploadedLogFilesList />

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -39,7 +39,6 @@ import {
 import GamePicture from '../GamePicture'
 import TimeContainer from '../TimeContainer'
 
-import { InstallModal } from 'frontend/screens/Library/components'
 import { install } from 'frontend/helpers/library'
 import { hasProgress } from 'frontend/hooks/hasProgress'
 import ErrorComponent from 'frontend/components/UI/ErrorComponent'
@@ -71,6 +70,7 @@ import { hasAnticheatInfo } from 'frontend/hooks/hasAnticheatInfo'
 import { hasHelp } from 'frontend/hooks/hasHelp'
 import Genres from './components/Genres'
 import ReleaseDate from './components/ReleaseDate'
+import { openInstallGameModal } from 'frontend/state/InstallGameModal'
 
 export default React.memo(function GamePage(): JSX.Element | null {
   const { appName, runner } = useParams() as { appName: string; runner: Runner }
@@ -82,7 +82,6 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
   const { gameInfo: locationGameInfo } = location.state
 
-  const [showModal, setShowModal] = useState({ game: '', show: false })
   const [showUninstallModal, setShowUninstallModal] = useState(false)
   const [wikiInfo, setWikiInfo] = useState<WikiInfo | null>(null)
 
@@ -260,7 +259,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
   }
 
   function handleModal() {
-    setShowModal({ game: appName, show: true })
+    openInstallGameModal({ appName, runner, gameInfo })
   }
 
   let hasUpdate = false
@@ -356,14 +355,6 @@ export default React.memo(function GamePage(): JSX.Element | null {
               className="backgroundImage"
             />
           )}
-        {gameInfo.runner !== 'sideload' && showModal.show && (
-          <InstallModal
-            appName={showModal.game}
-            runner={runner}
-            backdropClick={() => setShowModal({ game: '', show: false })}
-            gameInfo={gameInfo}
-          />
-        )}
         {showUninstallModal && (
           <UninstallModal
             appName={appName}

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -9,10 +9,10 @@ import { useTranslation } from 'react-i18next'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { NavLink } from 'react-router-dom'
 
-import { InstallModal } from 'frontend/screens/Library/components'
 import { CircularProgress } from '@mui/material'
 import UninstallModal from 'frontend/components/UI/UninstallModal'
 import GameContext from '../GameContext'
+import { openInstallGameModal } from 'frontend/state/InstallGameModal'
 
 interface Props {
   appName: string
@@ -59,7 +59,6 @@ export default function GamesSubmenu({
   const [hasShortcuts, setHasShortcuts] = useState(false)
   const [eosOverlayEnabled, setEosOverlayEnabled] = useState<boolean>(false)
   const [eosOverlayRefresh, setEosOverlayRefresh] = useState<boolean>(false)
-  const [showModal, setShowModal] = useState(false)
   const eosOverlayAppName = '98bc04bc842e4906993fd6d6644ffb8d'
   const [showUninstallModal, setShowUninstallModal] = useState(false)
   const [protonDBurl, setProtonDBurl] = useState(
@@ -147,7 +146,7 @@ export default function GamesSubmenu({
   }
 
   function handleEdit() {
-    setShowModal(true)
+    openInstallGameModal({ appName, runner, gameInfo })
   }
 
   async function handleEosOverlay() {
@@ -379,13 +378,6 @@ export default function GamesSubmenu({
           )}
         </div>
       </div>
-      {showModal && (
-        <InstallModal
-          appName={appName}
-          runner={runner}
-          backdropClick={() => setShowModal(false)}
-        />
-      )}
     </>
   )
 }

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -20,10 +20,13 @@ import WineSelector from './WineSelector'
 import { SelectField } from 'frontend/components/UI'
 import { useTranslation } from 'react-i18next'
 import ThirdPartyDialog from './ThirdPartyDialog'
+import {
+  closeInstallGameModal,
+  useInstallGameModal
+} from 'frontend/state/InstallGameModal'
 
 type Props = {
   appName: string
-  backdropClick: () => void
   runner: Runner
   gameInfo?: GameInfo | null
 }
@@ -35,12 +38,7 @@ export type AvailablePlatforms = {
   icon: IconDefinition
 }[]
 
-export default React.memo(function InstallModal({
-  appName,
-  backdropClick,
-  runner,
-  gameInfo = null
-}: Props) {
+function InstallModal({ appName, runner, gameInfo = null }: Props) {
   const { platform } = useContext(ContextProvider)
   const { t } = useTranslation('gamepage')
 
@@ -155,10 +153,12 @@ export default React.memo(function InstallModal({
   const showDownloadDialog = !isSideload && gameInfo
   const isThirdPartyManagedApp = gameInfo && !!gameInfo.thirdPartyManagedApp
 
+  const closeModal = () => closeInstallGameModal()
+
   return (
     <div className="InstallModal">
       <Dialog
-        onClose={backdropClick}
+        onClose={closeModal}
         showCloseButton
         className="InstallModal__dialog"
       >
@@ -169,7 +169,7 @@ export default React.memo(function InstallModal({
             winePrefix={winePrefix}
             wineVersion={wineVersion}
             availablePlatforms={availablePlatforms}
-            backdropClick={backdropClick}
+            backdropClick={closeModal}
             platformToInstall={platformToInstall}
             gameInfo={gameInfo}
             crossoverBottle={crossoverBottle}
@@ -197,7 +197,7 @@ export default React.memo(function InstallModal({
             winePrefix={winePrefix}
             wineVersion={wineVersion}
             availablePlatforms={availablePlatforms}
-            backdropClick={backdropClick}
+            backdropClick={closeModal}
             platformToInstall={platformToInstall}
             gameInfo={gameInfo}
             crossoverBottle={crossoverBottle}
@@ -223,7 +223,7 @@ export default React.memo(function InstallModal({
             winePrefix={winePrefix}
             wineVersion={wineVersion}
             availablePlatforms={availablePlatforms}
-            backdropClick={backdropClick}
+            backdropClick={closeModal}
             platformToInstall={platformToInstall}
             appName={appName}
             crossoverBottle={crossoverBottle}
@@ -246,4 +246,20 @@ export default React.memo(function InstallModal({
       </Dialog>
     </div>
   )
-})
+}
+
+export function InstallGameWrapper() {
+  const installGameModalState = useInstallGameModal()
+
+  if (!installGameModalState.isOpen) {
+    return <></>
+  }
+
+  return (
+    <InstallModal
+      appName={installGameModalState.appName!}
+      runner={installGameModalState.runner!}
+      gameInfo={installGameModalState.gameInfo}
+    />
+  )
+}

--- a/src/frontend/screens/Library/components/index.tsx
+++ b/src/frontend/screens/Library/components/index.tsx
@@ -1,1 +1,0 @@
-export { default as InstallModal } from './InstallModal'

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -27,21 +27,14 @@ import {
   sideloadedCategories
 } from 'frontend/helpers/library'
 import RecentlyPlayed from './components/RecentlyPlayed'
-import { InstallModal } from './components'
 import LibraryContext from './LibraryContext'
 import { Category, PlatformsFilters, StoresFilters } from 'frontend/types'
 import { hasHelp } from 'frontend/hooks/hasHelp'
 import EmptyLibraryMessage from './components/EmptyLibrary'
 import CategoriesManager from './components/CategoriesManager'
+import { openInstallGameModal } from 'frontend/state/InstallGameModal'
 
 const storage = window.localStorage
-
-type ModalState = {
-  game: string
-  show: boolean
-  runner: Runner
-  gameInfo: GameInfo | null
-}
 
 export default React.memo(function Library(): JSX.Element {
   const { t } = useTranslation()
@@ -180,12 +173,6 @@ export default React.memo(function Library(): JSX.Element {
 
   const [showCategories, setShowCategories] = useState(false)
 
-  const [showModal, setShowModal] = useState<ModalState>({
-    game: '',
-    show: false,
-    runner: 'legendary',
-    gameInfo: null
-  })
   const [sortDescending, setSortDescending] = useState(
     JSON.parse(storage?.getItem('sortDescending') || 'false')
   )
@@ -245,7 +232,7 @@ export default React.memo(function Library(): JSX.Element {
     runner: Runner,
     gameInfo: GameInfo | null
   ) {
-    setShowModal({ game: appName, show: true, runner, gameInfo })
+    openInstallGameModal({ appName, runner, gameInfo })
   }
 
   // cache list of games being installed
@@ -661,22 +648,6 @@ export default React.memo(function Library(): JSX.Element {
       <button id="backToTopBtn" onClick={backToTop} ref={backToTopElement}>
         <ArrowDropUp id="backToTopArrow" className="material-icons" />
       </button>
-
-      {showModal.show && (
-        <InstallModal
-          appName={showModal.game}
-          runner={showModal.runner}
-          gameInfo={showModal.gameInfo}
-          backdropClick={() =>
-            setShowModal({
-              game: '',
-              show: false,
-              runner: 'legendary',
-              gameInfo: null
-            })
-          }
-        />
-      )}
 
       {showCategories && <CategoriesManager />}
     </LibraryContext.Provider>

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -23,7 +23,6 @@ import { getGameInfo, getLegendaryConfig, notify } from '../helpers'
 import { i18n, t, TFunction } from 'i18next'
 
 import ContextProvider from './ContextProvider'
-import { InstallModal } from 'frontend/screens/Library/components'
 
 import {
   configStore,
@@ -949,7 +948,6 @@ class GlobalState extends PureComponent<Props> {
 
   render() {
     const {
-      showInstallModal,
       language,
       epic,
       gog,
@@ -1045,18 +1043,6 @@ class GlobalState extends PureComponent<Props> {
         }}
       >
         {this.props.children}
-        {showInstallModal.show && (
-          <InstallModal
-            appName={showInstallModal.appName}
-            runner={showInstallModal.runner}
-            gameInfo={showInstallModal.gameInfo}
-            backdropClick={() =>
-              this.setState({
-                showInstallModal: { ...showInstallModal, show: false }
-              })
-            }
-          />
-        )}
       </ContextProvider.Provider>
     )
   }

--- a/src/frontend/state/InstallGameModal.ts
+++ b/src/frontend/state/InstallGameModal.ts
@@ -1,0 +1,38 @@
+import { GameInfo, Runner } from 'common/types'
+import { create } from 'zustand'
+
+interface InstallGameModalState {
+  isOpen: boolean
+  appName?: string
+  runner?: Runner
+  gameInfo: GameInfo | null
+}
+
+export const useInstallGameModal = create<InstallGameModalState>()(() => ({
+  isOpen: false,
+  gameInfo: null
+}))
+
+interface OpenInstallGameModalParams {
+  appName: string
+  runner: Runner
+  gameInfo: GameInfo | null
+}
+export const openInstallGameModal = ({
+  appName,
+  runner,
+  gameInfo
+}: OpenInstallGameModalParams) => {
+  useInstallGameModal.setState({
+    isOpen: true,
+    appName,
+    runner,
+    gameInfo
+  })
+}
+
+export const closeInstallGameModal = () => {
+  useInstallGameModal.setState({
+    isOpen: false
+  })
+}


### PR DESCRIPTION
This PR moves how we handle the `InstallModal` rendering and moves the state to Zustand. This helps removing some repeated code and makes opening and closing the modal to produce fewer re-renderings.

This PR changes:
- Currently we have the component rendered inside different components: Library, GamePage, SubMenu, etc. This was like this I imagine to avoid having it global to avoid too many re-rendering, but with the cost of duplicating code for the render and the state
- Even with the previous consideration, the state was still producing unintentional re-renderings, like... clicking the install button on a game in the library would re-render the whole library, or clicking the install button in the game page would re-render the whole page, or clicking `Add Game` in the library would re-render the whole library. With this PR it won't re-render extra components
- Similar to the game settings PR, I took the opportunity to make the method names and state more declarative, so instead of doing something like `setShowModal(false)` we can now call `closeInstallGameModal()`

I tested all the places I could see:
- Install in library
- Install in game page from body
- Install in game page from 3-dots menu
- Edit sideloaded app
- Add sideloaded app
- Install EA game

I think they all work as expected, not sure if I'm missing something to test.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
