### PR TITLE
[Fix] Make sure `AvailablePlatforms.value` is an InstallPlatform

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -32,7 +32,7 @@ type Props = {
 export type AvailablePlatforms = {
   name: string
   available: boolean
-  value: string
+  value: InstallPlatform
   icon: IconDefinition
 }[]
 
@@ -62,7 +62,7 @@ export default React.memo(function InstallModal({
     {
       name: 'Linux',
       available: isLinux && (isSideload || isLinuxNative),
-      value: 'Linux',
+      value: 'linux',
       icon: faLinux
     },
     {
@@ -89,7 +89,7 @@ export default React.memo(function InstallModal({
     (p) => p.available
   )
 
-  const getDefaultplatform = () => {
+  const getDefaultplatform = (): InstallPlatform => {
     if (isLinux && gameInfo?.is_linux_native) {
       return 'linux'
     }


### PR DESCRIPTION
This currently causes the platform selector to be empty on installing a Linux-native GOG game

Before:
![image](https://github.com/user-attachments/assets/cf35d563-7193-4f1c-b85f-7735787e995c)

After:
![image](https://github.com/user-attachments/assets/ac325b99-ebdf-4caf-ad79-9466cc54087d)

Error message:
![image](https://github.com/user-attachments/assets/ce0b0bbc-bf4a-47fe-a73a-93bf014f25bf)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
