### PR TITLE
[Fix] Respect `HTTPS_PROXY` env var in downloadHelperBinaries script

### DIFF
--- a/meta/downloadHelperBinaries.ts
+++ b/meta/downloadHelperBinaries.ts
@@ -4,6 +4,8 @@ import { dirname, join } from 'path'
 import { Readable } from 'stream'
 import { finished } from 'stream/promises'
 
+import { setGlobalDispatcher, ProxyAgent } from 'undici'
+
 type SupportedPlatform = 'win32' | 'darwin' | 'linux'
 type DownloadedBinary = 'legendary' | 'gogdl' | 'nile' | 'comet'
 
@@ -200,6 +202,13 @@ async function storeDownloadedTags() {
 }
 
 async function main() {
+  const proxyUri = process.env['HTTPS_PROXY']
+  if (proxyUri) {
+    console.log(`Using proxy: ${proxyUri}`)
+    const proxyAgent = new ProxyAgent(proxyUri)
+    setGlobalDispatcher(proxyAgent)
+  }
+
   if (!(await pathExists('public/bin'))) {
     console.error('public/bin not found, are you in the source root?')
     return

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "typed-emitter": "^2.1.0",
     "typescript": "4.9.4",
     "typescript-eslint": "^7.17.0",
+    "undici": "^7.8.0",
     "unimported": "1.26.0",
     "vite": "5.2.8",
     "vite-plugin-svgr": "4.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       typescript-eslint:
         specifier: ^7.17.0
         version: 7.18.0(eslint@9.7.0)(typescript@4.9.4)
+      undici:
+        specifier: ^7.8.0
+        version: 7.8.0
       unimported:
         specifier: 1.26.0
         version: 1.26.0(eslint@9.7.0)
@@ -5521,6 +5524,10 @@ packages:
   undici@6.21.1:
     resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
     engines: {node: '>=18.17'}
+
+  undici@7.8.0:
+    resolution: {integrity: sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==}
+    engines: {node: '>=20.18.1'}
 
   unified@10.1.2:
     resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
@@ -11908,6 +11915,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici@6.21.1: {}
+
+  undici@7.8.0: {}
 
   unified@10.1.2:
     dependencies:


### PR DESCRIPTION
Not sure how to test this, but this should make the Snap build work

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
