### PR TITLE
Fix error creating folder while installing a wine version

### DIFF
--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -199,7 +199,9 @@ async function installVersion({
   const tarFile =
     installDir + '/' + versionInfo.download.split('/').slice(-1)[0]
   const installSubDir =
-    versionInfo.installDir ?? installDir + '/' + versionInfo.version
+    versionInfo.installDir !== undefined && versionInfo.installDir !== ''
+      ? versionInfo.installDir
+      : installDir + '/' + versionInfo.version
   const sourceChecksum = versionInfo.checksum
     ? (
         await axiosClient.get(versionInfo.checksum, {


### PR DESCRIPTION
If a wine version was removed, the versionInfo.installDir variable was set to empty instead of undefined, so trying to install it again would fail while creating the folder. Fix that by checking if versionInfo is undefined OR empty. Now removing and installing the same wine version without closing and opening again heroic works as expected.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
