### PR TITLE
[UX] Change ignored protons warning

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -612,6 +612,7 @@
                 "show": "I understand, show them",
                 "title": "Are you sure?"
             },
+            "info_label": "Non-GE Proton versions ignored",
             "label": "Allow using non-GE Proton builds to run games",
             "wine_selector_warning": "Non-GE versions of Proton are ignored by default, enable them in the Advanced global settings"
         },

--- a/src/frontend/screens/Settings/components/WineVersionSelector.tsx
+++ b/src/frontend/screens/Settings/components/WineVersionSelector.tsx
@@ -28,20 +28,26 @@ export default function WineVersionSelector() {
       setRefreshing(true)
       let wineList: WineInstallation[] = await window.api.getAlternativeWine()
 
-      const { allowNonGEProton } = await window.api.requestAppSettings()
-      setShowHiddenProtonsMessage(!allowNonGEProton)
+      if (isLinux) {
+        const { allowNonGEProton } = await window.api.requestAppSettings()
 
-      if (!allowNonGEProton) {
-        wineList = wineList.filter((wineItem) => {
-          // do not ignore wine/corssover/gptk/etc
-          if (!wineItem.name.match(/proton/i)) return true
-          // do not ignore wine-ge-proton, ge-proton, and proton-ge
-          if (wineItem.name.match(/wine|GE/)) return true
-          // do not ignore currently selected wine, in case stock proton is already delected
-          if (wineItem.bin == wineVersion.bin) return true
+        let protonsBeingIgnored = false
+        if (!allowNonGEProton) {
+          wineList = wineList.filter((wineItem) => {
+            // do not ignore wine/corssover/gptk/etc
+            if (!wineItem.name.match(/proton/i)) return true
+            // do not ignore wine-ge-proton, ge-proton, and proton-ge
+            if (wineItem.name.match(/wine|GE/)) return true
 
-          return false
-        })
+            protonsBeingIgnored = true
+
+            // do not ignore currently selected wine, in case stock proton is already delected
+            if (wineItem.bin == wineVersion.bin) return true
+
+            return false
+          })
+        }
+        setShowHiddenProtonsMessage(protonsBeingIgnored)
       }
 
       // System Wine might change names (version strings) with updates. This
@@ -111,13 +117,20 @@ export default function WineVersionSelector() {
               )}
             </span>
           )}
-          {showHiddenProtonsMessage && (
-            <span className="warning">
-              {t(
-                'setting.allow_non_ge_proton.wine_selector_warning',
-                'Non-GE versions of Proton are ignored by default, enable them in the Advanced global settings'
+          {isLinux && showHiddenProtonsMessage && (
+            <InfoBox
+              text={t(
+                'setting.allow_non_ge_proton.info_label',
+                'Non-GE Proton versions ignored'
               )}
-            </span>
+            >
+              <span>
+                {t(
+                  'setting.allow_non_ge_proton.wine_selector_warning',
+                  'Non-GE versions of Proton are ignored by default, enable them in the Advanced global settings'
+                )}
+              </span>
+            </InfoBox>
           )}
           {isLinux && (
             <InfoBox text={t('infobox.wine-path', 'Wine Path')}>

--- a/src/frontend/screens/Settings/components/WineVersionSelector.tsx
+++ b/src/frontend/screens/Settings/components/WineVersionSelector.tsx
@@ -34,7 +34,7 @@ export default function WineVersionSelector() {
         let protonsBeingIgnored = false
         if (!allowNonGEProton) {
           wineList = wineList.filter((wineItem) => {
-            // do not ignore wine/corssover/gptk/etc
+            // do not ignore wine/crossover/gptk/etc
             if (!wineItem.name.match(/proton/i)) return true
             // do not ignore wine-ge-proton, ge-proton, and proton-ge
             if (wineItem.name.match(/wine|GE/)) return true


### PR DESCRIPTION
A few fixes:
- Only show the warning on linux (it was showing on mac)
- Only show the warning if the user actually have Non-GE protons
- Show an InfoBox object that can be clicked for mode details so it doesn't look that off

Before:
<img width="673" height="223" alt="image" src="https://github.com/user-attachments/assets/4fe423ff-cdff-4315-965f-b0d8c7528a36" />

After:
<img width="669" height="225" alt="image" src="https://github.com/user-attachments/assets/ced69685-5864-40f7-a26f-7ee14159d83f" />

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
