### PR TITLE
[UX] Improved SelectField navigation with gamepad

### DIFF
--- a/src/frontend/components/UI/SelectField/index.tsx
+++ b/src/frontend/components/UI/SelectField/index.tsx
@@ -39,6 +39,7 @@ export default function SelectField({
       <Select
         id={htmlId}
         value={value}
+        tabIndex={-1}
         onChange={onChange}
         disabled={disabled}
         sx={{


### PR DESCRIPTION
Noticed the SelectField component was getting selected two times when navigating with a gamepad. Details below show before and after change:

<details>


Before:

https://github.com/user-attachments/assets/02fe764a-01e7-4f7c-a648-04e5b8e9fe71


After: 

https://github.com/user-attachments/assets/f6503915-84a1-4dd0-8122-28cf9c9e54d0


</details>

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
