### PR TITLE
[UX] Improve log info for sideloaded games

### DIFF
--- a/src/backend/logger/logger.ts
+++ b/src/backend/logger/logger.ts
@@ -776,7 +776,7 @@ export async function appendWinetricksGamePlayLog(gameInfo: GameInfo) {
 
 export function stopLogger(appName: string) {
   logsWriters[`${appName}-lastPlay`]?.logMessage(
-    '============= End of log ============='
+    '\n============= End of log ============='
   )
   delete logsWriters[`${appName}-lastPlay`]
 }

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -693,7 +693,7 @@ export async function launch(
   if (!gameSettings.verboseLogs) {
     appendGamePlayLog(
       gameInfo,
-      "IMPORTANT: Logs are disabled.\nEnable verbose logs in Game's settings > Advanced tab > 'Enable verbose logs' before reporting an issue.\n\n"
+      "IMPORTANT: Logs are disabled.\nEnable verbose logs in Game's settings > Advanced tab > 'Enable verbose logs' before reporting an issue.\n"
     )
   }
 

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -982,7 +982,7 @@ export async function launch(
   if (!gameSettings.verboseLogs) {
     appendGamePlayLog(
       gameInfo,
-      "IMPORTANT: Logs are disabled.\nEnable verbose logs in Game's settings > Advanced tab > 'Enable verbose logs' before reporting an issue.\n\n"
+      "IMPORTANT: Logs are disabled.\nEnable verbose logs in Game's settings > Advanced tab > 'Enable verbose logs' before reporting an issue.\n"
     )
   }
 

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -429,7 +429,7 @@ export async function launch(
   if (!gameSettings.verboseLogs) {
     appendGamePlayLog(
       gameInfo,
-      "IMPORTANT: Logs are disabled.\nEnable verbose logs in Game's settings > Advanced tab > 'Enable verbose logs' before reporting an issue.\n\n"
+      "IMPORTANT: Logs are disabled.\nEnable verbose logs in Game's settings > Advanced tab > 'Enable verbose logs' before reporting an issue.\n"
     )
   }
 


### PR DESCRIPTION
This PR fixes some issues with logs for sideloaded games:
- the logs didn't have the warning for verbose logs disabled
- the logs for native games were not always consistent (it was not respecting the verbose logs option and it could end up printing logs at the wrong part of the file)
- the `======= End log ========` line could end up at the end of another line instead of in its own line.

This PR closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4615 (the reported issue was not a bug, but it was missing the disabled verbose logs warning)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
