### PR TITLE
[TECH] Improve app loading when on Wayland on Linux

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -403,15 +403,23 @@ if (!gotTheLock) {
     }
 
     const headless = isCLINoGui || settings.startInTray
+
     if (!headless) {
-      mainWindow.once('ready-to-show', () => {
+      const isWayland = Boolean(process.env.WAYLAND_DISPLAY)
+      const showWindow = () => {
         const props = configStore.get_nodefault('window-props')
         mainWindow.show()
         // Apply maximize only if we show the window
         if (props?.maximized) {
           mainWindow.maximize()
         }
-      })
+      }
+      if (isWayland) {
+        // Electron + Wayland don't send ready-to-show
+        mainWindow.webContents.once('did-finish-load', showWindow)
+      } else {
+        mainWindow.once('ready-to-show', showWindow)
+      }
     }
 
     // set initial zoom level after a moment, if set in sync the value stays as 1


### PR DESCRIPTION
use `did-finish-load` event in wayland environments for showing main window
---

Currently, when running the launcher with native wayland (`ELECTRON_OZONE_PLATFORM_HINT=auto`), the `ready-to-show` event that we normally wait for to open the window is not fired.

Instead, for environments where the `WAYLAND_DISPLAY` environment variable is set, we can use the `did-finish-load` event instead. https://www.electronjs.org/docs/latest/api/web-contents#event-did-finish-load

It is reached at a similar point as `ready-to-show`.

Other apps also seem to use this similar workaround for Wayland environments, as it seems like a bug in Electron that has existed for a while now. One example is signal messenger, who added this workaround in this commit: https://github.com/signalapp/Signal-Desktop/commit/f51ab7e7c348a3dea8006622ce369f2d4a9dae5a

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
