### PR TITLE
Add fallback for Wine search on Mac OSX

### DIFF
--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -241,7 +241,11 @@ export async function getWineOnMac(): Promise<Set<WineInstallation>> {
       ) as PlistObject
       const version = info['CFBundleShortVersionString'] || ''
       const name = info['CFBundleName'] || ''
-      const wineBin = join(winePath, '/Contents/Resources/wine/bin/wine64')
+      let wineBin = join(winePath, '/Contents/Resources/wine/bin/wine64')
+      if (!existsSync(wineBin)) {
+        // Fallback to wine if wine64 is not found
+        wineBin = join(winePath, '/Contents/Resources/wine/bin/wine')
+      }
       if (existsSync(wineBin)) {
         wineSet.add({
           ...getWineExecs(wineBin),


### PR DESCRIPTION
I installed wine 10 using homebrew via `brew install --cask --no-quarantine wine-stable`.

The wine application has no `wine64` executable, only `wine` so I added a fallback.
I have assumed some instalations or older wine version might have `wine64`

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
