### PR TITLE
[UI] Optimize the Alphabet Filter in Library look like on narror window

### DIFF
--- a/src/frontend/screens/Library/components/AlphabetFilter/index.css
+++ b/src/frontend/screens/Library/components/AlphabetFilter/index.css
@@ -23,8 +23,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  margin-bottom: 24px;
-  margin-top: 16px;
+  margin: 8px var(--space-md-fixed);
 }
 
 .alphabet-filter-button {
@@ -38,10 +37,13 @@
   font-weight: 600;
   cursor: pointer;
 
-  padding: 8px 10px;
-  margin: 0 4px;
-  min-width: 36px;
+  padding: 8px 6px;
+  margin: 0 min(0.4%, 4px);
+  min-width: 24px;
+  width: 2.5%;
+  max-width: 42px;
   text-align: center;
+  vertical-align: middle;
 
   border-radius: var(--alphabet-filter-border-radius);
   transition: all var(--alphabet-filter-transition-speed);
@@ -79,6 +81,6 @@
 
 .alphabet-filter-button--disabled {
   color: var(--alphabet-filter-text-disabled);
-  cursor: not-allowed;
+  cursor: auto;
   opacity: 0.5;
 }


### PR DESCRIPTION
Dynamic adjust button width and margin Alphabet Filter in Library to get more compact look.\
This feature added in <https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4643>.

Previous:

<img width="1120" height="235" alt="image" src="https://github.com/user-attachments/assets/b0372bd1-7025-4a0c-bf87-bca55c398ff7" />

Now:

<img width="1150" height="159" alt="image" src="https://github.com/user-attachments/assets/159efe1a-cda0-40d2-ba48-7268539584e1" />

On a wide window still like the previous:

<img width="2277" height="159" alt="image" src="https://github.com/user-attachments/assets/831d5afb-57af-4a70-afdf-ebded237fe22" />

This PR equivalent to the following override. You can try it in settings awa:

```css
.alphabet-filter-container {
  margin: 8px var(--space-md-fixed);
}

.alphabet-filter-button {
  padding: 8px 6px;
  margin: 0 min(0.4%, 4px);
  min-width: 24px;
  width: 2.5%;
  max-width: 42px;

  vertical-align: middle;
}
```

Only tested on my current install.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
