### PR TITLE
[FIX] Scroll card into view when using controller

### DIFF
--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -27,13 +27,13 @@ const scrollCardIntoView = (ev: FocusEvent) => {
 
   if (rect.top < 100) {
     // if it's too close to the top, scroll a bit down
-    window.scrollTo({
+    document.body.scrollTo({
       top: trgt.parentElement!.offsetTop - 200,
       behavior: 'smooth'
     })
   } else if (rect.bottom > windowHeight - 100) {
     // if it's too close to the bottom, scroll a bit up
-    window.scrollTo({
+    document.body.scrollTo({
       top: trgt.parentElement!.offsetTop - windowHeight + rect.height + 150,
       behavior: 'smooth'
     })


### PR DESCRIPTION
Another issue related to the scroll happening in document.body instead of window.

When navigating with a controller, this improves the position of the scroll so the focused card is scrolled into view. This was already a thing but it broke along with the other scroll-related features.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
