### PR TITLE
[FIX] Back to top arrow

### DIFF
--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -237,17 +237,19 @@ export default React.memo(function Library(): JSX.Element {
 
   // bind back to top button
   useEffect(() => {
-    if (backToTopElement.current) {
-      document.body.addEventListener('scroll', () => {
-        const btn = document.getElementById('backToTopBtn')
-        const topSpan = document.getElementById('top')
-        if (btn && topSpan) {
-          btn.style.visibility =
-            document.body.scrollTop > 450 ? 'visible' : 'hidden'
-        }
-      })
+    const btn = document.getElementById('backToTopBtn')
+    const topSpan = document.getElementById('top')
+
+    const scrollCallback = () => {
+      if (btn && topSpan) {
+        btn.style.visibility =
+          document.body.scrollTop > 450 ? 'visible' : 'hidden'
+      }
     }
-  }, [backToTopElement])
+
+    document.body.addEventListener('scroll', scrollCallback)
+    return () => document.body.removeEventListener('scroll', scrollCallback)
+  }, [])
 
   const backToTop = () => {
     const anchor = document.getElementById('top')


### PR DESCRIPTION
Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4847

Not sure why we now depend on `document.body` instead of `window` to detect/calculate scroll position, but we need to change it for the back to top button.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
