### PR TITLE
[UX] Added extra bit of padding for inner buttons in game page

### DIFF
--- a/src/frontend/screens/Game/GamePage/components/CloudSavesSync.tsx
+++ b/src/frontend/screens/Game/GamePage/components/CloudSavesSync.tsx
@@ -38,7 +38,8 @@ const CloudSavesSync = ({ gameInfo }: Props) => {
       {showCloudSaveInfo && (
         <p
           style={{
-            color: autoSyncSaves ? '#07C5EF' : ''
+            color: autoSyncSaves ? '#07C5EF' : '',
+            margin: 0
           }}
           className="iconWithText"
         >

--- a/src/frontend/screens/Game/GamePage/components/InstalledInfo.tsx
+++ b/src/frontend/screens/Game/GamePage/components/InstalledInfo.tsx
@@ -124,7 +124,6 @@ const InstalledInfo = ({ gameInfo }: Props) => {
           )}
         </>
       )}
-      <br />
     </>
   )
 

--- a/src/frontend/screens/Game/GamePage/index.css
+++ b/src/frontend/screens/Game/GamePage/index.css
@@ -320,13 +320,17 @@
           font-size: var(--space-unit-fixed);
           line-height: 24px;
           gap: var(--space-md-fixed);
-          padding: var(--space-unit-fixed) 0;
+          padding: var(--space-unit-fixed);
           align-items: center;
           border-bottom: 1px solid var(--neutral-04);
           background-image: linear-gradient(to right, transparent, transparent);
           background-position: bottom;
           background-size: 100vw;
           background-repeat: no-repeat;
+
+          svg {
+            outline: none;
+          }
 
           &:focus-visible,
           &:has(:focus-visible) {


### PR DESCRIPTION
Noticed there's not a lot of breathing space for the buttons in the game page, which is especially noticeable if you're using a gamepad or keyboard navigation. Details below for comparisons:

<details>

Before:


<img width="542" height="583" alt="image" src="https://github.com/user-attachments/assets/d1e6a8ee-4501-40b4-bf12-fcb142a305e7" />


<img width="490" height="277" alt="image" src="https://github.com/user-attachments/assets/9d87c3d2-99eb-47cd-9e56-c08392f2ef89" />


After: 


<img width="471" height="460" alt="image" src="https://github.com/user-attachments/assets/1128de17-595a-478d-a511-22c62817fb74" />


<img width="474" height="295" alt="image" src="https://github.com/user-attachments/assets/773f5853-f4b5-4384-8995-652bb380dbc5" />

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
