### PR TITLE
Ensure install dialog show gui or exits when started with --no-gui

### DIFF
--- a/src/backend/__tests__/protocol.test.ts
+++ b/src/backend/__tests__/protocol.test.ts
@@ -95,7 +95,7 @@ describe('protocol.ts --no-gui behavior', () => {
   const mockMainWindow = {
     show: jest.fn()
   }
-  
+
   const mockGameInfo = {
     app_name: 'test-game',
     title: 'Test Game',
@@ -110,9 +110,13 @@ describe('protocol.ts --no-gui behavior', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     ;(getMainWindow as jest.Mock).mockReturnValue(mockMainWindow)
-    ;(gameManagerMap.legendary.getGameInfo as jest.Mock).mockReturnValue(mockGameInfo)
-    ;(gameManagerMap.legendary.getSettings as jest.Mock).mockResolvedValue(mockGameSettings)
-    
+    ;(gameManagerMap.legendary.getGameInfo as jest.Mock).mockReturnValue(
+      mockGameInfo
+    )
+    ;(gameManagerMap.legendary.getSettings as jest.Mock).mockResolvedValue(
+      mockGameSettings
+    )
+
     // Mock other game managers to return empty objects
     ;(gameManagerMap.gog.getGameInfo as jest.Mock).mockReturnValue({})
     ;(gameManagerMap.nile.getGameInfo as jest.Mock).mockReturnValue({})
@@ -143,7 +147,11 @@ describe('protocol.ts --no-gui behavior', () => {
         await handleProtocol(['heroic://launch/test-game'])
 
         expect(mockMainWindow.show).toHaveBeenCalled()
-        expect(sendFrontendMessage).toHaveBeenCalledWith('installGame', 'test-game', 'legendary')
+        expect(sendFrontendMessage).toHaveBeenCalledWith(
+          'installGame',
+          'test-game',
+          'legendary'
+        )
         expect(app.quit).not.toHaveBeenCalled()
       })
     })
@@ -167,7 +175,11 @@ describe('protocol.ts --no-gui behavior', () => {
 
         await handleProtocol(['heroic://launch/test-game'])
 
-        expect(sendFrontendMessage).toHaveBeenCalledWith('installGame', 'test-game', 'legendary')
+        expect(sendFrontendMessage).toHaveBeenCalledWith(
+          'installGame',
+          'test-game',
+          'legendary'
+        )
         expect(app.quit).not.toHaveBeenCalled()
         expect(mockMainWindow.show).not.toHaveBeenCalled()
       })
@@ -199,7 +211,7 @@ describe('protocol.ts --no-gui behavior', () => {
   describe('edge cases', () => {
     test('should handle invalid URLs gracefully', async () => {
       await handleProtocol(['not-a-heroic-url'])
-      
+
       // Should not crash or call any dialog/app methods
       expect(dialog.showMessageBox).not.toHaveBeenCalled()
       expect(app.quit).not.toHaveBeenCalled()

--- a/src/backend/__tests__/protocol.test.ts
+++ b/src/backend/__tests__/protocol.test.ts
@@ -1,0 +1,230 @@
+// Mock environment constants first, before any imports
+const mockIsCLINoGui = jest.fn()
+jest.mock('../constants/environment', () => ({
+  get isCLINoGui() {
+    return mockIsCLINoGui()
+  },
+  isSnap: false
+}))
+
+// Mock paths to avoid XDG_CONFIG_HOME issues
+jest.mock('../constants/paths', () => ({
+  windowIcon: 'mock-icon-path',
+  appFolder: '/mock/app/folder',
+  userHome: '/mock/home'
+}))
+
+import { handleProtocol } from '../protocol'
+import { app, dialog } from 'electron'
+import { gameManagerMap } from '../storeManagers'
+import { getMainWindow } from '../main_window'
+import { sendFrontendMessage } from '../ipc'
+
+// Mock electron modules
+jest.mock('electron', () => ({
+  app: {
+    quit: jest.fn()
+  },
+  dialog: {
+    showMessageBox: jest.fn()
+  }
+}))
+
+// Mock other dependencies
+jest.mock('../main_window', () => ({
+  getMainWindow: jest.fn()
+}))
+
+jest.mock('../ipc', () => ({
+  sendFrontendMessage: jest.fn()
+}))
+
+jest.mock('../storeManagers', () => ({
+  gameManagerMap: {
+    legendary: {
+      getGameInfo: jest.fn(),
+      getSettings: jest.fn()
+    },
+    gog: {
+      getGameInfo: jest.fn(),
+      getSettings: jest.fn()
+    },
+    nile: {
+      getGameInfo: jest.fn(),
+      getSettings: jest.fn()
+    },
+    sideload: {
+      getGameInfo: jest.fn(),
+      getSettings: jest.fn()
+    }
+  }
+}))
+
+jest.mock('../logger/logger', () => ({
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+  LogPrefix: {
+    ProtocolHandler: 'ProtocolHandler'
+  }
+}))
+
+// Mock i18next
+jest.mock('i18next', () => ({
+  t: jest.fn((key: string, fallback?: string) => fallback || key)
+}))
+
+// Mock launcher
+jest.mock('../launcher', () => ({
+  launchEventCallback: jest.fn()
+}))
+
+// Mock additional dependencies to avoid import issues
+jest.mock('../storeManagers/legendary/constants', () => ({
+  legendaryConfigPath: '/mock/legendary/config',
+  legendaryUserInfo: '/mock/legendary/user.json',
+  legendaryInstalled: '/mock/legendary/installed.json'
+}))
+
+jest.mock('process', () => ({
+  env: {
+    XDG_CONFIG_HOME: '/mock/xdg/config'
+  }
+}))
+
+describe('protocol.ts --no-gui behavior', () => {
+  const mockMainWindow = {
+    show: jest.fn()
+  }
+  
+  const mockGameInfo = {
+    app_name: 'test-game',
+    title: 'Test Game',
+    runner: 'legendary' as const,
+    is_installed: false
+  }
+
+  const mockGameSettings = {
+    ignoreGameUpdates: false
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(getMainWindow as jest.Mock).mockReturnValue(mockMainWindow)
+    ;(gameManagerMap.legendary.getGameInfo as jest.Mock).mockReturnValue(mockGameInfo)
+    ;(gameManagerMap.legendary.getSettings as jest.Mock).mockResolvedValue(mockGameSettings)
+    
+    // Mock other game managers to return empty objects
+    ;(gameManagerMap.gog.getGameInfo as jest.Mock).mockReturnValue({})
+    ;(gameManagerMap.nile.getGameInfo as jest.Mock).mockReturnValue({})
+    ;(gameManagerMap.sideload.getGameInfo as jest.Mock).mockReturnValue({})
+  })
+
+  describe('when game is not installed', () => {
+    beforeEach(() => {
+      mockGameInfo.is_installed = false
+    })
+
+    describe('with --no-gui flag', () => {
+      beforeEach(() => {
+        mockIsCLINoGui.mockReturnValue(true)
+      })
+
+      test('should exit app when user clicks No', async () => {
+        ;(dialog.showMessageBox as jest.Mock).mockResolvedValue({ response: 1 })
+
+        await handleProtocol(['heroic://launch/test-game'])
+
+        expect(app.quit).toHaveBeenCalled()
+      })
+
+      test('should show GUI and install when user clicks Yes', async () => {
+        ;(dialog.showMessageBox as jest.Mock).mockResolvedValue({ response: 0 })
+
+        await handleProtocol(['heroic://launch/test-game'])
+
+        expect(mockMainWindow.show).toHaveBeenCalled()
+        expect(sendFrontendMessage).toHaveBeenCalledWith('installGame', 'test-game', 'legendary')
+        expect(app.quit).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('without --no-gui flag', () => {
+      beforeEach(() => {
+        mockIsCLINoGui.mockReturnValue(false)
+      })
+
+      test('should not exit app when user clicks No', async () => {
+        ;(dialog.showMessageBox as jest.Mock).mockResolvedValue({ response: 1 })
+
+        await handleProtocol(['heroic://launch/test-game'])
+
+        expect(app.quit).not.toHaveBeenCalled()
+        expect(mockMainWindow.show).not.toHaveBeenCalled()
+      })
+
+      test('should install when user clicks Yes (normal behavior)', async () => {
+        ;(dialog.showMessageBox as jest.Mock).mockResolvedValue({ response: 0 })
+
+        await handleProtocol(['heroic://launch/test-game'])
+
+        expect(sendFrontendMessage).toHaveBeenCalledWith('installGame', 'test-game', 'legendary')
+        expect(app.quit).not.toHaveBeenCalled()
+        expect(mockMainWindow.show).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('when game is installed', () => {
+    beforeEach(() => {
+      mockGameInfo.is_installed = true
+    })
+
+    test('should launch game directly regardless of --no-gui flag', async () => {
+      mockIsCLINoGui.mockReturnValue(true)
+
+      // Mock launchEventCallback to avoid complex setup
+      const mockLaunchEventCallback = jest.fn()
+      jest.doMock('../launcher', () => ({
+        launchEventCallback: mockLaunchEventCallback
+      }))
+
+      await handleProtocol(['heroic://launch/test-game'])
+
+      // Should not show dialog for installed games
+      expect(dialog.showMessageBox).not.toHaveBeenCalled()
+      expect(app.quit).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('edge cases', () => {
+    test('should handle invalid URLs gracefully', async () => {
+      await handleProtocol(['not-a-heroic-url'])
+      
+      // Should not crash or call any dialog/app methods
+      expect(dialog.showMessageBox).not.toHaveBeenCalled()
+      expect(app.quit).not.toHaveBeenCalled()
+    })
+
+    test('should handle missing game info', async () => {
+      // Mock gameManagerMap to return empty object for missing games
+      ;(gameManagerMap.legendary.getGameInfo as jest.Mock).mockReturnValue({})
+
+      await handleProtocol(['heroic://launch/nonexistent-game'])
+
+      // Should not show dialog if game info cannot be found
+      expect(dialog.showMessageBox).not.toHaveBeenCalled()
+      expect(app.quit).not.toHaveBeenCalled()
+    })
+
+    test('should handle missing main window', async () => {
+      ;(getMainWindow as jest.Mock).mockReturnValue(null)
+      mockIsCLINoGui.mockReturnValue(true)
+
+      await handleProtocol(['heroic://launch/test-game'])
+
+      // Should return early if no main window available
+      expect(dialog.showMessageBox).not.toHaveBeenCalled()
+      expect(app.quit).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -114,7 +114,10 @@ async function handleLaunch(url: URL) {
   })
   if (response === 0) {
     if (isCLINoGui) {
-      logInfo('--no-gui flag detected but user wants to install, showing GUI', LogPrefix.ProtocolHandler)
+      logInfo(
+        '--no-gui flag detected but user wants to install, showing GUI',
+        LogPrefix.ProtocolHandler
+      )
       mainWindow.show()
     }
     sendFrontendMessage('installGame', appName, gameInfo.runner)

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -1,4 +1,4 @@
-import { dialog } from 'electron'
+import { dialog, app } from 'electron'
 import { logError, logInfo, LogPrefix } from './logger/logger'
 import i18next from 'i18next'
 import { GameInfo, LaunchOption, Runner } from 'common/types'
@@ -9,6 +9,7 @@ import { launchEventCallback } from './launcher'
 import { z } from 'zod'
 import { windowIcon } from './constants/paths'
 import { Path } from './schemas'
+import { isCLINoGui } from './constants/environment'
 
 const RUNNERS = z.enum(['legendary', 'gog', 'nile', 'sideload'])
 
@@ -112,9 +113,17 @@ async function handleLaunch(url: URL) {
     icon: windowIcon
   })
   if (response === 0) {
+    if (isCLINoGui) {
+      logInfo('--no-gui flag detected but user wants to install, showing GUI', LogPrefix.ProtocolHandler)
+      mainWindow.show()
+    }
     sendFrontendMessage('installGame', appName, gameInfo.runner)
   } else if (response === 1) {
     logInfo('Not installing game', LogPrefix.ProtocolHandler)
+    if (isCLINoGui) {
+      logInfo('--no-gui flag detected, exiting app', LogPrefix.ProtocolHandler)
+      app.quit()
+    }
   }
 }
 


### PR DESCRIPTION
This change addresses the bug reported in #4535, namely the issue with the install dialog appearing to just hang because
gui is missing to prompt the user to continue. Instead we exit cleanly if the user doesn't want to install or show them the
gui so that they can proceed with the install otherwise.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
