### PR TITLE
[Fix] Protocol handling on Windows

### DIFF
--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -39,7 +39,8 @@ async function handleLaunch(url: URL) {
   let args: string[] = []
   let altExe: Path | undefined = undefined
 
-  if (url.pathname) {
+  // Windows automatically adds a trailing / to shortcuts
+  if (url.pathname && url.pathname !== '/') {
     // Old-style pathname URLs:
     // - `heroic://launch/Quail`
     // - `heroic://launch/legendary/Quail`


### PR DESCRIPTION
When creating a shortcut, Windows automatically adds a trailing `/` to the path. This caused Heroic to assume its parsing the old-style protocol URL, while it was actually getting a new-style one. Because of this, shortcuts created on Windows since Heroic 2.16 wouldn't actually work

Note that this is a change on the handling side, meaning previously-non-working shortcuts will now just work again

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
