### PR TITLE
Feature: Validate downloaded binaries by file hash

### DIFF
--- a/meta/downloadHelperBinaries.ts
+++ b/meta/downloadHelperBinaries.ts
@@ -1,8 +1,9 @@
+import { createHash } from 'crypto'
 import { createWriteStream } from 'fs'
 import { chmod, stat, mkdir, readFile, writeFile } from 'fs/promises'
 import { dirname, join } from 'path'
-import { Readable } from 'stream'
-import { finished } from 'stream/promises'
+import { Readable, Transform } from 'stream'
+import { pipeline } from 'stream/promises'
 
 import { setGlobalDispatcher, ProxyAgent } from 'undici'
 
@@ -13,6 +14,53 @@ type DownloadedBinary =
   | 'nile'
   | 'comet'
   | 'epic-integration'
+
+const RELEASE_HASHES = {
+  'x64/win32/GalaxyCommunication.exe':
+    'abc208076a778ee738cae8451c9be7ab33c9787b0b69b2e7e4ffc70becc39e1e',
+  'x64/win32/EpicGamesLauncher.exe':
+    '36fcd337ed9396ec7a6263864fafb944fe2bcf70c965c3fe99ce4c0cca572fe2',
+  'x64/darwin/gogdl':
+    '0d3ea4c72d4914e509ac9ee860d279ddc09a84348d20894b491eac39e2f0dc3c',
+  'x64/linux/gogdl':
+    '01d7e42821d5310cdc59f09d1b573af7a1e2e35f56741a1076dab9da05fd0cd8',
+  'x64/linux/legendary':
+    'bbb64b92fd9af97c4dc020aaa2a4bbe392bac84c22d60fc6224805e119842e38',
+  'x64/linux/nile':
+    '3a8c080c864a5952a01d7661693c60727b34a355ae21e9eab2047096b606c1df',
+  'arm64/darwin/legendary':
+    '7a08199ce450ca65d68ad00f963136976bf0b51dd529a7c1633d60a3e45d4ff7',
+  'arm64/linux/gogdl':
+    '2c259c358e05ac15927f769b9691fd190846da3aec8a94804d36ebe5d48ad215',
+  'arm64/darwin/nile':
+    'a07b64bc48d4754b25acb22895f47ab9e54960ee25efa5ffbfc6e23a5259a377',
+  'x64/win32/comet.exe':
+    '590a89a83877d0b58ef515ad03865114fbcb3f71fad71d606d72a3eb20a334e9',
+  'x64/darwin/legendary':
+    '6e99106b0a8225cb78252a6c1df714651dd7190abc319d1ddfd0d00ee761b349',
+  'arm64/linux/legendary':
+    '7cac5bdbee077153412267758080aae09a6c5160434983378254b7a7a9a004e6',
+  'arm64/linux/nile':
+    'f5ba63cfeb415ec1f07a980d6a2bbcdf8fc11411e5fa224f838a88fe78ad0008',
+  'x64/win32/legendary.exe':
+    'd1744e56874042ce474fadb468e00138613a4d241e37689c207df6528af9d83f',
+  'x64/darwin/nile':
+    '37951bc7f993666a29b5c03135eb0a7f3ce335546eb2e3e59e0e2261d182a263',
+  'x64/linux/comet':
+    'cf9a0e44dbedd0fea283ac6398e1277df7516711b486c21629103c873b0a6a7d',
+  'arm64/linux/comet':
+    '7eca0d84d3c0b0e563a732a6300a20c115b5d60d25e44735d18e86a773b97a2f',
+  'x64/win32/nile.exe':
+    '2d1aea4d6f1171963a9552b9ac2b13f6d25a0f0036729b4cf6ecc2e2ffcd9096',
+  'arm64/darwin/gogdl':
+    'fab4d21a93cb029ec53ca14c0a741ce078b5b5d5cd7d1bd826e9d71e4a517b64',
+  'x64/win32/gogdl.exe':
+    '795b0f25359b8fec7d40375c29736da5d304ae5aeed3a944dcf167868081a2b7',
+  'arm64/darwin/comet':
+    '1275c7b804846bbc70d43445760366d5a9713c506ba67eac7ca51a7fb87c77b5',
+  'x64/darwin/comet':
+    '18a1e7e304f710165fb22bd0716aeefce4959a023165db9feb10fc918103b778'
+}
 
 const RELEASE_TAGS = {
   legendary: '0.20.37',
@@ -39,8 +87,29 @@ async function downloadFile(url: string, dst: string) {
     throw Error(`Failed to download ${url}: ${response.status}`)
   }
   await mkdir(dirname(dst), { recursive: true })
+  const hash = createHash('sha256')
+  let computedHash: string = ''
+  const hashTransform = new Transform({
+    transform(chunk, encoding, callback) {
+      hash.update(chunk)
+      callback(null, chunk)
+    },
+    flush(callback) {
+      computedHash = hash.digest('hex')
+      callback()
+    }
+  })
   const fileStream = createWriteStream(dst, { flags: 'w' })
-  await finished(Readable.fromWeb(response.body).pipe(fileStream))
+  await pipeline(Readable.fromWeb(response.body), hashTransform, fileStream)
+
+  // Validate the downloaded file hash matches the expected hash
+  // Errors when a binary has been swapped out on an existing release
+  const system = dst.replace('public/bin/', '')
+  if (computedHash !== RELEASE_HASHES[system]) {
+    throw Error(
+      `- ${system} (Hash mismatch) received '${computedHash}' expected '${RELEASE_HASHES[system]}'`
+    )
+  }
 }
 
 async function downloadAsset(


### PR DESCRIPTION
Relates to #4861

A malicious actor or maintainer not following best-practices for Release versioning, could swap out a binary file on a GitHub Release without the Heroic team knowing. It could be downloaded and bundled into a Heroic Release without their knowledge. This could break functionality or worse expose Heroic users to attack vectors.

This feature ensures that downloaded binaries from other projects, match the expected file hashes in this project. If the hash changes, assume the file has changed and the file needs to be checked for Viruses again. This feature could be used in conjunction with VirusTotal checking https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4868 to validate binaries are safe for Heroic users.

When a Release version number is updated, the corresponding hash should also be updated in `meta/downloadHelperBinaries.ts` to prevent the script from throwing an Error and blocking builds.

Steps:
- Run `pnpm download-helper-binaries`
- Script will download binaries as before
- Now checks the file hash against the list of known hashes
- If there is a mismatch, that means the file has changed, throw an Error to prevent the file being bundled.

Example error thrown:
```
Error: - x64/win32/GalaxyCommunication.exe (Hash mismatch) received 'abc208076a778ee738cae8451c9be7ab33c9787b0b69b2e7e4ffc70becc39e1e' expected 'bbb64b92fd9af97c4dc020aaa2a4bbe392bac84c22d60fc6224805e119842e38'
```

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
