### PR TITLE
[FIX] Enable dxvk-nvapi by default

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -292,7 +292,7 @@ class GlobalConfigV0 extends GlobalConfig {
       addStartMenuShortcuts: false,
       autoInstallDxvk: isLinux,
       autoInstallVkd3d: isLinux,
-      autoInstallDxvkNvapi: false,
+      autoInstallDxvkNvapi: isLinux,
       addSteamShortcuts: false,
       preferSystemLibs: false,
       checkForUpdatesOnStartup: !isFlatpak,


### PR DESCRIPTION
This has been the default since Proton 9

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
