### PR TITLE
[Fix] Add back option to unselect `Launch option`

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -210,6 +210,9 @@
         },
         "winetricks": "Installing Winetricks Packages"
     },
+    "launch": {
+        "options": "Launch Options..."
+    },
     "modifyInstall": {
         "dlcsCollapsible": "DLC",
         "nodlcs": "No DLC available",

--- a/src/frontend/screens/Game/GamePage/components/LaunchOptions.tsx
+++ b/src/frontend/screens/Game/GamePage/components/LaunchOptions.tsx
@@ -3,6 +3,7 @@ import GameContext from '../../GameContext'
 import { GameInfo, LaunchOption } from 'common/types'
 import { SelectField } from 'frontend/components/UI'
 import { MenuItem } from '@mui/material'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   gameInfo: GameInfo
@@ -11,8 +12,9 @@ interface Props {
 
 const LaunchOptions = ({ gameInfo, setLaunchArguments }: Props) => {
   const { appName, runner } = useContext(GameContext)
+  const { t } = useTranslation('gamepage')
   const [launchOptions, setLaunchOptions] = useState<LaunchOption[]>([])
-  const [selectedLaunchOptionIndex, setSelectedLaunchOptionIndex] = useState(0)
+  const [selectedLaunchOptionIndex, setSelectedLaunchOptionIndex] = useState(-1)
 
   useEffect(() => {
     void window.api.getLaunchOptions(appName, runner).then(setLaunchOptions)
@@ -53,6 +55,9 @@ const LaunchOptions = ({ gameInfo, setLaunchArguments }: Props) => {
       }}
       value={selectedLaunchOptionIndex.toString()}
     >
+      <MenuItem key={'-1'} value={'-1'}>
+        {t('launch.options', 'Launch Options...')}
+      </MenuItem>
       {launchOptions.map((option, index) => (
         <MenuItem key={index} value={index}>
           {labelForLaunchOption(option)}


### PR DESCRIPTION
The empty prompt select element got lost in the last version. This PR adds that back so users can unselect any `Launch option`.

Some games like Ghostrunner only show the Launch Option to run with DX12 but no option to NOT launch with DX12, so we need a generic/empty option to be able to run the game without an extra game argument

This closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4583 and closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3751

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
