### PR TITLE
[Feat] Make it possible to specify an alternative EXE when launching games from the protocol

### DIFF
--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -1,12 +1,13 @@
 import { dialog } from 'electron'
 import { logError, logInfo, LogPrefix } from './logger/logger'
 import i18next from 'i18next'
-import { GameInfo, Runner } from 'common/types'
+import { GameInfo, LaunchOption, Runner } from 'common/types'
 import { getMainWindow, sendFrontendMessage } from './main_window'
 import { gameManagerMap } from './storeManagers'
 import { launchEventCallback } from './launcher'
 import { z } from 'zod'
 import { windowIcon } from './constants/paths'
+import { Path } from './schemas'
 
 const RUNNERS = z.enum(['legendary', 'gog', 'nile', 'sideload'])
 
@@ -36,6 +37,7 @@ async function handleLaunch(url: URL) {
   let appName
   let runnerStr
   let args: string[] = []
+  let altExe: Path | undefined = undefined
 
   if (url.pathname) {
     // Old-style pathname URLs:
@@ -50,6 +52,8 @@ async function handleLaunch(url: URL) {
     appName = url.searchParams.get('appName')
     runnerStr = url.searchParams.get('runner')
     args = url.searchParams.getAll('arg')
+    const altExeParse = Path.safeParse(url.searchParams.get('altExe'))
+    if (altExeParse.success) altExe = altExeParse.data
   }
 
   if (!appName) {
@@ -74,11 +78,19 @@ async function handleLaunch(url: URL) {
   const settings = await gameManagerMap[gameInfo.runner].getSettings(appName)
 
   if (is_installed) {
+    let launchOption: LaunchOption | undefined = undefined
+    if (altExe)
+      launchOption = {
+        type: 'altExe',
+        executable: altExe
+      }
+
     return launchEventCallback({
       appName: appName,
       runner: gameInfo.runner,
       skipVersionCheck: settings.ignoreGameUpdates,
-      args
+      args,
+      launchArguments: launchOption
     })
   }
 

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -926,21 +926,25 @@ export async function launch(
   const appNameToLaunch =
     launchArguments?.type === 'dlc' ? launchArguments.dlcAppName : appName
 
+  const launchArgumentArgs =
+    launchArguments &&
+    (launchArguments.type === undefined || launchArguments.type === 'basic')
+      ? launchArguments.parameters
+      : undefined
+
   const command: LegendaryCommand = {
     subcommand: 'launch',
     appName: LegendaryAppName.parse(appNameToLaunch),
-    extraArguments: [
-      ...args,
-      launchArguments?.type !== 'dlc' ? launchArguments?.parameters : undefined,
-      gameSettings.launcherArgs
-    ]
+    extraArguments: [...args, launchArgumentArgs, gameSettings.launcherArgs]
       .filter(Boolean)
       .join(' '),
     ...wineFlags
   }
   if (skipVersionCheck) command['--skip-version-check'] = true
   if (languageCode) command['--language'] = NonEmptyString.parse(languageCode)
-  if (gameSettings.targetExe)
+  if (launchArguments?.type === 'altExe')
+    command['--override-exe'] = launchArguments.executable
+  else if (gameSettings.targetExe)
     command['--override-exe'] = Path.parse(gameSettings.targetExe)
   if (offlineMode) command['--offline'] = true
   if (isCLINoGui) command['--skip-version-check'] = true

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -1,5 +1,4 @@
 import {
-  BaseLaunchOption,
   ExecResult,
   ExtraInfo,
   GameInfo,
@@ -336,9 +335,13 @@ export async function launch(
     })
     return false
   }
-  const exeOverrideFlag = gameSettings.targetExe
-    ? ['--override-exe', gameSettings.targetExe]
-    : []
+
+  let exeOverrideFlag: string[] = []
+  if (launchArguments?.type === 'altExe') {
+    exeOverrideFlag = ['--override-exe', launchArguments.executable]
+  } else if (gameSettings.targetExe) {
+    exeOverrideFlag = ['--override-exe', gameSettings.targetExe]
+  }
 
   let commandEnv = {
     ...process.env,
@@ -401,13 +404,17 @@ export async function launch(
     ]
   }
 
+  const launchArgumentsArgs =
+    launchArguments &&
+    (launchArguments.type === undefined || launchArguments.type === 'basic')
+      ? launchArguments.parameters
+      : ''
+
   const commandParts = [
     'launch',
     ...exeOverrideFlag, // Check if this works
     ...wineFlag,
-    ...shlex.split(
-      (launchArguments as BaseLaunchOption | undefined)?.parameters ?? ''
-    ),
+    ...shlex.split(launchArgumentsArgs),
     ...shlex.split(gameSettings.launcherArgs ?? ''),
     appName,
     ...args

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -12,6 +12,7 @@ import { TitleBarOverlay } from 'electron'
 import { ChildProcess } from 'child_process'
 import type { HowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
 import { NileInstallInfo, NileInstallPlatform } from './types/nile'
+import type { Path } from 'backend/schemas'
 
 export type Runner = 'legendary' | 'gog' | 'sideload' | 'nile'
 
@@ -32,14 +33,25 @@ export type LaunchParams = {
   args?: string[]
 }
 
-export type LaunchOption = BaseLaunchOption | DLCLaunchOption
+export type LaunchOption =
+  | BaseLaunchOption
+  | AltExeLaunchOption
+  | DLCLaunchOption
 
-export interface BaseLaunchOption {
+// Option to append extra parameters to the launch command
+interface BaseLaunchOption {
   type?: 'basic'
   name: string
   parameters: string
 }
 
+// Option to launch an alternative executable instead
+interface AltExeLaunchOption {
+  type: 'altExe'
+  executable: Path
+}
+
+// Option to launch a DLC (another game) instead of the base game
 interface DLCLaunchOption {
   type: 'dlc'
   dlcAppName: string

--- a/src/frontend/screens/Game/GamePage/components/LaunchOptions.tsx
+++ b/src/frontend/screens/Game/GamePage/components/LaunchOptions.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
 import GameContext from '../../GameContext'
 import { GameInfo, LaunchOption } from 'common/types'
 import { useTranslation } from 'react-i18next'
@@ -27,6 +27,18 @@ const LaunchOptions = ({ gameInfo, setLaunchArguments }: Props) => {
     return null
   }
 
+  const labelForLaunchOption = useCallback((option: LaunchOption) => {
+    switch (option.type) {
+      case undefined:
+      case 'basic':
+        return option.name
+      case 'dlc':
+        return option.dlcTitle
+      case 'altExe':
+        return option.executable
+    }
+  }, [])
+
   return (
     <SelectField
       htmlId="launch_options"
@@ -45,7 +57,7 @@ const LaunchOptions = ({ gameInfo, setLaunchArguments }: Props) => {
     >
       {launchOptions.map((option, index) => (
         <option key={index} value={index}>
-          {option.type === 'dlc' ? option.dlcTitle : option.name}
+          {labelForLaunchOption(option)}
         </option>
       ))}
     </SelectField>


### PR DESCRIPTION
Closes #4411

A path supplied via the `altExe` parameter will be used just like the "Alternative EXE" option in the game settings

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
