### PR TITLE
[UX] Wine Manager - Make refresh button part a tab, clearer keyboard navigation

### DIFF
--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { WineVersionInfo, Type, WineManagerUISettings } from 'common/types'
 import { hasHelp } from 'frontend/hooks/hasHelp'
+import classNames from 'classnames'
 
 const WineItem = lazy(
   async () => import('frontend/screens/WineManager/components/WineItem')
@@ -178,17 +179,20 @@ export default function WineManager(): JSX.Element | null {
               }
               return null
             })}
-          </Tabs>
-          <button
-            className={'FormControl__button'}
-            title={t('generic.library.refresh', 'Refresh Library')}
-            onClick={() => refreshWineVersionInfo(true)}
-          >
-            <FontAwesomeIcon
-              className={'FormControl__segmentedFaIcon'}
-              icon={faSyncAlt}
+            <Tab
+              title={t('generic.library.refresh', 'Refresh Library')}
+              onClick={() => refreshWineVersionInfo(true)}
+              sx={{ minWidth: 0 }}
+              icon={
+                <FontAwesomeIcon
+                  className={classNames('FormControl__segmentedFaIcon', {
+                    'fa-spin': refreshing
+                  })}
+                  icon={faSyncAlt}
+                />
+              }
             />
-          </button>
+          </Tabs>
         </span>
         {wineVersionExplanation}
         {wineVersions.length ? (


### PR DESCRIPTION
Noticed a strange behavior when navigating with keyboard on Wine Manager. Tabs cycle between each other, making the refresh button inaccessible, so I would have to click "down" instead of "right" to access the button. Then I could navigate with "left" to the tabs again, trapping the side navigation inside it. 

To solve this I've made the refresh be a part of the tab group, meaning it can now be accessed normally using the arrow keys. Still not a fan of how tabs trap side navigation, it's much less accessible to gamepads that don't have the option of clicking elsewhere in the UI. 

Video showing how it looks below, also inadvertently fixed padding to make button nicer to look at:

<details>
Before:


https://github.com/user-attachments/assets/305e1bf4-c009-4077-b9bf-e933fa0920f6



After: 

https://github.com/user-attachments/assets/f688c7d6-e1db-462d-af5e-c7a2fe1de253


</details>

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
