### PR TITLE
[UX] Option to have no tray icon

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -758,6 +758,7 @@
         "maxworkers": "Maximum Number of Workers when downloading",
         "minimize-on-launch": "Minimize Heroic After Game Launch",
         "msync": "Enable Msync",
+        "no-tray-icon": "Hide System Tray Icon (requires restart)",
         "offlinemode": "Run Game Offline",
         "prefered_language": "Prefered Language (Language Code)",
         "preferSystemLibs": "Prefer system libraries",

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -359,7 +359,8 @@ class GlobalConfigV0 extends GlobalConfig {
       disableUMU: false,
       verboseLogs: false,
       downloadProtonToSteam: false,
-      advertiseAvxForRosetta: isMac && defaultWine.type === 'toolkit'
+      advertiseAvxForRosetta: isMac && defaultWine.type === 'toolkit',
+      noTrayIcon: false
     }
     // @ts-expect-error TODO: We need to settle on *one* place to define settings defaults
     return settings

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -115,7 +115,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
 
   const { title } = game
 
-  const { minimizeOnLaunch } = GlobalConfig.get().getSettings()
+  const { minimizeOnLaunch, noTrayIcon } = GlobalConfig.get().getSettings()
 
   const startPlayingDate = new Date()
 
@@ -155,7 +155,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   })
 
   const mainWindow = getMainWindow()
-  if (minimizeOnLaunch) {
+  if (minimizeOnLaunch && !noTrayIcon) {
     mainWindow?.hide()
   }
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -228,9 +228,9 @@ async function initializeWindow(): Promise<BrowserWindow> {
       })
     }
 
-    const { exitToTray } = GlobalConfig.get().getSettings()
+    const { exitToTray, noTrayIcon } = GlobalConfig.get().getSettings()
 
-    if (exitToTray) {
+    if (exitToTray && !noTrayIcon) {
       logInfo('Exitting to tray instead of quitting', LogPrefix.Backend)
       return mainWindow.hide()
     }
@@ -404,8 +404,8 @@ if (!gotTheLock) {
       logWarning('Protocol already registered.', LogPrefix.Backend)
     }
 
-    const headless = isCLINoGui || settings.startInTray
-
+    const headless =
+      isCLINoGui || (settings.startInTray && !settings.noTrayIcon)
     if (!headless) {
       const isWayland = Boolean(process.env.WAYLAND_DISPLAY)
       const showWindow = () => {

--- a/src/backend/tray_icon/__tests__/tray_icon.test.ts
+++ b/src/backend/tray_icon/__tests__/tray_icon.test.ts
@@ -116,7 +116,9 @@ describe('TrayIcon', () => {
 
           setRecentGames([])
 
-          const appIcon = await initTrayIcon(mainWindow)
+          const appIcon = (await initTrayIcon(
+            mainWindow
+          )) as Electron.CrossProcessExports.Tray
 
           expect(appIcon.menu[0]).toEqual({
             type: 'separator'
@@ -169,7 +171,9 @@ describe('TrayIcon', () => {
 
           // check it renders english
           i18next.language = 'en'
-          const appIcon = await initTrayIcon(mainWindow)
+          const appIcon = (await initTrayIcon(
+            mainWindow
+          )) as Electron.CrossProcessExports.Tray
           let items = appIcon.menu
           expect(items[items.length - 1].label).toEqual('Quit')
 
@@ -207,7 +211,9 @@ describe('TrayIcon', () => {
       // defaults to 5
       GlobalConfig.setConfigValue('maxRecentGames', undefined)
 
-      const appIcon = await initTrayIcon(mainWindow)
+      const appIcon = (await initTrayIcon(
+        mainWindow
+      )) as Electron.CrossProcessExports.Tray
 
       const items = appIcon.menu
 

--- a/src/backend/tray_icon/__tests__/tray_icon.test.ts
+++ b/src/backend/tray_icon/__tests__/tray_icon.test.ts
@@ -23,6 +23,18 @@ describe('TrayIcon', () => {
     configStore.get = jest.fn()
   })
 
+  it('shows no icon if noTrayIcon setting', async () => {
+    GlobalConfig.setConfigValue('noTrayIcon', true)
+
+    const noAppIcon = await initTrayIcon(mainWindow)
+    expect(noAppIcon).toBeNull()
+
+    GlobalConfig.setConfigValue('noTrayIcon', false)
+
+    const appIcon = await initTrayIcon(mainWindow)
+    expect(appIcon).not.toBeNull()
+  })
+
   describe('content', () => {
     describe('contextMenu', () => {
       beforeEach(() => {

--- a/src/backend/tray_icon/__tests__/tray_icon.test.ts
+++ b/src/backend/tray_icon/__tests__/tray_icon.test.ts
@@ -74,7 +74,9 @@ describe('TrayIcon', () => {
         it('updates the content', async () => {
           setRecentGames([{ title: 'game 1', appName: '12345' }])
 
-          const appIcon = await initTrayIcon(mainWindow)
+          const appIcon = (await initTrayIcon(
+            mainWindow
+          )) as Electron.CrossProcessExports.Tray
 
           expect(appIcon.menu[0]).toEqual({
             click: expect.any(Function),

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -16,6 +16,9 @@ const iconDark = fixAsarPath(join(publicDir, 'icon-dark.png'))
 const iconLight = fixAsarPath(join(publicDir, 'icon-light.png'))
 
 export const initTrayIcon = async (mainWindow: BrowserWindow) => {
+  const { noTrayIcon } = GlobalConfig.get().getSettings()
+  if (noTrayIcon) return null
+
   // create icon
   const appIcon = new Tray(getIcon(process.platform))
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -109,6 +109,7 @@ export interface AppSettings extends GameSettings {
   egsLinkedPath: string
   enableUpdates: boolean
   exitToTray: boolean
+  noTrayIcon: boolean
   experimentalFeatures?: ExperimentalFeatures
   framelessWindow: boolean
   hideChangelogsOnStartup: boolean

--- a/src/frontend/screens/Settings/components/MinimizeOnGameLaunch.tsx
+++ b/src/frontend/screens/Settings/components/MinimizeOnGameLaunch.tsx
@@ -9,16 +9,18 @@ const MinimizeOnGameLaunch = () => {
     'minimizeOnLaunch',
     false
   )
+  const [noTrayIcon] = useSetting('noTrayIcon', false)
 
   return (
     <ToggleSwitch
       htmlId="minimizeOnLaunch"
-      value={minimizeOnLaunch}
+      value={minimizeOnLaunch && !noTrayIcon}
       handleChange={() => setMinimizeOnLaunch(!minimizeOnLaunch)}
       title={t(
         'setting.minimize-on-launch',
         'Minimize Heroic After Game Launch'
       )}
+      disabled={noTrayIcon}
     />
   )
 }

--- a/src/frontend/screens/Settings/components/TraySettings.tsx
+++ b/src/frontend/screens/Settings/components/TraySettings.tsx
@@ -7,24 +7,35 @@ const TraySettings = () => {
   const { t } = useTranslation()
   const [exitToTray, setExitToTray] = useSetting('exitToTray', false)
   const [startInTray, setStartInTray] = useSetting('startInTray', false)
+  const [noTrayIcon, setNoTrayIcon] = useSetting('noTrayIcon', false)
 
   return (
     <>
       <ToggleSwitch
-        htmlId="exitToTray"
-        value={exitToTray}
-        handleChange={() => setExitToTray(!exitToTray)}
-        title={t('setting.exit-to-tray', 'Exit to System Tray')}
+        htmlId="noTrayIcon"
+        value={noTrayIcon}
+        handleChange={() => setNoTrayIcon(!noTrayIcon)}
+        title={t(
+          'setting.no-tray-icon',
+          'Hide System Tray Icon (requires restart)'
+        )}
       />
 
-      {exitToTray && (
-        <ToggleSwitch
-          htmlId="startInTray"
-          value={startInTray}
-          handleChange={() => setStartInTray(!startInTray)}
-          title={t('setting.start-in-tray', 'Start Minimized')}
-        />
-      )}
+      <ToggleSwitch
+        htmlId="exitToTray"
+        value={exitToTray && !noTrayIcon}
+        handleChange={() => setExitToTray(!exitToTray)}
+        title={t('setting.exit-to-tray', 'Exit to System Tray')}
+        disabled={noTrayIcon}
+      />
+
+      <ToggleSwitch
+        htmlId="startInTray"
+        value={startInTray && !noTrayIcon}
+        handleChange={() => setStartInTray(!startInTray)}
+        title={t('setting.start-in-tray', 'Start Minimized')}
+        disabled={!exitToTray || noTrayIcon}
+      />
     </>
   )
 }


### PR DESCRIPTION
This PR closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2819

A new option to start heroic with no Tray icon (on mac they it can still be accessed from the dock for example)

Toggling the option disables the other tray-related options.

![image](https://github.com/user-attachments/assets/d359f360-f230-40f5-8025-ab39de8b36ed)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
