### PR TITLE
[Fix] Fixup getDiskInfo on Windows when only a single drive is connected

### DIFF
--- a/src/backend/utils/filesystem/windows.ts
+++ b/src/backend/utils/filesystem/windows.ts
@@ -39,7 +39,11 @@ async function getDiskInfo_windows(path: Path): Promise<DiskInfo> {
 
   let parsedDisks: Win32_LogicalDisk[]
   try {
-    parsedDisks = Win32_LogicalDisk.array().parse(JSON.parse(stdout))
+    const parsed = Win32_LogicalDisk.or(Win32_LogicalDisk.array()).parse(
+      JSON.parse(stdout)
+    )
+    if (Array.isArray(parsed)) parsedDisks = parsed
+    else parsedDisks = [parsed]
   } catch {
     parsedDisks = []
   }


### PR DESCRIPTION
With a single drive connected, the PowerShell command we run will return a single object instead of an array. Account for this by allowing both a single `Win32_LogicalDisk` or an array of them to be the parse result, then handle both cases accordingly

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
