### PR TITLE
[UX] Fix showing wine version on mac logs

### DIFF
--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -603,17 +603,16 @@ class GameLogWriter extends LogWriter {
             delete gameSettings.autoInstallDxvk
             delete gameSettings.autoInstallDxvkNvapi
             delete gameSettings.autoInstallVkd3d
+            delete gameSettings.wineCrossoverBottle
           }
 
           if (wineType.type === 'crossover') {
             delete gameSettings.autoInstallDxvk
             delete gameSettings.autoInstallDxvkNvapi
             delete gameSettings.autoInstallVkd3d
+            delete gameSettings.winePrefix
           }
         }
-
-        delete gameSettings.wineVersion
-        delete gameSettings.winePrefix
       } else {
         // remove settings that are not used on native Mac games
         delete gameSettings.enableDXVKFpsLimit


### PR DESCRIPTION
Latest release included a PR I made removing settings from logs depending on the platform and other settings.

There was a bug an it was ALWAYS ignoring the wine type and wine prefix on mac logs incorrectly: the correct thing should have been:
- do not hide the wine type
- hide crossover bottle if not crossover
- hide wine prefix folder if crossover

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
