### PR TITLE
[Feat] Return Proton first in the Wine version list

### DIFF
--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -196,7 +196,7 @@ export async function getLinuxWineSet(
     customWineSet = getCustomWinePaths()
   }
 
-  return new Set([...defaultWineSet, ...altWine, ...proton, ...customWineSet])
+  return new Set([...proton, ...altWine, ...defaultWineSet, ...customWineSet])
 }
 
 /// --------------- MACOS ------------------


### PR DESCRIPTION
Proton is the preferred runner now, so incentivize selecting it by displaying it before Wine

This also moves the "Wine Default" option behind any versions installed by Heroic. The system Wine is usually standard Wine(-Staging at best), which isn't helpful to run games most of the time

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
