### PR TITLE
[UX] Show Flatpak's runtime version when missing mangohud/gamescope

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -672,7 +672,8 @@
             "enableForceGrabCursor": "Enable Force Grab Cursor",
             "enableLimiter": "Enable FPS Limiter",
             "enableUpscaling": "Enables Upscaling",
-            "missingMsg": "We could not find gamescope on the PATH. Install it or add it to the PATH."
+            "missingMsg": "We could not find gamescope on the PATH. Install it or add it to the PATH.",
+            "missingMsgFlatpak": "We could not find a compatible version of Gamescope. Install Gamescope's flatpak package with runtime 24.08 and restart Heroic."
         },
         "hideChangelogsOnStartup": "Don't show changelogs on Startup",
         "ignoreGameUpdates": "Ignore game updates",

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -97,7 +97,8 @@ import {
   isMac,
   isSteamDeckGameMode,
   isWindows,
-  isIntelMac
+  isIntelMac,
+  isFlatpak
 } from './constants/environment'
 
 let powerDisplayId: number | null
@@ -341,10 +342,14 @@ async function prepareLaunch(
   if (gameSettings.showMangohud && !isSteamDeckGameMode) {
     const mangoHudBin = await searchForExecutableOnPath('mangohud')
     if (!mangoHudBin) {
+      let reason =
+        'Mangohud is enabled, but `mangohud` executable could not be found on $PATH'
+      if (isFlatpak) {
+        reason = `${reason}. Make sure to install Mangohud's flatpak package with runtime 24.08`
+      }
       return {
         success: false,
-        failureReason:
-          'Mangohud is enabled, but `mangohud` executable could not be found on $PATH'
+        failureReason: reason
       }
     }
 
@@ -369,9 +374,13 @@ async function prepareLaunch(
   ) {
     const gameScopeBin = await searchForExecutableOnPath('gamescope')
     if (!gameScopeBin) {
-      logWarning(
+      let warningMessage =
         'Gamescope is enabled, but `gamescope` executable could not be found on $PATH'
-      )
+      if (isFlatpak) {
+        warningMessage = `${warningMessage}. Make sure to install Gamescope's flatpak package with runtime 24.08`
+      }
+
+      logWarning(warningMessage)
     } else {
       // Gamescope does not provide a version option and they changed
       // cli options on version 3.12. So we do what lutris does.

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -639,7 +639,6 @@ addHandler('getMaxCpus', () => cpus().length)
 
 addHandler('getHeroicVersion', app.getVersion)
 addHandler('isFullscreen', () => isSteamDeckGameMode || isCLIFullscreen)
-addHandler('isFlatpak', () => isFlatpak)
 addHandler('getGameOverride', async () => getGameOverride())
 addHandler('getGameSdl', async (event, appName) => getGameSdl(appName))
 

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -157,7 +157,6 @@ interface AsyncIPCFunctions {
   isFrameless: () => boolean
   isMaximized: () => boolean
   isMinimized: () => boolean
-  isFlatpak: () => boolean
   showUpdateSetting: () => boolean
   getLatestReleases: () => Promise<Release[]>
   getCurrentChangelog: () => Promise<Release | null>

--- a/src/frontend/screens/Settings/components/EacRuntime.tsx
+++ b/src/frontend/screens/Settings/components/EacRuntime.tsx
@@ -20,8 +20,7 @@ const EacRuntime = () => {
   const handleEacRuntime = async () => {
     if (!eacRuntime) {
       if (!useGameMode) {
-        const isFlatpak = await window.api.isFlatpak()
-        if (isFlatpak) {
+        if (window.isFlatpak) {
           showDialogModal({
             showDialog: true,
             message: t(

--- a/src/frontend/screens/Settings/components/GameMode.tsx
+++ b/src/frontend/screens/Settings/components/GameMode.tsx
@@ -17,10 +17,9 @@ const GameMode = () => {
     return <></>
   }
 
-  async function handleGameMode() {
+  function handleGameMode() {
     if (useGameMode && eacRuntime) {
-      const isFlatpak = await window.api.isFlatpak()
-      if (isFlatpak) {
+      if (window.isFlatpak) {
         showDialogModal({
           showDialog: true,
           title: t(

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -79,10 +79,15 @@ const Gamescope = () => {
   if (!isInstalled) {
     return (
       <div style={{ color: 'red' }}>
-        {t(
-          'setting.gamescope.missingMsg',
-          'We could not found gamescope on the PATH. Install it or add it to the PATH.'
-        )}
+        {window.isFlatpak
+          ? t(
+              'setting.gamescope.missingMsgFlatpak',
+              "We could not find a compatible version of Gamescope. Install Gamescope's flatpak package with runtime 24.08 and restart Heroic."
+            )
+          : t(
+              'setting.gamescope.missingMsg',
+              'We could not find gamescope on the PATH. Install it or add it to the PATH.'
+            )}
       </div>
     )
   }

--- a/src/frontend/screens/Settings/components/UseFramelessWindow.tsx
+++ b/src/frontend/screens/Settings/components/UseFramelessWindow.tsx
@@ -16,7 +16,7 @@ const UseFramelessWindow = () => {
     return <></>
   }
 
-  async function toggleFramelessWindow() {
+  function toggleFramelessWindow() {
     if (!framelessWindow) {
       showDialogModal({
         title: t(

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -168,6 +168,7 @@ declare global {
     ) => Promise<string>
     setTheme: (themeClass: string) => void
     isSteamDeckGameMode: boolean
+    isFlatpak: boolean
     platform: NodeJS.Platform
     setCustomCSS: (cssString: string) => void
   }

--- a/src/preload/api/wine.ts
+++ b/src/preload/api/wine.ts
@@ -3,7 +3,6 @@ import { makeListenerCaller, makeHandlerInvoker, frontendListenerSlot } from '..
 export const toggleDXVK = makeHandlerInvoker('toggleDXVK')
 export const toggleVKD3D = makeHandlerInvoker('toggleVKD3D')
 export const toggleDXVKNVAPI = makeHandlerInvoker('toggleDXVKNVAPI')
-export const isFlatpak = makeHandlerInvoker('isFlatpak')
 export const isRuntimeInstalled = makeHandlerInvoker('isRuntimeInstalled')
 export const downloadRuntime = makeHandlerInvoker('downloadRuntime')
 export const showItemInFolder = makeListenerCaller('showItemInFolder')

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { contextBridge } from 'electron'
 import api from './api'
+import { isFlatpak, isSteamDeckGameMode } from 'backend/constants/environment'
 
 contextBridge.exposeInMainWorld('api', api)
-contextBridge.exposeInMainWorld('isSteamDeckGameMode', process.env.XDG_CURRENT_DESKTOP === 'gamescope')
+contextBridge.exposeInMainWorld('isSteamDeckGameMode', isSteamDeckGameMode)
+contextBridge.exposeInMainWorld('isFlatpak', isFlatpak)
 contextBridge.exposeInMainWorld('platform', process.platform)
 
 if (navigator.userAgent.includes('Windows')) {


### PR DESCRIPTION
When using Heroic as a Flatpak and mangohud or gamescope are not found, the message only told the user to install them and add them to the PATH, when the solution is to actually install the flatpak packages of those tools (because users might see they actually have the tools installed and in the PATH, but they might not know they need the flatpak version)

Since they also have to install the correct version matching the Flatpak runtime, I included that in the message to make it more obvious.

This should solve many issues of users not knowing how to solve the missing mangohud/gamescope problems.

Also, since `isFlatpak` is a static value that can never change, we don't need an api endpoint, we can just inject the value into the window object at boot using the preload script (we are already sending some static data there), this removes a little bit of complexity in a few places, which I included in this PR.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
