### PR TITLE
[Feat] (Auto-)Updater improvements

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -107,6 +107,7 @@
         "info": {
             "update": {
                 "detail": "Do you want to download the update in the background?",
+                "detailNoAutoupdate": "Automatic updates are not supported for your packaging format. Please use your package manager to update.",
                 "message": "There is a new Version available!",
                 "message-finished": "Do you want to restart Heroic now?",
                 "title": "Heroic Games Launcher",

--- a/src/backend/constants/environment.ts
+++ b/src/backend/constants/environment.ts
@@ -18,3 +18,4 @@ export const isFlatpak = Boolean(env.FLATPAK_ID)
 export const isSnap = Boolean(env.SNAP)
 export const isAppImage = Boolean(env.APPIMAGE)
 export const flatpakRuntimeVersion = env.FLATPAK_RUNTIME_VERSION
+export const autoUpdateSupported = isWindows || isMac || isAppImage

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -136,8 +136,7 @@ import {
   isMac,
   isSnap,
   isSteamDeckGameMode,
-  isWindows,
-  autoUpdateSupported
+  isWindows
 } from './constants/environment'
 import {
   configPath,
@@ -253,7 +252,7 @@ async function initializeWindow(): Promise<BrowserWindow> {
   } else {
     Menu.setApplicationMenu(null)
     mainWindow.loadFile(join(publicDir, 'index.html'))
-    if (globalConf.checkForUpdatesOnStartup && autoUpdateSupported) {
+    if (globalConf.checkForUpdatesOnStartup) {
       autoUpdater.checkForUpdates()
     }
   }

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -136,7 +136,8 @@ import {
   isMac,
   isSnap,
   isSteamDeckGameMode,
-  isWindows
+  isWindows,
+  autoUpdateSupported
 } from './constants/environment'
 import {
   configPath,
@@ -252,7 +253,7 @@ async function initializeWindow(): Promise<BrowserWindow> {
   } else {
     Menu.setApplicationMenu(null)
     mainWindow.loadFile(join(publicDir, 'index.html'))
-    if (globalConf.checkForUpdatesOnStartup && !isLinux) {
+    if (globalConf.checkForUpdatesOnStartup && autoUpdateSupported) {
       autoUpdater.checkForUpdates()
     }
   }

--- a/src/backend/updater.ts
+++ b/src/backend/updater.ts
@@ -11,25 +11,40 @@ autoUpdater.autoDownload = false
 autoUpdater.autoInstallOnAppQuit = false
 
 async function showAutoupdateDialog() {
-  if (autoUpdateSupported) {
-    return
-  }
+  let messageDetail
+  let buttons
 
-  const { response } = await dialog.showMessageBox({
-    title: t('box.info.update.title', 'Heroic Games Launcher'),
-    message: t('box.info.update.message', 'There is a new Version available!'),
-    detail: t(
+  if (autoUpdateSupported) {
+    messageDetail = t(
       'box.info.update.detail',
       'Do you want to download the update in the background?'
-    ),
-
-    icon: nativeImage.createFromPath(windowIcon),
-    buttons: [
+    )
+    buttons = [
       t('box.update', 'Update'),
       t('box.postpone', 'Postpone'),
       t('box.changelog', 'Changelog')
     ]
+  } else {
+    messageDetail = t(
+      'box.info.update.detailNoAutoupdate',
+      'Automatic updates are not supported for your packaging format. Please use your package manager to update.'
+    )
+    buttons = [t('box.ok'), t('box.changelog', 'Changelog')]
+  }
+
+  let { response } = await dialog.showMessageBox({
+    title: t('box.info.update.title', 'Heroic Games Launcher'),
+    message: t('box.info.update.message', 'There is a new Version available!'),
+    detail: messageDetail,
+
+    icon: nativeImage.createFromPath(windowIcon),
+    buttons
   })
+
+  // "Ok" button becomes "Postpone" (to just close the dialog), "Changelog" gets
+  // the correct index (1 -> 2)
+  if (!autoUpdateSupported) response++
+
   if (response === 0) {
     autoUpdater.downloadUpdate()
   }

--- a/src/backend/updater.ts
+++ b/src/backend/updater.ts
@@ -5,13 +5,13 @@ import { t } from 'i18next'
 import { showDialogBoxModalAuto } from './dialog/dialog'
 import { logError, LogPrefix } from './logger'
 import { windowIcon } from './constants/paths'
-import { isLinux } from './constants/environment'
+import { autoUpdateSupported } from './constants/environment'
 
 autoUpdater.autoDownload = false
 autoUpdater.autoInstallOnAppQuit = false
 
 async function showAutoupdateDialog() {
-  if (isLinux) {
+  if (autoUpdateSupported) {
     return
   }
 


### PR DESCRIPTION
1. We can safely enable the auto-updater for AppImage setups, since those (usually) live in a user-writable location
2. If we don't have the auto-updater, we still want to notify the user about the update being available

Can't really test this

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
