### PR TITLE
fix: avoid using GOGGalaxyClient user agent

### DIFF
--- a/src/backend/storeManagers/gog/user.ts
+++ b/src/backend/storeManagers/gog/user.ts
@@ -8,6 +8,7 @@ import { GOGCredentials, UserData } from 'common/types/gog'
 import { runRunnerCommand } from './library'
 import { gogdlAuthConfig } from 'backend/constants'
 import { clearCache } from 'backend/utils'
+import { app } from 'electron'
 
 function authLogSanitizer(line: string) {
   try {
@@ -75,7 +76,7 @@ export class GOGUser {
       .get(`https://embed.gog.com/userData.json`, {
         headers: {
           Authorization: `Bearer ${user.access_token}`,
-          'User-Agent': 'GOGGalaxyClient/2.0.45.61 (GOG Galaxy)'
+          'User-Agent': `HeroicGamesLauncher/${app.getVersion()}`
         }
       })
       .catch((error) => {


### PR DESCRIPTION
this should prevent false positive emails from GOG that users are on old version of Galaxy

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
