### PR TITLE
[UX] Add icon to notifications

### DIFF
--- a/src/backend/dialog/dialog.ts
+++ b/src/backend/dialog/dialog.ts
@@ -4,6 +4,7 @@ import { ButtonOptions, DialogType } from 'common/types'
 import { getMainWindow } from '../main_window'
 import { sendFrontendMessage } from '../ipc'
 import { isSteamDeckGameMode } from 'backend/constants/environment'
+import { windowIcon } from 'backend/constants/paths'
 
 const { showErrorBox, showMessageBox } = dialog
 
@@ -65,7 +66,8 @@ function notify({ body, title }: NotifyType) {
     const mainWindow = getMainWindow()
     const notify = new Notification({
       body,
-      title
+      title,
+      icon: windowIcon
     })
 
     notify.on('click', () => mainWindow?.show())


### PR DESCRIPTION
Hello,

this little change adds the heroic icon to notifications which I think looks nicer and is more what I expected to see, unless there is a specific reason why this wasn't done before that I'm not aware of?

before:
<img width="460" height="96" alt="2025-07-16_19-36-12_screenshot" src="https://github.com/user-attachments/assets/0d7d1c8d-476d-414e-a4cf-b9a9e52ff169" />

now:
<img width="461" height="95" alt="2025-07-16_19-17-36_screenshot" src="https://github.com/user-attachments/assets/2b544cf4-8ec4-4c99-8d59-0cf2a0ade06e" />

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
