### PR TITLE
[UX] Show `(i)` tooltips for when focusing setting with controller

### DIFF
--- a/src/frontend/components/UI/InfoIcon/index.css
+++ b/src/frontend/components/UI/InfoIcon/index.css
@@ -1,0 +1,23 @@
+.InfoIcon {
+  position: relative;
+
+  & > span {
+    display: none;
+    right: 0px;
+  }
+}
+
+.isRTL .InfoIcon > span {
+  right: unset;
+  left: 0px;
+}
+
+body.controllerLayout label:focus + .InfoIcon > span {
+  display: block;
+  position: absolute;
+  width: min(400px, 70vw);
+  top: 100%;
+  z-index: 1;
+  padding: 0.3rem 0.5rem;
+  background: var(--background);
+}

--- a/src/frontend/components/UI/InfoIcon/index.tsx
+++ b/src/frontend/components/UI/InfoIcon/index.tsx
@@ -1,0 +1,18 @@
+import './index.css'
+
+import React from 'react'
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
+interface Props {
+  text: string
+}
+
+export default function InfoIcon({ text }: Props) {
+  return (
+    <div className="InfoIcon">
+      <FontAwesomeIcon className="helpIcon" icon={faCircleInfo} title={text} />
+      <span>{text}</span>
+    </div>
+  )
+}

--- a/src/frontend/screens/Game/GamePage/components/CloudSavesSync.tsx
+++ b/src/frontend/screens/Game/GamePage/components/CloudSavesSync.tsx
@@ -2,9 +2,8 @@ import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import GameContext from '../../GameContext'
 import { CloudOff, CloudQueue } from '@mui/icons-material'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import { GameInfo } from 'common/types'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 interface Props {
   gameInfo: GameInfo
@@ -59,10 +58,8 @@ const CloudSavesSync = ({ gameInfo }: Props) => {
           <b>{t('info.syncsaves')}</b>
           {': '}
           {t('cloud_save_unsupported', 'Unsupported')}
-          <FontAwesomeIcon
-            className="helpIcon"
-            icon={faCircleInfo}
-            title={t(
+          <InfoIcon
+            text={t(
               'help.cloud_save_unsupported',
               'This game does not support cloud saves. This information is provided by the game developers. Some games do implement their own cloud save system'
             )}

--- a/src/frontend/screens/Settings/components/AdvertiseAvxForRosetta.tsx
+++ b/src/frontend/screens/Settings/components/AdvertiseAvxForRosetta.tsx
@@ -4,9 +4,8 @@ import { useTranslation } from 'react-i18next'
 import SettingsContext from '../SettingsContext'
 import useSetting from 'frontend/hooks/useSetting'
 import { ToggleSwitch } from 'frontend/components/UI'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import { defaultWineVersion } from '..'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const AdvertiseAvxForRosetta = () => {
   const { t } = useTranslation()
@@ -33,10 +32,8 @@ const AdvertiseAvxForRosetta = () => {
         title={t('setting.advertiseAvxForRosetta', 'Advertise AVX for Rosetta')}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.advertiseAvxForRosetta',
           'Enables AVX instruction set support when running Windows games through Rosetta on Apple Silicon Macs. This may be required for some games like Death Stranding that need AVX support.'
         )}

--- a/src/frontend/screens/Settings/components/AutoDXVK.tsx
+++ b/src/frontend/screens/Settings/components/AutoDXVK.tsx
@@ -1,12 +1,11 @@
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import { defaultWineVersion } from '..'
 import useSetting from 'frontend/hooks/useSetting'
 import { ToggleSwitch } from 'frontend/components/UI'
 import SettingsContext from '../SettingsContext'
 import ContextProvider from 'frontend/state/ContextProvider'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const AutoDXVK = () => {
   const { t } = useTranslation()
@@ -54,10 +53,8 @@ const AutoDXVK = () => {
         disabled={installingDxvk || (isLinux && autoInstallVkd3d)}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.dxvk',
           'DXVK is a Vulkan-based translational layer for DirectX 9, 10 and 11 games. Enabling may improve compatibility. Might cause issues especially for older DirectX games.'
         )}

--- a/src/frontend/screens/Settings/components/AutoDXVKNVAPI.tsx
+++ b/src/frontend/screens/Settings/components/AutoDXVKNVAPI.tsx
@@ -4,8 +4,7 @@ import useSetting from 'frontend/hooks/useSetting'
 import { useTranslation } from 'react-i18next'
 import { defaultWineVersion } from '..'
 import SettingsContext from '../SettingsContext'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const AutoDXVKNVAPI = () => {
   const { t } = useTranslation()
@@ -54,10 +53,8 @@ const AutoDXVKNVAPI = () => {
         disabled={installingDxvkNvapi}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.dxvknvapi',
           'DXVK-NVAPI is an implementation of NVAPI built on top of DXVK and the linux native NVAPI, it allows for the usage of DLSS on Nvidia GPUs.'
         )}

--- a/src/frontend/screens/Settings/components/AutoVKD3D.tsx
+++ b/src/frontend/screens/Settings/components/AutoVKD3D.tsx
@@ -2,10 +2,9 @@ import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import { defaultWineVersion } from '..'
 import SettingsContext from '../SettingsContext'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const AutoVKD3D = () => {
   const { t } = useTranslation()
@@ -53,10 +52,8 @@ const AutoVKD3D = () => {
         disabled={!autoInstallDxvk || installingVKD3D}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.vkd3d',
           'VKD3D is a Vulkan-based translational layer for DirectX 12 games. Enabling may improve compatibility significantly. Has no effect on older DirectX games, it requires DXVK.'
         )}

--- a/src/frontend/screens/Settings/components/DisableLogs.tsx
+++ b/src/frontend/screens/Settings/components/DisableLogs.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import useSetting from 'frontend/hooks/useSetting'
 import { ToggleSwitch } from 'frontend/components/UI'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const DisableLogs = () => {
   const { t } = useTranslation()
@@ -18,10 +17,8 @@ const DisableLogs = () => {
         title={t('setting.disable_logs', 'Disable Logs')}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.disable_logs',
           'Toggle this checkbox ON to disable most of the writes to log files (critical information is always logged). Make sure to turn OFF this setting before reporting any issue.'
         )}

--- a/src/frontend/screens/Settings/components/DownloadProtonToSteam.tsx
+++ b/src/frontend/screens/Settings/components/DownloadProtonToSteam.tsx
@@ -4,8 +4,7 @@ import { ToggleSwitch } from 'frontend/components/UI'
 import ContextProvider from 'frontend/state/ContextProvider'
 import useSetting from 'frontend/hooks/useSetting'
 import SettingsContext from '../SettingsContext'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const DownloadProtonToSteam = () => {
   const { t } = useTranslation()
@@ -32,10 +31,8 @@ const DownloadProtonToSteam = () => {
         handleChange={() => setDownloadProtonToSteam(!downloadProtonToSteam)}
         value={downloadProtonToSteam}
       />
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.download_proton_steam',
           "When enabled, GE-Proton will be downloaded directly to the Steam compatibility tools directory instead of the default Heroic path. It will use the Steam path set in the 'Default Steam path' setting above."
         )}

--- a/src/frontend/screens/Settings/components/EnableDXVKFpsLimit.tsx
+++ b/src/frontend/screens/Settings/components/EnableDXVKFpsLimit.tsx
@@ -3,10 +3,9 @@ import { useTranslation } from 'react-i18next'
 import { ToggleSwitch, TextInputField } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import SettingsContext from '../SettingsContext'
 import { defaultWineVersion } from '..'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const EnableDXVKFpsLimit = () => {
   const { t } = useTranslation()
@@ -39,10 +38,8 @@ const EnableDXVKFpsLimit = () => {
           title={t('setting.dxfpslimit', 'Limit DirectX Games FPS')}
         />
 
-        <FontAwesomeIcon
-          className="helpIcon"
-          icon={faCircleInfo}
-          title={t(
+        <InfoIcon
+          text={t(
             'help.dxfpslimit',
             'Sets a frame rate cap for DirectX Games (9-12)'
           )}

--- a/src/frontend/screens/Settings/components/EnableEsync.tsx
+++ b/src/frontend/screens/Settings/components/EnableEsync.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const EnableEsync = () => {
   const { t } = useTranslation()
@@ -19,10 +18,8 @@ const EnableEsync = () => {
         title={t('setting.esync', 'Enable Esync')}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.esync',
           'Esync aims to reduce wineserver overhead in CPU-intensive games. Enabling may improve performance.'
         )}

--- a/src/frontend/screens/Settings/components/EnableFSR.tsx
+++ b/src/frontend/screens/Settings/components/EnableFSR.tsx
@@ -3,10 +3,9 @@ import { useTranslation } from 'react-i18next'
 import { SelectField, ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import SettingsContext from '../SettingsContext'
 import { MenuItem } from '@mui/material'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const EnableFSR = () => {
   const { t } = useTranslation()
@@ -33,10 +32,8 @@ const EnableFSR = () => {
           )}
         />
 
-        <FontAwesomeIcon
-          className="helpIcon"
-          icon={faCircleInfo}
-          title={t(
+        <InfoIcon
+          text={t(
             'help.amdfsr',
             "AMD's FSR helps boost framerate by upscaling lower resolutions in Fullscreen Mode. Image quality increases from 5 to 1 at the cost of a slight performance hit. Enabling may improve performance."
           )}

--- a/src/frontend/screens/Settings/components/EnableFsync.tsx
+++ b/src/frontend/screens/Settings/components/EnableFsync.tsx
@@ -3,9 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import SettingsContext from '../SettingsContext'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const EnableFsync = () => {
   const { t } = useTranslation()
@@ -27,10 +26,8 @@ const EnableFsync = () => {
         title={t('setting.fsync', 'Enable Fsync')}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.fsync',
           'Fsync aims to reduce wineserver overhead in CPU-intensive games. Enabling may improve performance on supported Linux kernels.'
         )}

--- a/src/frontend/screens/Settings/components/EnableMsync.tsx
+++ b/src/frontend/screens/Settings/components/EnableMsync.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from 'react-i18next'
 import SettingsContext from '../SettingsContext'
 import useSetting from 'frontend/hooks/useSetting'
 import { ToggleSwitch } from 'frontend/components/UI'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const EnableMsync = () => {
   const { t } = useTranslation()
@@ -27,10 +26,8 @@ const EnableMsync = () => {
         title={t('setting.msync', 'Enable Msync')}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.msync',
           'Msync aims to reduce wineserver overhead in CPU-intensive games. Enabling may improve performance on supported Linux kernels.'
         )}

--- a/src/frontend/screens/Settings/components/GameMode.tsx
+++ b/src/frontend/screens/Settings/components/GameMode.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const GameMode = () => {
   const { t } = useTranslation()
@@ -55,10 +54,8 @@ const GameMode = () => {
         title={t('setting.gamemode')}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.gamemode',
           'Feral GameMode applies automatic and temporary tweaks to the system when running games. Enabling may improve performance.'
         )}

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -8,9 +8,8 @@ import {
 } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import { MenuItem } from '@mui/material'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const Gamescope = () => {
   const { t } = useTranslation()
@@ -139,10 +138,8 @@ const Gamescope = () => {
             label={'Upscale Method'}
             htmlId="upscaleMethod"
             afterSelect={
-              <FontAwesomeIcon
-                className="helpIcon"
-                icon={faCircleInfo}
-                title={t(
+              <InfoIcon
+                text={t(
                   'help.gamescope.upscaleMethod',
                   'The upscaling method gamescope should use.'
                 )}
@@ -171,10 +168,8 @@ const Gamescope = () => {
               maxLength={4}
               value={gamescope.gameWidth}
               afterInput={
-                <FontAwesomeIcon
-                  className="helpIcon"
-                  icon={faCircleInfo}
-                  title={t(
+                <InfoIcon
+                  text={t(
                     'help.gamescope.gameWidth',
                     'The width resolution used by the game. A 16:9 aspect ratio is assumed by gamescope.'
                   )}
@@ -197,10 +192,8 @@ const Gamescope = () => {
               maxLength={4}
               value={gamescope.gameHeight}
               afterInput={
-                <FontAwesomeIcon
-                  className="helpIcon"
-                  icon={faCircleInfo}
-                  title={t(
+                <InfoIcon
+                  text={t(
                     'help.gamescope.gameHeight',
                     'The height resolution used by the game. A 16:9 aspect ratio is assumed by gamescope.'
                   )}
@@ -225,10 +218,8 @@ const Gamescope = () => {
               maxLength={4}
               value={gamescope.upscaleWidth}
               afterInput={
-                <FontAwesomeIcon
-                  className="helpIcon"
-                  icon={faCircleInfo}
-                  title={t(
+                <InfoIcon
+                  text={t(
                     'help.gamescope.upscaleWidth',
                     'The width resolution used by gamescope. A 16:9 aspect ratio is assumed.'
                   )}
@@ -251,10 +242,8 @@ const Gamescope = () => {
               maxLength={4}
               value={gamescope.upscaleHeight}
               afterInput={
-                <FontAwesomeIcon
-                  className="helpIcon"
-                  icon={faCircleInfo}
-                  title={t(
+                <InfoIcon
+                  text={t(
                     'help.gamescope.upscaleHeight',
                     'The height resolution used by gamescope. A 16:9 aspect ratio is assumed.'
                   )}
@@ -314,10 +303,8 @@ const Gamescope = () => {
             maxLength={3}
             value={gamescope.fpsLimiter}
             afterInput={
-              <FontAwesomeIcon
-                className="helpIcon"
-                icon={faCircleInfo}
-                title={t(
+              <InfoIcon
+                text={t(
                   'help.gamescope.fpsLimiter',
                   'The frame rate limit gamescope should limit per second.'
                 )}
@@ -343,10 +330,8 @@ const Gamescope = () => {
             maxLength={3}
             value={gamescope.fpsLimiterNoFocus}
             afterInput={
-              <FontAwesomeIcon
-                className="helpIcon"
-                icon={faCircleInfo}
-                title={t(
+              <InfoIcon
+                text={t(
                   'help.gamescope.fpsLimiterNoFocus',
                   'The frame rate limit gamescope should limit per second if the game is not focused.'
                 )}
@@ -379,10 +364,8 @@ const Gamescope = () => {
             'Enable Force Grab Cursor'
           )}
         />
-        <FontAwesomeIcon
-          className="helpIcon"
-          icon={faCircleInfo}
-          title={t(
+        <InfoIcon
+          text={t(
             'help.gamescope.forceGrabCursor',
             'Always use relative mouse mode instead of flipping dependent on cursor visibility. (Useful for when applications keep losing focus)'
           )}
@@ -395,10 +378,8 @@ const Gamescope = () => {
         placeholder=""
         value={additionalOptions}
         afterInput={
-          <FontAwesomeIcon
-            className="helpIcon"
-            icon={faCircleInfo}
-            title={t(
+          <InfoIcon
+            text={t(
               'help.gamescope.additionalOptions',
               'Additional commandline flags to pass into gamescope.'
             )}

--- a/src/frontend/screens/Settings/components/Mangohud.tsx
+++ b/src/frontend/screens/Settings/components/Mangohud.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const Mangohud = () => {
   const { t } = useTranslation()
@@ -25,10 +24,8 @@ const Mangohud = () => {
         title={t('setting.mangohud')}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.mangohud',
           'MangoHUD is an overlay that displays and monitors FPS, temperatures, CPU/GPU load and other system resources.'
         )}

--- a/src/frontend/screens/Settings/components/PlaytimeSync.tsx
+++ b/src/frontend/screens/Settings/components/PlaytimeSync.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import SettingsContext from '../SettingsContext'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const PlaytimeSync = () => {
   const { t } = useTranslation()
@@ -29,10 +28,8 @@ const PlaytimeSync = () => {
           'Disable playtime synchronization'
         )}
       />
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.disablePlaytimeSync',
           "Disables playtime synchronization with given store's servers (currently only GOG is supported)"
         )}

--- a/src/frontend/screens/Settings/components/PreferSystemLibs.tsx
+++ b/src/frontend/screens/Settings/components/PreferSystemLibs.tsx
@@ -3,9 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import { defaultWineVersion } from '..'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const PreferSystemLibs = () => {
   const { t } = useTranslation()
@@ -36,10 +35,8 @@ const PreferSystemLibs = () => {
         title={t('setting.preferSystemLibs', 'Prefer system libraries')}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.preferSystemLibs',
           'Custom Wine versions (Wine-GE, Wine-Lutris) are shipped with their library dependencies. By enabling this option, these shipped libraries will be ignored and Wine will load system libraries instead. Warning! Issues may occur if dependencies are not met.'
         )}

--- a/src/frontend/screens/Settings/components/SteamRuntime.tsx
+++ b/src/frontend/screens/Settings/components/SteamRuntime.tsx
@@ -3,10 +3,9 @@ import { useTranslation } from 'react-i18next'
 import { ToggleSwitch } from 'frontend/components/UI'
 import ContextProvider from 'frontend/state/ContextProvider'
 import useSetting from 'frontend/hooks/useSetting'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import { defaultWineVersion } from '..'
 import SettingsContext from '../SettingsContext'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const SteamRuntime = () => {
   const { t } = useTranslation()
@@ -37,10 +36,8 @@ const SteamRuntime = () => {
         title={t('setting.steamruntime', 'Use Steam Runtime')}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.steamruntime',
           'Custom libraries provided by Steam to help run Linux and Windows (Proton) games. Enabling might improve compatibility.'
         )}

--- a/src/frontend/screens/Settings/components/UseDGPU.tsx
+++ b/src/frontend/screens/Settings/components/UseDGPU.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const UseDGPU = () => {
   const { t } = useTranslation()
@@ -51,10 +50,8 @@ const UseDGPU = () => {
         title={t('setting.primerun.description', 'Use Dedicated Graphics Card')}
       />
 
-      <FontAwesomeIcon
-        className="helpIcon"
-        icon={faCircleInfo}
-        title={t(
+      <InfoIcon
+        text={t(
           'help.primerun',
           'Use dedicated graphics card to render game on multi-GPU systems. Only needed on gaming laptops or desktops that use a headless GPU for rendering (NVIDIA Optimus, AMD CrossFire)'
         )}

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -892,6 +892,10 @@ class GlobalState extends PureComponent<Props> {
     window.addEventListener(
       'controller-changed',
       (e: CustomEvent<{ controllerId: string }>) => {
+        document.body.classList.toggle(
+          'controllerLayout',
+          e.detail.controllerId !== ''
+        )
         this.setState({ activeController: e.detail.controllerId })
       }
     )


### PR DESCRIPTION
We've had this issue since... forever https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1680 where, when using a controller to navigate heroic's UI, there was no way to see the text/title of the `(i)` tooltips next to the fields.

This PR fixes that by adding a new `InfoIcon` component that handles displaying its text as a small popover when a label next to it is focus and a controller is being used.

For any other case the title is the same as before with the `<title>` tag of the SVG icon.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
