### PR TITLE
[Fix] Wine downloading on Windows

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -919,12 +919,11 @@ export async function downloadDefaultWine() {
   await updateWineVersionInfos(true)
   // get list of wines on wineDownloaderInfoStore
   const availableWine = wineDownloaderInfoStore.get('wine-releases', [])
-  // use GE-Proton type if on Linux and GamePortingToolkit if on Mac
-  const release = availableWine.find(async (version) => {
+  const isMacOSUpToDate = await isMacSonomaOrHigher()
+  const release = availableWine.find((version) => {
     if (isLinux) {
       return version.type === 'GE-Proton'
     } else if (isMac) {
-      const isMacOSUpToDate = await isMacSonomaOrHigher()
       if (isIntelMac || !isMacOSUpToDate) {
         return version.type === 'Wine-Crossover'
       } else {

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -915,6 +915,7 @@ async function ContinueWithFoundWine(
 }
 
 export async function downloadDefaultWine() {
+  if (isWindows) return null
   // refresh wine list
   await updateWineVersionInfos(true)
   // get list of wines on wineDownloaderInfoStore
@@ -1325,6 +1326,7 @@ export async function checkRosettaInstall() {
 }
 
 export async function isMacSonomaOrHigher() {
+  if (!isMac) return false
   logInfo('Checking if macOS is Sonoma or higher', LogPrefix.Backend)
 
   const release = (await getSystemInfo(true)).OS.version


### PR DESCRIPTION
Returning a Promise from `Array.find` causes it to match the first element (as promises are truthy). This caused two issues:
1. Wine was downloaded on Windows
2. The first available Wine version (CrossOver on macOS, Wine-GE on Linux) was always downloaded

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
