### PR TITLE
Made tour highlight better center the element it's targeting

### DIFF
--- a/src/frontend/components/Tour/Tour.scss
+++ b/src/frontend/components/Tour/Tour.scss
@@ -113,6 +113,9 @@
 .heroic-tour-highlight {
   background: rgba(29, 232, 245, 0.1) !important;
   border: 2px solid var(--brand-primary) !important;
+  padding: 2px;
+  // negate space added by border
+  margin: -4px;
 }
 
 .introjs-tooltip-title {


### PR DESCRIPTION
Noticed a small issue with the tours, in which the border was interfering with the centering of the highlight. I also added a small padding to the whole region to make it breath just a bit more in terms of UI. Before and after comparison below:

<details>

Before:

<img width="528" height="371" alt="Captura de ecrã 2025-07-14, às 16 54 43" src="https://github.com/user-attachments/assets/780164a8-d973-41f7-8006-b03815d1a975" />


<img width="528" height="371" alt="Captura de ecrã 2025-07-14, às 16 54 37" src="https://github.com/user-attachments/assets/204ab999-e254-4845-8cef-fae299e11f8a" />

After: 

<img width="528" height="371" alt="Captura de ecrã 2025-07-14, às 16 54 48" src="https://github.com/user-attachments/assets/be12df65-0865-4eef-a0da-3a27d62a8e84" />


<img width="528" height="371" alt="Captura de ecrã 2025-07-14, às 16 54 30" src="https://github.com/user-attachments/assets/3e181a8e-a15c-4662-95a1-e9f8a43e7e7a" />

</details>

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
