### PR TITLE
[FIX] Find wine64 path of system's GPTK outside of heroic/tools

### DIFF
--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -404,7 +404,7 @@ export async function getSystemGamePortingToolkitWine(): Promise<
   logInfo('Searching for Gaming Porting Toolkit Wine', LogPrefix.GlobalConfig)
   const { stdout } = await execAsync('mdfind wine64')
   const wineBin = stdout.split('\n').filter((p) => {
-    return p.match(/game-porting-toolkit.*\/wine64$/)
+    return p.match(/^(?!.*heroic\/tools).*game-porting-toolkit.*\/wine64$/)
   })[0]
 
   if (existsSync(wineBin)) {


### PR DESCRIPTION
There's an issue when looking for the `wine64` path of the system's GPTK.

Because we are using `mfind wine64`, it returns all the files matching `wine64` in the system and it's not guaranteed that the first one matching `game-porting-toolkit` will be the system's game porting toolkit.

This was reported in Discord https://discord.com/channels/812703221789097985/812703424995000361/1383906105691869235 and I can reproduce it consistently.

Just install gptk 2 or 3 using heroic and then add some logs to inspect the detected path of the system's gptk (or you can try selecting it for a game and you can see the paths there).


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
