### PR TITLE
[FIX] Do not use wine path for rockstar fix on windows

### DIFF
--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -878,19 +878,23 @@ export async function launch(
   }
 
   // We can get this env variable either from the game's settings or from known fixes
-  if (commandEnv['USE_FAKE_EPIC_EXE']) {
-    const fakeExeWinPath = 'C:\\windows\\command\\EpicGamesLauncher.exe'
-    const fakeEpicExePathInPrefix = await getWinePath({
-      path: fakeExeWinPath,
-      gameSettings,
-      variant: 'unix'
-    })
+  if (commandEnv['USE_FAKE_EPIC_EXE'] && !isWindows) {
+    if (isWindows) {
+      commandEnv['LEGENDARY_WRAPPER_EXE'] = fakeEpicExePath
+    } else {
+      // on linux and mac, we copy the fake exe
+      const fakeExeWinPath = 'C:\\windows\\command\\EpicGamesLauncher.exe'
+      const fakeEpicExePathInPrefix = await getWinePath({
+        path: fakeExeWinPath,
+        gameSettings,
+        variant: 'unix'
+      })
 
-    // we copy the file inside the prefix to avoid permission issues
-    if (!existsSync(fakeEpicExePathInPrefix))
-      copyFileSync(fakeEpicExePath, fakeEpicExePathInPrefix)
-
-    commandEnv['LEGENDARY_WRAPPER_EXE'] = fakeExeWinPath
+      // we copy the file inside the prefix to avoid permission issues
+      if (!existsSync(fakeEpicExePathInPrefix))
+        copyFileSync(fakeEpicExePath, fakeEpicExePathInPrefix)
+      commandEnv['LEGENDARY_WRAPPER_EXE'] = fakeExeWinPath
+    }
   }
 
   const wrappers = setupWrappers(


### PR DESCRIPTION
The latest release included the automatic fix for Rockstar games using the fake EpicGamesLauncher.exe file but the code has a bug, it tries to use a `wine` path even on windows, causing things to fail with an `TypeError: Cannot read properties of undefined (reading 'type')` trying to fine the `wine type` for when the wine information is undefined in windows.

For users with this issue, as a workaround, deleting the `known fix` file `C:\Users\<your user>\AppData\Roaming\heroic\fixes\8769e24080ea413b8ebca3f1b8c50951.json` should get rid of the error and then the manual steps of the wiki should be usted instead https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki/Rockstar-Games-from-Epic-Games

I don't have a windows machine to test if just pointing to the fake exe for legendary works, would be great to have someone test that.

I reverted the env variable in the known fixes repo cause it makes all new installations of GTAV GTAV-Enhanced and RDR2 fail on windows by default.

Users of other platforms won't get the env variable automatically but it's easier to fix that issue adding the env variable than for windows users to find the correct known-fixes file to delete.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
