### PR TITLE
[FIX] Kill epic game with appName pattern in Mac too

### DIFF
--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -81,12 +81,7 @@ import { Path } from 'backend/schemas'
 import { mkdirSync } from 'fs'
 import { configStore } from 'backend/constants/key_value_stores'
 import { epicRedistPath, legendaryInstalled } from './constants'
-import {
-  isCLINoGui,
-  isLinux,
-  isMac,
-  isWindows
-} from 'backend/constants/environment'
+import { isCLINoGui, isMac, isWindows } from 'backend/constants/environment'
 import { fakeEpicExePath } from 'backend/constants/paths'
 
 import type LogWriter from 'backend/logger/log_writer'
@@ -1049,7 +1044,7 @@ export async function stop(appName: string, stopWine = true) {
   // not a perfect solution but it's the only choice for now
 
   // @adityaruplaha: this is kinda arbitary and I don't understand it.
-  const pattern = isLinux ? appName : 'legendary'
+  const pattern = isWindows ? 'legendary' : appName
   killPattern(pattern)
 
   if (stopWine && !isNative(appName)) {


### PR DESCRIPTION
Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4794

I understand we were picking either the appName or `legendary` for the pattern as a linux vs windows difference?

on MacOS, the `legendary` process is not there while the game runs so we were just trying to kill a legendary process that either didn't exist OR if any other legendary command was in progress we would kill that instead of the game, and the button didn't really work on MacOS

I checked and the game process on MacOS also has the `appname` command argument just like on linux, so we should use that instead

I only changed this on legendary, I don't have an amazon account to know what the command looks like, but it might need the same change cause it has similar code with the `isLinux` check.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
