### PR TITLE
[Feat] Clarify "Use dedicated graphics card" / PRIME run option

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -769,10 +769,6 @@
         "prefered_language": "Prefered Language (Language Code)",
         "preferSystemLibs": "Prefer system libraries",
         "primerun": {
-            "confirmation": {
-                "message": "Only one graphics card was detected in this system. Please note that this option is intended for multi-GPU systems with headless GPUs (like laptops). On single-GPU systems, the GPU is automatically used & enabling this option can cause issues. Do you really want to enable this option?",
-                "title": "Only 1 GPU detected"
-            },
             "description": "Use Dedicated Graphics Card"
         },
         "runexe": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -369,7 +369,7 @@
             "part7": " to skip the launcher in some games, etc."
         },
         "preferSystemLibs": "Custom Wine versions (Wine-GE, Wine-Lutris) are shipped with their library dependencies. By enabling this option, these shipped libraries will be ignored and Wine will load system libraries instead. Warning! Issues may occur if dependencies are not met.",
-        "primerun": "Use dedicated graphics card to render game on multi-GPU systems. Only needed on gaming laptops or desktops that use a headless GPU for rendering (NVIDIA Optimus, AMD CrossFire)",
+        "primerun": "Sets PRIME-related environment variables to force the use of your dedicated GPU. Might cause issues with titles using DXVK/VKD3D (most Windows games)",
         "steam_path": {
             "info": "This path lets Heroic determine what version of Proton Steam uses, for adding non-Steam games to Steam."
         },
@@ -769,7 +769,7 @@
         "prefered_language": "Prefered Language (Language Code)",
         "preferSystemLibs": "Prefer system libraries",
         "primerun": {
-            "description": "Use Dedicated Graphics Card"
+            "description": "Force-use dedicated graphics card"
         },
         "runexe": {
             "title": "Run EXE on Prefix"

--- a/src/frontend/screens/Settings/components/UseDGPU.tsx
+++ b/src/frontend/screens/Settings/components/UseDGPU.tsx
@@ -24,13 +24,16 @@ const UseDGPU = () => {
         htmlId="usedgpu"
         value={useDGPU}
         handleChange={() => setUseDGPU(!useDGPU)}
-        title={t('setting.primerun.description', 'Use Dedicated Graphics Card')}
+        title={t(
+          'setting.primerun.description',
+          'Force-use dedicated graphics card'
+        )}
       />
 
       <InfoIcon
         text={t(
           'help.primerun',
-          'Use dedicated graphics card to render game on multi-GPU systems. Only needed on gaming laptops or desktops that use a headless GPU for rendering (NVIDIA Optimus, AMD CrossFire)'
+          'Sets PRIME-related environment variables to force the use of your dedicated GPU. Might cause issues with titles using DXVK/VKD3D (most Windows games)'
         )}
       />
     </div>

--- a/src/frontend/screens/Settings/components/UseDGPU.tsx
+++ b/src/frontend/screens/Settings/components/UseDGPU.tsx
@@ -4,41 +4,18 @@ import { ToggleSwitch } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
 import InfoIcon from 'frontend/components/UI/InfoIcon'
+import { useAwaited } from 'frontend/hooks/useAwaited'
 
 const UseDGPU = () => {
   const { t } = useTranslation()
-  const { platform, showDialogModal } = useContext(ContextProvider)
+  const { platform } = useContext(ContextProvider)
   const isLinux = platform === 'linux'
+  const systemInfo = useAwaited(window.api.systemInfo.get)
 
   const [useDGPU, setUseDGPU] = useSetting('nvidiaPrime', false)
 
-  if (!isLinux) {
+  if (!isLinux || !systemInfo || systemInfo.GPUs.length === 1) {
     return <></>
-  }
-
-  async function toggleUseDGPU() {
-    if (!useDGPU) {
-      const { GPUs } = await window.api.systemInfo.get()
-      if (GPUs.length === 1) {
-        showDialogModal({
-          title: t(
-            'setting.primerun.confirmation.title',
-            'Only 1 GPU detected'
-          ),
-          message: t(
-            'setting.primerun.confirmation.message',
-            'Only one graphics card was detected in this system. Please note that this option is intended for multi-GPU systems with headless GPUs (like laptops). On single-GPU systems, the GPU is automatically used & enabling this option can cause issues. Do you really want to enable this option?'
-          ),
-          buttons: [
-            { text: t('box.yes'), onClick: () => setUseDGPU(true) },
-            { text: t('box.no') }
-          ],
-          type: 'MESSAGE'
-        })
-        return
-      }
-    }
-    setUseDGPU(!useDGPU)
   }
 
   return (
@@ -46,7 +23,7 @@ const UseDGPU = () => {
       <ToggleSwitch
         htmlId="usedgpu"
         value={useDGPU}
-        handleChange={toggleUseDGPU}
+        handleChange={() => setUseDGPU(!useDGPU)}
         title={t('setting.primerun.description', 'Use Dedicated Graphics Card')}
       />
 


### PR DESCRIPTION
Users often toggle this option by mistake, either while only using one GPU (seems like a warning wasn't enough there), or thinking they *have to* toggle it for their dGPU to be used. To address this, we now
- only show the option if we have more than one GPU
- make it more clear that this option is likely not necessary & may cause issues

Tested on both a single-GPU and dual-GPU system, only on Linux (this option only applied to Linux to begin with)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
