### PR TITLE
[FIX] Using = in env var value

### DIFF
--- a/src/frontend/components/UI/TwoColTableInput/index.tsx
+++ b/src/frontend/components/UI/TwoColTableInput/index.tsx
@@ -78,7 +78,7 @@ export function TableInput({
     } else {
       // else, validate input
       if (validation) {
-        const [keyError, valueError] = validation(newVarValue, newVarValue)
+        const [keyError, valueError] = validation(newVarName, newVarValue)
         setKeyError(keyError)
         setValueError(valueError)
       }


### PR DESCRIPTION
After the PR that enabled the virtual keyboard on all inputs, the env variables and wrapper tables were broken

After that I made a PR refactoring the code of that React component, but there was a typo and the value was used instead of the name when validating the key/value pair.

This fixes that.

Until this is released, if you need to edit env variables and heroic complains about the name not being valid, you'll have to update it manually (or use the build from this PR):
- at the bottom of the settings dialog of each game you'll see a line that goes `AppName: <some name or number>`
- go to heroic's config folder `~/config/heroic/GamesConfig` or `~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig/` if flatpak
- look for a file named with the appName (if the message was `AppName: 1234`, look for `1234.json`)
- edit the file with a text editor:

```
...
    "enviromentOptions": [
      {
        "key": "WINEDLLOVERRIDE",
        "value": "opengl32.dll=n,b"
      }
    ],
...
```

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
