### PR TITLE
[Tech] DX improvements to `useGlobalState`/`GlobalStateV2`

### DIFF
--- a/src/frontend/components/UI/LogFileUploadDialog/index.tsx
+++ b/src/frontend/components/UI/LogFileUploadDialog/index.tsx
@@ -3,11 +3,11 @@ import { useTranslation } from 'react-i18next'
 import { CircularProgress } from '@mui/material'
 
 import { Dialog, DialogContent, DialogFooter, DialogHeader } from '../Dialog'
-import { useShallowGlobalState } from 'frontend/state/GlobalStateV2'
+import useGlobalState from 'frontend/state/GlobalStateV2'
 
 export default function LogUploadDialog() {
   const { t } = useTranslation()
-  const { uploadLogFileProps, setUploadLogFileProps } = useShallowGlobalState(
+  const { uploadLogFileProps, setUploadLogFileProps } = useGlobalState.keys(
     'uploadLogFileProps',
     'setUploadLogFileProps'
   )

--- a/src/frontend/screens/Settings/sections/LogSettings/components/UploadedLogFilesList/index.tsx
+++ b/src/frontend/screens/Settings/sections/LogSettings/components/UploadedLogFilesList/index.tsx
@@ -11,10 +11,7 @@ import SvgButton from 'frontend/components/UI/SvgButton'
 
 import useUploadedLogFiles from 'frontend/state/UploadedLogFiles'
 import type { UploadedLogData } from 'common/types'
-import {
-  useGlobalState,
-  useShallowGlobalState
-} from 'frontend/state/GlobalStateV2'
+import useGlobalState from 'frontend/state/GlobalStateV2'
 
 import './index.css'
 
@@ -69,7 +66,7 @@ const UploadedLogFileItem = memo(function UploadedLogFileItem(
 })
 
 export default function UploadedLogFilesList() {
-  const { showUploadedLogFileList } = useShallowGlobalState(
+  const { showUploadedLogFileList } = useGlobalState.keys(
     'showUploadedLogFileList'
   )
   const uploadedLogFiles = useUploadedLogFiles()

--- a/src/frontend/screens/Settings/sections/LogSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/LogSettings/index.tsx
@@ -9,10 +9,7 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import { GameInfo } from 'common/types'
 import { openDiscordLink } from 'frontend/helpers'
 import { faDiscord } from '@fortawesome/free-brands-svg-icons'
-import {
-  useGlobalState,
-  useShallowGlobalState
-} from 'frontend/state/GlobalStateV2'
+import useGlobalState from 'frontend/state/GlobalStateV2'
 import Upload from '@mui/icons-material/Upload'
 import Cloud from '@mui/icons-material/Cloud'
 import classNames from 'classnames'
@@ -71,9 +68,7 @@ const LogBox: React.FC<LogBoxProps> = ({ logFileContent }) => {
 export default function LogSettings() {
   const { t } = useTranslation()
   const { appName } = useContext(SettingsContext)
-  const { setUploadLogFileProps } = useShallowGlobalState(
-    'setUploadLogFileProps'
-  )
+  const { setUploadLogFileProps } = useGlobalState.keys('setUploadLogFileProps')
   const isInSettingsMenu = appName === 'default'
 
   const [logFileContent, setLogFileContent] = useState<string>('')

--- a/src/frontend/state/GlobalStateV2.ts
+++ b/src/frontend/state/GlobalStateV2.ts
@@ -35,17 +35,26 @@ const useGlobalState = <T>(
 
 useGlobalState.setState = useGlobalStateRaw.setState
 
-function useShallowGlobalState<Keys extends (keyof GlobalStateV2)[]>(
+/**
+ * Shorthand to select properties from {@link GlobalStateV2}
+ * @example
+ * ```ts
+ * const { foo, bar } = useGlobalStateKeys('foo', 'bar')
+ * ```
+ * is equivalent to
+ * ```ts
+ * const { foo, bar } = useGlobalState(({ foo, bar }) => ({ foo, bar }))
+ * ```
+ * @param keys The keys to return. Properties of {@link GlobalStateV2}
+ */
+const useGlobalStateKeys = <Keys extends (keyof GlobalStateV2)[]>(
   ...keys: Keys
-): Pick<GlobalStateV2, Keys[number]> {
-  return useGlobalState(
-    useShallow(
-      (state) =>
-        Object.fromEntries(keys.map((key) => [key, state[key]])) as {
-          [key in Keys[number]]: GlobalStateV2[key]
-        }
-    )
+): Pick<GlobalStateV2, Keys[number]> =>
+  useGlobalState(
+    (state) =>
+      Object.fromEntries(keys.map((key) => [key, state[key]])) as {
+        [key in Keys[number]]: GlobalStateV2[key]
+      }
   )
-}
 
-export { useGlobalState, useShallowGlobalState }
+export { useGlobalState, useGlobalStateKeys as useShallowGlobalState }

--- a/src/frontend/state/GlobalStateV2.ts
+++ b/src/frontend/state/GlobalStateV2.ts
@@ -33,8 +33,6 @@ const useGlobalState = <T>(
   selector: Parameters<typeof useShallow<GlobalStateV2, T>>[0]
 ) => useGlobalStateRaw(useShallow(selector))
 
-useGlobalState.setState = useGlobalStateRaw.setState
-
 /**
  * Shorthand to select properties from {@link GlobalStateV2}
  * @example
@@ -57,4 +55,8 @@ const useGlobalStateKeys = <Keys extends (keyof GlobalStateV2)[]>(
       }
   )
 
-export { useGlobalState, useGlobalStateKeys as useShallowGlobalState }
+export default {
+  ...useGlobalState,
+  keys: useGlobalStateKeys,
+  setState: useGlobalStateRaw.setState
+}

--- a/src/frontend/state/GlobalStateV2.ts
+++ b/src/frontend/state/GlobalStateV2.ts
@@ -13,7 +13,7 @@ interface GlobalStateV2 {
   showUploadedLogFileList: boolean
 }
 
-const useGlobalState = create<GlobalStateV2>()((set) => ({
+const useGlobalStateRaw = create<GlobalStateV2>()((set) => ({
   uploadLogFileProps: false,
   setUploadLogFileProps: (uploadLogFileProps) => {
     set({ uploadLogFileProps })
@@ -21,6 +21,19 @@ const useGlobalState = create<GlobalStateV2>()((set) => ({
 
   showUploadedLogFileList: false
 }))
+
+/**
+ * Wrapper around {@link useGlobalStateRaw} to only re-render if
+ * the return value of `selector` changes
+ * @param selector A function picking state out of {@link GlobalStateV2}. If the
+ *                 return value of this function changes, the component is
+ *                 re-rendered
+ */
+const useGlobalState = <T>(
+  selector: Parameters<typeof useShallow<GlobalStateV2, T>>[0]
+) => useGlobalStateRaw(useShallow(selector))
+
+useGlobalState.setState = useGlobalStateRaw.setState
 
 function useShallowGlobalState<Keys extends (keyof GlobalStateV2)[]>(
   ...keys: Keys


### PR DESCRIPTION
@arielj recently asked me some questions about `useGlobalState` usage, which revealed some potential DX traps one can fall into when using it

- `useGlobalState` now automatically wraps the provided selector in `useShallow`
- `useShallowGlobalState` was renamed to `useGlobalStateKeys` to clarify what it does
- Documentation for both functions was added
- Export is done as a single default export. This is done (1) to preserve the `setState` function on `useGlobalState` (technically that's possible by just assigning a property, but that seems like a bad idea to me) and (2) since most state consumers need all methods anyways
  - `useGlobalStateKeys` is exported as `keys`, to be used as `useGlobalState.keys`

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [X] Created / Updated documentation (If necessary)
