### PR TITLE
[FIX] Do not check for UMU experimental feature

### DIFF
--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -562,21 +562,6 @@ export async function isUmuSupported(
   if (!isLinux) return false
   if (gameSettings.wineVersion.type !== 'proton') return false
   if (gameSettings.disableUMU === true) return false
-  if (gameSettings.disableUMU === undefined) {
-    // If the disableUMU setting is undefined it means the game was installed and configured
-    // before the introduction of this setting, so the usage of UMU was dictated by the
-    // experimental feature configuration.
-    //
-    // We have to check this to not enable UMU incorrectly even if the setting is not editable
-    // anymore.
-    // If we don't, we would end up enabling UMU for games that are already functional with proton
-    // without UMU to not mess their prefix
-    const experimentalFeatures =
-      GlobalConfig.get().getSettings().experimentalFeatures
-
-    // if UMU was never enabled or was enabled and then disabled
-    if (!experimentalFeatures?.umuSupport) return false
-  }
   if (!checkUmuInstalled) return true
   if (!existsSync(await getUmuPath())) return false
 


### PR DESCRIPTION
It becomes disabled with no indication that it is disabled, so get rid of this check. Proton 10 requires UMU to run as well, causing confusion for users

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
