### PR TITLE
[UX] Ignore DLCs when calculating available alphabet filter letters

### DIFF
--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -418,6 +418,8 @@ export default React.memo(function Library(): JSX.Element {
         favouritesIds.includes(`${game.app_name}_${game.runner}`)
       )
     } else {
+      library = library.filter((game) => !game.install.is_dlc)
+
       if (currentCustomCategories && currentCustomCategories.length > 0) {
         const gamesInSelectedCategories = new Set<string>()
 


### PR DESCRIPTION
DLCs where looped through when calculating which letters should be available for the new alphabet filter feature. This was an issue because we don't show DLCs in the library, so a letter could be marked as available when we wouldn't have anything to show for that letter in the library.

This fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4817, because the `Galaxy Common Redistributables` download is added to the GOG's library and is flagged is a DLC, so it was counted for the letters but not displayed as a card.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
