### PR TITLE
[Fix] Make the Winetricks log message show up again

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -822,10 +822,10 @@ async function prepareWineLaunch(
     }
   }
 
-  logWriter.writeString(
+  logWriter.logInfo(
     Winetricks.listInstalled(runner, appName).then((installedPackages) => {
       const packagesString = installedPackages.join(', ')
-      return `Winetricks packages: ${packagesString}`
+      return `Winetricks packages: ${packagesString}\n\n`
     })
   )
 


### PR DESCRIPTION
This was accidentally included in an `isMac` conditional block
While I was at it, I also made the formatting a little easier to read (using a regular `logInfo` & adding some padding)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
