### PR TITLE
[Fix] Add margin to sideload import Infobox

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -322,22 +322,25 @@ export default function SideloadDialog({
             </span>
           </div>
           <div className="sideloadForm">
-            <InfoBox
-              text={t(
-                'sideload.import-hint.title',
-                'Important! Are you adding a game from Epic/GOG/Amazon? Click here!'
-              )}
-            >
-              <div className="sideloadImportHint">
-                <Trans i18n={i18n} key="sideload.import-hint.content">
-                  Do NOT use this feature for that.
-                  <br />
-                  Instead, <NavLink to={'/login'}>log into</NavLink> the store,
-                  look for the game in your library, open the installation
-                  dialog, and click the &quot;Import Game&quot; button
-                </Trans>
-              </div>
-            </InfoBox>
+            <div className="sideloadImportBox">
+              <InfoBox
+                text={t(
+                  'sideload.import-hint.title',
+                  'Important! Are you adding a game from Epic/GOG/Amazon? Click here!'
+                )}
+              >
+                <div className="sideloadImportHint">
+                  <Trans i18n={i18n} key="sideload.import-hint.content">
+                    Do NOT use this feature for that.
+                    <br />
+                    Instead, <NavLink to={'/login'}>log into</NavLink> the
+                    store, look for the game in your library, open the
+                    installation dialog, and click the &quot;Import Game&quot;
+                    button
+                  </Trans>
+                </div>
+              </InfoBox>
+            </div>
             <TextInputField
               label={t('sideload.info.title', 'Game/App Title')}
               placeholder={t(

--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -322,25 +322,22 @@ export default function SideloadDialog({
             </span>
           </div>
           <div className="sideloadForm">
-            <div className="sideloadImportBox">
-              <InfoBox
-                text={t(
-                  'sideload.import-hint.title',
-                  'Important! Are you adding a game from Epic/GOG/Amazon? Click here!'
-                )}
-              >
-                <div className="sideloadImportHint">
-                  <Trans i18n={i18n} key="sideload.import-hint.content">
-                    Do NOT use this feature for that.
-                    <br />
-                    Instead, <NavLink to={'/login'}>log into</NavLink> the
-                    store, look for the game in your library, open the
-                    installation dialog, and click the &quot;Import Game&quot;
-                    button
-                  </Trans>
-                </div>
-              </InfoBox>
-            </div>
+            <InfoBox
+              text={t(
+                'sideload.import-hint.title',
+                'Important! Are you adding a game from Epic/GOG/Amazon? Click here!'
+              )}
+            >
+              <div className="sideloadImportHint">
+                <Trans i18n={i18n} key="sideload.import-hint.content">
+                  Do NOT use this feature for that.
+                  <br />
+                  Instead, <NavLink to={'/login'}>log into</NavLink> the store,
+                  look for the game in your library, open the installation
+                  dialog, and click the &quot;Import Game&quot; button
+                </Trans>
+              </div>
+            </InfoBox>
             <TextInputField
               label={t('sideload.info.title', 'Game/App Title')}
               placeholder={t(

--- a/src/frontend/screens/Library/components/InstallModal/index.scss
+++ b/src/frontend/screens/Library/components/InstallModal/index.scss
@@ -16,6 +16,10 @@
   }
 }
 
+.InstallModal__dialog button[aria-label='close'] {
+  z-index: 1;
+}
+
 .InstallModal__dialog > .anticheatInfo {
   display: flex;
   padding: var(--space-xs) var(--space-md);
@@ -107,8 +111,4 @@
   a {
     text-decoration: underline;
   }
-}
-
-.sideloadImportBox {
-  margin-right: 32px;
 }

--- a/src/frontend/screens/Library/components/InstallModal/index.scss
+++ b/src/frontend/screens/Library/components/InstallModal/index.scss
@@ -108,3 +108,7 @@
     text-decoration: underline;
   }
 }
+
+.sideloadImportBox {
+  margin-right: 32px;
+}


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4660
Because entire form overlaps with the button we can add right margin just to the InfoBox to prevent overlapping with the dialog's close button.

![image](https://github.com/user-attachments/assets/c832e069-2c4b-414b-a040-8dc83fdab3d7)


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
