### PR TITLE
Change "Allow non-GE Proton" to only hide Valve Proton versions

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -617,17 +617,6 @@
             },
             "label": "Allow installation of games with broken or denied anticheat"
         },
-        "allow_non_ge_proton": {
-            "confirmation": {
-                "dont_show": "Don't show them",
-                "message": "We recommend GE-Proton to be used with Heroic because non-GE Proton builds lack winetricks and protofixes. You can still use then if you want.",
-                "show": "I understand, show them",
-                "title": "Are you sure?"
-            },
-            "info_label": "Non-GE Proton versions ignored",
-            "label": "Allow using non-GE Proton builds to run games",
-            "wine_selector_warning": "Non-GE versions of Proton are ignored by default, enable them in the Advanced global settings"
-        },
         "alt-gogdl-bin": "Choose an Alternative GOGDL Binary to use",
         "alt-legendary-bin": "Choose an Alternative Legendary Binary",
         "alt-nile-bin": "Choose an Alternative Nile Binary",
@@ -792,6 +781,17 @@
             "warning": "Please check twice if the path is correct (click to retry)"
         },
         "select_theme": "Select Theme",
+        "show_valve_proton": {
+            "confirmation": {
+                "dont_show": "Don't show them",
+                "message": "We recommend custom Proton forks (GE-Proton, Proton-CachyOS, etc.) to be used with Heroic because Valve's Proton builds lack winetricks and protofixes. You can still use then if you want.",
+                "show": "I understand, show them",
+                "title": "Are you sure?"
+            },
+            "info_label": "Valve Proton versions ignored",
+            "label": "Allow using Valve Proton builds to run games",
+            "wine_selector_warning": "Valve versions of Proton are ignored by default, enable them in the Advanced global settings"
+        },
         "showfps": "Show FPS (DX9, 10 and 11)",
         "showMetalOverlay": "Show Stats Overlay",
         "start-in-tray": "Start Minimized",

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -361,7 +361,8 @@ class GlobalConfigV0 extends GlobalConfig {
       verboseLogs: true,
       downloadProtonToSteam: false,
       advertiseAvxForRosetta: isMac && defaultWine.type === 'toolkit',
-      noTrayIcon: false
+      noTrayIcon: false,
+      showValveProton: false
     }
     // @ts-expect-error TODO: We need to settle on *one* place to define settings defaults
     return settings

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -152,10 +152,14 @@ export async function getLinuxWineSet(
 
   const protonPaths = [`${toolsPath}/proton/`]
 
+  const { showValveProton } = GlobalConfig.get().getSettings()
+
   await getSteamLibraries().then((libs) => {
     libs.forEach((path) => {
-      protonPaths.push(`${path}/steam/steamapps/common`)
-      protonPaths.push(`${path}/steamapps/common`)
+      if (showValveProton) {
+        protonPaths.push(`${path}/steam/steamapps/common`)
+        protonPaths.push(`${path}/steamapps/common`)
+      }
       protonPaths.push(`${path}/root/compatibilitytools.d`)
       protonPaths.push(`${path}/compatibilitytools.d`)
       return

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -122,7 +122,7 @@ export interface AppSettings extends GameSettings {
   allowInstallationBrokenAnticheat: boolean
   disableUMU: boolean
   verboseLogs: boolean
-  allowNonGEProton: boolean
+  showValveProton: boolean
 }
 
 export type LibraryTopSectionOptions =

--- a/src/frontend/screens/Settings/components/ShowValveProton.tsx
+++ b/src/frontend/screens/Settings/components/ShowValveProton.tsx
@@ -4,38 +4,38 @@ import useSetting from 'frontend/hooks/useSetting'
 import { ToggleSwitch } from 'frontend/components/UI'
 import ContextProvider from 'frontend/state/ContextProvider'
 
-const AllowNonGEProton = () => {
+const ShowValveProton = () => {
   const { t } = useTranslation()
   const { showDialogModal } = useContext(ContextProvider)
-  const [allowNonGEProton, setAllowNonGEProton] = useSetting(
-    'allowNonGEProton',
+  const [showValveProton, setShowValveProton] = useSetting(
+    'showValveProton',
     false
   )
 
   const toggleConfig = () => {
-    if (allowNonGEProton) {
-      setAllowNonGEProton(false)
+    if (showValveProton) {
+      setShowValveProton(false)
     } else {
       showDialogModal({
         title: t(
-          'setting.allow_non_ge_proton.confirmation.title',
+          'setting.show_valve_proton.confirmation.title',
           'Are you sure?'
         ),
         message: t(
-          'setting.allow_non_ge_proton.confirmation.message',
-          'We recommend GE-Proton to be used with Heroic because non-GE Proton builds lack winetricks and protofixes. You can still use then if you want.'
+          'setting.show_valve_proton.confirmation.message',
+          "We recommend custom Proton forks (GE-Proton, Proton-CachyOS, etc.) to be used with Heroic because Valve's Proton builds lack winetricks and protofixes. You can still use then if you want."
         ),
         buttons: [
           {
             text: t(
-              'setting.allow_non_ge_proton.confirmation.show',
+              'setting.show_valve_proton.confirmation.show',
               'I understand, show them'
             ),
-            onClick: () => setAllowNonGEProton(true)
+            onClick: () => setShowValveProton(true)
           },
           {
             text: t(
-              'setting.allow_non_ge_proton.confirmation.dont_show',
+              'setting.show_valve_proton.confirmation.dont_show',
               "Don't show them"
             )
           }
@@ -48,16 +48,16 @@ const AllowNonGEProton = () => {
   return (
     <div className="toggleRow">
       <ToggleSwitch
-        htmlId="allowNonGEProton"
-        value={allowNonGEProton}
+        htmlId="showValveProton"
+        value={showValveProton}
         handleChange={() => toggleConfig()}
         title={t(
-          'setting.allow_non_ge_proton.label',
-          'Allow using non-GE Proton builds to run games'
+          'setting.show_valve_proton.label',
+          'Allow using Valve Proton builds to run games'
         )}
       />
     </div>
   )
 }
 
-export default AllowNonGEProton
+export default ShowValveProton

--- a/src/frontend/screens/Settings/components/WineVersionSelector.tsx
+++ b/src/frontend/screens/Settings/components/WineVersionSelector.tsx
@@ -26,29 +26,7 @@ export default function WineVersionSelector() {
   useEffect(() => {
     const getAltWine = async () => {
       setRefreshing(true)
-      let wineList: WineInstallation[] = await window.api.getAlternativeWine()
-
-      if (isLinux) {
-        const { allowNonGEProton } = await window.api.requestAppSettings()
-
-        let protonsBeingIgnored = false
-        if (!allowNonGEProton) {
-          wineList = wineList.filter((wineItem) => {
-            // do not ignore wine/crossover/gptk/etc
-            if (!wineItem.name.match(/proton/i)) return true
-            // do not ignore wine-ge-proton, ge-proton, and proton-ge
-            if (wineItem.name.match(/wine|GE/)) return true
-
-            protonsBeingIgnored = true
-
-            // do not ignore currently selected wine, in case stock proton is already delected
-            if (wineItem.bin == wineVersion.bin) return true
-
-            return false
-          })
-        }
-        setShowHiddenProtonsMessage(protonsBeingIgnored)
-      }
+      const wineList: WineInstallation[] = await window.api.getAlternativeWine()
 
       // System Wine might change names (version strings) with updates. This
       // will then lead to it not being found in the alt wine list, as it
@@ -69,6 +47,12 @@ export default function WineVersionSelector() {
     void getAltWine()
     return window.api.handleWineVersionsUpdated(getAltWine)
   }, [])
+
+  useEffect(() => {
+    void window.api.requestAppSettings().then(({ showValveProton }) => {
+      setShowHiddenProtonsMessage(!showValveProton)
+    })
+  }, [isLinux])
 
   useEffect(() => {
     const updateWine = async () => {
@@ -120,14 +104,14 @@ export default function WineVersionSelector() {
           {isLinux && showHiddenProtonsMessage && (
             <InfoBox
               text={t(
-                'setting.allow_non_ge_proton.info_label',
-                'Non-GE Proton versions ignored'
+                'setting.show_valve_proton.info_label',
+                'Valve Proton versions ignored'
               )}
             >
               <span>
                 {t(
-                  'setting.allow_non_ge_proton.wine_selector_warning',
-                  'Non-GE versions of Proton are ignored by default, enable them in the Advanced global settings'
+                  'setting.show_valve_proton.wine_selector_warning',
+                  'Valve versions of Proton are ignored by default, enable them in the Advanced global settings'
                 )}
               </span>
             </InfoBox>

--- a/src/frontend/screens/Settings/components/index.ts
+++ b/src/frontend/screens/Settings/components/index.ts
@@ -1,5 +1,5 @@
 export { default as AdvertiseAvxForRosetta } from './AdvertiseAvxForRosetta'
-export { default as AllowNonGEProton } from './AllowNonGEProton'
+export { default as ShowValveProton } from './ShowValveProton'
 export { default as AlternativeExe } from './AlternativeExe'
 export { default as AltGOGdlBin } from './AltGOGdlBin'
 export { default as AltLegendaryBin } from './AltLegendaryBin'

--- a/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
@@ -16,7 +16,7 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import { GameStatus } from 'common/types'
 import {
   AllowInstallationBrokenAnticheat,
-  AllowNonGEProton,
+  ShowValveProton,
   AltGOGdlBin,
   AltLegendaryBin,
   AltNileBin,
@@ -180,7 +180,7 @@ export default function AdvancedSetting() {
 
       <AllowInstallationBrokenAnticheat />
 
-      <AllowNonGEProton />
+      <ShowValveProton />
 
       <hr />
 


### PR DESCRIPTION
Instead of hiding all custom Proton versions instead of GE's, we can just not include Valve's versions (since those are the only ones with issues; -CachyOS, -Sarek and -EM all have umu support)

Closes #4798

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
