### PR TITLE
[Fix] Tray icon language doesn't follow config

### DIFF
--- a/src/backend/backend_events.ts
+++ b/src/backend/backend_events.ts
@@ -6,6 +6,7 @@ import type { GameStatus, RecentGame } from 'common/types'
 type BackendEvents = {
   gameStatusUpdate: (payload: GameStatus) => void
   recentGamesChanged: (recentGames: RecentGame[]) => void
+  languageChanged: () => void
   settingChanged: (obj: {
     key: string
     oldValue: unknown

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -145,6 +145,7 @@ import {
   getGameSdl
 } from 'backend/storeManagers/legendary/library'
 import { storeMap } from 'common/utils'
+import { backendEvents } from './backend_events'
 
 app.commandLine?.appendSwitch('ozone-platform-hint', 'auto')
 
@@ -448,6 +449,8 @@ if (!gotTheLock) {
       logInfo(['Changing Language to:', language], LogPrefix.Backend)
       await i18next.changeLanguage(language)
       gameInfoStore.clear()
+      GlobalConfig.get().setSetting('language', language)
+      backendEvents.emit('languageChanged')
     })
 
     downloadAntiCheatData()

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -29,7 +29,7 @@ export const initTrayIcon = async (mainWindow: BrowserWindow) => {
     mainWindow.show()
   })
 
-  ipcMain.on('changeLanguage', async () => {
+  backendEvents.on('languageChanged', async () => {
     await loadContextMenu()
   })
 


### PR DESCRIPTION
This PR fixes 2 issues:

- The `TrayIcon` was listening to the wrong event to re-render the context menu, it was listening for the event to change the language (before the change) and not an event AFTER the change. Because of that it was always showing the old language when changed. This adds that new event so it's updated at the right time.
- Another problem was that we were NOT storing the language setting in the backend when changed, only in the frontend, so, after a restart, the language in the backend was always `en` while the frontend had the correct value (frontend language is stored in the chrome store). I added that fix so the TrayIcon shows the correct language when started.

One thing I didn't include was updating the backend value with the frontend value cause it's not really that critical, users can just change language after this and it will be corrected.

Closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4279

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
