### PR TITLE
[UX] Show tab and message when Cloud Saves are not supported

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -818,6 +818,8 @@
         "open-config-file": "Open Config File",
         "reset-heroic": "Reset Heroic",
         "saves": {
+            "gog_linux_native_warning": "Linux native games do not support GOG's Cloud Saves feature. Use the Windows version instead.",
+            "not_supported": "This game does not support Cloud Saves.",
             "warning": "Cloud Saves feature is in Beta, please backup your saves before syncing (in case something goes wrong)"
         },
         "systemInformation": {

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -77,8 +77,8 @@ export default function GamesSettings() {
   const isWin = platform === 'win32'
   const isMac = platform === 'darwin'
   const isCrossover = wineVersion?.type === 'crossover'
-  const hasCloudSaves =
-    gameInfo?.cloud_save_enabled && gameInfo.install.platform !== 'linux'
+  const showCloudSavesTab =
+    gameInfo?.runner === 'gog' || gameInfo?.runner === 'legendary'
   const isBrowserGame = gameInfo?.install.platform === 'Browser'
   const isSideloaded = gameInfo?.runner === 'sideload'
 
@@ -156,7 +156,7 @@ export default function GamesSettings() {
           value="advanced"
         />
 
-        {hasCloudSaves && (
+        {showCloudSavesTab && (
           <Tab
             label={t('settings.navbar.sync', 'Cloud Saves Sync')}
             value="saves"

--- a/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
@@ -21,6 +21,8 @@ interface Props {
   autoSyncSaves: boolean
   setAutoSyncSaves: (value: boolean) => void
   syncCommands: { name: string; value: string }[]
+  featureSupported: boolean
+  isLinuxNative: boolean
 }
 
 export default function GOGSyncSaves({
@@ -28,7 +30,9 @@ export default function GOGSyncSaves({
   setGogSaves,
   autoSyncSaves,
   setAutoSyncSaves,
-  syncCommands
+  syncCommands,
+  featureSupported,
+  isLinuxNative
 }: Props) {
   const [isLoading, setIsLoading] = useState(true)
   const [isSyncing, setIsSyncing] = useState(false)
@@ -67,7 +71,7 @@ export default function GOGSyncSaves({
       setIsSyncing(false)
       setIsLoading(false)
     }
-    getLocations()
+    if (featureSupported && !isLinuxNative) getLocations()
   }, [retry])
 
   const handleRetry = () => {
@@ -86,6 +90,24 @@ export default function GOGSyncSaves({
       })
 
     setIsSyncing(false)
+  }
+
+  if (isLinuxNative || !featureSupported) {
+    return (
+      <div style={{ color: 'red' }}>
+        {isLinuxNative &&
+          t(
+            'settings.saves.gog_linux_native_warning',
+            "Linux native games do not support GOG's Cloud Saves feature. Use the Windows version instead."
+          )}
+        <br />
+        {!featureSupported &&
+          t(
+            'settings.saves.not_supported',
+            'Cloud Saves are not supported by this game.'
+          )}
+      </div>
+    )
   }
 
   return (

--- a/src/frontend/screens/Settings/sections/SyncSaves/index.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/index.tsx
@@ -9,7 +9,7 @@ import LegendarySyncSaves from './legendary'
 
 const SyncSaves = () => {
   const { t } = useTranslation()
-  const { runner } = useContext(SettingsContext)
+  const { runner, gameInfo } = useContext(SettingsContext)
   const { platform } = useContext(ContextProvider)
   const isWin = platform === 'win32'
 
@@ -32,6 +32,7 @@ const SyncSaves = () => {
   if (runner === 'legendary') {
     return (
       <LegendarySyncSaves
+        featureSupported={!!gameInfo?.cloud_save_enabled}
         savesPath={savesPath}
         setSavesPath={setSavesPath}
         autoSyncSaves={autoSyncSaves}
@@ -46,6 +47,8 @@ const SyncSaves = () => {
   if (runner === 'gog') {
     return (
       <GOGSyncSaves
+        featureSupported={!!gameInfo?.cloud_save_enabled}
+        isLinuxNative={gameInfo?.install.platform === 'linux'}
         gogSaves={gogSavesLocations}
         setGogSaves={setGogSavesLocations}
         autoSyncSaves={autoSyncSaves}

--- a/src/frontend/screens/Settings/sections/SyncSaves/legendary.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/legendary.tsx
@@ -23,6 +23,7 @@ interface Props {
   setSavesPath: (value: string) => void
   winePrefix?: string
   syncCommands: { name: string; value: string }[]
+  featureSupported: boolean
 }
 
 export default function LegendarySyncSaves({
@@ -32,7 +33,8 @@ export default function LegendarySyncSaves({
   setAutoSyncSaves,
   isProton,
   winePrefix,
-  syncCommands
+  syncCommands,
+  featureSupported
 }: Props) {
   const [isSyncing, setIsSyncing] = useState(false)
   const [isLoading, setLoading] = useState(false)
@@ -60,7 +62,7 @@ export default function LegendarySyncSaves({
       setLoading(false)
       setRetry(false)
     }
-    setDefaultSaveFolder()
+    if (featureSupported) setDefaultSaveFolder()
   }, [winePrefix, isProton, retry])
 
   async function handleSync() {
@@ -73,6 +75,17 @@ export default function LegendarySyncSaves({
       }
     )
     setIsSyncing(false)
+  }
+
+  if (!featureSupported) {
+    return (
+      <div style={{ color: 'red' }}>
+        {t(
+          'settings.saves.not_supported',
+          'This game does not support Cloud Saves.'
+        )}
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
Currently, we do not display the `Cloud Saves Sync` tab in the game's settings if the game shows that it doesn't support cloud saves in the metadata and if the game is linux native.

It had happened many times in the past that users can't find the `Cloud Saves Sync` tab and they think there's some bug when, in reality, they may be hitting one of those conditions.

So, instead of hiding the tab and letting the user figure out why they can't see it, it's more user-friendly to show the tab and explain why it doesn't work. And in the case of a GOG linux-native game we can also instruct the user to use the Windows version instead so they don't need to figure that out.

I did leave the tab ignored for Amazon games and Sideloaded apps/games because I understand Amazon doesn't cloud saves at all and for sideloaded games it makes no sense.

This is similar to what we do with the Gamescope tab, that we show it with an error message if the `gamescope` binary cannot be found.

The style is not great but I used the same as the Gamescope tab for consistency (just a div with red text (this is not great for themes though))

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
