### PR TITLE
[UX] Improve "Use Default Wine Settings" tooltip to avoid confusion

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -56,7 +56,7 @@ export default function WineSelector({
 
       if (!wineVersion || !defaultPrefix || !defaultBottle) return
       setDescription(
-        `${defaultPrefix} / ${wineVersion.name.replace('Proton - ', '')}`
+        `${wineVersion.name.replace('Proton - ', '')}\n${defaultPrefix}`
       )
 
       if (!useDefaultSettings && wineVersion.type === 'crossover') {


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4480

The tooltip was using `/` as a separator between the wine prefix path and the wine version, which is the same character used by unix systems as a path separator, giving the impression that the whole string was a path

This PR changes the tooltip to:
- use multiple lines instead of a separator
- show the wine version first to ensure it's not mixed with the path

Before:
![image](https://github.com/user-attachments/assets/30e66d0b-f337-4342-b8ca-c8d5aa658b30)

After:
![image](https://github.com/user-attachments/assets/9fb4f904-bcf9-4353-b00c-f038bd8857c7)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
