### PR TITLE
Added new Gamescope toggle: Enable Force Grab Cursor

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -330,7 +330,8 @@
             "gameWidth": "The width resolution used by the game. A 16:9 aspect ratio is assumed by gamescope.",
             "upscaleHeight": "The height resolution used by gamescope. A 16:9 aspect ratio is assumed.",
             "upscaleMethod": "The upscaling method gamescope should use.",
-            "upscaleWidth": "The width resolution used by gamescope. A 16:9 aspect ratio is assumed."
+            "upscaleWidth": "The width resolution used by gamescope. A 16:9 aspect ratio is assumed.",
+            "forceGrabCursor": "Always use relative mouse mode instead of flipping dependent on cursor visibility. (Useful for when applications keep losing focus)"
         },
         "general": "Sync with EGL if you have a working installation of the Epic Games Launcher elsewhere and want to import your games to avoid downloading them again.",
         "mangohud": "MangoHUD is an overlay that displays and monitors FPS, temperatures, CPU/GPU load and other system resources.",
@@ -651,6 +652,7 @@
         "gamescope": {
             "enableLimiter": "Enable FPS Limiter",
             "enableUpscaling": "Enables Upscaling",
+            "enableForceGrabCursor": "Enable Force Grab Cursor",
             "missingMsg": "We could not found gamescope on the PATH. Install it or add it to the PATH."
         },
         "hideChangelogsOnStartup": "Don't show changelogs on Startup",

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -443,6 +443,10 @@ async function prepareLaunch(
         }
       }
 
+      if (gameSettings.gamescope.enableForceGrabCursor) {
+        gameScopeCommand.push('--force-grab-cursor')
+      }
+
       if (gameSettings.showMangohud) {
         gameScopeCommand.push('--mangoapp')
       }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -746,6 +746,7 @@ export interface WindowProps extends Electron.Rectangle {
 interface GameScopeSettings {
   enableUpscaling: boolean
   enableLimiter: boolean
+  enableForceGrabCursor: boolean
   windowType: string
   gameWidth: string
   gameHeight: string

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -18,6 +18,7 @@ const Gamescope = () => {
   const [gamescope, setGamescope] = useSetting('gamescope', {
     enableUpscaling: false,
     enableLimiter: false,
+    enableForceGrabCursor: false,
     windowType: 'fullscreen',
     gameWidth: '',
     gameHeight: '',
@@ -361,6 +362,31 @@ const Gamescope = () => {
           />
         </div>
       )}
+      {/* Enable Force Grab Cursor*/}
+      <div className="toggleRow">
+        <ToggleSwitch
+          htmlId="gamescopeForceGrabCursorToggle"
+          value={gamescope.enableForceGrabCursor || false}
+          handleChange={() =>
+            setGamescope({
+              ...gamescope,
+              enableForceGrabCursor: !gamescope.enableForceGrabCursor
+            })
+          }
+          title={t(
+            'setting.gamescope.enableForceGrabCursor',
+            'Enable Force Grab Cursor'
+          )}
+        />
+        <FontAwesomeIcon
+          className="helpIcon"
+          icon={faCircleInfo}
+          title={t(
+            'help.gamescope.forceGrabCursor',
+            'Always use relative mouse mode instead of flipping dependent on cursor visibility. (Useful for when applications keep losing focus)'
+          )}
+        />
+      </div>
       {/* Additional Options */}
       <TextInputField
         label={t('options.gamescope.additionalOptions', 'Additional Options')}


### PR DESCRIPTION
This PR is to add a QOL toggle that I've been using locally for awhile on multiple devices, it seems to be a common enough issue that a toggle would save people looking up the CLI arg and add it to the additional options.

Appends --force-grab-cursor to gamescope launch command, enabling will force the use of relative mouse mode at all times instead of flipping depending on cursor visibility. In games which flip visibility often can leave the mouse in the wrong mode, which will eventually cause the window to lose focus once the mouse escapes its bounds.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
