### PR TITLE
[UX] Remove alt launch action when it makes no sense

### DIFF
--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -80,7 +80,10 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
       is.installingRedist ||
       is.installingWinetricksPackages ||
       is.launching ||
-      is.playing
+      is.playing ||
+      is.moving ||
+      is.updating ||
+      is.reparing
     ) {
       return <></>
     }
@@ -158,7 +161,7 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
 
   return (
     <div className="playButtons">
-      {is_installed && !is.queued && (
+      {is_installed && !is.queued && !is.uninstalling && (
         <>
           <button
             disabled={


### PR DESCRIPTION
Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4793

The latest release included the new alternative Play with/without logs. This alternative button was displayed in some states like when updating/uninstalling/moving incorrectly.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
