### PR TITLE
[UX] Support Env variables on windows and rockstar tweak

### DIFF
--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -871,14 +871,12 @@ export async function launch(
   let commandEnv = {
     ...process.env,
     ...setupWrapperEnvVars({ appName, appRunner: 'legendary' }),
-    ...(isWindows
-      ? {}
-      : setupEnvVars(gameSettings, gameInfo.install.install_path)),
+    ...setupEnvVars(gameSettings, gameInfo.install.install_path),
     ...getKnownFixesEnvVariables(appName, 'legendary')
   }
 
   // We can get this env variable either from the game's settings or from known fixes
-  if (commandEnv['USE_FAKE_EPIC_EXE'] && !isWindows) {
+  if (commandEnv['USE_FAKE_EPIC_EXE']) {
     if (isWindows) {
       commandEnv['LEGENDARY_WRAPPER_EXE'] = fakeEpicExePath
     } else {

--- a/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
+++ b/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { InfoBox } from 'frontend/components/UI'
 import {
@@ -6,22 +6,15 @@ import {
   TableInput
 } from 'frontend/components/UI/TwoColTableInput'
 import { EnviromentVariable } from 'common/types'
-import ContextProvider from 'frontend/state/ContextProvider'
 import useSetting from 'frontend/hooks/useSetting'
 
 const EnvVariablesTable = () => {
   const { t } = useTranslation()
-  const { platform } = useContext(ContextProvider)
-  const isWindows = platform === 'win32'
 
   const [environmentOptions, setEnvironmentOptions] = useSetting(
     'enviromentOptions',
     []
   )
-
-  if (isWindows) {
-    return <></>
-  }
 
   const getEnvironmentVariables = () => {
     const columns: ColumnProps[] = []


### PR DESCRIPTION
I tried this in a VM and it seems to work kind of, the game fails to open but I think it's because I'm inside a VM, but it seems to be doing the correct workflow (not showing the `buy now` screen of the rockstar launcher)

I included a fix for the fake exe integration and also enabled env variables to be configurable and applied in windows.

Please, if anyone has a windows machine not in a VM, can you try this with either GTAV, GTAV enhanced or RDR2?

Steps:
- go to the game's settings > advanced tab
- set the env variable `USE_FAKE_EPIC_EXE = true`
- launch the game

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
