### PR TITLE
[UX] Default to WineCrossover and DXVK on for Intel macs

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -17,7 +17,8 @@ import {
   isWindows,
   getSteamCompatFolder,
   configStore,
-  isLinux
+  isLinux,
+  isIntelMac
 } from './constants'
 
 import { logError, logInfo, LogPrefix } from './logger/logger'
@@ -290,7 +291,7 @@ class GlobalConfigV0 extends GlobalConfig {
       enableUpdates: false,
       addDesktopShortcuts: false,
       addStartMenuShortcuts: false,
-      autoInstallDxvk: isLinux,
+      autoInstallDxvk: isLinux || isIntelMac,
       autoInstallVkd3d: isLinux,
       autoInstallDxvkNvapi: isLinux,
       addSteamShortcuts: false,

--- a/src/backend/constants.ts
+++ b/src/backend/constants.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'child_process'
-import { homedir } from 'os'
+import { homedir, cpus } from 'os'
 import { join, resolve } from 'path'
 import { parse } from '@node-steam/vdf'
 
@@ -28,6 +28,7 @@ const fontsStore = new TypeCheckedStoreBackend('fontsStore', {
 })
 
 const isMac = process.platform === 'darwin'
+const isIntelMac = isMac && cpus()[0].model.includes('Intel') // so we can have different behavior for Intel Mac
 const isWindows = process.platform === 'win32'
 const isLinux = process.platform === 'linux'
 const isSteamDeckGameMode = process.env.XDG_CURRENT_DESKTOP === 'gamescope'
@@ -261,6 +262,7 @@ export {
   isFlatpak,
   isSnap,
   isMac,
+  isIntelMac,
   isWindows,
   isLinux,
   legendaryConfigPath,

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -34,7 +34,8 @@ import {
   GITHUB_API,
   isMac,
   configStore,
-  isLinux
+  isLinux,
+  isIntelMac
 } from './constants'
 import {
   appendGamePlayLog,
@@ -922,7 +923,11 @@ export async function downloadDefaultWine() {
     if (isLinux) {
       return version.type === 'GE-Proton'
     } else if (isMac) {
-      return version.type === 'Game-Porting-Toolkit'
+      if (isIntelMac) {
+        return version.type === 'Wine-Crossover'
+      } else {
+        return version.type === 'Game-Porting-Toolkit'
+      }
     }
     return false
   })

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -41,7 +41,7 @@ export default function WineManager(): JSX.Element | null {
     </p>
   )
 
-  const { refreshWineVersionInfo, refreshing, platform } =
+  const { refreshWineVersionInfo, refreshing, platform, isIntelMac } =
     useContext(ContextProvider)
   const isLinux = platform === 'linux'
 
@@ -55,9 +55,14 @@ export default function WineManager(): JSX.Element | null {
     value: 'gpt',
     enabled: !isLinux
   }
+  const wineCrossover: WineManagerUISettings = {
+    type: 'Wine-Crossover',
+    value: 'winecrossover',
+    enabled: !isLinux
+  }
 
   const [repository, setRepository] = useState<WineManagerUISettings>(
-    isLinux ? protonge : gamePortingToolkit
+    isLinux ? protonge : isIntelMac ? wineCrossover : gamePortingToolkit
   )
   const [wineManagerSettings, setWineManagerSettings] = useState<
     WineManagerUISettings[]
@@ -65,7 +70,7 @@ export default function WineManager(): JSX.Element | null {
     protonge,
     { type: 'Wine-GE', value: 'winege', enabled: isLinux },
     gamePortingToolkit,
-    { type: 'Wine-Crossover', value: 'winecrossover', enabled: !isLinux }
+    wineCrossover
   ])
 
   const getWineVersions = (repo: Type) => {

--- a/src/frontend/state/ContextProvider.tsx
+++ b/src/frontend/state/ContextProvider.tsx
@@ -33,6 +33,7 @@ const initialContext: ContextType = {
   libraryTopSection: 'disabled',
   handleLibraryTopSection: () => null,
   platform: 'unknown',
+  isIntelMac: false,
   refresh: async () => Promise.resolve(),
   refreshLibrary: async () => Promise.resolve(),
   refreshWineVersionInfo: async () => Promise.resolve(),

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -73,6 +73,7 @@ interface StateProps {
   libraryStatus: GameStatus[]
   libraryTopSection: string
   platform: NodeJS.Platform
+  isIntelMac: boolean
   refreshing: boolean
   refreshingInTheBackground: boolean
   hiddenGames: HiddenGame[]
@@ -168,6 +169,8 @@ class GlobalState extends PureComponent<Props> {
     libraryStatus: [],
     libraryTopSection: globalSettings?.libraryTopSection || 'disabled',
     platform: window.platform,
+    isIntelMac:
+      window.platform === 'darwin' && navigator.platform === 'MacIntel',
     refreshing: false,
     refreshingInTheBackground: true,
     hiddenGames: configStore.get('games.hidden', []),

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -32,6 +32,7 @@ export interface ContextType {
   libraryTopSection: string
   handleLibraryTopSection: (value: LibraryTopSectionOptions) => void
   platform: NodeJS.Platform | 'unknown'
+  isIntelMac: boolean
   refresh: (library: Runner, checkUpdates?: boolean) => Promise<void>
   refreshLibrary: (options: RefreshOptions) => Promise<void>
   refreshWineVersionInfo: (fetch: boolean) => void


### PR DESCRIPTION
Currently, Heroic defaults to using the Game Porting Toolkit for any mac machine, even though it doesn't support Intel mac. Also, because of that default, DXVK is turned off by default.

The default experience for Intel mac users is really poor because Heroic was setting an invalid configuration from the beginning, leading to a lot of support threads.

This PR changes that to default to Wine-Crossover and DXVK turned on when the computer is an Intel mac.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
