### PR TITLE
[fix] When importing a game, the status says installing instead of importing

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -285,6 +285,7 @@
         "hasUpdates": "New Version Available!",
         "installed": "Installed",
         "installing": "Installing",
+        "importing": "Importing",
         "launching": "Launching",
         "moving": "Moving Installation, please wait",
         "moving-files": "Moving file '{{file}}': {{percent}}%",

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -977,7 +977,7 @@ addHandler(
     sendGameStatusUpdate({
       appName,
       runner,
-      status: 'installing'
+      status: 'importing'
     })
 
     const abortMessage = () => {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -226,6 +226,7 @@ export interface GameSettings {
 
 export type Status =
   | 'installing'
+  | 'importing'
   | 'updating'
   | 'launching'
   | 'playing'

--- a/src/frontend/screens/Game/GameContext.tsx
+++ b/src/frontend/screens/Game/GameContext.tsx
@@ -11,6 +11,7 @@ const initialContext: GameContextType = {
   gameInstallInfo: null,
   is: {
     installing: false,
+    importing: false,
     installingWinetricksPackages: false,
     installingRedist: false,
     launching: false,

--- a/src/frontend/screens/Game/GamePage/components/GameStatus.tsx
+++ b/src/frontend/screens/Game/GamePage/components/GameStatus.tsx
@@ -87,11 +87,11 @@ const GameStatus = ({ gameInfo, progress, handleUpdate, hasUpdate }: Props) => {
       return `${t('status.updating')} ${currentProgress}`
     }
 
-    if (!is.updating && is.installing) {
+    if (!is.updating && (is.installing || is.importing)) {
       if (!currentProgress) {
         return `${t('status.processing', 'Processing files, please wait')}...`
       }
-      return `${t('status.installing')} ${currentProgress}`
+      return `${t(is.importing ? 'status.importing' : 'status.installing')} ${currentProgress}`
     }
 
     if (is.queued) {

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -135,6 +135,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const isBrowserGame = gameInfo?.install.platform === 'Browser'
 
   const isInstalling = status === 'installing'
+  const isImporting = status === 'importing'
   const isPlaying = status === 'playing'
   const isUpdating = status === 'updating'
   const isQueued = status === 'queued'
@@ -306,6 +307,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       gameExtraInfo: extraInfo,
       is: {
         installing: isInstalling,
+        importing: isImporting,
         installingWinetricksPackages: isInstallingWinetricksPackages,
         installingRedist: isInstallingRedist,
         launching: isLaunching,

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -252,6 +252,7 @@ export interface GameContextType {
   gameInstallInfo: InstallInfo | null
   is: {
     installing: boolean
+    importing: boolean
     installingWinetricksPackages: boolean
     installingRedist: boolean
     launching: boolean


### PR DESCRIPTION
When importing a game, the status says installing instead of importing bug fix

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
