### PR TITLE
[UX] Print list of GOG games in GOG log

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1680,7 +1680,7 @@ async function callRunner(
       await writer.logInfo(
         [prefix, safeCommand, '\n\n'].filter(Boolean).join(' ')
       )
-      await writer.logInfo('Game Output:')
+      if (appName) await writer.logInfo('Game Output:')
     }
 
     const files = options.logWriters


### PR DESCRIPTION
This PR adds 2 improvements to logs:

- We now print GOG's library in the GOG's logs like we do for Legendary (this can be useful for debugging purposes)
- We don't print `Game output` in logs if it's not a game log (this was adding noise to runner logs, incorrectly)

Note that we don't have the GOG game version at the point I'm printing this to the logs, so I didn't include that (if you compare it with legendary's log)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
