### PR TITLE
[Fix] Ensure `prefixOrBottleFolder` exists before trying to write into it

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -671,6 +671,7 @@ async function prepareWineLaunch(
   if (prefixOrBottleFolder) {
     const appsNamesPath = join(prefixOrBottleFolder, 'installed_games')
     if (!existsSync(appsNamesPath)) {
+      mkdirSync(prefixOrBottleFolder, { recursive: true })
       writeFileSync(appsNamesPath, JSON.stringify([appName]), 'utf-8')
       hasUpdated = true
     } else {


### PR DESCRIPTION
This resolves an issue reported on Discord: <https://discord.com/channels/812703221789097985/1385183179698081854/1385183179698081854>

Relevant log snippet:
```
(18:55:48) ERROR:   [Backend]:          Error: ENOENT: no such file or directory, open '/mnt/game/heroic/Prefixes/default/Dragon Age Inquisition – Game of the Year Edition/installed_games'
    at Object.writeFileSync (node:fs:2426:20)
    at vn (/app/bin/heroic/resources/app.asar/build/main/main.js:145:1342)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at Module.Fd [as launch] (/app/bin/heroic/resources/app.asar/build/main/main.js:105:7143)
    at Zo (/app/bin/heroic/resources/app.asar/build/main/main.js:143:1914)
    at Session.<anonymous> (node:electron/js2c/browser_init:2:106823)
```

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
