### PR TITLE
[FIX] Update version to 2.18.1 and fix plausible missed platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroic",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "versionNames": {
     "stable": "\"Waterfall Beard\" Jorul",
     "beta": "Caesar Clown"

--- a/src/backend/utils/plausible.ts
+++ b/src/backend/utils/plausible.ts
@@ -94,6 +94,7 @@ export function startPlausible() {
     gog: providersObject.gog || false,
     epic: providersObject.epic || false,
     amazon: providersObject.amazon || false,
+    sideloaded: providersObject.sideloaded || false,
     providers: loggedInProviders.join(', '),
     OS: process.platform,
     isFlatpak: isFlatpak,
@@ -103,11 +104,13 @@ export function startPlausible() {
     isSteamDeck: !!isSteamDeck
   }
 
-  logInfo('Starting Plausible Analytics', LogPrefix.Backend)
-  logInfo(`Shared Data: ${JSON.stringify(props)}`, LogPrefix.Backend)
-  plausible.trackEvent('App Loaded', {
-    props
-  })
+  if (process.platform) {
+    logInfo('Starting Plausible Analytics', LogPrefix.Backend)
+    logInfo(`Shared Data: ${JSON.stringify(props)}`, LogPrefix.Backend)
+    plausible.trackEvent('App Loaded', {
+      props
+    })
+  }
 }
 
 backendEvents.on('settingChanged', ({ key, newValue }) => {


### PR DESCRIPTION
Bump version, send sideloaded info to plausible properly and avoid sending empty information.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
