### PR TITLE
Fix busted appimage path for non-steam shortcuts

### DIFF
--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -269,7 +269,7 @@ async function addNonSteamGame(props: {
     if (isFlatpak) {
       newEntry.Exe = `"flatpak"`
     } else if (!isWindows && isAppImage) {
-      newEntry.Exe = `"${isAppImage}"`
+      newEntry.Exe = `"${process.env.APPIMAGE}"`
     } else if (isWindows && process.env.PORTABLE_EXECUTABLE_FILE) {
       newEntry.Exe = `"${process.env.PORTABLE_EXECUTABLE_FILE}"`
       newEntry.StartDir = `"${process.env.PORTABLE_EXECUTABLE_DIR}"`


### PR DESCRIPTION
Reverts a change from commit 747ff3e59dc0598f333c843c3db842a9982bd4dc which broke exposing the correct path to the running appimage when creating non-steam game shortcuts for export to the Steam library as reported in issue #4597 under v2.17.x.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
