### PR TITLE
[Tech] Added store specific types that inherit game info

### DIFF
--- a/src/backend/storeManagers/gog/electronStores.ts
+++ b/src/backend/storeManagers/gog/electronStores.ts
@@ -1,6 +1,6 @@
 import { TypeCheckedStoreBackend } from '../../electron_store'
 import CacheStore from '../../cache'
-import { GameInfo } from 'common/types'
+import { GOGGameInfo } from 'common/types'
 import {
   GOGSessionSyncQueueItem,
   GamesDBData,
@@ -20,7 +20,7 @@ const configStore = new TypeCheckedStoreBackend('gogConfigStore', {
 })
 
 const apiInfoCache = new CacheStore<GamesDBData>('gog_api_info')
-const libraryStore = new CacheStore<GameInfo[], 'games'>('gog_library', null)
+const libraryStore = new CacheStore<GOGGameInfo[], 'games'>('gog_library', null)
 const syncStore = new TypeCheckedStoreBackend('gogSyncStore', {
   cwd: 'gog_store',
   name: 'saveTimestamps',

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -28,7 +28,7 @@ import {
 } from '../../utils'
 import {
   ExtraInfo,
-  GameInfo,
+  GOGGameInfo,
   GameSettings,
   ExecResult,
   InstallArgs,
@@ -139,7 +139,7 @@ export async function getExtraInfo(appName: string): Promise<ExtraInfo> {
   return extra
 }
 
-export function getGameInfo(appName: string): GameInfo {
+export function getGameInfo(appName: string): GOGGameInfo {
   const info = getGogLibraryGameInfo(appName)
   if (!info) {
     logError(

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -2,12 +2,12 @@ import { sendFrontendMessage } from '../../ipc'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import { GOGUser } from './user'
 import {
-  GameInfo,
   InstalledInfo,
   GOGImportData,
   ExecResult,
   CallRunnerOptions,
-  LaunchOption
+  LaunchOption,
+  GOGGameInfo
 } from 'common/types'
 import {
   GOGCloudSavesLocation,
@@ -55,7 +55,7 @@ import { runGogdlCommandStub } from './e2eMock'
 import { gogdlConfigPath } from './constants'
 import { userDataPath } from 'backend/constants/paths'
 
-const library: Map<string, GameInfo> = new Map()
+const library: Map<string, GOGGameInfo> = new Map()
 const installedGames: Map<string, InstalledInfo> = new Map()
 
 export async function initGOGLibraryManager() {
@@ -353,7 +353,7 @@ export async function refresh(): Promise<ExecResult> {
   }
   refreshInstalled()
   await loadLocalLibrary()
-  const redistGameInfo: GameInfo = {
+  const redistGameInfo: GOGGameInfo = {
     app_name: 'gog-redist',
     runner: 'gog',
     title: 'Galaxy Common Redistributables',
@@ -389,7 +389,7 @@ export async function refresh(): Promise<ExecResult> {
     (entry) => entry.platform_id === 'gog'
   )
 
-  const gamesObjects: GameInfo[] = [redistGameInfo]
+  const gamesObjects: GOGGameInfo[] = [redistGameInfo]
   apiInfoCache.use_in_memory() // Prevent blocking operations
   for (const game of filteredApiArray) {
     let retries = 5
@@ -472,11 +472,11 @@ export async function refresh(): Promise<ExecResult> {
   return defaultExecResult
 }
 
-export function getGameInfo(slug: string): GameInfo | undefined {
+export function getGameInfo(slug: string): GOGGameInfo | undefined {
   return library.get(slug) || getInstallAndGameInfo(slug)
 }
 
-export function getInstallAndGameInfo(slug: string): GameInfo | undefined {
+export function getInstallAndGameInfo(slug: string): GOGGameInfo | undefined {
   const lib = libraryStore.get('games', [])
   const game = lib.find((value) => value.app_name === slug)
 
@@ -946,7 +946,7 @@ export async function checkForGameUpdate(
  */
 export async function gogToUnifiedInfo(
   info: GamesDBData | undefined
-): Promise<GameInfo> {
+): Promise<GOGGameInfo> {
   if (!info || info.type !== 'game' || !info.game.visible_in_library) {
     // @ts-expect-error TODO: Handle this somehow
     return {}
@@ -966,7 +966,7 @@ export async function gogToUnifiedInfo(
     ?.replace('{formatter}', '')
     .replace('{ext}', 'jpg')
 
-  const object: GameInfo = {
+  const object: GOGGameInfo = {
     runner: 'gog',
     developer: info.game.developers.map((dev) => dev.name).join(', '),
     app_name: String(info.external_id),

--- a/src/backend/storeManagers/legendary/electronStores.ts
+++ b/src/backend/storeManagers/legendary/electronStores.ts
@@ -1,11 +1,11 @@
 import CacheStore from '../../cache'
-import { ExtraInfo, GameInfo } from 'common/types'
+import { ExtraInfo, LegendaryGameInfo } from 'common/types'
 import { GameOverride, LegendaryInstallInfo } from 'common/types/legendary'
 
 export const installStore = new CacheStore<LegendaryInstallInfo>(
   'legendary_install_info'
 )
-export const libraryStore = new CacheStore<GameInfo[], 'library'>(
+export const libraryStore = new CacheStore<LegendaryGameInfo[], 'library'>(
   'legendary_library',
   null
 )

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -4,7 +4,7 @@ import axios from 'axios'
 import {
   ExecResult,
   ExtraInfo,
-  GameInfo,
+  LegendaryGameInfo,
   InstallArgs,
   InstallPlatform,
   InstallProgress,
@@ -102,7 +102,7 @@ export async function checkGameUpdates() {
  *
  * @returns GameInfo
  */
-export function getGameInfo(appName: string): GameInfo {
+export function getGameInfo(appName: string): LegendaryGameInfo {
   const info = getLegLibraryGameInfo(appName)
   if (!info) {
     logError(
@@ -666,7 +666,7 @@ export async function install(
 }
 
 async function installEA(
-  gameInfo: GameInfo,
+  gameInfo: LegendaryGameInfo,
   platformToInstall: string
 ): Promise<{
   status: 'done' | 'error' | 'abort'

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync } from 'graceful-fs'
 
 import {
-  GameInfo,
+  LegendaryGameInfo,
   InstalledInfo,
   CallRunnerOptions,
   ExecResult,
@@ -55,7 +55,7 @@ const fallBackImage = 'fallback'
 
 const allGames: Set<string> = new Set()
 let installedGames: Map<string, InstalledJsonMetadata> = new Map()
-const library: Map<string, GameInfo> = new Map()
+const library: Map<string, LegendaryGameInfo> = new Map()
 
 export async function initLegendaryLibraryManager() {
   loadGamesInAccount()
@@ -183,12 +183,12 @@ export function getListOfGames() {
  *
  * @param appName The AppName of the game you want the info of
  * @param forceReload Discards game info in `library` and always reads info from metadata files
- * @returns GameInfo
+ * @returns LegendaryGameInfo
  */
 export function getGameInfo(
   appName: string,
   forceReload = false
-): GameInfo | undefined {
+): LegendaryGameInfo | undefined {
   if (!hasGame(appName)) {
     logWarning(
       ['Requested game', appName, 'was not found in library'],

--- a/src/backend/storeManagers/nile/electronStores.ts
+++ b/src/backend/storeManagers/nile/electronStores.ts
@@ -1,10 +1,10 @@
 import CacheStore from 'backend/cache'
 import { TypeCheckedStoreBackend } from 'backend/electron_store'
-import { GameInfo } from 'common/types'
+import { NileGameInfo } from 'common/types'
 import { NileInstallInfo } from 'common/types/nile'
 
 export const installStore = new CacheStore<NileInstallInfo>('nile_install_info')
-export const libraryStore = new CacheStore<GameInfo[], 'library'>(
+export const libraryStore = new CacheStore<NileGameInfo[], 'library'>(
   'nile_library',
   null
 )

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -1,7 +1,7 @@
 import {
   ExecResult,
   ExtraInfo,
-  GameInfo,
+  NileGameInfo,
   GameSettings,
   InstallArgs,
   InstallPlatform,
@@ -68,7 +68,7 @@ export async function getSettings(appName: string): Promise<GameSettings> {
   return gameConfig.config || (await gameConfig.getSettings())
 }
 
-export function getGameInfo(appName: string): GameInfo {
+export function getGameInfo(appName: string): NileGameInfo {
   const info = nileLibraryGetGameInfo(appName)
   if (!info) {
     logError(

--- a/src/backend/storeManagers/nile/library.ts
+++ b/src/backend/storeManagers/nile/library.ts
@@ -6,11 +6,11 @@ import {
   logInfo,
   logWarning
 } from 'backend/logger'
-import { CallRunnerOptions, ExecResult, GameInfo } from 'common/types'
+import { CallRunnerOptions, ExecResult, NileGameInfo } from 'common/types'
 import {
   FuelSchema,
   NileGameDownloadInfo,
-  NileGameInfo,
+  NileGameInfo as NileGameInfoJSON,
   NileInstallInfo,
   NileInstallMetadataInfo
 } from 'common/types/nile'
@@ -26,7 +26,7 @@ import { runNileCommandStub } from './e2eMock'
 import { nileConfigPath, nileInstalled, nileLibrary } from './constants'
 
 const installedGames: Map<string, NileInstallMetadataInfo> = new Map()
-const library: Map<string, GameInfo> = new Map()
+const library: Map<string, NileGameInfo> = new Map()
 
 export async function initNileLibraryManager() {
   // Migrate user data from global Nile config if necessary
@@ -46,7 +46,7 @@ function loadGamesInAccount() {
   if (!existsSync(nileLibrary)) {
     return
   }
-  const libraryJSON: NileGameInfo[] = JSON.parse(
+  const libraryJSON: NileGameInfoJSON[] = JSON.parse(
     readFileSync(nileLibrary, 'utf-8')
   )
   libraryJSON.forEach((game) => {
@@ -285,7 +285,7 @@ export async function refresh(): Promise<ExecResult | null> {
 export function getGameInfo(
   appName: string,
   forceReload = false
-): GameInfo | undefined {
+): NileGameInfo | undefined {
   if (!forceReload) {
     const gameInMemory = library.get(appName)
     if (gameInMemory) {

--- a/src/backend/storeManagers/sideload/library.ts
+++ b/src/backend/storeManagers/sideload/library.ts
@@ -1,4 +1,4 @@
-import { ExecResult, GameInfo } from 'common/types'
+import { ExecResult, SideloadGameInfo } from 'common/types'
 import { readdirSync } from 'graceful-fs'
 import { dirname, join } from 'path'
 import { libraryStore } from './electronStores'
@@ -18,8 +18,8 @@ export function addNewApp({
   description,
   customUserAgent,
   launchFullScreen
-}: GameInfo): void {
-  const game: GameInfo = {
+}: SideloadGameInfo): void {
+  const game: SideloadGameInfo = {
     runner: 'sideload',
     app_name,
     title,
@@ -79,7 +79,7 @@ export async function refresh() {
   return null
 }
 
-export function getGameInfo(): GameInfo {
+export function getGameInfo(): SideloadGameInfo {
   logWarning(`getGameInfo not implemented on Sideload Library Manager`)
   return {
     app_name: '',

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -151,11 +151,11 @@ export interface ExtraInfo {
 
 export type GameConfigVersion = 'auto' | 'v0' | 'v0.1'
 
-export type GameInfo = 
-  | SideloadGameInfo 
-  | LegendaryGameInfo 
-  | GOGGameInfo 
-  | NileGameInfo 
+export type GameInfo =
+  | SideloadGameInfo
+  | LegendaryGameInfo
+  | GOGGameInfo
+  | NileGameInfo
 
 interface BaseGameInfo {
   store_url?: string
@@ -177,7 +177,6 @@ interface BaseGameInfo {
   save_folder?: string
   // ...and this is the folder with them filled in
   save_path?: string
-  gog_save_location?: GOGCloudSavesLocation[]
   title: string
   canRunOffline: boolean
   thirdPartyManagedApp?: string
@@ -193,7 +192,6 @@ interface BaseGameInfo {
   launchFullScreen?: boolean
 }
 
-
 export interface SideloadGameInfo extends BaseGameInfo {
   runner: 'sideload'
 }
@@ -204,6 +202,7 @@ export interface LegendaryGameInfo extends BaseGameInfo {
 
 export interface GOGGameInfo extends BaseGameInfo {
   runner: 'gog'
+  gog_save_location?: GOGCloudSavesLocation[]
 }
 
 export interface NileGameInfo extends BaseGameInfo {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -151,8 +151,13 @@ export interface ExtraInfo {
 
 export type GameConfigVersion = 'auto' | 'v0' | 'v0.1'
 
-export interface GameInfo {
-  runner: 'legendary' | 'gog' | 'sideload' | 'nile'
+export type GameInfo = 
+  | SideloadGameInfo 
+  | LegendaryGameInfo 
+  | GOGGameInfo 
+  | NileGameInfo 
+
+interface BaseGameInfo {
   store_url?: string
   app_name: string
   art_cover: string
@@ -186,6 +191,23 @@ export interface GameInfo {
   dlcList?: GameMetadataInner[]
   customUserAgent?: string
   launchFullScreen?: boolean
+}
+
+
+export interface SideloadGameInfo extends BaseGameInfo {
+  runner: 'sideload'
+}
+
+export interface LegendaryGameInfo extends BaseGameInfo {
+  runner: 'legendary'
+}
+
+export interface GOGGameInfo extends BaseGameInfo {
+  runner: 'gog'
+}
+
+export interface NileGameInfo extends BaseGameInfo {
+  runner: 'nile'
 }
 
 export interface GameSettings {

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -32,6 +32,7 @@ import type {
   RuntimeName,
   RunWineCommandArgs,
   SaveSyncArgs,
+  SideloadGameInfo,
   StatusPromise,
   ToolArgs,
   Tools,
@@ -84,7 +85,7 @@ interface SyncIPCFunctions {
   showItemInFolder: (item: string) => void
   clipboardWriteText: (text: string) => void
   processShortcut: (combination: string) => void
-  addNewApp: (args: GameInfo) => void
+  addNewApp: (args: SideloadGameInfo) => void
   showLogFileInFolder: (args: GetLogFileArgs) => void
   addShortcut: (appName: string, runner: Runner, fromMenu: boolean) => void
   removeShortcut: (appName: string, runner: Runner) => void

--- a/src/frontend/hooks/hasStatus.ts
+++ b/src/frontend/hooks/hasStatus.ts
@@ -26,10 +26,10 @@ export function hasStatus(
 
   const {
     thirdPartyManagedApp = undefined,
-    is_installed,
+    is_installed = false,
     runner = 'sideload',
-    isEAManaged
-  } = { ...newGameInfo }
+    isEAManaged = false
+  } = newGameInfo || {}
 
   React.useEffect(() => {
     if (newGameInfo) {


### PR DESCRIPTION
Adding more and more runners would mean the main GameInfo get's poluted with lot's of runner specific props. 
I've made GameInfo a union type so that we can slowly start moving props to those. gog_save_location has already been moved.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
