### PR TITLE
[FIX] Prevent error if corrupted installed_games file

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -674,9 +674,16 @@ async function prepareWineLaunch(
       writeFileSync(appsNamesPath, JSON.stringify([appName]), 'utf-8')
       hasUpdated = true
     } else {
-      const installedGames: string[] = JSON.parse(
-        readFileSync(appsNamesPath, 'utf-8')
-      )
+      let installedGames: string[] = []
+
+      try {
+        installedGames = JSON.parse(
+          readFileSync(appsNamesPath, 'utf-8')
+        ) as string[]
+      } catch (error) {
+        logError(error)
+      }
+
       if (!installedGames.includes(appName)) {
         installedGames.push(appName)
         writeFileSync(appsNamesPath, JSON.stringify(installedGames), 'utf-8')


### PR DESCRIPTION
I'm not sure if this could be related to https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4678

but a user reported this error in discord:
```
An exception occurred when launching the game:
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at vn (/tmp/.mount_HeroicnfhRHc/resources/app.asar/build/main/main.js:145:1410)
    at Module.Fd [as launch] (/tmp/.mount_HeroicnfhRHc/resources/app.asar/build/main/main.js:105:7143)
    at Zo (/tmp/.mount_HeroicnfhRHc/resources/app.asar/build/main/main.js:143:1914)
    at Session.<anonymous> (node:electron/js2c/browser_init:2:106823)
```

And did some digging and the issue is the `installed_games` file seems to exist but has invalid json content (I can't confirm yet what's in the invalid file, I asked the user).

So this adds a try/catch around the `JSON.parse` call (which is always a good practice anyway cause it can throw).


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
