### PR TITLE
[macOS] Add Wine-Staging-macOS to WineManager

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -99,7 +99,6 @@
                 "title-finished": "Update Finished"
             }
         },
-        "launchAnyway": "Launch Game Anyway",
         "no": "NO",
         "ok": "OK",
         "postpone": "Postpone",
@@ -126,8 +125,6 @@
             "exe": "Select EXE",
             "script": "Select script ..."
         },
-        "shaderPreCachingDisabledMessage": "Steam's Shader Pre-cache is disabled. Please enable it on the Steam Settings in Desktop Mode to ensure the game works properly with UMU.",
-        "shaderPreCachingDisabledTitle": "Shader Pre-Caching Disabled",
         "shortcuts": {
             "message": "Shortcuts were created on Desktop and Start Menu",
             "message-mac": "Shortcuts were created on the Applications folder",

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -55,6 +55,13 @@ export default function WineManager(): JSX.Element | null {
     value: 'gpt',
     enabled: !isLinux
   }
+
+  const wineStagingMacOS: WineManagerUISettings = {
+    type: 'Wine-Staging-macOS',
+    value: 'winestagingmacos',
+    enabled: !isLinux
+  }
+
   const wineCrossover: WineManagerUISettings = {
     type: 'Wine-Crossover',
     value: 'winecrossover',
@@ -81,7 +88,8 @@ export default function WineManager(): JSX.Element | null {
     protonge,
     { type: 'Wine-GE', value: 'winege', enabled: isLinux },
     gamePortingToolkit,
-    wineCrossover
+    wineCrossover,
+    wineStagingMacOS
   ])
 
   const getWineVersions = (repo: Type) => {


### PR DESCRIPTION
Re-adds the option since it keeps getting updated and some users said some games works better with it then with wine-crossover.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
