### PR TITLE
Fix error while collecting Plausible data

### DIFF
--- a/src/backend/utils/plausible.ts
+++ b/src/backend/utils/plausible.ts
@@ -83,7 +83,7 @@ export function startPlausible() {
     gog: !!GOGUser.isLoggedIn(),
     epic: !!LegendaryUser.isLoggedIn(),
     amazon: !!NileUser.isLoggedIn(),
-    sideloaded: libraryStore.raw_store.games.length > 0
+    sideloaded: libraryStore.raw_store.games?.length > 0
   }
   const loggedInProviders = Object.entries(providersObject)
     .filter(([, v]) => v)


### PR DESCRIPTION
In the current main, when accepting the analytics pop-up on a clean install, an error occurs:
<img width="1322" height="851" alt="Plausible fix" src="https://github.com/user-attachments/assets/4f2b08ce-b7cf-4045-97a8-7d4092fa28d7" />
This happened because libraryStore.raw_store.games is undefined, and trying to access its length property fails. Fix that by accessing the property using the "?." operator instead of "."

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
