### PR TITLE
[FIX] Remember scroll position of library when changing screens

### DIFF
--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -218,14 +218,17 @@ export default React.memo(function Library(): JSX.Element {
     const scrollPosition = parseInt(storage?.getItem('scrollPosition') || '0')
 
     const storeScrollPosition = () => {
-      storage?.setItem('scrollPosition', window.scrollY.toString() || '0')
+      storage?.setItem(
+        'scrollPosition',
+        document.body.scrollTop.toString() || '0'
+      )
     }
 
-    window.addEventListener('scroll', storeScrollPosition)
-    window.scrollTo(0, scrollPosition || 0)
+    document.body.addEventListener('scroll', storeScrollPosition)
+    document.body.scrollTo(0, scrollPosition || 0)
 
     return () => {
-      window.removeEventListener('scroll', storeScrollPosition)
+      document.body.removeEventListener('scroll', storeScrollPosition)
     }
   }, [])
 


### PR DESCRIPTION
This fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4811

We used to have this, but it broke at some point. We scroll the body element, not the window now.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
