### PR TITLE
[FIX] Fix logger error opening second instance of Heroic

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -312,8 +312,7 @@ const processZoomForScreen = (zoomFactor: number) => {
 }
 
 if (!gotTheLock) {
-  initLogger()
-  logInfo('Heroic is already running, quitting this instance')
+  console.log('Heroic is already running, quitting this instance')
   app.quit()
 } else {
   app.on('second-instance', (event, argv) => {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -312,6 +312,7 @@ const processZoomForScreen = (zoomFactor: number) => {
 }
 
 if (!gotTheLock) {
+  initLogger()
   logInfo('Heroic is already running, quitting this instance')
   app.quit()
 } else {


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4783

There's an issue on windows (and I think mac too) when opening a second instance of Heroic (from a shortcut for example)

In linux this is not an issue because it uses the `heroic://` protocol, but in window it opens the second instance and detects the previous one running, then it tries to write to the logs which are not initialized yet for that instance.


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
