### PR TITLE
[FIX] Show path of EA games in logs and add extra info

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -537,17 +537,38 @@ async function prepareLaunch(
     rpcClient = constructAndUpdateRPC(gameInfo)
   }
 
-  const installPath =
-    gameInfo.runner === 'sideload'
-      ? gameInfo.folder_name
-      : gameInfo.install.install_path
   await logWriter.logInfo([
     'Launching',
     `"${gameInfo.title}" (${gameInfo.runner})`
   ])
   const native = gameManagerMap[gameInfo.runner].isNative(gameInfo.app_name)
   await logWriter.logInfo(['Native?', native])
-  await logWriter.logInfo(['Installed in:', installPath, '\n\n'])
+
+  const isThirdPartyManagedApp = gameInfo && !!gameInfo.thirdPartyManagedApp
+
+  if (isThirdPartyManagedApp) {
+    if (!isWindows) {
+      let prefixOrBottleFolder: string | null = gameSettings.winePrefix
+      if (isMac && gameSettings.wineVersion.type === 'crossover') {
+        prefixOrBottleFolder = await getCrossoverBottleFolder(gameSettings)
+      }
+      if (prefixOrBottleFolder)
+        await logWriter.logInfo(['Installed in:', prefixOrBottleFolder])
+    }
+
+    await logWriter.logInfo([
+      'Managed by a third-party app:',
+      gameInfo.thirdPartyManagedApp,
+      '\n\n'
+    ])
+  } else {
+    const installPath =
+      gameInfo.runner === 'sideload'
+        ? gameInfo.folder_name
+        : gameInfo.install.install_path
+
+    await logWriter.logInfo(['Installed in:', installPath, '\n\n'])
+  }
 
   await logWriter.logInfo([
     'System Info:',


### PR DESCRIPTION
This PR fixes some small annoyances with logs of EA App games:

- Because there's no installation path, it was showing `Installed in: undefined`, now instead it shows the prefix/bottle on linux/mac (on windows this is skipped)
- When reading a log, it's useful to have the information of the game being managed by a third party app

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
