### PR TITLE
[UX] Hide DXVK-NVAPI option on the SteamDeck

### DIFF
--- a/src/backend/constants/environment.ts
+++ b/src/backend/constants/environment.ts
@@ -7,6 +7,11 @@ export const isWindows = process.platform === 'win32'
 export const isLinux = process.platform === 'linux'
 export const isSteamDeckGameMode =
   process.env.XDG_CURRENT_DESKTOP === 'gamescope'
+export const isSteamDeckDesktopMode =
+  env.SESSION_MANAGER?.includes('unix/steamdeck') &&
+  env.HOME === '/home/deck' &&
+  env.DESKTOP_SESSION?.includes('steamos')
+export const isSteamDeck = isSteamDeckGameMode || isSteamDeckDesktopMode
 export const isCLIFullscreen = process.argv.includes('--fullscreen')
 export const isCLINoGui = process.argv.includes('--no-gui')
 export const isFlatpak = Boolean(env.FLATPAK_ID)

--- a/src/backend/constants/environment.ts
+++ b/src/backend/constants/environment.ts
@@ -7,7 +7,7 @@ export const isWindows = process.platform === 'win32'
 export const isLinux = process.platform === 'linux'
 export const isSteamDeckGameMode =
   process.env.XDG_CURRENT_DESKTOP === 'gamescope'
-export const isSteamDeckDesktopMode =
+const isSteamDeckDesktopMode =
   env.SESSION_MANAGER?.includes('unix/steamdeck') &&
   env.HOME === '/home/deck' &&
   env.DESKTOP_SESSION?.includes('steamos')

--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -32,7 +32,12 @@ import { existsSync, mkdirSync, openSync } from 'graceful-fs'
 import { Winetricks } from 'backend/tools'
 import { gameAnticheatInfo } from 'backend/anticheat/utils'
 import { isUmuSupported } from 'backend/utils/compatibility_layers'
-import { isLinux, isMac, isWindows } from 'backend/constants/environment'
+import {
+  isLinux,
+  isMac,
+  isSteamDeck,
+  isWindows
+} from 'backend/constants/environment'
 import { gamesConfigPath } from 'backend/constants/paths'
 
 export enum LogPrefix {
@@ -561,6 +566,10 @@ class GameLogWriter extends LogWriter {
             delete gameSettings.autoInstallDxvk
             delete gameSettings.autoInstallVkd3d
           }
+        }
+
+        if (isSteamDeck) {
+          delete gameSettings.autoInstallDxvkNvapi
         }
       } else {
         // remove settings that are not used on native Linux games

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -181,7 +181,7 @@ export default function GamesSettings() {
             <AutoDXVK />
             {isLinux && (
               <>
-                <AutoDXVKNVAPI />
+                {!window.isSteamDeck && <AutoDXVKNVAPI />}
                 <AutoVKD3D />
               </>
             )}

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -167,6 +167,7 @@ declare global {
       canvas_height: number
     ) => Promise<string>
     setTheme: (themeClass: string) => void
+    isSteamDeck: boolean
     isSteamDeckGameMode: boolean
     isFlatpak: boolean
     platform: NodeJS.Platform

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,11 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { contextBridge } from 'electron'
 import api from './api'
-import { isFlatpak, isSteamDeckGameMode } from 'backend/constants/environment'
+import {
+  isFlatpak,
+  isSteamDeck,
+  isSteamDeckGameMode
+} from 'backend/constants/environment'
 
 contextBridge.exposeInMainWorld('api', api)
 contextBridge.exposeInMainWorld('isSteamDeckGameMode', isSteamDeckGameMode)
 contextBridge.exposeInMainWorld('isFlatpak', isFlatpak)
+contextBridge.exposeInMainWorld('isSteamDeck', isSteamDeck)
 contextBridge.exposeInMainWorld('platform', process.platform)
 
 if (navigator.userAgent.includes('Windows')) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,11 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { contextBridge } from 'electron'
 import api from './api'
-import {
-  isFlatpak,
-  isSteamDeck,
-  isSteamDeckGameMode
-} from 'backend/constants/environment'
+import { isFlatpak, isSteamDeck, isSteamDeckGameMode } from 'backend/constants/environment'
 
 contextBridge.exposeInMainWorld('api', api)
 contextBridge.exposeInMainWorld('isSteamDeckGameMode', isSteamDeckGameMode)


### PR DESCRIPTION
The `DXVK-NVAPI` option makes no sense on a SteamDeck since it's always an AMD GPU. We can hide it to remove noise from the settings.

Not sure what's the best way to detect if the devise is a steamdeck (I just checked a few env variables looking at my steamdeck's `printenv` output). We have the `getSteamDeckInfo` function that checks CPU/GPU information against some predefined values but I can't really use it cause it's an async function and I need the code to be sync to use it in the preload/index.ts file.

Closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3861

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
