### PR TITLE
[UX] Ignore iOS games in library

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -525,12 +525,10 @@ function loadFile(app_name: string): boolean {
     return false
   }
 
-  // skip games that are only available for Android, obtanied from the Epic Mobile Store app
-  // TODO: I don't own any game on PC and the mobile store so I don't know if they have to be
-  // handled differently, for now we are only skipping if it's only available for Android
+  // skip games that are only available for Android or iOS, obtanied from the Epic Mobile Store app
   if (
     releaseInfo.every((info) =>
-      info.platform?.every((plat) => plat === 'Android')
+      info.platform?.every((plat) => plat === 'Android' || plat === 'iOS')
     )
   ) {
     return false

--- a/src/common/types/legendary.ts
+++ b/src/common/types/legendary.ts
@@ -3,7 +3,12 @@
 import { LaunchOption } from 'common/types'
 
 // Possible platforms for `legendary list --platform`
-export type LegendaryInstallPlatform = 'Windows' | 'Win32' | 'Mac' | 'Android'
+export type LegendaryInstallPlatform =
+  | 'Windows'
+  | 'Win32'
+  | 'Mac'
+  | 'Android'
+  | 'iOS'
 
 // Metadata in `~/.config/legendary/installed.json`
 export interface InstalledJsonMetadata {

--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -233,6 +233,7 @@ export default function SideloadDialog({
         ]
       // FIXME: Can these happen?
       case 'Android':
+      case 'iOS':
       case 'Browser':
         return []
     }


### PR DESCRIPTION
Back then I made a PR [ignoring Android games](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4364) but I had no iOS games to implement the same thing.

This PR finally solves that by also filtering out iOS games

Closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4441

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
