### PR TITLE
[Fix] Return "macOS" as the OS name on macOS

### DIFF
--- a/src/backend/utils/systeminfo/osInfo/index.ts
+++ b/src/backend/utils/systeminfo/osInfo/index.ts
@@ -12,7 +12,7 @@ async function getOsInfo(): Promise<{ name: string; version?: string }> {
       // FIXME: I'd like to return the OS's codename ("Monterey", "Ventura", and
       //        so on) here, but the only way for applications to obtain those
       //        seems to be scraping a license file (https://unix.stackexchange.com/questions/234104/get-osx-codename-from-command-line)
-      return { name: '' }
+      return { name: 'macOS' }
     default:
       return { name: '' }
   }


### PR DESCRIPTION
Originally I thought "OS:  X.Y.Z (darwin)" would be fine to output temporarily, but since the codename detection FIXME doesn't seem easy to solve, let's at least do "OS: macOS X.Y.Z" for now

To test:
1. Look at any macOS log, note the OS part of the system info message says "OS:  X.Y.Z (darwin)"
2. Run this PR & again check the log, now the message says "OS: macOS X.Y.Z (darwin)"

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
