### PR TITLE
Fixed renaming the category would selects it. Now renaming would keep…

### DIFF
--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -394,9 +394,15 @@ class GlobalState extends PureComponent<Props> {
     this.setState({ customCategories: { ...newCustomCategories } })
     configStore.set('games.customCategories', newCustomCategories)
 
+    const selectedCategories = this.getCurrentCustomCategories()
     const newCurrentCustomCategories =
       this.state.currentCustomCategories.filter((cat) => cat !== oldName)
-    this.setCurrentCustomCategories([...newCurrentCustomCategories, newName])
+    if (!selectedCategories.includes(oldName)) {
+      this.setCurrentCustomCategories(newCurrentCustomCategories)
+      return
+    }
+    newCurrentCustomCategories.push(newName)
+    this.setCurrentCustomCategories(newCurrentCustomCategories)
   }
 
   addGameToCustomCategory = (category: string, appName: string) => {


### PR DESCRIPTION
… it unselected.

Now renaming would not select the category using:  
`if (!selectedCategories.includes(oldName)) {
      this.setCurrentCustomCategories(newCurrentCustomCategories)
      return
    }`
Above code will check if the category is selected or not.
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
