### PR TITLE
[FEATURE] add wine version in logs

### DIFF
--- a/src/backend/utils/__tests__/compatibility_layers.test.ts
+++ b/src/backend/utils/__tests__/compatibility_layers.test.ts
@@ -15,6 +15,7 @@ describe('getDefaultWine', () => {
     const expected = {
       bin: '',
       name: 'Default Wine - Not Found',
+      version: '',
       type: 'wine'
     }
     jest.spyOn(child_process, 'execSync').mockImplementation(() => {

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -28,6 +28,7 @@ export function getDefaultWine(): WineInstallation {
   const defaultWine: WineInstallation = {
     bin: '',
     name: 'Default Wine - Not Found',
+    version: '',
     type: 'wine'
   }
 
@@ -125,10 +126,18 @@ export async function getLinuxWineSet(
 
   readdirSync(`${toolsPath}/wine/`).forEach((version) => {
     const wineBin = join(toolsPath, 'wine', version, 'bin', 'wine')
+    const wineVersionPath: string = join(toolsPath, 'wine', version, 'version')
+    let wineVersion: string = ''
+
+    if (existsSync(wineVersionPath)) {
+      wineVersion = readFileSync(wineVersionPath, 'utf-8')
+    }
+
     altWine.add({
       bin: wineBin,
       name: `Wine - ${version}`,
       type: 'wine',
+      version: wineVersion,
       ...getWineLibs(wineBin),
       ...getWineExecs(wineBin)
     })
@@ -174,10 +183,24 @@ export async function getLinuxWineSet(
         const protonBin = join(path, version, 'proton')
         // check if bin exists to avoid false positives
         if (existsSync(protonBin)) {
+          let protonVersion = ''
+          const protonVersionPath = join(path, version, 'version')
+
+          if (existsSync(protonVersionPath)) {
+            const content = readFileSync(protonVersionPath, 'utf-8')
+
+            protonVersion = content
+              .replaceAll('\n', ' ')
+              .trim()
+              .split(' ')
+              .reverse()[0]
+          }
+
           proton.add({
             bin: protonBin,
             name: `Proton - ${version}`,
-            type: 'proton'
+            type: 'proton',
+            version: protonVersion
             // No need to run this.getWineExecs here since Proton ships neither Wineboot nor Wineserver
           })
         }

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -27,6 +27,8 @@ import {
 } from './utilities'
 import { axiosClient, calculateEta, downloadFile } from 'backend/utils'
 import type { WineManagerStatus } from 'common/types'
+import { writeFileSync } from 'fs'
+import { join } from 'path'
 
 interface getVersionsProps {
   repositorys?: Repositorys[]
@@ -350,6 +352,14 @@ async function installVersion({
     rmSync(`${installSubDir}_backup`, { recursive: true })
   }
   unlinkFile(tarFile)
+
+  // only Wine-GE don't have a version file so I create it
+  if (existsSync(installSubDir) && versionInfo.type === 'Wine-GE') {
+    writeFileSync(
+      join(installSubDir, 'version'),
+      versionInfo.download.split('/').slice(-1)[0].split('.')[0]
+    )
+  }
 
   // resolve with disksize
   versionInfo.disksize = getFolderSize(installSubDir)

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -311,6 +311,7 @@ export interface WineInstallation {
   bin: string
   name: string
   type: 'wine' | 'proton' | 'crossover' | 'toolkit'
+  version?: string
   lib?: string
   lib32?: string
   wineserver?: string


### PR DESCRIPTION
Add the wine version in the logs. Useful when using latest version of wine / proton but will be display even if a specific version is chosen.

Resolve #3260

Example with Proton Experimental
<img width="915" height="161" alt="image" src="https://github.com/user-attachments/assets/caa04a03-872d-4ba3-a5b4-1230d7db29eb" />

Example with GE-Proton-latest
<img width="777" height="140" alt="image" src="https://github.com/user-attachments/assets/5bbb3450-a2a5-49fd-9f39-c5cfac8c84b9" />

Example with Wine-GE-latest
<img width="866" height="208" alt="image" src="https://github.com/user-attachments/assets/aacddf65-0cc1-4013-b22f-260695f1d78b" />

Any suggestion to improve the code ?

First contribution on github in general so any comments would be appreciated.

Thank you.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
