### PR TITLE
Feature: Binary validation using VirusTotal

### DIFF
--- a/.github/workflows/binary-validation.yml
+++ b/.github/workflows/binary-validation.yml
@@ -6,11 +6,7 @@ on:
 
 jobs:
   validate:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2022, ubuntu-22.04, macos-13]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-deps
@@ -30,7 +26,7 @@ jobs:
             const analysis = '${{steps.virustotal.outputs.analysis}}';
             if (!analysis) return;
             console.log('VirusTotal Report:');
-            let lines = analysis.split(',');
+            const lines = analysis.split(',');
             for (let line of lines) {
               console.log('- [' + line.replace('./public/bin/', '').replace('=https', '](https') + ')');
             }


### PR DESCRIPTION
Relates to #4861

This is a new GitHub Workflows, which only runs if triggered manually via the UI. The purpose is to run a Virus report on each of the helper binaries depended upon. If useful this could be updated to run whevenever the binary list is changed. But for now it has to be manually run.

Steps:
- Requires `VT_API_KEY` secret to be set in the repository settings.
- Installs Heroic dependencies (same step as other workflows)
- Runs https://github.com/crazy-max/ghaction-virustotal on the downloaded files at: `./public/bin/**/*`
- Logs out the links to each report in markdown format (this could be adjusted later to comment on a PR)

Example run:
https://github.com/kmturley/HeroicGamesLauncher/actions/runs/16898430747/job/47872856107

I will post the report output as a comment on this PR

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
