### PR TITLE
[UI] disable DXVK-NVAPI when DXVK is disabled

### DIFF
--- a/src/frontend/screens/Settings/components/AutoDXVK.tsx
+++ b/src/frontend/screens/Settings/components/AutoDXVK.tsx
@@ -16,6 +16,7 @@ const AutoDXVK = () => {
   const { platform } = useContext(ContextProvider)
   const isLinux = platform === 'linux'
   const [autoInstallVkd3d] = useSetting('autoInstallVkd3d', false)
+  const [autoInstallDxvkNvapi] = useSetting('autoInstallDxvkNvapi', false)
   const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
   const { appName } = useContext(SettingsContext)
   const [installingDxvk, setInstallingDxvk] = React.useState(false)
@@ -50,7 +51,10 @@ const AutoDXVK = () => {
             : t('setting.autodxvk', 'Auto Install/Update DXVK on Prefix')
         }
         fading={installingDxvk}
-        disabled={installingDxvk || (isLinux && autoInstallVkd3d)}
+        disabled={
+          installingDxvk ||
+          (isLinux && (autoInstallDxvkNvapi || autoInstallVkd3d))
+        }
       />
 
       <InfoIcon

--- a/src/frontend/screens/Settings/components/AutoDXVKNVAPI.tsx
+++ b/src/frontend/screens/Settings/components/AutoDXVKNVAPI.tsx
@@ -8,6 +8,7 @@ import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const AutoDXVKNVAPI = () => {
   const { t } = useTranslation()
+  const [autoInstallDxvk] = useSetting('autoInstallDxvk', false)
   const [autoInstallDXVKNVAPI, setAutoInstallDXVKNVAPI] = useSetting(
     'autoInstallDxvkNvapi',
     false
@@ -50,7 +51,7 @@ const AutoDXVKNVAPI = () => {
               )
         }
         fading={installingDxvkNvapi}
-        disabled={installingDxvkNvapi}
+        disabled={!autoInstallDxvk || installingDxvkNvapi}
       />
 
       <InfoIcon


### PR DESCRIPTION
Disables DXVK-NVAPI when DXVK is also disabled.

**NOTE: Currently, this behavior works for VKD3D but not for  DXVK-NVAPI.**


- if any of DXVK-NVAPI or VKD3D are enabled, DXVK gets disabled 

<img width="391" height="183" alt="Auto InstallUpdate DXVK on Prefix" src="https://github.com/user-attachments/assets/5f9b2197-2593-47ec-96e8-7ce9c751f680" />

---

- if DXVK is enabled, any of DXVK-NVAPI or VKD3D can be toggle on/off properly.

<img width="382" height="180" alt="Auto InstallUpdate DXVK on Prefix" src="https://github.com/user-attachments/assets/fb43a68e-5cf7-49d1-aaad-d6ebe2eb8edf" />


---

- if DXVK gets disabled, any of DXVK-NVAPI or VKD3D are disabled as well

<img width="402" height="183" alt="Auto InstallUpdate DXVK on Prefix" src="https://github.com/user-attachments/assets/68b357d7-bc5b-4d12-8916-14f6704ac29a" />


Closes: 
- https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3239

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
