### PR TITLE
[Fix] Revert DXVK update logic

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -182,6 +182,8 @@ async function initializeWindow(): Promise<BrowserWindow> {
       }
     }
 
+    void DXVK.getLatest()
+
     Winetricks.download()
     if (shouldDownloadWine) {
       downloadDefaultWine()

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -210,7 +210,10 @@ export const DXVK = {
       logWarning('32-bit prefix detected!', LogPrefix.DXVKInstaller)
     }
 
-    await DXVK.getLatest()
+    if (!existsSync(`${toolsPath}/${tool}/latest_${tool}`)) {
+      logWarning('dxvk not found!', LogPrefix.DXVKInstaller)
+      await DXVK.getLatest()
+    }
 
     const globalVersion = readFileSync(`${toolsPath}/${tool}/latest_${tool}`)
       .toString()


### PR DESCRIPTION
This PR reverts these 2 changes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4221 and https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4434

That is causing too many calls to the GitHub API, causing rate-limiting issues in some cases and timeouts that prevent games from launching when running with Wine.

This closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4581 closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4576 and closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4570

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
