### PR TITLE
[UX] Skip games that can only be installed on Android devices

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -540,6 +540,17 @@ function loadFile(app_name: string): boolean {
     return false
   }
 
+  // skip games that are only available for Android, obtanied from the Epic Mobile Store app
+  // TODO: I don't own any game on PC and the mobile store so I don't know if they have to be
+  // handled differently, for now we are only skipping if it's only available for Android
+  if (
+    releaseInfo.every(
+      (info) => info.platform?.every((plat) => plat === 'Android')
+    )
+  ) {
+    return false
+  }
+
   if (!customAttributes) {
     logWarning(['Incomplete metadata for', app_name], LogPrefix.Legendary)
   }

--- a/src/common/types/legendary.ts
+++ b/src/common/types/legendary.ts
@@ -3,7 +3,7 @@
 import { LaunchOption } from 'common/types'
 
 // Possible platforms for `legendary list --platform`
-export type LegendaryInstallPlatform = 'Windows' | 'Win32' | 'Mac'
+export type LegendaryInstallPlatform = 'Windows' | 'Win32' | 'Mac' | 'Android'
 
 // Metadata in `~/.config/legendary/installed.json`
 export interface InstalledJsonMetadata {


### PR DESCRIPTION
With the new Epic mobile app, they are giving away mobile games like the do on PC, but those can't really be handled by legendary yet (fetching game info fails, and it shows no version in the logs).

So we should skip them from now to not show them in the library (it just crashes the install dialog and the details page)

Maybe in some future they can be installed but not yet.

Note that I only own an Android phone, I don't know how things look like for iOS devices so I don't have a fix for that

Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4354

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
