### PR TITLE
[UX] Allow setting the `Disable UMU` default in General Settings > Game Defaults

### DIFF
--- a/src/backend/__tests__/config.test.ts
+++ b/src/backend/__tests__/config.test.ts
@@ -6,7 +6,7 @@ import {
   heroicInstallPath,
   setPlatformConstants
 } from 'backend/constants'
-import { existsSync, rmSync } from 'graceful-fs'
+import { existsSync, mkdirSync, rmSync } from 'graceful-fs'
 
 describe('GlobalConfig', () => {
   const sharedDefaults = {
@@ -67,6 +67,9 @@ describe('GlobalConfig', () => {
   describe('getSettings', () => {
     describe('returns defaults if no settings yet', () => {
       const getSettings = () => {
+        // create config dir if needed
+        if (!existsSync(configPath)) mkdirSync(configPath, { recursive: true })
+
         // clear global config so we initialize a new one
         if (existsSync(configPath)) rmSync(configPath)
         GlobalConfig['globalInstance'] = null as any

--- a/src/backend/__tests__/config.test.ts
+++ b/src/backend/__tests__/config.test.ts
@@ -1,0 +1,99 @@
+import { GlobalConfig } from 'backend/config'
+import {
+  configPath,
+  defaultWinePrefix,
+  getSteamCompatFolder,
+  heroicInstallPath,
+  setPlatformConstants
+} from 'backend/constants'
+import { existsSync, rmSync } from 'graceful-fs'
+
+describe('GlobalConfig', () => {
+  const sharedDefaults = {
+    checkUpdatesInterval: 10,
+    enableUpdates: false,
+    addDesktopShortcuts: false,
+    addStartMenuShortcuts: false,
+    addSteamShortcuts: false,
+    checkForUpdatesOnStartup: true,
+    autoUpdateGames: false,
+    framelessWindow: false,
+    beforeLaunchScriptPath: '',
+    afterLaunchScriptPath: '',
+    verboseLogs: false,
+    hideChangelogsOnStartup: false,
+    language: 'en',
+    maxWorkers: 0,
+    minimizeOnLaunch: false,
+    libraryTopSection: 'disabled'
+  }
+
+  const windowsDefaults = {
+    wineVersion: {}
+  }
+
+  const macDefaults = {
+    enableMsync: true,
+    wineCrossoverBottle: 'Heroic'
+  }
+
+  const linuxDefaults = {
+    autoInstallDxvk: true,
+    autoInstallVkd3d: true,
+    autoInstallDxvkNvapi: true,
+    preferSystemLibs: false,
+    customWinePaths: [],
+    nvidiaPrime: false,
+    enviromentOptions: [],
+    wrapperOptions: [],
+    showFps: false,
+    useGameMode: false,
+    defaultInstallPath: heroicInstallPath,
+    defaultSteamPath: getSteamCompatFolder(),
+    defaultWinePrefix: defaultWinePrefix,
+    // winePrefix: '/home/<user>/Games/Heroic/Prefixes/default',
+    // wineVersion: {
+    //   bin: '/usr/bin/wine',
+    //   name: 'Wine Default - wine-10.2 (Staging)',
+    //   type: 'wine',
+    //   wineserver: '/usr/bin/wineserver'
+    // },
+    enableEsync: true,
+    enableFsync: true,
+    eacRuntime: true,
+    battlEyeRuntime: true,
+    disableUMU: false
+  }
+  describe('getSettings', () => {
+    describe('returns defaults if no settings yet', () => {
+      const getSettings = () => {
+        // clear global config so we initialize a new one
+        if (existsSync(configPath)) rmSync(configPath)
+        GlobalConfig['globalInstance'] = null as any
+
+        return GlobalConfig.get().getSettings()
+      }
+
+      it('Linux defaults', () => {
+        setPlatformConstants('linux')
+        const settings = getSettings()
+        expect(settings).toMatchObject(sharedDefaults)
+        expect(settings).toMatchObject(linuxDefaults)
+      })
+
+      it('Windows defaults', () => {
+        setPlatformConstants('win32')
+        const settings = getSettings()
+        expect(settings).toMatchObject(sharedDefaults)
+        expect(settings).toMatchObject(windowsDefaults)
+      })
+
+      it('MacOS defaults', () => {
+        setPlatformConstants('darwin')
+        const settings = getSettings()
+        expect(settings).toMatchObject(sharedDefaults)
+        expect(settings).toMatchObject(macDefaults)
+      })
+    })
+  })
+})

--- a/src/backend/__tests__/config.test.ts
+++ b/src/backend/__tests__/config.test.ts
@@ -1,5 +1,6 @@
 import { GlobalConfig } from 'backend/config'
 import {
+  appFolder,
   configPath,
   defaultWinePrefix,
   getSteamCompatFolder,
@@ -68,7 +69,7 @@ describe('GlobalConfig', () => {
     describe('returns defaults if no settings yet', () => {
       const getSettings = () => {
         // create config dir if needed
-        if (!existsSync(configPath)) mkdirSync(configPath, { recursive: true })
+        if (!existsSync(appFolder)) mkdirSync(appFolder, { recursive: true })
 
         // clear global config so we initialize a new one
         if (existsSync(configPath)) rmSync(configPath)

--- a/src/backend/__tests__/game_config.test.ts
+++ b/src/backend/__tests__/game_config.test.ts
@@ -1,0 +1,40 @@
+import { GlobalConfig } from 'backend/config'
+import {
+  configPath,
+  gamesConfigPath,
+  setPlatformConstants
+} from 'backend/constants'
+import { GameConfig } from 'backend/game_config'
+import { existsSync, mkdirSync, rmSync } from 'graceful-fs'
+import { join } from 'path'
+
+describe('GameSettings', () => {
+  describe('getSettings', () => {
+    describe('returns defaults if no settings yet', () => {
+      const getSettings = async () => {
+        const appName = 'some-app-name'
+
+        // create config dir if needed
+        if (!existsSync(gamesConfigPath))
+          mkdirSync(gamesConfigPath, { recursive: true })
+
+        // delete game config if present config
+        const path = join(gamesConfigPath, appName + '.json')
+        if (existsSync(path)) rmSync(path)
+
+        // reset global config singleton so we can test different platforms
+        GlobalConfig['globalInstance'] = null as any
+        if (existsSync(configPath)) rmSync(configPath)
+
+        const config = GameConfig.get(appName)
+        return await config.getSettings()
+      }
+
+      it('linux defaults', async () => {
+        setPlatformConstants('linux')
+        const settings = await getSettings()
+        expect(settings.disableUMU).toBe(false)
+      })
+    })
+  })
+})

--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -27,9 +27,27 @@ const fontsStore = new TypeCheckedStoreBackend('fontsStore', {
   name: 'fonts'
 })
 
-const isMac = process.platform === 'darwin'
-const isWindows = process.platform === 'win32'
-const isLinux = process.platform === 'linux'
+let isMac = false
+let isWindows = false
+let isLinux = false
+
+// This is meant to be used only during tests to change the `isXYZ` platform constants
+// and allow testing different platform logic
+export function setPlatformConstants(
+  force_platform?: 'darwin' | 'win32' | 'linux'
+) {
+  if (force_platform) {
+    isMac = force_platform === 'darwin'
+    isWindows = force_platform === 'win32'
+    isLinux = force_platform === 'linux'
+  } else {
+    isMac = process.platform === 'darwin'
+    isWindows = process.platform === 'win32'
+    isLinux = process.platform === 'linux'
+  }
+}
+setPlatformConstants()
+
 const isSteamDeckGameMode = process.env.XDG_CURRENT_DESKTOP === 'gamescope'
 const isCLIFullscreen = process.argv.includes('--fullscreen')
 const isCLINoGui = process.argv.includes('--no-gui')

--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -248,6 +248,7 @@ export function createNecessaryFolders() {
 }
 
 export {
+  appFolder,
   currentGameConfigVersion,
   currentGlobalConfigVersion,
   currentLogFile,

--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -9,7 +9,8 @@ import {
   isMac,
   isWindows,
   userHome,
-  defaultWinePrefix
+  defaultWinePrefix,
+  isLinux
 } from './constants'
 import { logError, logInfo, LogPrefix } from './logger/logger'
 import { join } from 'path'
@@ -235,7 +236,8 @@ class GameConfigV0 extends GameConfig {
       beforeLaunchScriptPath,
       afterLaunchScriptPath,
       gamescope,
-      verboseLogs
+      verboseLogs,
+      disableUMU
     } = GlobalConfig.get().getSettings()
 
     // initialize generic defaults
@@ -277,10 +279,12 @@ class GameConfigV0 extends GameConfig {
       // read game's settings
       const settings = JSON.parse(readFileSync(this.path, 'utf-8'))
       gameSettings = settings[this.appName] || ({} as GameSettings)
-    } else {
+    }
+
+    if (isLinux && gameSettings.disableUMU === undefined) {
       // only set the `disableUMU` default value when getting settings for a new game
       // we want it to be `undefined` for games that were installed already
-      defaultSettings.disableUMU = false
+      defaultSettings.disableUMU = disableUMU
     }
 
     if (!isWindows) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -90,6 +90,7 @@ export interface AppSettings extends GameSettings {
   disableController: boolean
   disablePlaytimeSync: boolean
   disableLogs: boolean
+  disableUMU: boolean
   discordRPC: boolean
   downloadNoHttps: boolean
   egsLinkedPath: string
@@ -104,7 +105,6 @@ export interface AppSettings extends GameSettings {
   minimizeOnLaunch: boolean
   startInTray: boolean
   allowInstallationBrokenAnticheat: boolean
-  disableUMU: boolean
   verboseLogs: boolean
 }
 

--- a/src/frontend/screens/Settings/components/DisableUMU.tsx
+++ b/src/frontend/screens/Settings/components/DisableUMU.tsx
@@ -14,7 +14,11 @@ const DisableUMU = () => {
   const [disableUMU, setDisableUMU] = useSetting('disableUMU', false)
   const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
 
-  if (isDefault || platform !== 'linux' || wineVersion.type !== 'proton') {
+  if (platform !== 'linux') {
+    return <></>
+  }
+
+  if (!isDefault && wineVersion.type !== 'proton') {
     return <></>
   }
 


### PR DESCRIPTION
This PR adds the `Disable UMU` setting in the `defaults` in general settings so it can be configured for all new games added instead of disabling it manually for each game if the user doesn't want to use umu at all.

This doesn't globally disable umu though, for games that are already installed it has to be manually disabled.

I also added some tests for the global config and game config to start adding tests for these things when we change defaults and that (it's not covering all settings and many cases, but it's a start)

Since it doesn't exactly disable UMU globally, it doesn't fully solve https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4374, but I think it's good enough since the option to change the default value aligns more with how the other settings work.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
