### PR TITLE
Fix invalid JSON in game info if output in multiple chunks

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1489,7 +1489,7 @@ async function callRunner(
         options.onOutput(data, child)
       }
 
-      stdout.push(data.trim())
+      stdout.push(data)
     })
 
     child.stderr.setEncoding('utf-8')
@@ -1516,7 +1516,7 @@ async function callRunner(
         options.onOutput(data, child)
       }
 
-      stderr.push(data.trim())
+      stderr.push(data)
     })
 
     child.on('close', (code, signal) => {
@@ -1532,8 +1532,8 @@ async function callRunner(
       }
 
       res({
-        stdout: stdout.join('\n'),
-        stderr: stderr.join('\n')
+        stdout: stdout.join(),
+        stderr: stderr.join()
       })
     })
 

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1283,7 +1283,7 @@ const memoryLog = (limit = 50) => {
       }
     },
     join: (separator = '') => {
-      return lines.reverse().join(separator)
+      return lines.toReversed().join(separator)
     }
   }
 }


### PR DESCRIPTION
- memoryLog's join call returns the wrong output for every other call, as reverse changes the order in place. Since join is called twice in the callRunner's child close handler, the res call has the wrong order of stdout, also breaking the JSON.
- Chunks don't have to be entire lines. Long JSON can be output in parts. Don't try to insert line breaks manually, just don't trim in the first place to keep the original line breaks, ensuring there are no spurious line breaks in the output breaking the JSON.

   <img width="870" alt="Screenshot 2025-05-18 at 1 18 56 am copy" src="https://github.com/user-attachments/assets/aec920ec-b166-4f91-906c-cee521a7aedd" />


Fixes #3333

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
