### PR TITLE
[UX] Fix focused frame on game sub-menu from being off center 

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.css
+++ b/src/frontend/screens/Game/GamePage/index.css
@@ -506,11 +506,11 @@
       }
 
       &:first-child {
-        margin-top: -0.15rem;
+        margin-top: -0.1rem;
       }
 
       &:last-child {
-        margin-bottom: -0.15rem;
+        margin-bottom: -0.1 rem;
       }
     }
 

--- a/src/frontend/screens/Game/GamePage/index.css
+++ b/src/frontend/screens/Game/GamePage/index.css
@@ -494,7 +494,7 @@
 
     .gameTools .link {
       width: 100%;
-      padding: 0 0 0.5rem;
+      padding: 0.3rem;
       text-align: start;
       white-space: nowrap;
       font-size: 1rem;
@@ -505,8 +505,12 @@
         color: var(--navbar-active);
       }
 
+      &:first-child {
+        margin-top: -0.15rem;
+      }
+
       &:last-child {
-        padding-bottom: 0;
+        margin-bottom: -0.15rem;
       }
     }
 


### PR DESCRIPTION
Noticed the focus on the lists were off-centered. This can be replicated with a keyboard, just clicking down. In the details are the before and after images:

<details>
Before: 

<img width="239" height="540" alt="image" src="https://github.com/user-attachments/assets/9b4601c8-131c-40fa-8f3b-4dd4b7be6a4b" />

After:

<img width="270" height="554" alt="image" src="https://github.com/user-attachments/assets/d01e11dd-ed6f-458d-8d21-1daaaa70da44" />

<img width="243" height="538" alt="image" src="https://github.com/user-attachments/assets/493f70e7-78eb-4d5f-a5ce-7c35ff2f328b" />

</details>

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
