### PR TITLE
[FIX] Don't enable mangohud in steam deck gamemode

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -340,7 +340,7 @@ async function prepareLaunch(
   let mangoHudCommand: string[] = []
   let gameModeBin: string | null = null
   const gameScopeCommand: string[] = []
-  if (gameSettings.showMangohud) {
+  if (gameSettings.showMangohud && !isSteamDeckGameMode) {
     const mangoHudBin = await searchForExecutableOnPath('mangohud')
     if (!mangoHudBin) {
       return {


### PR DESCRIPTION
Fixes some error popups that show if using mangohud in the gamescope session

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
