### PR TITLE
[FIX] Catch error if no anticheat json file so launching doesn't fail

### DIFF
--- a/src/backend/anticheat/utils.ts
+++ b/src/backend/anticheat/utils.ts
@@ -37,16 +37,21 @@ async function gameAnticheatInfo(
   if (appNamespace === undefined) return null
   if (isWindows) return null
 
-  const data = await readFile(anticheatDataPath, 'utf-8')
-  const jsonData = JSON.parse(data)
-  return jsonData.find((info: AntiCheatInfo) => {
-    const namespace = info.storeIds.epic?.namespace
-    if (namespace) {
-      return namespace.toLowerCase().includes(appNamespace)
-    } else {
-      return false
-    }
-  })
+  try {
+    const data = await readFile(anticheatDataPath, 'utf-8')
+    const jsonData = JSON.parse(data)
+    return jsonData.find((info: AntiCheatInfo) => {
+      const namespace = info.storeIds.epic?.namespace
+      if (namespace) {
+        return namespace.toLowerCase().includes(appNamespace)
+      } else {
+        return false
+      }
+    })
+  } catch {
+    logWarning('AreWeAntiCheatYet file not present', LogPrefix.Backend)
+    return null
+  }
 }
 
 export { downloadAntiCheatData, gameAnticheatInfo }


### PR DESCRIPTION
Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4853

Currently, if there's no `areweanticheatyet.json` info file, launching a game fails because we print the anticheat info in the logs.

This catches that error so launching continues as usual.

I could check for the file existence, but I don't know if there are other possible read errors so better to just try/catch it.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
