### PR TITLE
[UI] Fix text wrapping for non-alphabetic scripts

### DIFF
--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -51,6 +51,7 @@
 .selectStyle {
   text-indent: 22px;
   padding-inline-end: 4rem;
+  white-space: nowrap;
 }
 
 .selectFieldWrapper.isRTL .MuiOutlinedInput-root {


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4776

Make sure text don't wrap to multiple lines in the Categories and Filters buttons.

Before

<img width="314" height="120" alt="image" src="https://github.com/user-attachments/assets/2328f3c6-6493-4ba3-b991-4953f9b978f5" />

After

<img width="403" height="121" alt="image" src="https://github.com/user-attachments/assets/43d599c7-c4de-4ac2-84de-605cf537f658" />

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
