### PR TITLE
Update SteamApp HeaderArt Url

### DIFF
--- a/src/backend/shortcuts/nonesteamgame/steamhelper.ts
+++ b/src/backend/shortcuts/nonesteamgame/steamhelper.ts
@@ -83,7 +83,7 @@ async function prepareImagesForSteam(props: {
     [
       headerArt,
       props.steamID
-        ? `${steamDBBaseURL}/${props.steamID}/library_hero.jpg`
+        ? `${steamDBBaseURL}/${props.steamID}/header.jpg`
         : props.gameInfo.art_cover
     ],
     [


### PR DESCRIPTION
Switch Headerart url from "library_hero.jpg" which is used for the backgroundArt and instead use "header.jpg"

Example using ESO Online:
**Before**
![ESO-Wide-Before](https://github.com/user-attachments/assets/d433b0de-faa5-451d-a7cd-ffbc3ae2b035)
**After**
![ESO-Wide-After](https://github.com/user-attachments/assets/28f38cd5-4a68-49bf-ae89-5adb113be3ab)

Icons Downloaded:

- https://cdn.cloudflare.steamstatic.com/steam/apps/306130/library_600x900_2x.jpg
- https://cdn.cloudflare.steamstatic.com/steam/apps/306130/logo.png
- https://cdn.cloudflare.steamstatic.com/steam/apps/306130/header.jpg
- https://cdn.cloudflare.steamstatic.com/steam/apps/306130/library_hero.jpg

This fixes #4150 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
