### PR TITLE
[FIX] Add SPDX license to AUR release

### DIFF
--- a/.github/workflows/release_aur.yml
+++ b/.github/workflows/release_aur.yml
@@ -47,7 +47,7 @@ jobs:
           pkgdesc="An Open source Launcher for Epic, Amazon and GOG Games"
           arch=('x86_64')
           url="$url"
-          license=('GPL3')
+          license=('GPL-3.0-or-later')
           _filename=$_filename
           source=("$source")
           noextract=("$_filename")


### PR DESCRIPTION
<--- Put the description here --->
The AUR package `heroic-games-launcher-bin` is missing `depends()` and has a non-compliant `license()` header. I didn't know if y'all specify `GPL-3.0-or-later` or `GPL-3.0-only`, so I chose `GPL-3.0-or-later` since it is more common to see than not.

The `depends()` were found using `namcap`, which is a great tool for anyone writing PKGBUILDs on Arch.
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
