### PR TITLE
[Feat] "Disable smooth scrolling" accessibility option

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4,6 +4,7 @@
         "all_tiles_in_color": "Show all game tiles in color",
         "content_font_family_default": "Content Font Family (Default: {{fontFamily}})",
         "disable_dialog_backdrop_close": "Disable closing dialogs by clicking outside",
+        "disable_smooth_scrolling": "Disable smooth scrolling (requires restart)",
         "fonts": "Fonts",
         "title": "Accessibility",
         "titles_always_visible": "Always show titles in library",

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -337,6 +337,10 @@ if (!gotTheLock) {
 
     const settings = GlobalConfig.get().getSettings()
 
+    if (settings?.disableSmoothScrolling) {
+      app.commandLine.appendSwitch('disable-smooth-scrolling')
+    }
+
     // Make sure lock is not present when starting up
     playtimeSyncQueue.delete('lock')
     if (!settings.disablePlaytimeSync) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -89,6 +89,7 @@ export interface AppSettings extends GameSettings {
   defaultWinePrefix: string
   disableController: boolean
   disablePlaytimeSync: boolean
+  disableSmoothScrolling: boolean
   disableLogs: boolean
   discordRPC: boolean
   downloadNoHttps: boolean

--- a/src/frontend/screens/Accessibility/index.tsx
+++ b/src/frontend/screens/Accessibility/index.tsx
@@ -14,10 +14,12 @@ import { ThemeSelector } from 'frontend/components/UI/ThemeSelector'
 import ToggleSwitch from 'frontend/components/UI/ToggleSwitch'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSyncAlt } from '@fortawesome/free-solid-svg-icons'
+import SettingsContext from '../Settings/SettingsContext'
+import useSettingsContext from '../../hooks/useSettingsContext'
 import './index.css'
 import { hasHelp } from 'frontend/hooks/hasHelp'
 
-export default React.memo(function Accessibility() {
+const Accessibility = React.memo(function Accessibility() {
   const { t } = useTranslation()
   const {
     isRTL,
@@ -238,3 +240,13 @@ export default React.memo(function Accessibility() {
     </div>
   )
 })
+
+export default function AccessibilityWrapper() {
+  const settingsContext = useSettingsContext({ appName: 'default' })
+  if (!settingsContext) return <></>
+  return (
+    <SettingsContext.Provider value={settingsContext}>
+      <Accessibility />
+    </SettingsContext.Provider>
+  )
+}

--- a/src/frontend/screens/Accessibility/index.tsx
+++ b/src/frontend/screens/Accessibility/index.tsx
@@ -14,6 +14,7 @@ import { ThemeSelector } from 'frontend/components/UI/ThemeSelector'
 import ToggleSwitch from 'frontend/components/UI/ToggleSwitch'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSyncAlt } from '@fortawesome/free-solid-svg-icons'
+import useSetting from '../../hooks/useSetting'
 import SettingsContext from '../Settings/SettingsContext'
 import useSettingsContext from '../../hooks/useSettingsContext'
 import './index.css'
@@ -45,6 +46,10 @@ const Accessibility = React.memo(function Accessibility() {
   const [refreshing, setRefreshing] = useState(false)
   const [contentFont, setContentFont] = useState('')
   const [actionFont, setActionFont] = useState('')
+  const [smoothScrollingDisabled, setSmoothScrollingDisabled] = useSetting(
+    'disableSmoothScrolling',
+    false
+  )
 
   const defaultPrimaryFont = getComputedStyle(
     document.documentElement
@@ -232,6 +237,22 @@ const Accessibility = React.memo(function Accessibility() {
               title={t(
                 'accessibility.disable_dialog_backdrop_close',
                 'Disable closing dialogs by clicking outside'
+              )}
+            />
+          </label>
+        </span>
+
+        <span className="setting">
+          <label className={classNames('toggleWrapper', { isRTL: isRTL })}>
+            <ToggleSwitch
+              htmlId="disableSmoothScrolling"
+              value={smoothScrollingDisabled}
+              handleChange={() => {
+                setSmoothScrollingDisabled(!smoothScrollingDisabled)
+              }}
+              title={t(
+                'accessibility.disable_smooth_scrolling',
+                'Disable smooth scrolling (requires restart)'
               )}
             />
           </label>


### PR DESCRIPTION
There's now a new toggle in the "Accessibility" screen to disable smooth scrolling
This was already possible by starting Heroic with `--disable-smooth-scrolling`, but in the long run that's rather clunky

Resolves #4502 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
