### PR TITLE
[Tech]  No longer use GameManagers as singletons

### DIFF
--- a/src/backend/__tests__/protocol.test.ts
+++ b/src/backend/__tests__/protocol.test.ts
@@ -28,7 +28,7 @@ jest.mock('../config', () => ({
 
 import { handleProtocol, shouldHideWindowForProtocolArgs } from '../protocol'
 import { app, dialog } from 'electron'
-import { gameManagerMap } from '../storeManagers'
+import { libraryManagerMap } from '../storeManagers'
 import { getMainWindow } from '../main_window'
 import { sendFrontendMessage } from '../ipc'
 
@@ -52,22 +52,18 @@ jest.mock('../ipc', () => ({
 }))
 
 jest.mock('../storeManagers', () => ({
-  gameManagerMap: {
+  libraryManagerMap: {
     legendary: {
-      getGameInfo: jest.fn(),
-      getSettings: jest.fn()
+      getGame: jest.fn()
     },
     gog: {
-      getGameInfo: jest.fn(),
-      getSettings: jest.fn()
+      getGame: jest.fn()
     },
     nile: {
-      getGameInfo: jest.fn(),
-      getSettings: jest.fn()
+      getGame: jest.fn()
     },
     sideload: {
-      getGameInfo: jest.fn(),
-      getSettings: jest.fn()
+      getGame: jest.fn()
     }
   }
 }))
@@ -120,23 +116,33 @@ describe('protocol.ts --no-gui behavior', () => {
   const mockGameSettings = {
     ignoreGameUpdates: false
   }
+  const emptyGameInfoMock = { getGameInfo: () => ({}) }
 
   beforeEach(() => {
     jest.clearAllMocks()
     mockHideWindowOnProtocolLaunch.mockReturnValue(false)
     mockMainWindow.isVisible.mockReturnValue(true)
+
+    const gameMock = {
+      getGameInfo: () => mockGameInfo,
+      getSettings: () => mockGameSettings
+    }
+
     ;(getMainWindow as jest.Mock).mockReturnValue(mockMainWindow)
-    ;(gameManagerMap.legendary.getGameInfo as jest.Mock).mockReturnValue(
-      mockGameInfo
-    )
-    ;(gameManagerMap.legendary.getSettings as jest.Mock).mockResolvedValue(
-      mockGameSettings
+    ;(libraryManagerMap.legendary.getGame as jest.Mock).mockReturnValue(
+      gameMock
     )
 
     // Mock other game managers to return empty objects
-    ;(gameManagerMap.gog.getGameInfo as jest.Mock).mockReturnValue({})
-    ;(gameManagerMap.nile.getGameInfo as jest.Mock).mockReturnValue({})
-    ;(gameManagerMap.sideload.getGameInfo as jest.Mock).mockReturnValue({})
+    ;(libraryManagerMap.gog.getGame as jest.Mock).mockReturnValue(
+      emptyGameInfoMock
+    )
+    ;(libraryManagerMap.nile.getGame as jest.Mock).mockReturnValue(
+      emptyGameInfoMock
+    )
+    ;(libraryManagerMap.sideload.getGame as jest.Mock).mockReturnValue(
+      emptyGameInfoMock
+    )
   })
 
   describe('when game is not installed', () => {
@@ -235,7 +241,9 @@ describe('protocol.ts --no-gui behavior', () => {
 
     test('should handle missing game info', async () => {
       // Mock gameManagerMap to return empty object for missing games
-      ;(gameManagerMap.legendary.getGameInfo as jest.Mock).mockReturnValue({})
+      ;(libraryManagerMap.legendary.getGame as jest.Mock).mockReturnValue(
+        emptyGameInfoMock
+      )
 
       await handleProtocol(['heroic://launch/nonexistent-game'])
 

--- a/src/backend/downloadmanager/downloadqueue.ts
+++ b/src/backend/downloadmanager/downloadqueue.ts
@@ -1,4 +1,4 @@
-import { gameManagerMap, libraryManagerMap } from 'backend/storeManagers'
+import { libraryManagerMap } from 'backend/storeManagers'
 import { TypeCheckedStoreBackend } from './../electron_store'
 import { logError, logInfo, LogPrefix, logWarning } from 'backend/logger'
 import { getFileSize, removeFolder, sendGameStatusUpdate } from '../utils'
@@ -243,7 +243,9 @@ function cancelCurrentDownload({ removeDownloaded = false }) {
 
     if (removeDownloaded) {
       const { appName, runner } = currentElement.params
-      const { folder_name } = gameManagerMap[runner].getGameInfo(appName)
+      const { folder_name } = libraryManagerMap[runner]
+        .getGame(appName)
+        .getGameInfo()
       if (folder_name) {
         removeFolder(currentElement.params.path, folder_name)
       }
@@ -273,7 +275,7 @@ function resumeCurrentDownload() {
 function stopCurrentDownload() {
   const { appName, runner } = currentElement!.params
   callAbortController(appName)
-  gameManagerMap[runner].stop(appName, false)
+  libraryManagerMap[runner].getGame(appName).stop(false)
 }
 
 // notify the user based on the status of the element and the status of the queue
@@ -285,9 +287,9 @@ function processNotification(element: DMQueueElement, status: DMStatus) {
   ) {
     return
   }
-  const { title } = gameManagerMap[element.params.runner].getGameInfo(
-    element.params.appName
-  )
+  const { title } = libraryManagerMap[element.params.runner]
+    .getGame(element.params.appName)
+    .getGameInfo()
 
   if (status === 'abort') {
     if (isPaused()) {

--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -1,4 +1,4 @@
-import { gameManagerMap } from 'backend/storeManagers'
+import { libraryManagerMap } from 'backend/storeManagers'
 import { logError, LogPrefix, logWarning } from 'backend/logger'
 import {
   downloadFile,
@@ -30,7 +30,7 @@ async function installQueueElement(params: InstallParams): Promise<{
     build,
     branch
   } = params
-  const { title } = gameManagerMap[runner].getGameInfo(appName)
+  const { title } = libraryManagerMap[runner].getGame(appName).getGameInfo()
 
   if (!isOnline()) {
     logWarning(
@@ -84,15 +84,17 @@ async function installQueueElement(params: InstallParams): Promise<{
   try {
     downloadFixesFor(appName, runner)
 
-    const { status, error } = await gameManagerMap[runner].install(appName, {
-      path: path.replaceAll("'", ''),
-      installDlcs,
-      sdlList: sdlList.filter((el) => el !== ''),
-      platformToInstall,
-      installLanguage,
-      build,
-      branch
-    })
+    const { status, error } = await libraryManagerMap[runner]
+      .getGame(appName)
+      .install({
+        path: path.replaceAll("'", ''),
+        installDlcs,
+        sdlList: sdlList.filter((el) => el !== ''),
+        platformToInstall,
+        installLanguage,
+        build,
+        branch
+      })
 
     if (status === 'error') {
       errorMessage(error ?? '')
@@ -116,7 +118,7 @@ async function updateQueueElement(params: InstallParams): Promise<{
   error?: string | undefined
 }> {
   const { appName, runner } = params
-  const { title } = gameManagerMap[runner].getGameInfo(appName)
+  const { title } = libraryManagerMap[runner].getGame(appName).getGameInfo()
 
   if (!isOnline()) {
     logWarning(
@@ -160,7 +162,7 @@ async function updateQueueElement(params: InstallParams): Promise<{
   }
 
   try {
-    const { status } = await gameManagerMap[runner].update(appName, {
+    const { status } = await libraryManagerMap[runner].getGame(appName).update({
       build: params.build,
       branch: params.branch,
       language: params.installLanguage,

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -33,7 +33,8 @@ import {
   sendGameStatusUpdate,
   checkWineBeforeLaunch,
   isMacSonomaOrHigher,
-  askForceUninstall
+  askForceUninstall,
+  getGame
 } from './utils'
 import {
   createGameLogWriter,
@@ -45,7 +46,6 @@ import {
   logWarning
 } from './logger'
 import { GlobalConfig } from './config'
-import { GameConfig } from './game_config'
 import { DXVK, runWineCommandOnGame, Winetricks } from './tools'
 import gogSetup from './storeManagers/gog/setup'
 import nileSetup from './storeManagers/nile/setup'
@@ -54,7 +54,7 @@ import shlex from 'shlex'
 import { isOnline } from './online_monitor'
 import { showDialogBoxModalAuto } from './dialog/dialog'
 import { legendarySetup } from './storeManagers/legendary/setup'
-import { gameManagerMap, libraryManagerMap } from 'backend/storeManagers'
+import { libraryManagerMap } from 'backend/storeManagers'
 import * as VDF from '@node-steam/vdf'
 import { readFileSync, writeFileSync } from 'fs'
 import { LegendaryCommand } from './storeManagers/legendary/commands'
@@ -100,6 +100,7 @@ import { gameAnticheatInfo } from './anticheat/utils'
 import type { PartialDeep } from 'type-fest'
 import type LogWriter from './logger/log_writer'
 import { isEnabled } from './storeManagers/legendary/eos_overlay/eos_overlay'
+import { Game } from 'common/types/game_manager'
 
 let powerDisplayId: number | null
 
@@ -110,10 +111,14 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   skipVersionCheck,
   args
 }) => {
-  const game = gameManagerMap[runner].getGameInfo(appName)
+  const game = libraryManagerMap[runner].getGame(appName)
+  const gameInfo = game.getGameInfo()
 
-  if (game.install.install_path && !existsSync(game.install.install_path)) {
-    await askForceUninstall(runner, appName)
+  if (
+    gameInfo.install.install_path &&
+    !existsSync(gameInfo.install.install_path)
+  ) {
+    await askForceUninstall(game)
 
     sendGameStatusUpdate({
       appName,
@@ -124,24 +129,24 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     return { status: 'abort' }
   }
 
-  const gameSettings = await gameManagerMap[runner].getSettings(appName)
+  const gameSettings = await game.getSettings()
   const { autoSyncSaves, savesPath, gogSaves = [] } = gameSettings
 
   if (!launchArguments && gameSettings.lastUsedLaunchOption) {
     launchArguments = gameSettings.lastUsedLaunchOption
   }
 
-  const { title } = game
+  const { title } = gameInfo
 
   const { minimizeOnLaunch, noTrayIcon } = GlobalConfig.get().getSettings()
 
   const startPlayingDate = new Date()
 
-  if (!tsStore.has(game.app_name)) {
-    tsStore.set(`${game.app_name}.firstPlayed`, startPlayingDate.toISOString())
+  if (!tsStore.has(appName)) {
+    tsStore.set(`${appName}.firstPlayed`, startPlayingDate.toISOString())
   }
 
-  logInfo(`Launching ${title} (${game.app_name})`, LogPrefix.Backend)
+  logInfo(`Launching ${title} (${appName})`, LogPrefix.Backend)
 
   if (autoSyncSaves && isOnline()) {
     sendGameStatusUpdate({
@@ -151,12 +156,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     })
     logInfo(`Downloading saves for ${title}`, LogPrefix.Backend)
     try {
-      await gameManagerMap[runner].syncSaves(
-        appName,
-        '--skip-upload',
-        savesPath,
-        gogSaves
-      )
+      await game.syncSaves('--skip-upload', savesPath, gogSaves)
       logInfo(`Saves for ${title} downloaded`, LogPrefix.Backend)
     } catch (error) {
       logError(
@@ -183,7 +183,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     powerDisplayId = powerSaveBlocker.start('prevent-display-sleep')
   }
 
-  const logWriter = await createGameLogWriter(game.app_name, game.runner)
+  const logWriter = await createGameLogWriter(appName, runner)
 
   if (!gameSettings.verboseLogs) {
     await logWriter.logWarning('IMPORTANT: Logs are disabled', {
@@ -195,12 +195,12 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     )
   }
 
-  const isNative = gameManagerMap[runner].isNative(appName)
+  const isNative = game.isNative()
 
   // check if isNative, if not, check if wine is valid
   if (!isNative) {
     const isWineOkToLaunch = await checkWineBeforeLaunch(
-      game,
+      gameInfo,
       gameSettings,
       logWriter
     )
@@ -223,7 +223,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     }
   }
 
-  await runBeforeLaunchScript(game, gameSettings, logWriter)
+  await runBeforeLaunchScript(gameInfo, gameSettings, logWriter)
 
   sendGameStatusUpdate({
     appName,
@@ -231,8 +231,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     status: 'launching'
   })
 
-  const command = gameManagerMap[runner].launch(
-    appName,
+  const command = game.launch(
     logWriter,
     launchArguments,
     args,
@@ -255,7 +254,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
       return false
     })
     .finally(async () => {
-      await runAfterLaunchScript(game, gameSettings, logWriter)
+      await runAfterLaunchScript(gameInfo, gameSettings, logWriter)
       await logWriter.close()
     })
 
@@ -282,11 +281,9 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   const { disablePlaytimeSync } = GlobalConfig.get().getSettings()
   if (runner === 'gog') {
     if (!disablePlaytimeSync) {
-      await gameManagerMap['gog'].updateGOGPlaytime(
-        appName,
-        startPlayingDate,
-        finishedPlayingDate
-      )
+      await libraryManagerMap['gog']
+        .getGame(appName)
+        .updateGOGPlaytime(startPlayingDate, finishedPlayingDate)
     } else {
       logWarning(
         'Posting playtime session to server skipped - playtime sync disabled',
@@ -294,7 +291,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
       )
     }
   }
-  await addRecentGame(game)
+  await addRecentGame(gameInfo)
 
   if (autoSyncSaves && isOnline()) {
     sendGameStatusUpdate({
@@ -311,12 +308,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
 
     logInfo(`Uploading saves for ${title}`, LogPrefix.Backend)
     try {
-      await gameManagerMap[runner].syncSaves(
-        appName,
-        '--skip-download',
-        savesPath,
-        gogSaves
-      )
+      await game.syncSaves('--skip-download', savesPath, gogSaves)
       logInfo(`Saves uploaded for ${title}`, LogPrefix.Backend)
     } catch (error) {
       logError(
@@ -526,7 +518,9 @@ async function prepareLaunch(
     'Launching',
     `"${gameInfo.title}" (${gameInfo.runner})`
   ])
-  const native = gameManagerMap[gameInfo.runner].isNative(gameInfo.app_name)
+  const native = libraryManagerMap[gameInfo.runner]
+    .getGame(gameInfo.app_name)
+    .isNative()
   await logWriter.logInfo(['Native?', native])
 
   const isThirdPartyManagedApp = gameInfo && !!gameInfo.thirdPartyManagedApp
@@ -811,19 +805,16 @@ async function getCrossoverBottleFolder(gameSettings: GameSettings) {
 }
 
 async function prepareWineLaunch(
-  runner: Runner,
-  appName: string,
+  game: Game,
   logWriter: LogWriter
 ): Promise<{
   success: boolean
   failureReason?: string
   envVars?: Record<string, string>
 }> {
-  const gameInfo = gameManagerMap[runner].getGameInfo(appName)
+  const gameInfo = game.getGameInfo()
 
-  const gameSettings =
-    GameConfig.get(appName).config ||
-    (await GameConfig.get(appName).getSettings())
+  const gameSettings = await game.getSettings()
 
   if (!(await validWine(gameSettings.wineVersion))) {
     const defaultWine = GlobalConfig.get().getSettings().wineVersion
@@ -864,7 +855,7 @@ async function prepareWineLaunch(
   }
 
   logWriter.logInfo(
-    Winetricks.listInstalled(runner, appName).then((installedPackages) => {
+    Winetricks.listInstalled(game).then((installedPackages) => {
       const packagesString = installedPackages.join(', ')
       return `Winetricks packages: ${packagesString}\n\n`
     })
@@ -873,8 +864,8 @@ async function prepareWineLaunch(
   // We only want to log this for legendary on Linux
   // On windows, the overlay is installed globally
   // On mac, the overlay doesn't work
-  if (runner === 'legendary' && isLinux) {
-    const checkEOSOverlayStatusPromise = isEnabled(appName)
+  if (gameInfo.runner === 'legendary' && isLinux) {
+    const checkEOSOverlayStatusPromise = isEnabled(gameInfo.app_name)
 
     // The first time a game runs, the overlay is not enabled yet at this point
     void logWriter.logInfo(
@@ -907,14 +898,14 @@ async function prepareWineLaunch(
     const appsNamesPath = join(prefixOrBottleFolder, 'installed_games')
     if (!existsSync(appsNamesPath)) {
       mkdirSync(prefixOrBottleFolder, { recursive: true })
-      writeFileSync(appsNamesPath, JSON.stringify([appName]), 'utf-8')
+      writeFileSync(appsNamesPath, JSON.stringify([gameInfo.app_name]), 'utf-8')
       hasUpdated = true
     } else {
       const installedGames: string[] = JSON.parse(
         readFileSync(appsNamesPath, 'utf-8')
       )
-      if (!installedGames.includes(appName)) {
-        installedGames.push(appName)
+      if (!installedGames.includes(gameInfo.app_name)) {
+        installedGames.push(gameInfo.app_name)
         writeFileSync(appsNamesPath, JSON.stringify(installedGames), 'utf-8')
         hasUpdated = true
       }
@@ -926,26 +917,29 @@ async function prepareWineLaunch(
       ['Created/Updated Wineprefix at', gameSettings.winePrefix],
       LogPrefix.Backend
     )
-    if (runner === 'gog') {
-      await gogSetup(appName)
+    if (gameInfo.runner === 'gog') {
+      await gogSetup(gameInfo.app_name)
       sendFrontendMessage('gameStatusUpdate', {
-        appName,
+        appName: gameInfo.app_name,
         runner: 'gog',
         status: 'launching'
       })
     }
-    if (runner === 'nile') {
-      await nileSetup(appName)
+    if (gameInfo.runner === 'nile') {
+      await nileSetup(gameInfo.app_name)
     }
-    if (runner === 'legendary') {
-      await legendarySetup(appName, logWriter)
+    if (gameInfo.runner === 'legendary') {
+      await legendarySetup(gameInfo.app_name, logWriter)
     }
 
-    await installFixes(appName, runner)
+    await installFixes(gameInfo.app_name, gameInfo.runner)
   }
 
   try {
-    if (runner === 'gog' && experimentalFeatures?.cometSupport !== false) {
+    if (
+      gameInfo.runner === 'gog' &&
+      experimentalFeatures?.cometSupport !== false
+    ) {
       const galaxyCommWinePath =
         'C:\\ProgramData\\GOG.com\\Galaxy\\redists\\GalaxyCommunication.exe'
       const communicationDest = await getWinePath({
@@ -1047,7 +1041,7 @@ async function installFixes(appName: string, runner: Runner) {
   }
 
   if (knownFixes.runInPrefix) {
-    const gameInfo = gameManagerMap[runner].getGameInfo(appName)
+    const gameInfo = getGame(appName, runner).getGameInfo()
 
     sendGameStatusUpdate({
       appName,
@@ -1818,11 +1812,11 @@ async function callRunner(
     })
 
     child.on('close', (code, signal) => {
-      errorHandler({
-        error: `${stdout.join().concat(stderr.join())}`,
-        runner: runner.name,
-        appName
-      })
+      errorHandler(
+        `${stdout.join().concat(stderr.join())}`,
+        appName,
+        runner.name
+      )
 
       if (signal && !child.killed) {
         rej(new Error(`Process terminated with signal ${signal}`))
@@ -1855,11 +1849,7 @@ async function callRunner(
         }
       }
 
-      errorHandler({
-        error: `${error}`,
-        runner: runner.name,
-        appName
-      })
+      errorHandler(error, appName, runner.name)
 
       logError(
         ['Error running', 'command', `"${safeCommand}":`, error],

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -56,7 +56,8 @@ import {
   checkRosettaInstall,
   writeConfig,
   createNecessaryFolders,
-  clearAchievementCache
+  clearAchievementCache,
+  getGame
 } from './utils'
 import { startPlausible } from './utils/plausible'
 
@@ -100,7 +101,6 @@ import { createMainWindow, getMainWindow, isFrameless } from './main_window'
 import { playtimeSyncQueue } from './storeManagers/gog/electronStores'
 import {
   autoUpdate,
-  gameManagerMap,
   initStoreManagers,
   libraryManagerMap
 } from './storeManagers'
@@ -375,7 +375,7 @@ if (!gotTheLock) {
     // Make sure lock is not present when starting up
     playtimeSyncQueue.delete('lock')
     if (!settings.disablePlaytimeSync) {
-      runOnceWhenOnline(() => gameManagerMap['gog'].syncQueuedPlaytimeGOG())
+      runOnceWhenOnline(() => libraryManagerMap['gog'].syncQueuedPlaytime())
     } else {
       logDebug('Skipping playtime sync queue upload - playtime sync disabled', {
         prefix: LogPrefix.Backend
@@ -728,7 +728,7 @@ addListener('createNewWindow', (e, url) => {
 
 addHandler('isGameAvailable', async (e, args) => {
   const { appName, runner } = args
-  return gameManagerMap[runner].isGameAvailable(appName)
+  return libraryManagerMap[runner].getGame(appName).isGameAvailable()
 })
 
 addHandler('getGameInfo', async (event, appName, runner) => {
@@ -739,7 +739,7 @@ addHandler('getGameInfo', async (event, appName, runner) => {
   ) {
     return null
   }
-  const tempGameInfo = gameManagerMap[runner].getGameInfo(appName)
+  const tempGameInfo = libraryManagerMap[runner].getGame(appName).getGameInfo()
   // The game managers return an empty object if they couldn't fetch the game
   // info, since most of the backend assumes getting it can never fail (and
   // an empty object is a little easier to work with than `null`)
@@ -752,9 +752,7 @@ addHandler('getGameInfo', async (event, appName, runner) => {
 addHandler(
   'getAchievements',
   async (event, appName, runner, lang = 'en-US') => {
-    if (runner === 'gog')
-      return gameManagerMap['gog'].getAchievements(appName, lang)
-    return []
+    return getGame(appName, runner).getAchievements?.(lang) ?? []
   }
 )
 
@@ -766,12 +764,12 @@ addHandler('getExtraInfo', async (event, appName, runner) => {
   ) {
     return null
   }
-  return gameManagerMap[runner].getExtraInfo(appName)
+  return libraryManagerMap[runner].getGame(appName).getExtraInfo()
 })
 
 addHandler('getGameSettings', async (event, appName, runner) => {
   try {
-    return await gameManagerMap[runner].getSettings(appName)
+    return await libraryManagerMap[runner].getGame(appName).getSettings()
   } catch (error) {
     logError(error, LogPrefix.Backend)
     return null
@@ -955,10 +953,10 @@ addHandler('repair', async (event, appName, runner) => {
     status: 'repairing'
   })
 
-  const { title } = gameManagerMap[runner].getGameInfo(appName)
+  const { title } = libraryManagerMap[runner].getGame(appName).getGameInfo()
 
   try {
-    await gameManagerMap[runner].repair(appName)
+    await libraryManagerMap[runner].getGame(appName).repair()
   } catch (error) {
     notify({
       title,
@@ -985,10 +983,12 @@ addHandler(
       status: 'moving'
     })
 
-    const { title } = gameManagerMap[runner].getGameInfo(appName)
+    const { title } = libraryManagerMap[runner].getGame(appName).getGameInfo()
     notify({ title, body: i18next.t('notify.moving', 'Moving Game') })
 
-    const moveRes = await gameManagerMap[runner].moveInstall(appName, path)
+    const moveRes = await libraryManagerMap[runner]
+      .getGame(appName)
+      .moveInstall(path)
     if (moveRes.status === 'error') {
       notify({
         title,
@@ -1052,7 +1052,7 @@ addHandler(
       }
     }
 
-    const title = gameManagerMap[runner].getGameInfo(appName).title
+    const { title } = libraryManagerMap[runner].getGame(appName).getGameInfo()
     sendGameStatusUpdate({
       appName,
       runner,
@@ -1072,11 +1072,9 @@ addHandler(
     }
 
     try {
-      const { abort, error } = await gameManagerMap[runner].importGame(
-        appName,
-        path,
-        platform
-      )
+      const { abort, error } = await libraryManagerMap[runner]
+        .getGame(appName)
+        .importGame(path, platform)
       if (abort || error) {
         abortMessage()
         return { status: 'done' }
@@ -1088,7 +1086,7 @@ addHandler(
     }
 
     if (winePrefix && wineVersion) {
-      const gameSettings = await gameManagerMap[runner].getSettings(appName)
+      const gameSettings = await getGame(appName, runner).getSettings()
       writeConfig(appName, {
         ...gameSettings,
         winePrefix,
@@ -1113,7 +1111,7 @@ addHandler(
 
 addHandler('kill', async (event, appName, runner) => {
   callAbortController(appName)
-  return gameManagerMap[runner].stop(appName)
+  return libraryManagerMap[runner].getGame(appName).stop()
 })
 
 addHandler('changeInstallPath', async (event, { appName, path, runner }) => {
@@ -1129,7 +1127,7 @@ addHandler('egsSync', async (event, args) => {
 })
 
 addHandler('syncGOGSaves', async (event, gogSaves, appName, arg) =>
-  gameManagerMap['gog'].syncSaves(appName, arg, '', gogSaves)
+  libraryManagerMap['gog'].getGame(appName).syncSaves(arg, '', gogSaves)
 )
 
 addHandler('getLaunchOptions', async (event, appName, runner) => {
@@ -1174,7 +1172,9 @@ addHandler('syncSaves', async (event, { arg = '', path, appName, runner }) => {
     return 'App is offline, cannot sync saves!'
   }
 
-  const output = await gameManagerMap[runner].syncSaves(appName, arg, path)
+  const output = await libraryManagerMap[runner]
+    .getGame(appName)
+    .syncSaves(arg, path)
   logInfo(output, LogPrefix.Backend)
   return output
 })
@@ -1377,7 +1377,7 @@ addHandler('getAllGameOverrides', async () => {
 })
 
 addHandler('isNative', (e, { appName, runner }) => {
-  return gameManagerMap[runner].isNative(appName)
+  return libraryManagerMap[runner].getGame(appName).isNative()
 })
 
 addHandler('pathExists', async (e, path: string) => {
@@ -1422,7 +1422,7 @@ addHandler(
       return
     }
     if (runner === 'gog') {
-      return gameManagerMap['gog'].getGOGPlaytime(appName)
+      return libraryManagerMap[runner].getGame(appName).getGOGPlaytime()
     }
 
     return
@@ -1430,14 +1430,14 @@ addHandler(
 )
 
 addHandler('getPrivateBranchPassword', (e, appName) =>
-  gameManagerMap['gog'].getBranchPassword(appName)
+  libraryManagerMap['gog'].getGame(appName).getBranchPassword()
 )
 addHandler('setPrivateBranchPassword', (e, appName, password) =>
-  gameManagerMap['gog'].setBranchPassword(appName, password)
+  libraryManagerMap['gog'].getGame(appName).setBranchPassword(password)
 )
 
 addHandler('getAvailableCyberpunkMods', async () =>
-  gameManagerMap['gog'].getCyberpunkMods()
+  libraryManagerMap['gog'].getCyberpunkMods()
 )
 addHandler('setCyberpunkModConfig', async (e, props) =>
   libraryManagerMap['gog'].setCyberpunkModConfig(props)

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -4,7 +4,7 @@ import i18next from 'i18next'
 import { GameInfo, LaunchOption, Runner } from 'common/types'
 import { getMainWindow } from './main_window'
 import { sendFrontendMessage } from './ipc'
-import { gameManagerMap } from './storeManagers'
+import { libraryManagerMap } from './storeManagers'
 import { launchEventCallback } from './launcher'
 import { z } from 'zod'
 import { windowIcon } from './constants/paths'
@@ -110,7 +110,9 @@ async function handleLaunch(url: URL) {
   }
 
   const { is_installed, title } = gameInfo
-  const settings = await gameManagerMap[gameInfo.runner].getSettings(appName)
+  const settings = await libraryManagerMap[gameInfo.runner]
+    .getGame(appName)
+    .getSettings()
   const hideForThisLaunch =
     urlRequestsNoGui(url) ||
     GlobalConfig.get().getSettings().hideWindowOnProtocolLaunch === true
@@ -183,11 +185,13 @@ function findGame(
   if (!appName) return
 
   // If a runner is specified, search for the game in that runner and return it (if found)
-  if (runner) return gameManagerMap[runner].getGameInfo(appName)
+  if (runner) return libraryManagerMap[runner].getGame(appName).getGameInfo()
 
   // If no runner is specified, search for the game in all runners and return the first one found
   for (const runner of RUNNERS.options) {
-    const maybeGameInfo = gameManagerMap[runner].getGameInfo(appName)
+    const maybeGameInfo = libraryManagerMap[runner]
+      .getGame(appName)
+      .getGameInfo()
     if (maybeGameInfo.app_name) return maybeGameInfo
   }
   return

--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -10,7 +10,7 @@ import {
   writeFileSync
 } from 'graceful-fs'
 import { app } from 'electron'
-import { gameManagerMap, libraryManagerMap } from 'backend/storeManagers'
+import { libraryManagerMap } from 'backend/storeManagers'
 import { LegendaryAppName } from './storeManagers/legendary/commands/base'
 import { legendaryInstalled } from './storeManagers/legendary/constants'
 
@@ -34,8 +34,8 @@ async function getDefaultSavePath(
 }
 
 async function getDefaultLegendarySavePath(appName: string): Promise<string> {
-  const { save_folder, save_path } =
-    gameManagerMap['legendary'].getGameInfo(appName)
+  const game = libraryManagerMap['legendary'].getGame(appName)
+  const { save_folder, save_path } = game.getGameInfo()
   logInfo(
     ['Computing save path for save folder', save_folder],
     LogPrefix.Legendary
@@ -62,10 +62,8 @@ async function getDefaultLegendarySavePath(appName: string): Promise<string> {
     }
   }
 
-  if (!gameManagerMap['legendary'].isNative(appName)) {
-    await verifyWinePrefix(
-      await gameManagerMap['legendary'].getSettings(appName)
-    )
+  if (!game.isNative()) {
+    await verifyWinePrefix(await game.getSettings())
   }
 
   logInfo(['Computing default save path for', appName], LogPrefix.Legendary)
@@ -80,11 +78,7 @@ async function getDefaultLegendarySavePath(appName: string): Promise<string> {
     {
       abortId: appName + '-savePath',
       logMessagePrefix: 'Getting default save path',
-      env: gameManagerMap['legendary'].isNative(appName)
-        ? {}
-        : setupWineEnvVars(
-            await gameManagerMap['legendary'].getSettings(appName)
-          )
+      env: game.isNative() ? {} : setupWineEnvVars(await game.getSettings())
     }
   )
 
@@ -108,9 +102,9 @@ async function getDefaultGogSavePaths(
   appName: string,
   alreadyDefinedGogSaves: GOGCloudSavesLocation[]
 ): Promise<GOGCloudSavesLocation[]> {
-  const gameSettings = await gameManagerMap['gog'].getSettings(appName)
-  const installInfo = gameManagerMap['gog'].getGameInfo(appName)
-    .install as InstalledInfo
+  const game = libraryManagerMap['gog'].getGame(appName)
+  const gameSettings = await game.getSettings()
+  const installInfo = game.getGameInfo().install as InstalledInfo
   const gog_save_location = await libraryManagerMap['gog'].getSaveSyncLocation(
     appName,
     installInfo
@@ -146,7 +140,7 @@ async function getDefaultGogSavePaths(
     APPLICATION_DATA_LOCAL_LOW: '%APPDATA%\\..\\LocalLow',
     APPLICATION_DATA_ROAMING: '%APPDATA%',
     APPLICATION_SUPPORT: '$HOME/Library/Application Support',
-    DOCUMENTS: gameManagerMap['gog'].isNative(appName)
+    DOCUMENTS: game.isNative()
       ? app.getPath('documents')
       : '%USERPROFILE%\\Documents'
   } satisfies Record<SaveFolderVariable, string>
@@ -189,7 +183,7 @@ async function getDefaultGogSavePaths(
     // Path now contains no more GOG-defined variables, but might
     // still contain Windows (%NAME%) or Unix ($NAME) ones
     let absolutePath: string
-    if (!gameManagerMap['gog'].isNative(appName)) {
+    if (!game.isNative()) {
       absolutePath = await getWinePath({
         path: locationWithVariablesRemoved,
         gameSettings

--- a/src/backend/shortcuts/ipc_handler.ts
+++ b/src/backend/shortcuts/ipc_handler.ts
@@ -1,4 +1,3 @@
-import { gameManagerMap } from 'backend/storeManagers'
 import { existsSync } from 'graceful-fs'
 import { addListener, addHandler } from 'backend/ipc'
 import i18next from 'i18next'
@@ -7,13 +6,13 @@ import {
   isAddedToSteam,
   removeNonSteamGame
 } from './nonesteamgame/nonesteamgame'
-import { getInfo } from '../utils'
 import { shortcutFiles } from './shortcuts/shortcuts'
 import { notify } from 'backend/dialog/dialog'
 import { isMac } from 'backend/constants/environment'
+import { getGame } from '../utils'
 
 addListener('addShortcut', async (event, appName, runner, fromMenu) => {
-  gameManagerMap[runner].addShortcuts(appName, fromMenu)
+  getGame(appName, runner).addShortcuts(fromMenu)
 
   const body = i18next.t(
     'box.shortcuts.message',
@@ -32,7 +31,7 @@ addListener('addShortcut', async (event, appName, runner, fromMenu) => {
 })
 
 addHandler('shortcutsExists', (event, appName, runner) => {
-  const title = gameManagerMap[runner].getGameInfo(appName).title
+  const { title } = getGame(appName, runner).getGameInfo()
 
   const [desktopFile, menuFile] = shortcutFiles(title)
 
@@ -40,7 +39,7 @@ addHandler('shortcutsExists', (event, appName, runner) => {
 })
 
 addListener('removeShortcut', async (event, appName, runner) => {
-  gameManagerMap[runner].removeShortcuts(appName)
+  getGame(appName, runner).removeShortcuts()
 
   const body = i18next.t(
     'box.shortcuts.message-remove',
@@ -59,19 +58,16 @@ addListener('removeShortcut', async (event, appName, runner) => {
 })
 
 addHandler('addToSteam', async (event, appName, runner) => {
-  const gameInfo = getInfo(appName, runner)
-
-  return addNonSteamGame({
-    gameInfo
-  })
+  const game = getGame(appName, runner)
+  return addNonSteamGame(game)
 })
 
 addHandler('removeFromSteam', async (event, appName, runner) => {
-  const gameInfo = getInfo(appName, runner)
-  await removeNonSteamGame({ gameInfo })
+  const game = getGame(appName, runner)
+  await removeNonSteamGame(game)
 })
 
 addHandler('isAddedToSteam', async (event, appName, runner) => {
-  const gameInfo = getInfo(appName, runner)
-  return isAddedToSteam({ gameInfo })
+  const game = getGame(appName, runner)
+  return isAddedToSteam(game)
 })

--- a/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
+++ b/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
@@ -1,11 +1,11 @@
 import { readFileSync, copyFileSync, mkdirSync } from 'graceful-fs'
-import { GameInfo } from 'common/types'
 import { join } from 'path'
 import { DirResult, dirSync } from 'tmp'
 import { addNonSteamGame, removeNonSteamGame } from '../nonesteamgame'
 import { showDialogBoxModalAuto } from 'backend/dialog/dialog'
 import { GlobalConfig } from 'backend/config'
 import { logInfo, logError, logWarning } from 'backend/logger'
+import type { Game } from 'common/types/game_manager'
 
 jest.mock('backend/logger')
 jest.mock('backend/dialog/dialog')
@@ -15,6 +15,12 @@ jest.mock('backend/wiki_game_info/wiki_game_info')
 
 let tmpDir = {} as DirResult
 let tmpSteamUserConfigDir = ''
+
+function makeGameMock(title: string = 'MyGame', id: string = 'Game'): Game {
+  return {
+    getGameInfo: () => ({ title, app_name: id })
+  } as Game
+}
 
 function copyTestFile(file: string, alternativeUserPath = '') {
   const testFileDir = join(__dirname, 'test_data')
@@ -46,16 +52,14 @@ describe('NonSteamGame', () => {
     const shortcutFilePath = join(tmpSteamUserConfigDir, 'shortcuts.vdf')
 
     const contentBefore = readFileSync(shortcutFilePath).toString()
-    const game = { title: 'Discord', app_name: 'Discord' } as GameInfo
+    const game = makeGameMock('Discord', 'Discord')
 
-    await addNonSteamGame({
-      gameInfo: game
-    })
+    await addNonSteamGame(game)
 
     const contentAfter = readFileSync(shortcutFilePath).toString()
     expect(contentBefore).toStrictEqual(contentAfter)
     expect(logInfo).toBeCalledWith(
-      `${game.title} was successfully added to Steam.`,
+      `${game.getGameInfo().title} was successfully added to Steam.`,
       'Shortcuts'
     )
   })
@@ -63,37 +67,33 @@ describe('NonSteamGame', () => {
   test('Add and remove game to shortcuts.vdf', async () => {
     copyTestFile('shortcuts_valid.vdf')
     const shortcutFilePath = join(tmpSteamUserConfigDir, 'shortcuts.vdf')
-    const game = { title: 'MyGame', app_name: 'game' } as GameInfo
+    const game = makeGameMock()
     const contentBefore = readFileSync(shortcutFilePath).toString()
 
-    await addNonSteamGame({
-      gameInfo: game
-    })
+    await addNonSteamGame(game)
 
     const contentBetween = readFileSync(shortcutFilePath).toString()
 
-    await removeNonSteamGame({
-      gameInfo: game
-    })
+    await removeNonSteamGame(game)
 
     const contentAfter = readFileSync(shortcutFilePath).toString()
     expect(contentBefore).toStrictEqual(contentAfter)
     expect(contentBefore).not.toBe(contentBetween)
-    expect(contentBetween).toContain(game.title)
+    expect(contentBetween).toContain(game.getGameInfo().title)
     expect(logInfo).toBeCalledWith(
-      `${game.title} was successfully added to Steam.`,
+      `${game.getGameInfo().title} was successfully added to Steam.`,
       'Shortcuts'
     )
     expect(logInfo).toBeCalledWith(
-      `${game.title} was successfully removed from Steam.`,
+      `${game.getGameInfo().title} was successfully removed from Steam.`,
       'Shortcuts'
     )
     expect(logInfo).toBeCalledWith(
-      `Prepare Steam images for ${game.title}`,
+      `Prepare Steam images for ${game.getGameInfo().title}`,
       'Shortcuts'
     )
     expect(logInfo).toBeCalledWith(
-      `Remove Steam images for ${game.title}`,
+      `Remove Steam images for ${game.getGameInfo().title}`,
       'Shortcuts'
     )
   })
@@ -101,16 +101,12 @@ describe('NonSteamGame', () => {
   test('Create shortcuts.vdf if not exist', async () => {
     const shortcutFilePath = join(tmpSteamUserConfigDir, 'shortcuts.vdf')
 
-    const game = { title: 'MyGame', app_name: 'game' } as GameInfo
+    const game = makeGameMock()
 
     // add and remove to see if empty shortcuts.vdf is correctly created
-    await addNonSteamGame({
-      gameInfo: game
-    })
+    await addNonSteamGame(game)
 
-    await removeNonSteamGame({
-      gameInfo: game
-    })
+    await removeNonSteamGame(game)
 
     const contentAfter = readFileSync(shortcutFilePath)
 
@@ -121,80 +117,21 @@ describe('NonSteamGame', () => {
       Buffer.from([0, 115, 104, 111, 114, 116, 99, 117, 116, 115, 0, 8, 8])
     )
     expect(logInfo).toBeCalledWith(
-      `${game.title} was successfully added to Steam.`,
+      `${game.getGameInfo().title} was successfully added to Steam.`,
       'Shortcuts'
     )
     expect(logInfo).toBeCalledWith(
-      `${game.title} was successfully removed from Steam.`,
+      `${game.getGameInfo().title} was successfully removed from Steam.`,
       'Shortcuts'
     )
     expect(logInfo).toBeCalledWith(
-      `Prepare Steam images for ${game.title}`,
+      `Prepare Steam images for ${game.getGameInfo().title}`,
       'Shortcuts'
     )
     expect(logInfo).toBeCalledWith(
-      `Remove Steam images for ${game.title}`,
+      `Remove Steam images for ${game.getGameInfo().title}`,
       'Shortcuts'
     )
-  })
-
-  test('Catch corrupt shortcuts.vdf because of missing AppName', async () => {
-    copyTestFile('shortcuts_missing_appname.vdf')
-
-    const shortcutFilePath = join(tmpSteamUserConfigDir, 'shortcuts.vdf')
-
-    const game = {} as GameInfo
-
-    await addNonSteamGame({
-      gameInfo: game
-    })
-    expect(logInfo).not.toBeCalled()
-    expect(logError).toBeCalledWith(
-      `Can't add "${game.title}" to Steam user "steam_user". "${shortcutFilePath}" is corrupted!\n` +
-        'One of the game entries is missing the AppName parameter!',
-      'Shortcuts'
-    )
-    expect(showDialogBoxModalAuto).toBeCalled()
-  })
-
-  test('Catch corrupt shortcuts.vdf because of missing Exe', async () => {
-    copyTestFile('shortcuts_missing_exe.vdf')
-
-    const shortcutFilePath = join(tmpSteamUserConfigDir, 'shortcuts.vdf')
-
-    const game = {} as GameInfo
-
-    await addNonSteamGame({
-      gameInfo: game
-    })
-
-    expect(logInfo).not.toBeCalled()
-    expect(logError).toBeCalledWith(
-      `Can't add "${game.title}" to Steam user "steam_user". "${shortcutFilePath}" is corrupted!\n` +
-        'One of the game entries is missing the Exe parameter!',
-      'Shortcuts'
-    )
-    expect(showDialogBoxModalAuto).toBeCalled()
-  })
-
-  test('Catch corrupt shortcuts.vdf because of missing LaunchOptions', async () => {
-    copyTestFile('shortcuts_missing_launchoptions.vdf')
-
-    const shortcutFilePath = join(tmpSteamUserConfigDir, 'shortcuts.vdf')
-
-    const game = {} as GameInfo
-
-    await addNonSteamGame({
-      gameInfo: game
-    })
-
-    expect(logInfo).not.toBeCalled()
-    expect(logError).toBeCalledWith(
-      `Can't add "${game.title}" to Steam user "steam_user". "${shortcutFilePath}" is corrupted!\n` +
-        'One of the game entries is missing the LaunchOptions parameter!',
-      'Shortcuts'
-    )
-    expect(showDialogBoxModalAuto).toBeCalled()
   })
 
   test(
@@ -216,56 +153,52 @@ describe('NonSteamGame', () => {
       const shortcutFilePath = join(tmpSteamUserConfigDir, 'shortcuts.vdf')
       const shortcutFilePath2 = join(secondUserDir, 'shortcuts.vdf')
 
-      const game = { title: 'MyGame', app_name: 'game' } as GameInfo
+      const game = makeGameMock()
       const contentBefore = readFileSync(shortcutFilePath).toString()
       const contentBefore2 = readFileSync(shortcutFilePath2).toString()
 
-      await addNonSteamGame({
-        gameInfo: game
-      })
+      await addNonSteamGame(game)
 
       const contentBetween = readFileSync(shortcutFilePath).toString()
       const contentBetween2 = readFileSync(shortcutFilePath2).toString()
 
-      await removeNonSteamGame({
-        gameInfo: game
-      })
+      await removeNonSteamGame(game)
 
       const contentAfter = readFileSync(shortcutFilePath).toString()
       const contentAfter2 = readFileSync(shortcutFilePath2).toString()
 
       expect(contentBefore).toStrictEqual(contentAfter)
       expect(contentBefore).not.toBe(contentBetween)
-      expect(contentBetween).toContain(game.title)
+      expect(contentBetween).toContain(game.getGameInfo().title)
 
       expect(contentBefore2).toStrictEqual(contentAfter2)
       expect(contentBefore2).toStrictEqual(contentBetween2)
 
       expect(logInfo).toBeCalledWith(
-        `Prepare Steam images for ${game.title}`,
+        `Prepare Steam images for ${game.getGameInfo().title}`,
         'Shortcuts'
       )
       expect(logInfo).toBeCalledWith(
-        `Remove Steam images for ${game.title}`,
+        `Remove Steam images for ${game.getGameInfo().title}`,
         'Shortcuts'
       )
 
       expect(logInfo).toBeCalledTimes(2)
       expect(logWarning).toBeCalledWith(
-        `${game.title} could not be added to all found Steam users.`,
+        `${game.getGameInfo().title} could not be added to all found Steam users.`,
         'Shortcuts'
       )
       expect(logWarning).toBeCalledWith(
-        `${game.title} could not be removed from all found Steam users.`,
+        `${game.getGameInfo().title} could not be removed from all found Steam users.`,
         'Shortcuts'
       )
       expect(logError).toBeCalledWith(
-        `Can't add "${game.title}" to Steam user "steam_user2". "${shortcutFilePath2}" is corrupted!\n` +
+        `Can't add "${game.getGameInfo().title}" to Steam user "steam_user2". "${shortcutFilePath2}" is corrupted!\n` +
           'One of the game entries is missing the AppName parameter!',
         'Shortcuts'
       )
       expect(logError).toBeCalledWith(
-        `Can't remove "${game.title}" from Steam user "steam_user2". "${shortcutFilePath2}" is corrupted!\n` +
+        `Can't remove "${game.getGameInfo().title}" from Steam user "steam_user2". "${shortcutFilePath2}" is corrupted!\n` +
           'One of the game entries is missing the AppName parameter!',
         'Shortcuts'
       )
@@ -285,16 +218,14 @@ describe('NonSteamGame', () => {
 
       const shortcutFilePath = join(tmpSteamUserConfigDir, 'shortcuts.vdf')
 
-      const game = { title: 'MyGame', app_name: 'Game' } as GameInfo
+      const game = makeGameMock()
 
-      await addNonSteamGame({
-        gameInfo: game
-      })
+      await addNonSteamGame(game)
 
       const contentAfter = readFileSync(shortcutFilePath).toString()
       expect(contentAfter).toContain('MyGame')
       expect(logInfo).toBeCalledWith(
-        `${game.title} was successfully added to Steam.`,
+        `${game.getGameInfo().title} was successfully added to Steam.`,
         'Shortcuts'
       )
       expect(logError).not.toBeCalled()

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -7,7 +7,6 @@ import {
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'graceful-fs'
 import { readFileSync } from 'fs-extra'
 import { join } from 'path'
-import { GameInfo } from 'common/types'
 import { ShortcutsResult } from '../types'
 import { getIcon } from '../utils'
 import {
@@ -25,6 +24,7 @@ import { GlobalConfig } from '../../config'
 import { getWikiGameInfo } from 'backend/wiki_game_info/wiki_game_info'
 import { tsStore } from 'backend/constants/key_value_stores'
 import { isAppImage, isFlatpak, isWindows } from 'backend/constants/environment'
+import type { Game } from 'common/types/game_manager'
 
 const getSteamUserdataDir = async () => {
   const { defaultSteamPath } = GlobalConfig.get().getSettings()
@@ -200,21 +200,13 @@ function checkIfAlreadyAdded(object: Partial<ShortcutObject>, title: string) {
 
 /**
  * Adds a non-steam game to steam via editing shortcuts.vdf
- * @param gameInfo @see GameInfo of the game to add
+ * @param game the {@link Game} to add
  * @returns boolean
  */
-async function addNonSteamGame(props: {
-  gameInfo: GameInfo
-  steamUserdataDir?: string
-  bkgDataUrl?: string
-  bigPicDataUrl?: string
-}): Promise<boolean> {
+async function addNonSteamGame(game: Game): Promise<boolean> {
+  const gameInfo = game.getGameInfo()
   const steamUserdataDir = await getSteamUserdataDir()
-  const wikiInfo = await getWikiGameInfo(
-    props.gameInfo.title,
-    props.gameInfo.app_name,
-    props.gameInfo.runner
-  )
+  const wikiInfo = await getWikiGameInfo(game)
   const steamID = wikiInfo?.pcgamingwiki?.steamID ?? wikiInfo?.gamesdb?.steamID
 
   const { folders, error } = checkSteamUserDataDir(steamUserdataDir)
@@ -222,7 +214,7 @@ async function addNonSteamGame(props: {
   if (error) {
     logError(error, LogPrefix.Shortcuts)
     showErrorInFrontend({
-      gameTitle: props.gameInfo.title,
+      gameTitle: gameInfo.title,
       error
     })
     return false
@@ -249,20 +241,20 @@ async function addNonSteamGame(props: {
     const checkResult = checkIfShortcutObjectIsValid(content)
     if (!checkResult.success) {
       errors.push(
-        `Can't add "${props.gameInfo.title}" to Steam user "${folder}". "${shortcutsFile}" is corrupted!`,
+        `Can't add "${gameInfo.title}" to Steam user "${folder}". "${shortcutsFile}" is corrupted!`,
         ...checkResult.errors
       )
       continue
     }
 
-    if (checkIfAlreadyAdded(content, props.gameInfo.title) > -1) {
+    if (checkIfAlreadyAdded(content, gameInfo.title) > -1) {
       added = true
       continue
     }
 
     // add new Entry
     const newEntry = {} as ShortcutEntry
-    newEntry.AppName = props.gameInfo.title
+    newEntry.AppName = gameInfo.title
     newEntry.Exe = `"${app.getPath('exe')}"`
     newEntry.StartDir = `"${process.cwd()}"`
 
@@ -277,11 +269,11 @@ async function addNonSteamGame(props: {
 
     newEntry.appid = generateShortcutId(newEntry.Exe, newEntry.AppName)
 
-    await getIcon(props.gameInfo.app_name, props.gameInfo)
+    await getIcon(gameInfo.app_name, gameInfo)
       .then((path) => (newEntry.icon = path))
       .catch((error) =>
         logWarning(
-          [`Couldn't find a icon for ${props.gameInfo.title} with:`, error],
+          [`Couldn't find a icon for ${gameInfo.title} with:`, error],
           LogPrefix.Shortcuts
         )
       )
@@ -292,7 +284,7 @@ async function addNonSteamGame(props: {
         bigPictureAppID: generateAppId(newEntry.Exe, newEntry.AppName),
         otherGridAppID: generateShortAppId(newEntry.Exe, newEntry.AppName)
       },
-      gameInfo: props.gameInfo,
+      gameInfo,
       steamID: steamID
     })
 
@@ -302,7 +294,7 @@ async function addNonSteamGame(props: {
       args.push('--no-sandbox')
     }
 
-    const { runner, app_name } = props.gameInfo
+    const { runner, app_name } = gameInfo
 
     args.push(`"heroic://launch?appName=${app_name}&runner=${runner}"`)
     newEntry.LaunchOptions = args.join(' ')
@@ -316,9 +308,7 @@ async function addNonSteamGame(props: {
     newEntry.Devkit = false
     newEntry.DevkitOverrideAppID = false
 
-    const lastPlayed = tsStore.get_nodefault(
-      `${props.gameInfo.app_name}.lastPlayed`
-    )
+    const lastPlayed = tsStore.get_nodefault(`${gameInfo.app_name}.lastPlayed`)
     if (lastPlayed) {
       newEntry.LastPlayTime = new Date(lastPlayed)
     } else {
@@ -342,7 +332,7 @@ async function addNonSteamGame(props: {
     const errorMessage = errors.join('\n')
     logError(errorMessage, LogPrefix.Shortcuts)
     showErrorInFrontend({
-      gameTitle: props.gameInfo.title,
+      gameTitle: gameInfo.title,
       error: errorMessage
     })
     return false
@@ -350,20 +340,20 @@ async function addNonSteamGame(props: {
 
   if (errors.length === 0) {
     logInfo(
-      `${props.gameInfo.title} was successfully added to Steam.`,
+      `${gameInfo.title} was successfully added to Steam.`,
       LogPrefix.Shortcuts
     )
 
     const message = i18next.t('notify.finished.add.steam.success', {
       defaultValue:
         '{{game}} was successfully added to Steam. A restart of Steam is required for changes to take effect.',
-      game: props.gameInfo.title
+      game: gameInfo.title
     })
     notifyFrontend({ message, adding: true })
     return true
   } else {
     logWarning(
-      `${props.gameInfo.title} could not be added to all found Steam users.`,
+      `${gameInfo.title} could not be added to all found Steam users.`,
       LogPrefix.Shortcuts
     )
     logError(errors.join('\n'), LogPrefix.Shortcuts)
@@ -371,7 +361,7 @@ async function addNonSteamGame(props: {
     const message = i18next.t('notify.finished.add.steam.corrupt', {
       defaultValue:
         '{{game}} could not be added to all found Steam users. See logs for more info. A restart of Steam is required for changes to take effect.',
-      game: props.gameInfo.title
+      game: gameInfo.title
     })
     notifyFrontend({ message, adding: true })
     return true
@@ -384,10 +374,8 @@ async function addNonSteamGame(props: {
  * @param steamUserdataDir Path to steam userdata directory, optional
  * @returns none
  */
-async function removeNonSteamGame(props: {
-  gameInfo: GameInfo
-  steamUserdataDir?: string
-}): Promise<void> {
+async function removeNonSteamGame(game: Game): Promise<void> {
+  const gameInfo = game.getGameInfo()
   const steamUserdataDir = await getSteamUserdataDir()
   const { folders, error } = checkSteamUserDataDir(steamUserdataDir)
 
@@ -414,7 +402,7 @@ async function removeNonSteamGame(props: {
     const checkResult = checkIfShortcutObjectIsValid(content)
     if (!checkResult.success) {
       errors.push(
-        `Can't remove "${props.gameInfo.title}" from Steam user "${folder}". "${shortcutsFile}" is corrupted!`,
+        `Can't remove "${gameInfo.title}" from Steam user "${folder}". "${shortcutsFile}" is corrupted!`,
         ...checkResult.errors
       )
       continue
@@ -422,7 +410,7 @@ async function removeNonSteamGame(props: {
     // This is just to make TS happy, in reality checkIfShortcutObjectIsValid already checks for this array
     content.shortcuts = content.shortcuts || []
 
-    const index = checkIfAlreadyAdded(content, props.gameInfo.title)
+    const index = checkIfAlreadyAdded(content, gameInfo.title)
 
     if (index < 0) {
       continue
@@ -451,7 +439,7 @@ async function removeNonSteamGame(props: {
         bigPictureAppID: generateAppId(exe, appName),
         otherGridAppID: generateShortAppId(exe, appName)
       },
-      gameInfo: props.gameInfo
+      gameInfo
     })
   }
 
@@ -463,19 +451,19 @@ async function removeNonSteamGame(props: {
     }
 
     logInfo(
-      `${props.gameInfo.title} was successfully removed from Steam.`,
+      `${gameInfo.title} was successfully removed from Steam.`,
       LogPrefix.Shortcuts
     )
 
     const message = i18next.t('notify.finished.remove.steam.success', {
       defaultValue:
         '{{game}} was successfully removed from Steam. A restart of Steam is required for changes to take effect.',
-      game: props.gameInfo.title
+      game: gameInfo.title
     })
     notifyFrontend({ message, adding: false })
   } else {
     logWarning(
-      `${props.gameInfo.title} could not be removed from all found Steam users.`,
+      `${gameInfo.title} could not be removed from all found Steam users.`,
       LogPrefix.Shortcuts
     )
     logError(errors.join('\n'), LogPrefix.Shortcuts)
@@ -483,7 +471,7 @@ async function removeNonSteamGame(props: {
     const message = i18next.t('notify.finished.remove.steam.corrupt', {
       defaultValue:
         '{{game}} could not be removed from all found Steam users. See logs for more info. A restart of Steam is required for changes to take effect.',
-      game: props.gameInfo.title
+      game: gameInfo.title
     })
     notifyFrontend({ message, adding: false })
   }
@@ -491,16 +479,11 @@ async function removeNonSteamGame(props: {
 
 /**
  * Checks if a game was added to shortcuts.vdf
- * @param gameInfo @see GameInfo of the game to check
- * @param steamUserdataDir Path to steam userdata directory, optional
+ * @param game The {@link Game} to check
  * @returns boolean
  */
-async function isAddedToSteam(props: {
-  gameInfo: GameInfo
-  steamUserdataDir?: string
-}): Promise<boolean> {
-  const steamUserdataDir =
-    props.steamUserdataDir || (await getSteamUserdataDir())
+async function isAddedToSteam(game: Game): Promise<boolean> {
+  const steamUserdataDir = await getSteamUserdataDir()
 
   const { folders, error } = checkSteamUserDataDir(steamUserdataDir)
 
@@ -524,7 +507,7 @@ async function isAddedToSteam(props: {
       continue
     }
 
-    const index = checkIfAlreadyAdded(content, props.gameInfo.title)
+    const index = checkIfAlreadyAdded(content, game.getGameInfo().title)
 
     if (index < 0) {
       continue

--- a/src/backend/shortcuts/shortcuts/shortcuts.ts
+++ b/src/backend/shortcuts/shortcuts/shortcuts.ts
@@ -21,6 +21,7 @@ import sanitize from 'sanitize-filename'
 import { libraryManagerMap } from 'backend/storeManagers'
 import { isMac } from 'backend/constants/environment'
 import { userHome } from 'backend/constants/paths'
+import type { Game } from 'common/types/game_manager'
 
 /**
  * Adds a desktop shortcut to $HOME/Desktop and to /usr/share/applications
@@ -29,7 +30,8 @@ import { userHome } from 'backend/constants/paths'
  * @async
  * @public
  */
-async function addShortcuts(gameInfo: GameInfo, fromMenu?: boolean) {
+async function addShortcuts(game: Game, fromMenu?: boolean) {
+  const gameInfo = game.getGameInfo()
   if (gameInfo.install.is_dlc) return
 
   const { app_name, runner, title } = gameInfo
@@ -39,7 +41,7 @@ async function addShortcuts(gameInfo: GameInfo, fromMenu?: boolean) {
     GlobalConfig.get().getSettings()
 
   if (addSteamShortcuts) {
-    addNonSteamGame({ gameInfo })
+    addNonSteamGame(game)
   }
 
   const launchWithProtocol = `heroic://launch?appName=${app_name}&runner=${runner}`
@@ -118,7 +120,8 @@ Categories=Game;
  * @async
  * @public
  */
-async function removeShortcuts(gameInfo: GameInfo) {
+async function removeShortcuts(game: Game) {
+  const gameInfo = game.getGameInfo()
   if (gameInfo.install.is_dlc) return
 
   const [desktopFile, menuFile] = shortcutFiles(gameInfo.title)

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -22,7 +22,6 @@ import {
   ExecResult,
   InstallArgs,
   InstalledInfo,
-  InstallPlatform,
   InstallProgress,
   LaunchOption,
   GOGAchievement
@@ -37,7 +36,6 @@ import {
   syncStore
 } from './electronStores'
 import {
-  logDebug,
   logError,
   logInfo,
   LogPrefix,
@@ -67,14 +65,13 @@ import { removeNonSteamGame } from '../../shortcuts/nonesteamgame/nonesteamgame'
 import shlex from 'shlex'
 import {
   GOGCloudSavesLocation,
-  GOGSessionSyncQueueItem,
   GogInstallPlatform,
   UserData
 } from 'common/types/gog'
 import { t } from 'i18next'
 import { showDialogBoxModalAuto } from '../../dialog/dialog'
 import { sendFrontendMessage } from '../../ipc'
-import { GameManager, RemoveArgs } from 'common/types/game_manager'
+import { Game, RemoveArgs } from 'common/types/game_manager'
 import {
   getWineFlagsArray,
   isUmuSupported
@@ -82,7 +79,6 @@ import {
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import { isOnline, runOnceWhenOnline } from 'backend/online_monitor'
 import { readdir, readFile } from 'fs/promises'
-import { statSync } from 'fs'
 import ini from 'ini'
 import { getRequiredRedistList, updateRedist } from './redist'
 import { spawn } from 'child_process'
@@ -92,9 +88,15 @@ import { isLinux, isMac, isWindows } from 'backend/constants/environment'
 
 import type LogWriter from 'backend/logger/log_writer'
 
-export default class GOGGameManager implements GameManager {
-  async getExtraInfo(appName: string): Promise<ExtraInfo> {
-    const gameInfo = this.getGameInfo(appName)
+export default class GOGGame implements Game {
+  private readonly id: string
+
+  constructor(id: string) {
+    this.id = id
+  }
+
+  async getExtraInfo(): Promise<ExtraInfo> {
+    const gameInfo = this.getGameInfo()
     let targetPlatform: GogInstallPlatform = 'windows'
 
     if (isMac && gameInfo.is_mac_native) {
@@ -106,14 +108,14 @@ export default class GOGGameManager implements GameManager {
     }
 
     const reqs = await libraryManagerMap['gog'].createReqsArray(
-      appName,
+      this.id,
       targetPlatform
     )
-    const productInfo = await libraryManagerMap['gog'].getProductApi(appName, [
+    const productInfo = await libraryManagerMap['gog'].getProductApi(this.id, [
       'changelog'
     ])
 
-    const gamesData = await libraryManagerMap['gog'].getGamesData(appName)
+    const gamesData = await libraryManagerMap['gog'].getGamesData(this.id)
 
     let gogStoreUrl = gamesData?._links?.store.href
     const releaseDate =
@@ -136,17 +138,14 @@ export default class GOGGameManager implements GameManager {
     return extra
   }
 
-  async getAchievements(
-    appName: string,
-    lang = 'en-US'
-  ): Promise<GOGAchievement[]> {
-    const cached = achievementStore.get(appName)
+  async getAchievements(lang = 'en-US'): Promise<GOGAchievement[]> {
+    const cached = achievementStore.get(this.id)
     if (cached) return cached
 
     if (!GOGUser.isLoggedIn()) return []
     const credentials = await GOGUser.getCredentials()
     if (!credentials) return []
-    const url = `https://gameplay.gog.com/clients/${appName}/users/${credentials?.user_id}/achievements`
+    const url = `https://gameplay.gog.com/clients/${this.id}/users/${credentials?.user_id}/achievements`
 
     const response: AxiosResponse | null = await axiosClient
       .get(url, {
@@ -164,18 +163,18 @@ export default class GOGGameManager implements GameManager {
     }
 
     const achievements: GOGAchievement[] = response.data.items
-    achievementStore.set(appName, achievements)
+    achievementStore.set(this.id, achievements)
 
     return achievements
   }
 
-  getGameInfo(appName: string): GameInfo {
-    const info = libraryManagerMap['gog'].getGameInfo(appName)
+  getGameInfo(): GameInfo {
+    const info = libraryManagerMap['gog'].getGameInfo(this.id)
     if (!info) {
       logError(
         [
           'Could not get game info for',
-          `${appName},`,
+          `${this.id},`,
           'returning empty object. Something is probably gonna go wrong soon'
         ],
         LogPrefix.Gog
@@ -194,24 +193,19 @@ export default class GOGGameManager implements GameManager {
     return info
   }
 
-  async getSettings(appName: string): Promise<GameSettings> {
+  async getSettings(): Promise<GameSettings> {
     return (
-      GameConfig.get(appName).config ||
-      (await GameConfig.get(appName).getSettings())
+      GameConfig.get(this.id).config ||
+      (await GameConfig.get(this.id).getSettings())
     )
   }
 
-  async importGame(
-    appName: string,
-    folderPath: string,
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    platform: InstallPlatform
-  ): Promise<ExecResult> {
+  async importGame(folderPath: string): Promise<ExecResult> {
     const res = await libraryManagerMap['gog'].runRunnerCommand(
       ['import', folderPath],
       {
-        abortId: appName,
-        logMessagePrefix: `Importing ${appName}`
+        abortId: this.id,
+        logMessagePrefix: `Importing ${this.id}`
       }
     )
 
@@ -220,7 +214,7 @@ export default class GOGGameManager implements GameManager {
     }
 
     if (res.error) {
-      logError(['Failed to import', `${appName}:`, res.error], LogPrefix.Gog)
+      logError([`Failed to import ${this.id}:`, res.error], LogPrefix.Gog)
       return res
     }
 
@@ -229,9 +223,9 @@ export default class GOGGameManager implements GameManager {
         JSON.parse(res.stdout),
         folderPath
       )
-      this.addShortcuts(appName)
+      this.addShortcuts()
     } catch (error) {
-      logError(['Failed to import', `${appName}:`, error], LogPrefix.Gog)
+      logError([`Failed to import ${this.id}:`, error], LogPrefix.Gog)
     }
 
     return res
@@ -244,19 +238,18 @@ export default class GOGGameManager implements GameManager {
     diskSpeed: undefined,
     downSpeed: undefined
   })
-  private tmpProgress: Record<string, InstallProgress> = {}
+  private tmpProgress: InstallProgress | undefined
 
   onInstallOrUpdateOutput(
-    appName: string,
     action: 'installing' | 'updating',
     data: string,
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     totalDownloadSize = -1
   ) {
-    if (!Object.hasOwn(this.tmpProgress, appName)) {
-      this.tmpProgress[appName] = this.defaultTmpProgress()
+    if (!this.tmpProgress) {
+      this.tmpProgress = this.defaultTmpProgress()
     }
-    const progress = this.tmpProgress[appName]
+    const progress = this.tmpProgress
 
     // parse log for percent
     if (!progress.percent) {
@@ -304,7 +297,7 @@ export default class GOGGameManager implements GameManager {
     ) {
       logInfo(
         [
-          `Progress for ${this.getGameInfo(appName).title}:`,
+          `Progress for ${this.getGameInfo().title}:`,
           `${progress.percent}%/${progress.bytes}/${progress.eta}`.trim(),
           `Down: ${progress.downSpeed}MB/s / Disk: ${progress.diskSpeed}MB/s`
         ],
@@ -312,34 +305,31 @@ export default class GOGGameManager implements GameManager {
       )
 
       sendProgressUpdate({
-        appName: appName,
+        appName: this.id,
         runner: 'gog',
         status: action,
         progress: progress
       })
 
       // reset
-      this.tmpProgress[appName] = this.defaultTmpProgress()
+      this.tmpProgress = this.defaultTmpProgress()
     }
   }
 
-  async install(
-    appName: string,
-    {
-      path,
-      installDlcs,
-      platformToInstall,
-      installLanguage,
-      build,
-      branch
-    }: InstallArgs
-  ): Promise<{
+  async install({
+    path,
+    installDlcs,
+    platformToInstall,
+    installLanguage,
+    build,
+    branch
+  }: InstallArgs): Promise<{
     status: 'done' | 'error' | 'abort'
     error?: string
   }> {
     const { maxWorkers } = GlobalConfig.get().getSettings()
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
-    const privateBranchPassword = privateBranchesStore.get(appName, '')
+    const privateBranchPassword = privateBranchesStore.get(this.id, '')
     const withDlcs = installDlcs?.length
       ? ['--with-dlcs', '--dlcs', installDlcs.join(',')]
       : ['--skip-dlcs']
@@ -351,7 +341,7 @@ export default class GOGGameManager implements GameManager {
 
     if (!credentials) {
       logError(
-        ['Failed to install', `${appName}:`, 'No credentials'],
+        ['Failed to install', `${this.id}:`, 'No credentials'],
         LogPrefix.Gog
       )
       return { status: 'error' }
@@ -364,13 +354,13 @@ export default class GOGGameManager implements GameManager {
 
     const commandParts: string[] = [
       'download',
-      appName,
+      this.id,
       '--platform',
       installPlatform,
       '--path',
       path,
       '--support',
-      join(gogSupportPath, appName),
+      join(gogSupportPath, this.id),
       ...withDlcs,
       '--lang',
       String(installLanguage),
@@ -384,19 +374,19 @@ export default class GOGGameManager implements GameManager {
     }
 
     const onOutput = (data: string) => {
-      this.onInstallOrUpdateOutput(appName, 'installing', data)
+      this.onInstallOrUpdateOutput('installing', data)
     }
 
     const installLogWriter = await createGameLogWriter(
-      appName,
+      this.id,
       'gog',
       'install'
     )
     const res = await libraryManagerMap['gog'].runRunnerCommand(commandParts, {
-      abortId: appName,
+      abortId: this.id,
       logWriters: [installLogWriter],
       onOutput,
-      logMessagePrefix: `Installing ${appName}`
+      logMessagePrefix: `Installing ${this.id}`
     })
 
     if (res.abort) {
@@ -405,7 +395,7 @@ export default class GOGGameManager implements GameManager {
 
     if (res.error) {
       logError(
-        ['Failed to install GOG game ', `${appName}:`, res.error],
+        ['Failed to install GOG game ', `${this.id}:`, res.error],
         LogPrefix.Gog
       )
       return { status: 'error', error: res.error }
@@ -414,7 +404,7 @@ export default class GOGGameManager implements GameManager {
     // Installation succeded
     // Save new game info to installed games store
     const installInfo = await libraryManagerMap['gog'].getInstallInfo(
-      appName,
+      this.id,
       installPlatform,
       {
         branch,
@@ -425,10 +415,10 @@ export default class GOGGameManager implements GameManager {
       logError('install info is undefined in GOG install', LogPrefix.Gog)
       return { status: 'error' }
     }
-    const gameInfo = this.getGameInfo(appName)
+    const gameInfo = this.getGameInfo()
     const isLinuxNative = installPlatform === 'linux'
     const additionalInfo = isLinuxNative
-      ? await libraryManagerMap['gog'].getLinuxInstallerInfo(appName)
+      ? await libraryManagerMap['gog'].getLinuxInstallerInfo(this.id)
       : null
 
     if (
@@ -451,7 +441,7 @@ export default class GOGGameManager implements GameManager {
       version: additionalInfo
         ? additionalInfo.version
         : installInfo.game.version,
-      appName: appName,
+      appName: this.id,
       installedDLCs: installDlcs,
       language: installLanguage,
       versionEtag: isLinuxNative ? '' : installInfo.manifest.versionEtag,
@@ -470,7 +460,7 @@ export default class GOGGameManager implements GameManager {
         LogPrefix.Gog
       )
       try {
-        await setup(appName, installedData)
+        await setup(this.id, installedData)
       } catch (e) {
         logWarning(
           [
@@ -493,12 +483,12 @@ export default class GOGGameManager implements GameManager {
         )
       }
     }
-    this.addShortcuts(appName)
+    this.addShortcuts()
     return { status: 'done' }
   }
 
-  isNative(appName: string): boolean {
-    const gameInfo = this.getGameInfo(appName)
+  isNative(): boolean {
+    const gameInfo = this.getGameInfo()
     if (isWindows) {
       return true
     }
@@ -514,22 +504,21 @@ export default class GOGGameManager implements GameManager {
     return false
   }
 
-  async addShortcuts(appName: string, fromMenu?: boolean) {
-    return addShortcutsUtil(this.getGameInfo(appName), fromMenu)
+  async addShortcuts(fromMenu?: boolean) {
+    return addShortcutsUtil(this, fromMenu)
   }
 
-  async removeShortcuts(appName: string) {
-    return removeShortcutsUtil(this.getGameInfo(appName))
+  async removeShortcuts() {
+    return removeShortcutsUtil(this)
   }
 
   async launch(
-    appName: string,
     logWriter: LogWriter,
     launchArguments?: LaunchOption,
     args: string[] = []
   ): Promise<boolean> {
-    const gameSettings = await this.getSettings(appName)
-    const gameInfo = this.getGameInfo(appName)
+    const gameSettings = await this.getSettings()
+    const gameInfo = this.getGameInfo()
 
     if (
       !gameInfo.install ||
@@ -540,11 +529,7 @@ export default class GOGGameManager implements GameManager {
     }
 
     if (!existsSync(gameInfo.install.install_path)) {
-      errorHandler({
-        error: 'appears to be deleted',
-        runner: 'gog',
-        appName: gameInfo.app_name
-      })
+      errorHandler('appears to be deleted', this.id, 'gog')
       return false
     }
 
@@ -556,12 +541,7 @@ export default class GOGGameManager implements GameManager {
       gameScopeCommand,
       gameModeBin,
       steamRuntime
-    } = await prepareLaunch(
-      gameSettings,
-      logWriter,
-      gameInfo,
-      this.isNative(appName)
-    )
+    } = await prepareLaunch(gameSettings, logWriter, gameInfo, this.isNative())
     if (!launchPrepSuccess) {
       logWriter.logError(['Launch aborted:', launchPrepFailReason])
       launchCleanup()
@@ -582,11 +562,11 @@ export default class GOGGameManager implements GameManager {
 
     let commandEnv = {
       ...process.env,
-      ...setupWrapperEnvVars({ appName, appRunner: 'gog' }),
+      ...setupWrapperEnvVars({ appName: this.id, appRunner: 'gog' }),
       ...(isWindows
         ? {}
         : setupEnvVars(gameSettings, gameInfo.install.install_path)),
-      ...getKnownFixesEnvVariables(appName, 'gog')
+      ...getKnownFixesEnvVariables(this.id, 'gog')
     }
 
     const wrappers = setupWrappers(
@@ -601,12 +581,12 @@ export default class GOGGameManager implements GameManager {
       ? ['--wrapper', shlex.join(wrappers)]
       : []
 
-    if (!this.isNative(appName)) {
+    if (!this.isNative()) {
       const {
         success: wineLaunchPrepSuccess,
         failureReason: wineLaunchPrepFailReason,
         envVars: wineEnvVars
-      } = await prepareWineLaunch('gog', appName, logWriter)
+      } = await prepareWineLaunch(this, logWriter)
       if (!wineLaunchPrepSuccess) {
         logWriter.logError(['Launch aborted:', wineLaunchPrepFailReason])
         if (wineLaunchPrepFailReason) {
@@ -673,7 +653,7 @@ export default class GOGGameManager implements GameManager {
               gameSettings
             })
 
-        const availableMods = await this.getCyberpunkMods()
+        const availableMods = await libraryManagerMap['gog'].getCyberpunkMods()
         const modsEnabledToLoad = gameInfo.install.cyberpunk.modsToLoad
         const modsAbleToLoad: string[] = []
 
@@ -735,7 +715,7 @@ export default class GOGGameManager implements GameManager {
 
     const userData: UserData | undefined = configStore.get_nodefault('userData')
 
-    sendGameStatusUpdate({ appName, runner: 'gog', status: 'playing' })
+    sendGameStatusUpdate({ appName: this.id, runner: 'gog', status: 'playing' })
 
     let child = undefined
 
@@ -768,7 +748,7 @@ export default class GOGGameManager implements GameManager {
     const { error, abort } = await libraryManagerMap['gog'].runRunnerCommand(
       commandParts,
       {
-        abortId: appName,
+        abortId: this.id,
         env: commandEnv,
         wrappers,
         logMessagePrefix: `Launching ${gameInfo.title}`,
@@ -794,11 +774,10 @@ export default class GOGGameManager implements GameManager {
   }
 
   async moveInstall(
-    appName: string,
     newInstallPath: string
   ): Promise<{ status: 'done' } | { status: 'error'; error: string }> {
-    const gameInfo = this.getGameInfo(appName)
-    const gameConfig = GameConfig.get(appName).config
+    const gameInfo = this.getGameInfo()
+    const gameConfig = await this.getSettings()
     logInfo(`Moving ${gameInfo.title} to ${newInstallPath}`, LogPrefix.Gog)
 
     const moveImpl = isWindows ? moveOnWindows : moveOnUnix
@@ -815,14 +794,14 @@ export default class GOGGameManager implements GameManager {
     }
 
     await libraryManagerMap['gog'].changeGameInstallPath(
-      appName,
+      this.id,
       moveResult.installPath
     )
     if (
       gameInfo.install.platform === 'windows' &&
       (isWindows || existsSync(gameConfig.winePrefix))
     ) {
-      await setup(appName, undefined, false)
+      await setup(this.id, undefined, false)
     }
     return { status: 'done' }
   }
@@ -831,25 +810,25 @@ export default class GOGGameManager implements GameManager {
    * This proces verifies and repairs game files
    * verification step doesn't have progress, but download does
    */
-  async repair(appName: string): Promise<ExecResult> {
+  async repair(): Promise<ExecResult> {
     const { installPlatform, gameData, credentials, withDlcs, workers } =
-      await this.getCommandParameters(appName)
+      await this.getCommandParameters()
 
     if (!credentials) {
       return { stderr: 'Unable to repair game, no credentials', stdout: '' }
     }
-    const privateBranchPassword = privateBranchesStore.get(appName, '')
+    const privateBranchPassword = privateBranchesStore.get(this.id, '')
 
     // Most of the data provided here is discarded and read from manifest instead
     const commandParts = [
       'repair',
-      appName,
+      this.id,
       '--platform',
       installPlatform!,
       '--path',
       gameData.install.install_path!,
       '--support',
-      join(gogSupportPath, appName),
+      join(gogSupportPath, this.id),
       withDlcs,
       '--lang',
       gameData.install.language || 'en-US',
@@ -861,22 +840,21 @@ export default class GOGGameManager implements GameManager {
       commandParts.push('--password', privateBranchPassword)
     }
 
-    const repairLogWriter = await createGameLogWriter(appName, 'gog', 'repair')
+    const repairLogWriter = await createGameLogWriter(this.id, 'gog', 'repair')
     const res = await libraryManagerMap['gog'].runRunnerCommand(commandParts, {
-      abortId: appName,
+      abortId: this.id,
       logWriters: [repairLogWriter],
-      logMessagePrefix: `Repairing ${appName}`
+      logMessagePrefix: `Repairing ${this.id}`
     })
 
     if (res.error) {
-      logError(['Failed to repair', `${appName}:`, res.error], LogPrefix.Gog)
+      logError(['Failed to repair', `${this.id}:`, res.error], LogPrefix.Gog)
     }
 
     return res
   }
 
   async syncSaves(
-    appName: string,
     arg: string,
     path: string,
     gogSaves?: GOGCloudSavesLocation[]
@@ -890,7 +868,7 @@ export default class GOGGameManager implements GameManager {
       return 'Unable to sync saves, no credentials'
     }
 
-    const gameInfo = libraryManagerMap['gog'].getGameInfo(appName)
+    const gameInfo = this.getGameInfo()
     if (!gameInfo || !gameInfo.install.platform) {
       return 'Unable to sync saves, game info not found'
     }
@@ -901,11 +879,11 @@ export default class GOGGameManager implements GameManager {
       const commandParts = [
         'save-sync',
         location.location,
-        appName,
+        this.id,
         '--os',
         gameInfo.install.platform,
         '--ts',
-        syncStore.get(`${appName}.${location.name}`, '0'),
+        syncStore.get(`${this.id}.${location.name}`, '0'),
         '--name',
         location.name,
         arg
@@ -916,7 +894,7 @@ export default class GOGGameManager implements GameManager {
       const res = await libraryManagerMap['gog'].runRunnerCommand(
         commandParts,
         {
-          abortId: appName,
+          abortId: this.id,
           logMessagePrefix: `Syncing saves for ${gameInfo.title}`,
           onOutput: (output) => (fullOutput += output)
         }
@@ -924,24 +902,21 @@ export default class GOGGameManager implements GameManager {
 
       if (res.error) {
         logError(
-          ['Failed to sync saves for', `${appName}`, `${res.error}`],
+          ['Failed to sync saves for', `${this.id}`, `${res.error}`],
           LogPrefix.Gog
         )
       }
       if (res.stdout) {
-        syncStore.set(`${appName}.${location.name}`, res.stdout.trim())
+        syncStore.set(`${this.id}.${location.name}`, res.stdout.trim())
       }
     }
 
     return fullOutput
   }
 
-  async uninstall({
-    appName,
-    shouldRemovePrefix
-  }: RemoveArgs): Promise<ExecResult> {
+  async uninstall({ shouldRemovePrefix }: RemoveArgs): Promise<ExecResult> {
     const array = installedGamesStore.get('installed', [])
-    const index = array.findIndex((game) => game.appName === appName)
+    const index = array.findIndex((game) => game.appName === this.id)
     if (index === -1) {
       throw Error("Game isn't installed")
     }
@@ -953,7 +928,7 @@ export default class GOGGameManager implements GameManager {
 
     const res: ExecResult = { stdout: '', stderr: '' }
     if (existsSync(uninstallerPath)) {
-      const gameSettings = GameConfig.get(appName).config
+      const gameSettings = await this.getSettings()
 
       const installDirectory = isWindows
         ? object.install_path
@@ -965,7 +940,7 @@ export default class GOGGameManager implements GameManager {
       const command = [
         uninstallerPath,
         '/VERYSILENT',
-        `/ProductId=${appName}`,
+        `/ProductId=${this.id}`,
         '/galaxyclient',
         '/KEEPSAVES'
       ]
@@ -1002,37 +977,35 @@ export default class GOGGameManager implements GameManager {
     if (existsSync(object.install_path)) {
       rmSync(object.install_path, { recursive: true })
     }
-    const manifestPath = join(gogdlConfigPath, 'manifests', appName)
+    const manifestPath = join(gogdlConfigPath, 'manifests', this.id)
     if (existsSync(manifestPath)) {
       rmSync(manifestPath) // Delete manifest so gogdl won't try to patch the not installed game
     }
-    const supportPath = join(gogSupportPath, appName)
+    const supportPath = join(gogSupportPath, this.id)
     if (existsSync(supportPath)) {
       rmSync(supportPath, { recursive: true }) // Remove unnecessary support dir
     }
     installedGamesStore.set('installed', array)
     libraryManagerMap['gog'].refreshInstalled()
-    const gameInfo = this.getGameInfo(appName)
+    const gameInfo = this.getGameInfo()
     gameInfo.is_installed = false
     gameInfo.install = { is_dlc: false }
-    await removeShortcutsUtil(gameInfo)
-    syncStore.delete(appName)
-    await removeNonSteamGame({ gameInfo })
+    await removeShortcutsUtil(this)
+    syncStore.delete(this.id)
+    await removeNonSteamGame(this)
     sendFrontendMessage('pushGameToLibrary', gameInfo)
     return res
   }
 
-  async update(
-    appName: string,
-    updateOverwrites?: {
-      build?: string
-      branch?: string
-      language?: string
-      dlcs?: string[]
-      dependencies?: string[]
-    }
-  ): Promise<{ status: 'done' | 'error' }> {
-    if (appName === 'gog-redist') {
+  async update(updateOverwrites?: {
+    build?: string
+    branch?: string
+    language?: string
+    dlcs?: string[]
+    dependencies?: string[]
+  }): Promise<{ status: 'done' | 'error' }> {
+    // TODO: Implement GOG redist as a subclass of GOGGame & move this logic to it
+    if (this.id === 'gog-redist') {
       const redist = await getRequiredRedistList()
       if (updateOverwrites?.dependencies?.length) {
         for (const dep of updateOverwrites.dependencies) {
@@ -1051,12 +1024,12 @@ export default class GOGGameManager implements GameManager {
       workers,
       dlcs,
       branch
-    } = await this.getCommandParameters(appName)
+    } = await this.getCommandParameters()
     if (!installPlatform || !credentials) {
       return { status: 'error' }
     }
 
-    const gameConfig = GameConfig.get(appName).config
+    const gameConfig = await this.getSettings()
     const installedDlcs = gameData.install.installedDLCs || []
 
     if (updateOverwrites?.dlcs) {
@@ -1124,7 +1097,7 @@ export default class GOGGameManager implements GameManager {
       }
     }
 
-    const privateBranchPassword = privateBranchesStore.get(appName, '')
+    const privateBranchPassword = privateBranchesStore.get(this.id, '')
 
     const overwrittenBuild: string[] = updateOverwrites?.build
       ? ['--build', updateOverwrites.build]
@@ -1149,13 +1122,13 @@ export default class GOGGameManager implements GameManager {
 
     const commandParts = [
       'update',
-      appName,
+      this.id,
       '--platform',
       installPlatform,
       '--path',
       gameData.install.install_path!,
       '--support',
-      join(gogSupportPath, appName),
+      join(gogSupportPath, this.id),
       overwrittenWithDlcs,
       '--lang',
       overwrittenLanguage,
@@ -1169,15 +1142,15 @@ export default class GOGGameManager implements GameManager {
     }
 
     const onOutput = (data: string) => {
-      this.onInstallOrUpdateOutput(appName, 'updating', data)
+      this.onInstallOrUpdateOutput('updating', data)
     }
 
-    const updateLogWriter = await createGameLogWriter(appName, 'gog', 'update')
+    const updateLogWriter = await createGameLogWriter(this.id, 'gog', 'update')
     const res = await libraryManagerMap['gog'].runRunnerCommand(commandParts, {
-      abortId: appName,
+      abortId: this.id,
       logWriters: [updateLogWriter],
       onOutput,
-      logMessagePrefix: `Updating ${appName}`
+      logMessagePrefix: `Updating ${this.id}`
     })
 
     if (res.abort) {
@@ -1185,9 +1158,9 @@ export default class GOGGameManager implements GameManager {
     }
 
     if (res.error) {
-      logError(['Failed to update', `${appName}:`, res.error], LogPrefix.Gog)
+      logError(['Failed to update', `${this.id}:`, res.error], LogPrefix.Gog)
       sendGameStatusUpdate({
-        appName: appName,
+        appName: this.id,
         runner: 'gog',
         status: 'done'
       })
@@ -1196,13 +1169,13 @@ export default class GOGGameManager implements GameManager {
 
     const installedArray = installedGamesStore.get('installed', [])
     const gameIndex = installedArray.findIndex(
-      (value) => appName === value.appName
+      (value) => this.id === value.appName
     )
     const gameObject = installedArray[gameIndex]
 
     if (gameData.install.platform !== 'linux') {
       const installInfo = await libraryManagerMap['gog'].getInstallInfo(
-        appName,
+        this.id,
         gameData.install.platform ?? 'windows',
         {
           branch: updateOverwrites?.branch,
@@ -1211,7 +1184,7 @@ export default class GOGGameManager implements GameManager {
       )
       // TODO: use installInfo.game.builds
       const { etag } = await libraryManagerMap['gog'].getMetaResponse(
-        appName,
+        this.id,
         gameData.install.platform ?? 'windows',
         installInfo?.manifest.versionEtag
       )
@@ -1222,8 +1195,9 @@ export default class GOGGameManager implements GameManager {
       gameObject.language = overwrittenLanguage
       gameObject.versionEtag = etag
     } else {
-      const installerInfo =
-        await libraryManagerMap['gog'].getLinuxInstallerInfo(appName)
+      const installerInfo = await libraryManagerMap[
+        'gog'
+      ].getLinuxInstallerInfo(this.id)
       if (!installerInfo) {
         return { status: 'error' }
       }
@@ -1236,14 +1210,14 @@ export default class GOGGameManager implements GameManager {
     gameObject.install_size = getFileSize(sizeOnDisk)
     installedGamesStore.set('installed', installedArray)
     libraryManagerMap['gog'].refreshInstalled()
-    const gameSettings = GameConfig.get(appName).config
+    const gameSettings = await this.getSettings()
     // Simple check if wine prefix exists and setup can be performed because of an
     // update
     if (
       gameObject.platform === 'windows' &&
       (isWindows || existsSync(gameSettings.winePrefix))
     ) {
-      await setup(appName, gameObject, false)
+      await setup(this.id, gameObject, false)
     } else if (gameObject.platform === 'linux') {
       const installer = join(gameObject.install_path, 'support/postinst.sh')
       if (existsSync(installer)) {
@@ -1257,7 +1231,7 @@ export default class GOGGameManager implements GameManager {
       }
     }
     sendGameStatusUpdate({
-      appName: appName,
+      appName: this.id,
       runner: 'gog',
       status: 'done'
     })
@@ -1270,10 +1244,10 @@ export default class GOGGameManager implements GameManager {
    * Reads game installed data and returns proper parameters
    * Useful for Update and Repair
    */
-  private async getCommandParameters(appName: string) {
+  private async getCommandParameters() {
     const { maxWorkers } = GlobalConfig.get().getSettings()
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
-    const gameData = this.getGameInfo(appName)
+    const gameData = this.getGameInfo()
     const credentials = await GOGUser.getCredentials()
 
     const numberOfDLCs = gameData.install?.installedDLCs?.length || 0
@@ -1305,25 +1279,25 @@ export default class GOGGameManager implements GameManager {
     }
   }
 
-  async forceUninstall(appName: string): Promise<void> {
+  async forceUninstall(): Promise<void> {
     const installed = installedGamesStore.get('installed', [])
-    const newInstalled = installed.filter((g) => g.appName !== appName)
+    const newInstalled = installed.filter((g) => g.appName !== this.id)
     installedGamesStore.set('installed', newInstalled)
     libraryManagerMap['gog'].refreshInstalled()
-    sendFrontendMessage('pushGameToLibrary', this.getGameInfo(appName))
+    sendFrontendMessage('pushGameToLibrary', this.getGameInfo())
   }
 
   // GOGDL now handles the signal, this is no longer needed
-  async stop(appName: string, stopWine = true): Promise<void> {
-    if (stopWine && !this.isNative(appName)) {
-      const gameSettings = await this.getSettings(appName)
+  async stop(stopWine = true): Promise<void> {
+    if (stopWine && !this.isNative()) {
+      const gameSettings = await this.getSettings()
       await shutdownWine(gameSettings)
     }
   }
 
-  async isGameAvailable(appName: string): Promise<boolean> {
+  async isGameAvailable(): Promise<boolean> {
     return new Promise((resolve) => {
-      const info = this.getGameInfo(appName)
+      const info = this.getGameInfo()
       if (info && info.is_installed) {
         if (
           info.install.install_path &&
@@ -1338,50 +1312,7 @@ export default class GOGGameManager implements GameManager {
     })
   }
 
-  private async postPlaytimeSession({
-    appName,
-    session_date,
-    time
-  }: GOGSessionSyncQueueItem) {
-    const userData: UserData | undefined = configStore.get_nodefault('userData')
-    if (!userData) {
-      logError('No userData, unable to post new session', {
-        prefix: LogPrefix.Gog
-      })
-      return null
-    }
-    const credentials = await GOGUser.getCredentials().catch(() => null)
-
-    if (!credentials) {
-      logError("Couldn't fetch credentials, unable to post new session", {
-        prefix: LogPrefix.Gog
-      })
-      return null
-    }
-
-    return axios
-      .post(
-        `https://gameplay.gog.com/games/${appName}/users/${userData?.galaxyUserId}/sessions`,
-        { session_date, time },
-        {
-          headers: {
-            Authorization: `Bearer ${credentials.access_token}`
-          }
-        }
-      )
-      .catch((e: AxiosError) => {
-        logDebug(['Failed to post session', e.toJSON()], {
-          prefix: LogPrefix.Gog
-        })
-        return null
-      })
-  }
-
-  async updateGOGPlaytime(
-    appName: string,
-    startPlayingDate: Date,
-    finishedPlayingDate: Date
-  ) {
+  async updateGOGPlaytime(startPlayingDate: Date, finishedPlayingDate: Date) {
     // Let server know about new session
     const sessionDate = Math.floor(startPlayingDate.getTime() / 1000) // In seconds
     const time = Math.floor(
@@ -1411,20 +1342,23 @@ export default class GOGGameManager implements GameManager {
         prefix: LogPrefix.Gog
       })
       const alreadySetData = playtimeSyncQueue.get(userData.galaxyUserId, [])
-      alreadySetData.push({ ...data, appName })
+      alreadySetData.push({ ...data, appName: this.id })
       playtimeSyncQueue.set(userData.galaxyUserId, alreadySetData)
-      runOnceWhenOnline(() => this.syncQueuedPlaytimeGOG())
+      runOnceWhenOnline(() => libraryManagerMap['gog'].syncQueuedPlaytime())
       return
     }
 
-    const response = await this.postPlaytimeSession({ ...data, appName }).catch(
-      () => null
-    )
+    const response = await libraryManagerMap['gog']
+      .postPlaytimeSession({
+        ...data,
+        appName: this.id
+      })
+      .catch(() => null)
 
     if (!response || response.status !== 201) {
       logError('Failed to post session', { prefix: LogPrefix.Gog })
       const alreadySetData = playtimeSyncQueue.get(userData.galaxyUserId, [])
-      alreadySetData.push({ ...data, appName })
+      alreadySetData.push({ ...data, appName: this.id })
       playtimeSyncQueue.set(userData.galaxyUserId, alreadySetData)
       return
     }
@@ -1432,50 +1366,7 @@ export default class GOGGameManager implements GameManager {
     logInfo('Posted session to gameplay.gog.com', { prefix: LogPrefix.Gog })
   }
 
-  async syncQueuedPlaytimeGOG() {
-    if (playtimeSyncQueue.has('lock')) {
-      return
-    }
-    const userData: UserData | undefined = configStore.get_nodefault('userData')
-    if (!userData) {
-      logError('Unable to syncQueued playtime, userData not present', {
-        prefix: LogPrefix.Gog
-      })
-      return
-    }
-    const queue = playtimeSyncQueue.get(userData.galaxyUserId, [])
-    if (queue.length === 0) {
-      return
-    }
-    playtimeSyncQueue.set('lock', [])
-    const failed = []
-
-    for (const session of queue) {
-      if (!isOnline()) {
-        failed.push(session)
-      }
-      const response = await this.postPlaytimeSession(session)
-
-      if (!response || response.status !== 201) {
-        logError('Failed to post session', { prefix: LogPrefix.Gog })
-        failed.push(session)
-      }
-    }
-    playtimeSyncQueue.set(userData.galaxyUserId, failed)
-    playtimeSyncQueue.delete('lock')
-    logInfo(
-      [
-        'Finished posting sessions to gameplay.gog.com',
-        'failed:',
-        failed.length
-      ],
-      {
-        prefix: LogPrefix.Gog
-      }
-    )
-  }
-
-  async getGOGPlaytime(appName: string): Promise<number | undefined> {
+  async getGOGPlaytime(): Promise<number | undefined> {
     if (!isOnline()) {
       return
     }
@@ -1487,7 +1378,7 @@ export default class GOGGameManager implements GameManager {
     }
     const response = await axios
       .get(
-        `https://gameplay.gog.com/games/${appName}/users/${userData?.galaxyUserId}/sessions`,
+        `https://gameplay.gog.com/games/${this.id}/users/${userData?.galaxyUserId}/sessions`,
         {
           headers: {
             Authorization: `Bearer ${credentials.access_token}`
@@ -1495,7 +1386,7 @@ export default class GOGGameManager implements GameManager {
         }
       )
       .catch((e: AxiosError) => {
-        logWarning(['Failed attempt to get playtime of', appName, e.toJSON()], {
+        logWarning(['Failed attempt to get playtime of', this.id, e.toJSON()], {
           prefix: LogPrefix.Gog
         })
         return null
@@ -1504,37 +1395,11 @@ export default class GOGGameManager implements GameManager {
     return response?.data?.time_sum
   }
 
-  getBranchPassword(appName: string): string {
-    return privateBranchesStore.get(appName, '')
+  getBranchPassword(): string {
+    return privateBranchesStore.get(this.id, '')
   }
 
-  setBranchPassword(appName: string, password: string): void {
-    privateBranchesStore.set(appName, password)
-  }
-
-  async getCyberpunkMods(): Promise<string[]> {
-    const gameInfo = libraryManagerMap['gog'].getGameInfo('1423049311')
-    if (!gameInfo || !gameInfo?.install?.install_path) {
-      return []
-    }
-
-    const modsPath = join(gameInfo.install.install_path, 'mods')
-    if (!existsSync(modsPath)) {
-      return []
-    }
-    const modsPathContents = await readdir(modsPath)
-
-    return modsPathContents.reduce((acc, next) => {
-      const modPath = join(modsPath, next)
-      const infoFilePath = join(modPath, 'info.json')
-
-      const modStat = statSync(modPath)
-
-      if (modStat.isDirectory() && existsSync(infoFilePath)) {
-        acc.push(next)
-      }
-
-      return acc
-    }, [] as string[])
+  setBranchPassword(password: string): void {
+    privateBranchesStore.set(this.id, password)
   }
 }

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -23,7 +23,9 @@ import {
   GOGDLInstallInfo,
   GOGCredentials,
   GOGv1Manifest,
-  GOGv2Manifest
+  GOGv2Manifest,
+  UserData,
+  GOGSessionSyncQueueItem
 } from 'common/types/gog'
 import { dirname, join } from 'node:path'
 import { existsSync, readFileSync } from 'graceful-fs'
@@ -42,7 +44,9 @@ import {
   installedGamesStore,
   installInfoStore,
   apiInfoCache,
-  privateBranchesStore
+  privateBranchesStore,
+  configStore,
+  playtimeSyncQueue
 } from './electronStores'
 import { callRunner } from '../../launcher'
 import { isOnline, runOnceWhenOnline } from '../../online_monitor'
@@ -54,12 +58,18 @@ import { checkForRedistUpdates } from './redist'
 import { runGogdlCommandStub } from './e2eMock'
 import { gogdlConfigPath } from './constants'
 import { userDataPath } from 'backend/constants/paths'
+import GOGGame from './games'
 import type { LibraryManager } from 'common/types/game_manager'
+import { libraryManagerMap } from '../index'
+import { readdir } from 'fs/promises'
+import { statSync } from 'fs'
 
 const library: Map<string, GameInfo> = new Map()
 const installedGames: Map<string, InstalledInfo> = new Map()
 
 export default class GOGLibraryManager implements LibraryManager {
+  private readonly gameCache: Map<string, GOGGame> = new Map()
+
   async init() {
     await this.refresh()
 
@@ -79,6 +89,15 @@ export default class GOGLibraryManager implements LibraryManager {
       }
     })
     runOnceWhenOnline(checkForRedistUpdates)
+  }
+
+  getGame(id: string): GOGGame {
+    const cached = this.gameCache.get(id)
+    if (cached) return cached
+
+    const game = new GOGGame(id)
+    this.gameCache.set(id, game)
+    return game
   }
 
   private async createMissingGogdlManifest(
@@ -145,6 +164,88 @@ export default class GOGLibraryManager implements LibraryManager {
       logError([`Unable to get data of ${appName}:`, e], LogPrefix.Gog)
       return
     }
+  }
+
+  async syncQueuedPlaytime() {
+    if (playtimeSyncQueue.has('lock')) {
+      return
+    }
+    const userData: UserData | undefined = configStore.get_nodefault('userData')
+    if (!userData) {
+      logError('Unable to syncQueued playtime, userData not present', {
+        prefix: LogPrefix.Gog
+      })
+      return
+    }
+    const queue = playtimeSyncQueue.get(userData.galaxyUserId, [])
+    if (queue.length === 0) {
+      return
+    }
+    playtimeSyncQueue.set('lock', [])
+    const failed = []
+
+    for (const session of queue) {
+      if (!isOnline()) {
+        failed.push(session)
+      }
+      const response = await this.postPlaytimeSession(session)
+
+      if (!response || response.status !== 201) {
+        logError('Failed to post session', { prefix: LogPrefix.Gog })
+        failed.push(session)
+      }
+    }
+    playtimeSyncQueue.set(userData.galaxyUserId, failed)
+    playtimeSyncQueue.delete('lock')
+    logInfo(
+      [
+        'Finished posting sessions to gameplay.gog.com',
+        'failed:',
+        failed.length
+      ],
+      {
+        prefix: LogPrefix.Gog
+      }
+    )
+  }
+
+  async postPlaytimeSession({
+    session_date,
+    time,
+    appName
+  }: GOGSessionSyncQueueItem) {
+    const userData: UserData | undefined = configStore.get_nodefault('userData')
+    if (!userData) {
+      logError('No userData, unable to post new session', {
+        prefix: LogPrefix.Gog
+      })
+      return null
+    }
+    const credentials = await GOGUser.getCredentials().catch(() => null)
+
+    if (!credentials) {
+      logError("Couldn't fetch credentials, unable to post new session", {
+        prefix: LogPrefix.Gog
+      })
+      return null
+    }
+
+    return axios
+      .post(
+        `https://gameplay.gog.com/games/${appName}/users/${userData?.galaxyUserId}/sessions`,
+        { session_date, time },
+        {
+          headers: {
+            Authorization: `Bearer ${credentials.access_token}`
+          }
+        }
+      )
+      .catch((e: AxiosError) => {
+        logDebug(['Failed to post session', e.toJSON()], {
+          prefix: LogPrefix.Gog
+        })
+        return null
+      })
   }
 
   async getSaveSyncLocation(
@@ -1447,5 +1548,31 @@ export default class GOGLibraryManager implements LibraryManager {
     installedGames.set(cpId, installed)
     installedGamesStore.set('installed', installedArray)
     sendFrontendMessage('pushGameToLibrary', game)
+  }
+
+  async getCyberpunkMods(): Promise<string[]> {
+    const gameInfo = libraryManagerMap['gog'].getGameInfo('1423049311')
+    if (!gameInfo || !gameInfo?.install?.install_path) {
+      return []
+    }
+
+    const modsPath = join(gameInfo.install.install_path, 'mods')
+    if (!existsSync(modsPath)) {
+      return []
+    }
+    const modsPathContents = await readdir(modsPath)
+
+    return modsPathContents.reduce((acc, next) => {
+      const modPath = join(modsPath, next)
+      const infoFilePath = join(modPath, 'info.json')
+
+      const modStat = statSync(modPath)
+
+      if (modStat.isDirectory() && existsSync(infoFilePath)) {
+        acc.push(next)
+      }
+
+      return acc
+    }, [] as string[])
   }
 }

--- a/src/backend/storeManagers/gog/redist.ts
+++ b/src/backend/storeManagers/gog/redist.ts
@@ -10,7 +10,7 @@ import {
   GOGv1Manifest,
   GOGv2Manifest
 } from 'common/types/gog'
-import { gameManagerMap, libraryManagerMap } from '..'
+import { libraryManagerMap } from '..'
 import { GlobalConfig } from 'backend/config'
 import {
   addToQueue,
@@ -112,7 +112,7 @@ async function pushRedistUpdateToQueue() {
 }
 
 export function createRedistDMQueueElement(): DMQueueElement {
-  const gameInfo = gameManagerMap['gog'].getGameInfo('gog-redist')
+  const gameInfo = libraryManagerMap['gog'].getGame('gog-redist').getGameInfo()
   const newElement: DMQueueElement = {
     params: {
       appName: 'gog-redist',
@@ -206,11 +206,9 @@ export async function updateRedist(redistToSync: string[]): Promise<{
     logMessagePrefix: 'GOG REDIST:',
     logWriters: [redistLogWriter],
     onOutput: (output) =>
-      gameManagerMap['gog'].onInstallOrUpdateOutput(
-        'gog-redist',
-        'updating',
-        output
-      )
+      libraryManagerMap['gog']
+        .getGame('gog-redist')
+        .onInstallOrUpdateOutput('updating', output)
   })
 
   if (res.error) {

--- a/src/backend/storeManagers/index.ts
+++ b/src/backend/storeManagers/index.ts
@@ -1,9 +1,3 @@
-import SideloadGameManager from 'backend/storeManagers/sideload/games'
-import GOGGameManager from 'backend/storeManagers/gog/games'
-import LegendaryGameManager from 'backend/storeManagers/legendary/games'
-import NileGameManager from 'backend/storeManagers/nile/games'
-import ZoomGameManager from 'backend/storeManagers/zoom/games'
-
 import SideloadLibraryManager from 'backend/storeManagers/sideload/library'
 import GOGLibraryManager from 'backend/storeManagers/gog/library'
 import LegendaryLibraryManager from 'backend/storeManagers/legendary/library'
@@ -14,15 +8,7 @@ import { logInfo, RunnerToLogPrefixMap } from 'backend/logger'
 import { addToQueue } from 'backend/downloadmanager/downloadqueue'
 
 import type { DMQueueElement, GameInfo, Runner } from 'common/types'
-import type { GameManager, LibraryManager } from 'common/types/game_manager'
-
-export const gameManagerMap = {
-  sideload: new SideloadGameManager(),
-  gog: new GOGGameManager(),
-  legendary: new LegendaryGameManager(),
-  nile: new NileGameManager(),
-  zoom: new ZoomGameManager()
-} satisfies Record<Runner, GameManager>
+import type { LibraryManager } from 'common/types/game_manager'
 
 export const libraryManagerMap = {
   sideload: new SideloadLibraryManager(),
@@ -56,11 +42,10 @@ function getDMElement(gameInfo: GameInfo, appName: string) {
 export function autoUpdate(runner: Runner, gamesToUpdate: string[]) {
   const logPrefix = RunnerToLogPrefixMap[runner]
   gamesToUpdate.forEach(async (appName) => {
-    const { ignoreGameUpdates } =
-      await gameManagerMap[runner].getSettings(appName)
-    const gameInfo = gameManagerMap[runner].getGameInfo(appName)
-    const gameIsAvailable =
-      await gameManagerMap[runner].isGameAvailable(appName)
+    const game = libraryManagerMap[runner].getGame(appName)
+    const { ignoreGameUpdates } = await game.getSettings()
+    const gameInfo = game.getGameInfo()
+    const gameIsAvailable = await game.isGameAvailable()
     if (!ignoreGameUpdates && gameIsAvailable) {
       logInfo(`Auto-Updating ${gameInfo.title}`, logPrefix)
       const dmQueueElement: DMQueueElement = getDMElement(gameInfo, appName)

--- a/src/backend/storeManagers/legendary/commands/base.ts
+++ b/src/backend/storeManagers/legendary/commands/base.ts
@@ -3,14 +3,8 @@ import path from 'path'
 import { existsSync } from 'graceful-fs'
 
 import { Path } from 'backend/schemas'
-import { libraryManagerMap } from '../../index'
 
-export const LegendaryAppName = z
-  .string()
-  .refine((val) => libraryManagerMap['legendary'].hasGame(val), {
-    message: 'AppName was not found on account'
-  })
-  .brand('LegendaryAppName')
+export const LegendaryAppName = z.string().brand('LegendaryAppName')
 export type LegendaryAppName = z.infer<typeof LegendaryAppName>
 
 export const LegendaryPlatform = z.enum(['Win32', 'Windows', 'Mac'] as const)

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -8,7 +8,6 @@ import {
   InstallArgs,
   InstallPlatform,
   InstallProgress,
-  WineCommandArgs,
   LaunchOption
 } from 'common/types'
 import { GameConfig } from '../../game_config'
@@ -37,7 +36,6 @@ import {
   setupWrapperEnvVars,
   setupWrappers,
   launchCleanup,
-  runWineCommand as runWineCommandUtil,
   getKnownFixesEnvVariables,
   getWinePath
 } from '../../launcher'
@@ -54,7 +52,7 @@ import { isOnline } from '../../online_monitor'
 import { showDialogBoxModalAuto } from '../../dialog/dialog'
 import { Catalog, Product } from 'common/types/epic-graphql'
 import { sendFrontendMessage } from '../../ipc'
-import { GameManager, RemoveArgs } from 'common/types/game_manager'
+import { Game } from 'common/types/game_manager'
 import {
   AllowedWineFlags,
   getWineFlags,
@@ -78,19 +76,25 @@ import { fakeEpicExePath } from 'backend/constants/paths'
 
 import type LogWriter from 'backend/logger/log_writer'
 
-export default class LegendaryGameManager implements GameManager {
+export default class LegendaryGame implements Game {
+  private readonly appName: LegendaryAppName
+
+  constructor(appName: LegendaryAppName) {
+    this.appName = appName
+  }
+
   /**
    * Alias for `LegendaryLibrary.getGameInfo(appName)`
    *
    * @returns GameInfo
    */
-  getGameInfo(appName: string): GameInfo {
-    const info = libraryManagerMap['legendary'].getGameInfo(appName)
+  getGameInfo(): GameInfo {
+    const info = libraryManagerMap['legendary'].getGameInfo(this.appName)
     if (!info) {
       logError(
         [
           'Could not get game info for',
-          `${appName},`,
+          `${this.appName},`,
           'returning empty object. Something is probably gonna go wrong soon'
         ],
         LogPrefix.Legendary
@@ -287,8 +291,8 @@ export default class LegendaryGameManager implements GameManager {
    * Get extra info from Epic's API.
    *
    */
-  async getExtraInfo(appName: string): Promise<ExtraInfo> {
-    const { namespace, title } = this.getGameInfo(appName)
+  async getExtraInfo(): Promise<ExtraInfo> {
+    const { namespace, title } = this.getGameInfo()
     if (namespace === undefined) return this.emptyExtraInfo
 
     const cachedExtraInfo = gameInfoStore.get(namespace)
@@ -332,10 +336,10 @@ export default class LegendaryGameManager implements GameManager {
    *
    * @returns GameConfig
    */
-  async getSettings(appName: string) {
+  async getSettings() {
     return (
-      GameConfig.get(appName).config ||
-      (await GameConfig.get(appName).getSettings())
+      GameConfig.get(this.appName).config ||
+      (await GameConfig.get(this.appName).getSettings())
     )
   }
 
@@ -344,10 +348,9 @@ export default class LegendaryGameManager implements GameManager {
    * Amends install path by adding the appropriate folder name.
    */
   async moveInstall(
-    appName: string,
     newInstallPath: string
   ): Promise<{ status: 'done' } | { status: 'error'; error: string }> {
-    const gameInfo = this.getGameInfo(appName)
+    const gameInfo = this.getGameInfo()
     logInfo(`Moving ${gameInfo.title} to ${newInstallPath}`, LogPrefix.Gog)
 
     const moveImpl = isWindows ? moveOnWindows : moveOnUnix
@@ -364,21 +367,21 @@ export default class LegendaryGameManager implements GameManager {
     }
 
     await libraryManagerMap['legendary'].changeGameInstallPath(
-      appName,
+      this.appName,
       moveResult.installPath
     )
     return { status: 'done' }
   }
 
   // used when downloading games, store the download size read from Legendary's output
-  private currentDownloadSize: Record<string, number> = {}
+  private currentDownloadSize: number | undefined
 
-  getCurrentDownloadSize(appName: string) {
-    return this.currentDownloadSize[appName]
+  getCurrentDownloadSize() {
+    return this.currentDownloadSize
   }
 
-  setCurrentDownloadSize(appName: string, size: number) {
-    return (this.currentDownloadSize[appName] = size)
+  setCurrentDownloadSize(size: number) {
+    this.currentDownloadSize = size
   }
 
   private defaultTmpProgres = () => ({
@@ -388,10 +391,9 @@ export default class LegendaryGameManager implements GameManager {
     diskSpeed: undefined,
     downSpeed: undefined
   })
-  private tmpProgress: Record<string, InstallProgress> = {}
+  private tmpProgress: InstallProgress | undefined
 
   onInstallOrUpdateOutput(
-    appName: string,
     action: 'installing' | 'updating',
     data: string,
     totalDownloadSize: number
@@ -401,14 +403,14 @@ export default class LegendaryGameManager implements GameManager {
     // store the download size, needed for correct calculation
     // when cancel/resume downloads
     if (downloadSizeMatch) {
-      this.currentDownloadSize[appName] = parseFloat(downloadSizeMatch[1])
+      this.currentDownloadSize = parseFloat(downloadSizeMatch[1])
     }
 
-    if (!Object.hasOwn(this.tmpProgress, appName)) {
-      this.tmpProgress[appName] = this.defaultTmpProgres()
+    if (!this.tmpProgress) {
+      this.tmpProgress = this.defaultTmpProgres()
     }
 
-    const progress = this.tmpProgress[appName]
+    const progress = this.tmpProgress
 
     // parse log for eta
     if (progress.eta === '') {
@@ -446,8 +448,7 @@ export default class LegendaryGameManager implements GameManager {
     // calculate percentage
     if (progress.bytes !== '') {
       const downloaded = parseFloat(progress.bytes)
-      const downloadCache =
-        totalDownloadSize - this.currentDownloadSize[appName]
+      const downloadCache = totalDownloadSize - (this.currentDownloadSize ?? 0)
       const totalDownloaded = downloaded + downloadCache
       const newPercent =
         Math.round((totalDownloaded / totalDownloadSize) * 10000) / 100
@@ -462,7 +463,7 @@ export default class LegendaryGameManager implements GameManager {
     ) {
       logInfo(
         [
-          `Progress for ${this.getGameInfo(appName).title}:`,
+          `Progress for ${this.getGameInfo().title}:`,
           `${progress.percent}%/${progress.bytes}/${progress.eta}`.trim(),
           `Down: ${progress.downSpeed}MB/s / Disk: ${progress.diskSpeed}MB/s`
         ],
@@ -470,14 +471,14 @@ export default class LegendaryGameManager implements GameManager {
       )
 
       sendProgressUpdate({
-        appName: appName,
+        appName: this.appName,
         runner: 'legendary',
         status: action,
         progress: progress
       })
 
       // reset
-      this.tmpProgress[appName] = this.defaultTmpProgres()
+      this.tmpProgress = this.defaultTmpProgres()
     }
   }
 
@@ -485,22 +486,22 @@ export default class LegendaryGameManager implements GameManager {
    * Update game.
    * Does NOT check for online connectivity.
    */
-  async update(appName: string): Promise<{ status: 'done' | 'error' }> {
+  async update(): Promise<{ status: 'done' | 'error' }> {
     sendGameStatusUpdate({
-      appName: appName,
+      appName: this.appName,
       runner: 'legendary',
       status: 'updating'
     })
     const { maxWorkers, downloadNoHttps } = GlobalConfig.get().getSettings()
-    const installPlatform = this.getGameInfo(appName).install.platform!
+    const installPlatform = this.getGameInfo().install.platform!
     const info = await libraryManagerMap['legendary'].getInstallInfo(
-      appName,
+      this.appName,
       installPlatform
     )
 
     const command: LegendaryCommand = {
       subcommand: 'update',
-      appName: LegendaryAppName.parse(appName),
+      appName: this.appName,
       '-y': true,
       '--skip-sdl': true
     }
@@ -509,7 +510,6 @@ export default class LegendaryGameManager implements GameManager {
 
     const onOutput = (data: string) => {
       this.onInstallOrUpdateOutput(
-        appName,
         'updating',
         data,
         info.manifest?.download_size
@@ -517,26 +517,26 @@ export default class LegendaryGameManager implements GameManager {
     }
 
     const updateLogWriter = await createGameLogWriter(
-      appName,
+      this.appName,
       'legendary',
       'update'
     )
     const res = await libraryManagerMap['legendary'].runRunnerCommand(command, {
-      abortId: appName,
+      abortId: this.appName,
       logWriters: [updateLogWriter],
       onOutput,
-      logMessagePrefix: `Updating ${appName}`
+      logMessagePrefix: `Updating ${this.appName}`
     })
 
     sendGameStatusUpdate({
-      appName: appName,
+      appName: this.appName,
       runner: 'legendary',
       status: 'done'
     })
 
     if (res.error) {
       logError(
-        ['Failed to update', `${appName}:`, res.error],
+        ['Failed to update', `${this.appName}:`, res.error],
         LogPrefix.Legendary
       )
       return { status: 'error' }
@@ -551,8 +551,8 @@ export default class LegendaryGameManager implements GameManager {
    * @async
    * @public
    */
-  async addShortcuts(appName: string, fromMenu?: boolean) {
-    return addShortcutsUtil(this.getGameInfo(appName), fromMenu)
+  async addShortcuts(fromMenu?: boolean) {
+    return addShortcutsUtil(this, fromMenu)
   }
 
   /**
@@ -560,22 +560,19 @@ export default class LegendaryGameManager implements GameManager {
    * @async
    * @public
    */
-  async removeShortcuts(appName: string) {
-    return removeShortcutsUtil(this.getGameInfo(appName))
+  async removeShortcuts() {
+    return removeShortcutsUtil(this)
   }
 
   /**
    * Install game.
    * Does NOT check for online connectivity.
    */
-  async install(
-    appName: string,
-    { path, sdlList, platformToInstall }: InstallArgs
-  ): Promise<{
+  async install({ path, sdlList, platformToInstall }: InstallArgs): Promise<{
     status: 'done' | 'error' | 'abort'
     error?: string
   }> {
-    const gameInfo = this.getGameInfo(appName)
+    const gameInfo = this.getGameInfo()
     if (gameInfo.thirdPartyManagedApp) {
       if (gameInfo.isEAManaged) {
         return this.installEA(gameInfo, platformToInstall)
@@ -591,13 +588,13 @@ export default class LegendaryGameManager implements GameManager {
     }
     const { maxWorkers, downloadNoHttps } = GlobalConfig.get().getSettings()
     const info = await libraryManagerMap['legendary'].getInstallInfo(
-      appName,
+      this.appName,
       platformToInstall
     )
 
     const command: LegendaryCommand = {
       subcommand: 'install',
-      appName: LegendaryAppName.parse(appName),
+      appName: this.appName,
       '--platform': LegendaryPlatform.parse(platformToInstall),
       '--base-path': Path.parse(path),
       '--skip-dlcs': true,
@@ -611,7 +608,6 @@ export default class LegendaryGameManager implements GameManager {
 
     const onOutput = (data: string) => {
       this.onInstallOrUpdateOutput(
-        appName,
         'installing',
         data,
         info.manifest?.download_size
@@ -619,22 +615,22 @@ export default class LegendaryGameManager implements GameManager {
     }
 
     const installLogWriter = await createGameLogWriter(
-      appName,
+      this.appName,
       'legendary',
       'install'
     )
     let res = await libraryManagerMap['legendary'].runRunnerCommand(command, {
-      abortId: appName,
+      abortId: this.appName,
       logWriters: [installLogWriter],
       onOutput,
-      logMessagePrefix: `Installing ${appName}`
+      logMessagePrefix: `Installing ${this.appName}`
     })
 
     // try to run the install again with higher memory limit
     if (res.stderr.includes('MemoryError:')) {
       command['--max-shared-memory'] = PositiveInteger.parse(5000)
       res = await libraryManagerMap['legendary'].runRunnerCommand(command, {
-        abortId: appName,
+        abortId: this.appName,
         logWriters: [installLogWriter],
         onOutput
       })
@@ -647,13 +643,13 @@ export default class LegendaryGameManager implements GameManager {
     if (res.error) {
       if (!res.error.includes('signal')) {
         logError(
-          ['Failed to install', `${appName}:`, res.error],
+          ['Failed to install', `${this.appName}:`, res.error],
           LogPrefix.Legendary
         )
       }
       return { status: 'error', error: res.error }
     }
-    this.addShortcuts(appName)
+    this.addShortcuts()
 
     return { status: 'done' }
   }
@@ -737,34 +733,33 @@ export default class LegendaryGameManager implements GameManager {
     return { status: 'done' }
   }
 
-  async uninstall({ appName }: RemoveArgs): Promise<ExecResult> {
-    const gameInfo = this.getGameInfo(appName)
+  async uninstall(): Promise<ExecResult> {
+    const gameInfo = this.getGameInfo()
     if (gameInfo.thirdPartyManagedApp) {
-      await thirdParty.removeInstalledGame(appName)
+      await thirdParty.removeInstalledGame(this.appName)
       return { stdout: '', stderr: '' }
     }
 
     const command: LegendaryCommand = {
       subcommand: 'uninstall',
-      appName: LegendaryAppName.parse(appName),
+      appName: this.appName,
       '-y': true
     }
 
     const res = await libraryManagerMap['legendary'].runRunnerCommand(command, {
-      abortId: appName,
-      logMessagePrefix: `Uninstalling ${appName}`
+      abortId: this.appName,
+      logMessagePrefix: `Uninstalling ${this.appName}`
     })
 
     if (res.error) {
       logError(
-        ['Failed to uninstall', `${appName}:`, res.error],
+        ['Failed to uninstall', `${this.appName}:`, res.error],
         LogPrefix.Legendary
       )
     } else if (!res.abort) {
-      libraryManagerMap['legendary'].installState(appName, false)
-      await removeShortcutsUtil(this.getGameInfo(appName))
-      const gameInfo = this.getGameInfo(appName)
-      await removeNonSteamGame({ gameInfo })
+      libraryManagerMap['legendary'].installState(this.appName, false)
+      await removeShortcutsUtil(this)
+      await removeNonSteamGame(this)
     }
     sendFrontendMessage('refreshLibrary', 'legendary')
     return res
@@ -774,12 +769,12 @@ export default class LegendaryGameManager implements GameManager {
    * Repair game.
    * Does NOT check for online connectivity.
    */
-  async repair(appName: string): Promise<ExecResult> {
+  async repair(): Promise<ExecResult> {
     const { maxWorkers, downloadNoHttps } = GlobalConfig.get().getSettings()
 
     const command: LegendaryCommand = {
       subcommand: 'repair',
-      appName: LegendaryAppName.parse(appName),
+      appName: this.appName,
       '-y': true,
       '--skip-sdl': true
     }
@@ -787,19 +782,19 @@ export default class LegendaryGameManager implements GameManager {
     if (downloadNoHttps) command['--no-https'] = true
 
     const repairLogWriter = await createGameLogWriter(
-      appName,
+      this.appName,
       'legendary',
       'repair'
     )
     const res = await libraryManagerMap['legendary'].runRunnerCommand(command, {
-      abortId: appName,
+      abortId: this.appName,
       logWriters: [repairLogWriter],
-      logMessagePrefix: `Repairing ${appName}`
+      logMessagePrefix: `Repairing ${this.appName}`
     })
 
     if (res.error) {
       logError(
-        ['Failed to repair', `${appName}:`, res.error],
+        ['Failed to repair', `${this.appName}:`, res.error],
         LogPrefix.Legendary
       )
     }
@@ -807,31 +802,34 @@ export default class LegendaryGameManager implements GameManager {
   }
 
   async importGame(
-    appName: string,
     folderPath: string,
     platform: InstallPlatform
   ): Promise<ExecResult> {
     const command: LegendaryCommand = {
       subcommand: 'import',
-      appName: LegendaryAppName.parse(appName),
+      appName: this.appName,
       installationDirectory: Path.parse(folderPath),
       '--with-dlcs': true,
       '--platform': LegendaryPlatform.parse(platform)
     }
 
-    logInfo(`Importing ${appName}.`, LogPrefix.Legendary)
+    logInfo(`Importing ${this.appName}.`, LogPrefix.Legendary)
 
-    const logWriter = await createGameLogWriter(appName, 'legendary', 'import')
+    const logWriter = await createGameLogWriter(
+      this.appName,
+      'legendary',
+      'import'
+    )
     const res = await libraryManagerMap['legendary'].runRunnerCommand(command, {
-      abortId: appName,
+      abortId: this.appName,
       logWriters: [logWriter]
     })
-    this.addShortcuts(appName)
+    this.addShortcuts()
     const errorMatch = res.stderr.match(/^.*ERROR:.*$/gm)?.join('') ?? ''
     res.error = (res.error ?? '') + errorMatch
     if (res.error) {
       logError(
-        ['Failed to import', `${appName}:`, res.error],
+        ['Failed to import', `${this.appName}:`, res.error],
         LogPrefix.Legendary
       )
     }
@@ -842,7 +840,7 @@ export default class LegendaryGameManager implements GameManager {
    * Sync saves.
    * Does NOT check for online connectivity.
    */
-  async syncSaves(appName: string, arg: string, path: string): Promise<string> {
+  async syncSaves(arg: string, path: string): Promise<string> {
     if (!path) {
       logError(
         'No path provided for SavesSync, check your settings!',
@@ -853,7 +851,7 @@ export default class LegendaryGameManager implements GameManager {
 
     const command: LegendaryCommand = {
       subcommand: 'sync-saves',
-      appName: LegendaryAppName.parse(appName),
+      appName: this.appName,
       [arg]: true,
       '--save-path': Path.parse(path),
       '-y': true
@@ -861,14 +859,14 @@ export default class LegendaryGameManager implements GameManager {
 
     let fullOutput = ''
     const res = await libraryManagerMap['legendary'].runRunnerCommand(command, {
-      abortId: appName,
-      logMessagePrefix: `Syncing saves for ${this.getGameInfo(appName).title}`,
+      abortId: this.appName,
+      logMessagePrefix: `Syncing saves for ${this.getGameInfo().title}`,
       onOutput: (output) => (fullOutput += output)
     })
 
     if (res.error) {
       logError(
-        ['Failed to sync saves for', `${appName}:`, res.error],
+        ['Failed to sync saves for', `${this.appName}:`, res.error],
         LogPrefix.Legendary
       )
     }
@@ -876,14 +874,13 @@ export default class LegendaryGameManager implements GameManager {
   }
 
   async launch(
-    appName: string,
     logWriter: LogWriter,
     launchArguments?: LaunchOption,
     args: string[] = [],
     skipVersionCheck = false
   ): Promise<boolean> {
-    const gameSettings = await this.getSettings(appName)
-    const gameInfo = this.getGameInfo(appName)
+    const gameSettings = await this.getSettings()
+    const gameInfo = this.getGameInfo()
 
     const {
       success: launchPrepSuccess,
@@ -894,12 +891,7 @@ export default class LegendaryGameManager implements GameManager {
       gameScopeCommand,
       steamRuntime,
       offlineMode
-    } = await prepareLaunch(
-      gameSettings,
-      logWriter,
-      gameInfo,
-      this.isNative(appName)
-    )
+    } = await prepareLaunch(gameSettings, logWriter, gameInfo, this.isNative())
     if (!launchPrepSuccess) {
       logWriter.logError(['Launch aborted:', launchPrepFailReason])
       launchCleanup()
@@ -916,9 +908,9 @@ export default class LegendaryGameManager implements GameManager {
 
     let commandEnv = {
       ...process.env,
-      ...setupWrapperEnvVars({ appName, appRunner: 'legendary' }),
+      ...setupWrapperEnvVars({ appName: this.appName, appRunner: 'legendary' }),
       ...setupEnvVars(gameSettings, gameInfo.install.install_path),
-      ...getKnownFixesEnvVariables(appName, 'legendary')
+      ...getKnownFixesEnvVariables(this.appName, 'legendary')
     }
 
     // Use the wrapper EXE to launch games.
@@ -956,13 +948,13 @@ export default class LegendaryGameManager implements GameManager {
       ? { '--wrapper': NonEmptyString.parse(shlex.join(wrappers)) }
       : {}
 
-    if (!this.isNative(appName)) {
+    if (!this.isNative()) {
       // -> We're using Wine/Proton on Linux or CX on Mac
       const {
         success: wineLaunchPrepSuccess,
         failureReason: wineLaunchPrepFailReason,
         envVars: wineEnvVars
-      } = await prepareWineLaunch('legendary', appName, logWriter)
+      } = await prepareWineLaunch(this, logWriter)
       if (!wineLaunchPrepSuccess) {
         logWriter.logError(['Launch aborted:', wineLaunchPrepFailReason])
         if (wineLaunchPrepFailReason) {
@@ -991,7 +983,9 @@ export default class LegendaryGameManager implements GameManager {
     }
 
     const appNameToLaunch =
-      launchArguments?.type === 'dlc' ? launchArguments.dlcAppName : appName
+      launchArguments?.type === 'dlc'
+        ? launchArguments.dlcAppName
+        : this.appName
 
     const launchArgumentArgs =
       launchArguments &&
@@ -1018,12 +1012,16 @@ export default class LegendaryGameManager implements GameManager {
     if (gameInfo.isEAManaged) command['--origin'] = true
     if (gameInfo.isUbisoftManaged) command['--ubisoft'] = true
 
-    sendGameStatusUpdate({ appName, runner: 'legendary', status: 'playing' })
+    sendGameStatusUpdate({
+      appName: this.appName,
+      runner: 'legendary',
+      status: 'playing'
+    })
 
     const { error } = await libraryManagerMap['legendary'].runRunnerCommand(
       command,
       {
-        abortId: appName,
+        abortId: this.appName,
         env: commandEnv,
         wrappers: wrappers,
         logMessagePrefix: `Launching ${gameInfo.title}`,
@@ -1036,8 +1034,8 @@ export default class LegendaryGameManager implements GameManager {
     return !error
   }
 
-  isNative(appName: string): boolean {
-    const gameInfo = this.getGameInfo(appName)
+  isNative(): boolean {
+    const gameInfo = this.getGameInfo()
 
     if (isWindows) {
       return true
@@ -1050,18 +1048,18 @@ export default class LegendaryGameManager implements GameManager {
     return false
   }
 
-  async forceUninstall(appName: string) {
+  async forceUninstall() {
     // Modify Legendary installed.json file:
     try {
       await libraryManagerMap['legendary'].runRunnerCommand(
         {
           subcommand: 'uninstall',
-          appName: LegendaryAppName.parse(appName),
+          appName: this.appName,
           '-y': true,
           '--keep-files': true
         },
         {
-          abortId: appName
+          abortId: this.appName
         }
       )
 
@@ -1079,57 +1077,25 @@ export default class LegendaryGameManager implements GameManager {
 
   // Could be removed if legendary handles SIGKILL and SIGTERM for us
   // which is send via AbortController
-  async stop(appName: string, stopWine = true) {
+  async stop(stopWine = true) {
     // until the legendary bug gets fixed, kill legendary on mac
     // not a perfect solution but it's the only choice for now
 
     // @adityaruplaha: this is kinda arbitary and I don't understand it.
-    const pattern = isWindows ? 'legendary' : appName
+    const pattern = isWindows ? 'legendary' : this.appName
     killPattern(pattern)
 
-    if (stopWine && !this.isNative(appName)) {
-      const gameSettings = await this.getSettings(appName)
+    if (stopWine && !this.isNative()) {
+      const gameSettings = await this.getSettings()
       await shutdownWine(gameSettings)
     }
   }
 
-  async isGameAvailable(appName: string): Promise<boolean> {
-    return new Promise((resolve) => {
-      const info = this.getGameInfo(appName)
-      if (info && info.is_installed) {
-        if (
-          info.install.install_path &&
-          existsSync(info.install.install_path)
-        ) {
-          resolve(true)
-        } else {
-          resolve(false)
-        }
-      }
-      resolve(false)
-    })
-  }
-
-  async runWineCommandOnGame(
-    appName: string,
-    { commandParts, wait = false, protonVerb, startFolder }: WineCommandArgs
-  ): Promise<ExecResult> {
-    if (this.isNative(appName)) {
-      logError('runWineCommand called on native game!', LogPrefix.Legendary)
-      return { stdout: '', stderr: '' }
-    }
-
-    const { folder_name, install } = this.getGameInfo(appName)
-    const gameSettings = await this.getSettings(appName)
-
-    return runWineCommandUtil({
-      gameSettings,
-      gameInstallPath: install.install_path,
-      installFolderName: folder_name,
-      commandParts,
-      wait,
-      protonVerb,
-      startFolder
-    })
+  async isGameAvailable(): Promise<boolean> {
+    const info = this.getGameInfo()
+    if (!info.is_installed) return false
+    if (info.install.install_path && existsSync(info.install.install_path))
+      return true
+    return false
   }
 }

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -50,6 +50,7 @@ import { runLegendaryCommandStub } from './e2eMock'
 import { legendaryConfigPath, legendaryMetadata } from './constants'
 import { isWindows } from 'backend/constants/environment'
 import { LibraryManager } from 'common/types/game_manager'
+import LegendaryGame from './games'
 
 const fallBackImage = 'fallback'
 
@@ -58,9 +59,22 @@ let installedGames: Map<string, InstalledJsonMetadata> = new Map()
 const library: Map<string, GameInfo> = new Map()
 
 export default class LegendaryLibraryManager implements LibraryManager {
+  private readonly gameCache: Map<LegendaryAppName, LegendaryGame> = new Map()
+
   async init() {
     this.loadGamesInAccount()
     this.refreshInstalled()
+  }
+
+  getGame(id: string): LegendaryGame {
+    const appName = LegendaryAppName.parse(id)
+
+    const cached = this.gameCache.get(appName)
+    if (cached) return cached
+
+    const game = new LegendaryGame(appName)
+    this.gameCache.set(appName, game)
+    return game
   }
 
   /**

--- a/src/backend/storeManagers/legendary/setup.ts
+++ b/src/backend/storeManagers/legendary/setup.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { gameManagerMap, libraryManagerMap } from '..'
+import { libraryManagerMap } from '..'
 import { sendGameStatusUpdate } from 'backend/utils'
 import { enable, getStatus, isEnabled } from './eos_overlay/eos_overlay'
 import { split } from 'shlex'
@@ -11,7 +11,7 @@ import { isLinux } from 'backend/constants/environment'
 import LogWriter from 'backend/logger/log_writer'
 
 export const legendarySetup = async (appName: string, logWriter: LogWriter) => {
-  const gameInfo = gameManagerMap['legendary'].getGameInfo(appName)
+  const gameInfo = libraryManagerMap['legendary'].getGame(appName).getGameInfo()
   if (!gameInfo) {
     return
   }

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -4,15 +4,10 @@ import {
   GameInfo,
   GameSettings,
   InstallArgs,
-  InstallPlatform,
   InstallProgress,
   LaunchOption
 } from 'common/types'
-import {
-  GameManager,
-  InstallResult,
-  RemoveArgs
-} from 'common/types/game_manager'
+import { Game, InstallResult } from 'common/types/game_manager'
 import { libraryManagerMap } from '..'
 import {
   LogPrefix,
@@ -60,19 +55,25 @@ import { isLinux, isWindows } from 'backend/constants/environment'
 
 import type LogWriter from 'backend/logger/log_writer'
 
-export default class NileGameManager implements GameManager {
-  async getSettings(appName: string): Promise<GameSettings> {
-    const gameConfig = GameConfig.get(appName)
+export default class NileGameManager implements Game {
+  private readonly id: string
+
+  constructor(id: string) {
+    this.id = id
+  }
+
+  async getSettings(): Promise<GameSettings> {
+    const gameConfig = GameConfig.get(this.id)
     return gameConfig.config || (await gameConfig.getSettings())
   }
 
-  getGameInfo(appName: string): GameInfo {
-    const info = libraryManagerMap['nile'].getGameInfo(appName)
+  getGameInfo(): GameInfo {
+    const info = libraryManagerMap['nile'].getGameInfo(this.id)
     if (!info) {
       logError(
         [
           'Could not get game info for',
-          `${appName},`,
+          `${this.id},`,
           'returning empty object. Something is probably gonna go wrong soon'
         ],
         LogPrefix.Nile
@@ -91,8 +92,8 @@ export default class NileGameManager implements GameManager {
     return info
   }
 
-  async getExtraInfo(appName: string): Promise<ExtraInfo> {
-    const info = libraryManagerMap['nile'].getGameInfo(appName)
+  async getExtraInfo(): Promise<ExtraInfo> {
+    const info = this.getGameInfo()
     return {
       reqs: [],
       about: info?.description
@@ -105,19 +106,14 @@ export default class NileGameManager implements GameManager {
     }
   }
 
-  async importGame(
-    appName: string,
-    folderPath: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    platform: InstallPlatform
-  ): Promise<ExecResult> {
-    const importLogWriter = await createGameLogWriter(appName, 'nile', 'import')
+  async importGame(folderPath: string): Promise<ExecResult> {
+    const importLogWriter = await createGameLogWriter(this.id, 'nile', 'import')
     const res = await libraryManagerMap['nile'].runRunnerCommand(
-      ['import', '--path', folderPath, appName],
+      ['import', '--path', folderPath, this.id],
       {
-        abortId: appName,
+        abortId: this.id,
         logWriters: [importLogWriter],
-        logMessagePrefix: `Importing ${appName}`
+        logMessagePrefix: `Importing ${this.id}`
       }
     )
 
@@ -126,14 +122,14 @@ export default class NileGameManager implements GameManager {
     }
 
     if (res.error) {
-      logError(['Failed to import', `${appName}:`, res.error], LogPrefix.Nile)
+      logError(['Failed to import', `${this.id}:`, res.error], LogPrefix.Nile)
       return res
     }
 
     const errorMatch = res.stderr.match(/ERROR \[IMPORT]:\t(.*)/)
     if (errorMatch) {
       logError(
-        ['Failed to import', `${appName}:`, errorMatch[1]],
+        ['Failed to import', `${this.id}:`, errorMatch[1]],
         LogPrefix.Nile
       )
       return {
@@ -143,10 +139,10 @@ export default class NileGameManager implements GameManager {
     }
 
     try {
-      this.addShortcuts(appName)
-      libraryManagerMap['nile'].installState(appName, true)
+      this.addShortcuts()
+      libraryManagerMap['nile'].installState(this.id, true)
     } catch (error) {
-      logError(['Failed to import', `${appName}:`, error], LogPrefix.Nile)
+      logError(['Failed to import', `${this.id}:`, error], LogPrefix.Nile)
     }
 
     return res
@@ -159,19 +155,13 @@ export default class NileGameManager implements GameManager {
     diskSpeed: undefined,
     downSpeed: undefined
   })
-  private tmpProgress: Record<string, InstallProgress> = {}
+  private tmpProgress: InstallProgress | undefined = undefined
 
-  onInstallOrUpdateOutput(
-    appName: string,
-    action: 'installing' | 'updating',
-    data: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    totalDownloadSize = -1
-  ) {
-    if (!Object.hasOwn(this.tmpProgress, appName)) {
-      this.tmpProgress[appName] = this.defaultTmpProgress()
+  onInstallOrUpdateOutput(action: 'installing' | 'updating', data: string) {
+    if (!this.tmpProgress) {
+      this.tmpProgress = this.defaultTmpProgress()
     }
-    const progress = this.tmpProgress[appName]
+    const progress = this.tmpProgress
 
     // parse log for percent
     if (!progress.percent) {
@@ -219,7 +209,7 @@ export default class NileGameManager implements GameManager {
     ) {
       logInfo(
         [
-          `Progress for ${this.getGameInfo(appName).title}:`,
+          `Progress for ${this.getGameInfo().title}:`,
           `${progress.percent}%/${progress.bytes}/${progress.eta}`.trim(),
           `Down: ${progress.downSpeed}MB/s / Disk: ${progress.diskSpeed}MB/s`
         ],
@@ -227,40 +217,37 @@ export default class NileGameManager implements GameManager {
       )
 
       sendProgressUpdate({
-        appName,
+        appName: this.id,
         runner: 'nile',
         status: action,
         progress
       })
 
       // reset
-      this.tmpProgress[appName] = this.defaultTmpProgress()
+      this.tmpProgress = this.defaultTmpProgress()
     }
   }
 
-  async install(
-    appName: string,
-    { path }: InstallArgs
-  ): Promise<InstallResult> {
+  async install({ path }: InstallArgs): Promise<InstallResult> {
     const { maxWorkers } = GlobalConfig.get().getSettings()
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
 
-    const commandParts = ['install', '--base-path', path, ...workers, appName]
+    const commandParts = ['install', '--base-path', path, ...workers, this.id]
 
     const onOutput = (data: string) => {
-      this.onInstallOrUpdateOutput(appName, 'installing', data)
+      this.onInstallOrUpdateOutput('installing', data)
     }
 
     const installLogWriter = await createGameLogWriter(
-      appName,
+      this.id,
       'nile',
       'install'
     )
     const res = await libraryManagerMap['nile'].runRunnerCommand(commandParts, {
-      abortId: appName,
+      abortId: this.id,
       logWriters: [installLogWriter],
       onOutput,
-      logMessagePrefix: `Installing ${appName}`
+      logMessagePrefix: `Installing ${this.id}`
     })
 
     if (res.abort) {
@@ -269,16 +256,16 @@ export default class NileGameManager implements GameManager {
 
     if (res.error) {
       if (!res.error.includes('signal')) {
-        logError(['Failed to install', appName, res.error], LogPrefix.Nile)
+        logError(['Failed to install', this.id, res.error], LogPrefix.Nile)
       }
       return { status: 'error', error: res.error }
     }
-    this.addShortcuts(appName)
-    libraryManagerMap['nile'].installState(appName, true)
-    const metadata = libraryManagerMap['nile'].getInstallMetadata(appName)
+    this.addShortcuts()
+    libraryManagerMap['nile'].installState(this.id, true)
+    const metadata = libraryManagerMap['nile'].getInstallMetadata(this.id)
 
     if (isWindows) {
-      await setup(appName, metadata?.path)
+      await setup(this.id, metadata?.path)
     }
 
     return { status: 'done' }
@@ -295,8 +282,8 @@ export default class NileGameManager implements GameManager {
    * @async
    * @public
    */
-  async addShortcuts(appName: string, fromMenu?: boolean) {
-    return addShortcutsUtil(this.getGameInfo(appName), fromMenu)
+  async addShortcuts(fromMenu?: boolean) {
+    return addShortcutsUtil(this, fromMenu)
   }
 
   /**
@@ -304,18 +291,17 @@ export default class NileGameManager implements GameManager {
    * @async
    * @public
    */
-  async removeShortcuts(appName: string) {
-    return removeShortcutsUtil(this.getGameInfo(appName))
+  async removeShortcuts() {
+    return removeShortcutsUtil(this)
   }
 
   async launch(
-    appName: string,
     logWriter: LogWriter,
     launchArguments?: LaunchOption,
     args: string[] = []
   ): Promise<boolean> {
-    const gameSettings = await this.getSettings(appName)
-    const gameInfo = this.getGameInfo(appName)
+    const gameSettings = await this.getSettings()
+    const gameInfo = this.getGameInfo()
 
     const {
       success: launchPrepSuccess,
@@ -347,11 +333,11 @@ export default class NileGameManager implements GameManager {
 
     let commandEnv = {
       ...process.env,
-      ...setupWrapperEnvVars({ appName, appRunner: 'nile' }),
+      ...setupWrapperEnvVars({ appName: this.id, appRunner: 'nile' }),
       ...(isWindows
         ? {}
         : setupEnvVars(gameSettings, gameInfo.install.install_path)),
-      ...getKnownFixesEnvVariables(appName, 'nile')
+      ...getKnownFixesEnvVariables(this.id, 'nile')
     }
 
     const wrappers = setupWrappers(
@@ -372,7 +358,7 @@ export default class NileGameManager implements GameManager {
         success: wineLaunchPrepSuccess,
         failureReason: wineLaunchPrepFailReason,
         envVars: wineEnvVars
-      } = await prepareWineLaunch('nile', appName, logWriter)
+      } = await prepareWineLaunch(this, logWriter)
       if (!wineLaunchPrepSuccess) {
         logWriter.logError(['Launch aborted:', wineLaunchPrepFailReason])
         if (wineLaunchPrepFailReason) {
@@ -416,16 +402,20 @@ export default class NileGameManager implements GameManager {
       ...wineFlag,
       ...shlex.split(launchArgumentsArgs),
       ...shlex.split(gameSettings.launcherArgs ?? ''),
-      appName,
+      this.id,
       ...args
     ]
 
-    sendGameStatusUpdate({ appName, runner: 'nile', status: 'playing' })
+    sendGameStatusUpdate({
+      appName: this.id,
+      runner: 'nile',
+      status: 'playing'
+    })
 
     const { error } = await libraryManagerMap['nile'].runRunnerCommand(
       commandParts,
       {
-        abortId: appName,
+        abortId: this.id,
         env: commandEnv,
         wrappers,
         logMessagePrefix: `Launching ${gameInfo.title}`,
@@ -442,11 +432,8 @@ export default class NileGameManager implements GameManager {
     return !error
   }
 
-  async moveInstall(
-    appName: string,
-    newInstallPath: string
-  ): Promise<InstallResult> {
-    const gameInfo = this.getGameInfo(appName)
+  async moveInstall(newInstallPath: string): Promise<InstallResult> {
+    const gameInfo = this.getGameInfo()
     logInfo(`Moving ${gameInfo.title} to ${newInstallPath}`, LogPrefix.Nile)
 
     const moveImpl = isWindows ? moveOnWindows : moveOnUnix
@@ -462,18 +449,18 @@ export default class NileGameManager implements GameManager {
     }
 
     await libraryManagerMap['nile'].changeGameInstallPath(
-      appName,
+      this.id,
       moveResult.installPath
     )
     return { status: 'done' }
   }
 
-  async repair(appName: string): Promise<ExecResult> {
-    const installInfo = this.getGameInfo(appName)
+  async repair(): Promise<ExecResult> {
+    const installInfo = this.getGameInfo()
     const { install_path } = installInfo.install ?? {}
 
     if (!install_path) {
-      const error = `Could not find install path for ${appName}`
+      const error = `Could not find install path for ${this.id}`
       logError(error, LogPrefix.Nile)
       return {
         stderr: '',
@@ -482,19 +469,19 @@ export default class NileGameManager implements GameManager {
       }
     }
 
-    logDebug([appName, 'is installed at', install_path], LogPrefix.Nile)
-    const repairLogWriter = await createGameLogWriter(appName, 'nile', 'repair')
+    logDebug([this.id, 'is installed at', install_path], LogPrefix.Nile)
+    const repairLogWriter = await createGameLogWriter(this.id, 'nile', 'repair')
     const res = await libraryManagerMap['nile'].runRunnerCommand(
-      ['verify', '--path', install_path, appName],
+      ['verify', '--path', install_path, this.id],
       {
-        abortId: appName,
+        abortId: this.id,
         logWriters: [repairLogWriter],
-        logMessagePrefix: `Repairing ${appName}`
+        logMessagePrefix: `Repairing ${this.id}`
       }
     )
 
     if (res.error) {
-      logError(['Failed to repair', `${appName}:`, res.error], LogPrefix.Nile)
+      logError(['Failed to repair', `${this.id}:`, res.error], LogPrefix.Nile)
     }
 
     return res
@@ -505,45 +492,45 @@ export default class NileGameManager implements GameManager {
     return ''
   }
 
-  async uninstall({ appName }: RemoveArgs): Promise<ExecResult> {
-    const commandParts = ['uninstall', appName]
+  // FIXME: This doesn't respect the `RemoveArgs` passed to it
+  async uninstall(): Promise<ExecResult> {
+    const commandParts = ['uninstall', this.id]
 
     const res = await libraryManagerMap['nile'].runRunnerCommand(commandParts, {
-      abortId: appName,
-      logMessagePrefix: `Uninstalling ${appName}`
+      abortId: this.id,
+      logMessagePrefix: `Uninstalling ${this.id}`
     })
 
     if (res.error) {
       logError(
-        ['Failed to uninstall', `${appName}:`, res.error],
+        ['Failed to uninstall', `${this.id}:`, res.error],
         LogPrefix.Nile
       )
     } else if (!res.abort) {
-      const gameInfo = this.getGameInfo(appName)
-      await removeShortcutsUtil(gameInfo)
-      await removeNonSteamGame({ gameInfo })
-      libraryManagerMap['nile'].installState(appName, false)
+      await removeShortcutsUtil(this)
+      await removeNonSteamGame(this)
+      libraryManagerMap['nile'].installState(this.id, false)
     }
     sendFrontendMessage('refreshLibrary', 'nile')
     return res
   }
 
-  async update(appName: string): Promise<InstallResult> {
+  async update(): Promise<InstallResult> {
     const { maxWorkers } = GlobalConfig.get().getSettings()
     const workers = maxWorkers ? ['--max-workers', `${maxWorkers}`] : []
 
-    const commandParts = ['update', ...workers, appName]
+    const commandParts = ['update', ...workers, this.id]
 
     const onOutput = (data: string) => {
-      this.onInstallOrUpdateOutput(appName, 'updating', data)
+      this.onInstallOrUpdateOutput('updating', data)
     }
 
-    const updateLogWriter = await createGameLogWriter(appName, 'nile', 'update')
+    const updateLogWriter = await createGameLogWriter(this.id, 'nile', 'update')
     const res = await libraryManagerMap['nile'].runRunnerCommand(commandParts, {
-      abortId: appName,
+      abortId: this.id,
       logWriters: [updateLogWriter],
       onOutput,
-      logMessagePrefix: `Updating ${appName}`
+      logMessagePrefix: `Updating ${this.id}`
     })
 
     if (res.abort) {
@@ -552,13 +539,13 @@ export default class NileGameManager implements GameManager {
 
     if (res.error) {
       if (!res.error.includes('signal')) {
-        logError(['Failed to update', appName, res.error], LogPrefix.Nile)
+        logError(['Failed to update', this.id, res.error], LogPrefix.Nile)
       }
       return { status: 'error', error: res.error }
     }
 
     sendGameStatusUpdate({
-      appName,
+      appName: this.id,
       runner: 'nile',
       status: 'done'
     })
@@ -566,23 +553,23 @@ export default class NileGameManager implements GameManager {
     return { status: 'done' }
   }
 
-  async forceUninstall(appName: string) {
-    libraryManagerMap['nile'].removeFromInstalledConfig(appName)
+  async forceUninstall() {
+    libraryManagerMap['nile'].removeFromInstalledConfig(this.id)
   }
 
-  async stop(appName: string, stopWine = true) {
-    const pattern = isLinux ? appName : 'nile'
+  async stop(stopWine = true) {
+    const pattern = isLinux ? this.id : 'nile'
     killPattern(pattern)
 
     if (stopWine && !this.isNative()) {
-      const gameSettings = await this.getSettings(appName)
+      const gameSettings = await this.getSettings()
       await shutdownWine(gameSettings)
     }
   }
 
-  async isGameAvailable(appName: string): Promise<boolean> {
+  async isGameAvailable(): Promise<boolean> {
     return new Promise((resolve) => {
-      const info = this.getGameInfo(appName)
+      const info = this.getGameInfo()
       resolve(
         Boolean(
           info?.is_installed &&

--- a/src/backend/storeManagers/nile/library.ts
+++ b/src/backend/storeManagers/nile/library.ts
@@ -24,11 +24,13 @@ import { copySync } from 'fs-extra'
 import { NileUser } from './user'
 import { runNileCommandStub } from './e2eMock'
 import { nileConfigPath, nileInstalled, nileLibrary } from './constants'
+import NileGame from './games'
 import type { LibraryManager } from 'common/types/game_manager'
 
 export default class NileLibraryManager implements LibraryManager {
   private installedGames: Map<string, NileInstallMetadataInfo> = new Map()
   private library: Map<string, GameInfo> = new Map()
+  private readonly gameCache: Map<string, NileGame> = new Map()
 
   async init() {
     // Migrate user data from global Nile config if necessary
@@ -39,6 +41,15 @@ export default class NileLibraryManager implements LibraryManager {
     }
 
     this.refresh()
+  }
+
+  getGame(id: string): NileGame {
+    const cached = this.gameCache.get(id)
+    if (cached) return cached
+
+    const game = new NileGame(id)
+    this.gameCache.set(id, game)
+    return game
   }
 
   /**

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -3,8 +3,6 @@ import {
   ExtraInfo,
   GameInfo,
   GameSettings,
-  InstallArgs,
-  InstallPlatform,
   LaunchOption
 } from 'common/types'
 import { libraryStore } from './electronStores'
@@ -20,12 +18,7 @@ import {
 } from '../../shortcuts/shortcuts/shortcuts'
 import { notify } from '../../dialog/dialog'
 import { launchGame } from 'backend/storeManagers/storeManagerCommon/games'
-import { GOGCloudSavesLocation } from 'common/types/gog'
-import {
-  GameManager,
-  InstallResult,
-  RemoveArgs
-} from 'common/types/game_manager'
+import { Game, InstallResult, RemoveArgs } from 'common/types/game_manager'
 import { removePrefix } from 'backend/utils/uninstaller'
 import { removeRecentGame } from 'backend/recent_games/recent_games'
 import { isLinux, isMac, isWindows } from 'backend/constants/environment'
@@ -33,10 +26,16 @@ import { removeNonSteamGame } from 'backend/shortcuts/nonesteamgame/nonesteamgam
 
 import type LogWriter from 'backend/logger/log_writer'
 
-export default class SideloadGameManager implements GameManager {
-  getGameInfo(appName: string): GameInfo {
+export default class SideloadGame implements Game {
+  private readonly id: string
+
+  constructor(id: string) {
+    this.id = id
+  }
+
+  getGameInfo(): GameInfo {
     const store = libraryStore.get('games', [])
-    const info = store.find((app) => app.app_name === appName)
+    const info = store.find((app) => app.app_name === this.id)
     if (!info) {
       // @ts-expect-error TODO: As with LegendaryGame and GOGGame, handle this properly
       return {}
@@ -44,24 +43,24 @@ export default class SideloadGameManager implements GameManager {
     return info
   }
 
-  async getSettings(appName: string): Promise<GameSettings> {
+  async getSettings(): Promise<GameSettings> {
     return (
-      GameConfig.get(appName).config ||
-      (await GameConfig.get(appName).getSettings())
+      GameConfig.get(this.id).config ||
+      (await GameConfig.get(this.id).getSettings())
     )
   }
 
-  async addShortcuts(appName: string, fromMenu?: boolean): Promise<void> {
-    return addShortcutsUtil(this.getGameInfo(appName), fromMenu)
+  async addShortcuts(fromMenu?: boolean): Promise<void> {
+    return addShortcutsUtil(this, fromMenu)
   }
 
-  async removeShortcuts(appName: string): Promise<void> {
-    return removeShortcutsUtil(this.getGameInfo(appName))
+  async removeShortcuts(): Promise<void> {
+    return removeShortcutsUtil(this)
   }
 
-  async isGameAvailable(appName: string): Promise<boolean> {
+  async isGameAvailable(): Promise<boolean> {
     return new Promise((resolve) => {
-      const { install } = this.getGameInfo(appName)
+      const { install } = this.getGameInfo()
 
       if (install && install.platform === 'Browser') {
         resolve(true)
@@ -74,59 +73,51 @@ export default class SideloadGameManager implements GameManager {
   }
 
   async launch(
-    appName: string,
     logWriter: LogWriter,
     launchArguments?: LaunchOption,
     args: string[] = []
   ): Promise<boolean> {
-    return launchGame(
-      appName,
-      logWriter,
-      this.getGameInfo(appName),
-      'sideload',
-      args
-    )
+    return launchGame(this, logWriter, args)
   }
 
-  async stop(appName: string): Promise<void> {
+  async stop(): Promise<void> {
     const {
       install: { executable = undefined }
-    } = this.getGameInfo(appName)
+    } = this.getGameInfo()
 
     if (executable) {
       const split = executable.split('/')
       const exe = split[split.length - 1]
       killPattern(exe)
 
-      if (!this.isNative(appName)) {
-        const gameSettings = await this.getSettings(appName)
+      if (!this.isNative()) {
+        const gameSettings = await this.getSettings()
         shutdownWine(gameSettings)
       }
     }
   }
 
   async uninstall({
-    appName,
     shouldRemovePrefix,
     deleteFiles = false
   }: RemoveArgs): Promise<ExecResult> {
     sendGameStatusUpdate({
-      appName,
+      appName: this.id,
       runner: 'sideload',
       status: 'uninstalling'
     })
 
     const old = libraryStore.get('games', [])
-    const current = old.filter((a: GameInfo) => a.app_name !== appName)
+    const current = old.filter((a: GameInfo) => a.app_name !== this.id)
 
-    const gameInfo = this.getGameInfo(appName)
+    const gameInfo = this.getGameInfo()
     const {
       title,
       install: { executable }
     } = gameInfo
 
     if (shouldRemovePrefix) {
-      removePrefix(appName, 'sideload')
+      removePrefix(this.id, 'sideload')
     }
     libraryStore.set('games', current)
 
@@ -136,12 +127,12 @@ export default class SideloadGameManager implements GameManager {
 
     notify({ title, body: i18next.t('notify.uninstalled') })
 
-    removeShortcutsUtil(gameInfo)
-    removeRecentGame(appName)
-    removeNonSteamGame({ gameInfo })
+    removeShortcutsUtil(this)
+    removeRecentGame(this.id)
+    removeNonSteamGame(this)
 
     sendGameStatusUpdate({
-      appName,
+      appName: this.id,
       runner: 'sideload',
       status: 'done'
     })
@@ -150,10 +141,10 @@ export default class SideloadGameManager implements GameManager {
     return { stderr: '', stdout: '' }
   }
 
-  isNative(appName: string): boolean {
+  isNative(): boolean {
     const {
       install: { platform }
-    } = this.getGameInfo(appName)
+    } = this.getGameInfo()
     if (platform) {
       if (platform === 'Browser') {
         return true
@@ -177,9 +168,9 @@ export default class SideloadGameManager implements GameManager {
     return false
   }
 
-  async getExtraInfo(appName: string): Promise<ExtraInfo> {
+  async getExtraInfo(): Promise<ExtraInfo> {
     logWarning(
-      `getExtraInfo not implemented on Sideload Game Manager. called for appName = ${appName}`
+      `getExtraInfo not implemented on Sideload Game Manager. called for ID = ${this.id}`
     )
     return {
       about: {
@@ -191,69 +182,51 @@ export default class SideloadGameManager implements GameManager {
     }
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  onInstallOrUpdateOutput(
-    appName: string,
-    action: 'installing' | 'updating',
-    data: string,
-    totalDownloadSize: number
-  ) {
+  onInstallOrUpdateOutput() {
     logWarning(
-      `onInstallOrUpdateOutput not implemented on Sideload Game Manager. called for appName = ${appName}`
+      `onInstallOrUpdateOutput not implemented on Sideload Game Manager. called for ID = ${this.id}`
     )
   }
 
-  async moveInstall(
-    appName: string,
-    newInstallPath: string
-  ): Promise<InstallResult> {
+  async moveInstall(): Promise<InstallResult> {
     logWarning(
-      `moveInstall not implemented on Sideload Game Manager. called for appName = ${appName}`
+      `moveInstall not implemented on Sideload Game Manager. called for ID = ${this.id}`
     )
     return { status: 'error' }
   }
 
-  async repair(appName: string): Promise<ExecResult> {
+  async repair(): Promise<ExecResult> {
     logWarning(
-      `repair not implemented on Sideload Game Manager. called for appName = ${appName}`
+      `repair not implemented on Sideload Game Manager. called for ID = ${this.id}`
     )
     return { stderr: '', stdout: '' }
   }
 
-  async syncSaves(
-    appName: string,
-    arg: string,
-    path: string,
-    gogSaves?: GOGCloudSavesLocation[]
-  ): Promise<string> {
+  async syncSaves(): Promise<string> {
     logWarning(
-      `syncSaves not implemented on Sideload Game Manager. called for appName = ${appName}`
+      `syncSaves not implemented on Sideload Game Manager. called for ID = ${this.id}`
     )
     return ''
   }
 
-  async forceUninstall(appName: string): Promise<void> {
+  async forceUninstall(): Promise<void> {
     logWarning(
-      `forceUninstall not implemented on Sideload Game Manager. called for appName = ${appName}`
+      `forceUninstall not implemented on Sideload Game Manager. called for ID = ${this.id}`
     )
   }
 
-  async install(appName: string, args: InstallArgs): Promise<InstallResult> {
+  async install(): Promise<InstallResult> {
     logWarning(
-      `install not implemented on Sideload Game Manager. called for appName = ${appName}`
+      `install not implemented on Sideload Game Manager. called for ID = ${this.id}`
     )
     return { status: 'error' }
   }
 
-  async importGame(
-    appName: string,
-    path: string,
-    platform: InstallPlatform
-  ): Promise<ExecResult> {
+  async importGame(): Promise<ExecResult> {
     return { stderr: '', stdout: '' }
   }
 
-  async update(appName: string): Promise<{ status: 'done' | 'error' }> {
+  async update(): Promise<{ status: 'done' | 'error' }> {
     return { status: 'error' }
   }
 }

--- a/src/backend/storeManagers/sideload/library.ts
+++ b/src/backend/storeManagers/sideload/library.ts
@@ -7,9 +7,14 @@ import { addShortcuts } from 'backend/shortcuts/shortcuts/shortcuts'
 import { sendFrontendMessage } from 'backend/ipc'
 import { isMac } from 'backend/constants/environment'
 import { LibraryManager } from 'common/types/game_manager'
+import SideloadGame from './games'
 
 export default class SideloadLibraryManager implements LibraryManager {
   init = () => Promise.resolve()
+
+  getGame(id: string): SideloadGame {
+    return new SideloadGame(id)
+  }
 
   addNewApp({
     app_name,
@@ -64,7 +69,7 @@ export default class SideloadLibraryManager implements LibraryManager {
       current[gameIndex] = { ...current[gameIndex], ...game }
     } else {
       current.push(game)
-      addShortcuts(game)
+      addShortcuts(new SideloadGame(app_name))
     }
 
     libraryStore.set('games', current)

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -1,4 +1,4 @@
-import { GameInfo, GameSettings, Runner } from 'common/types'
+import { GameSettings } from 'common/types'
 import { GameConfig } from '../../game_config'
 import { logInfo, LogPrefix, logWarning } from 'backend/logger'
 import { basename, dirname } from 'path'
@@ -23,12 +23,12 @@ import {
   deleteAbortController
 } from '../../utils/aborthandler/aborthandler'
 import { BrowserWindow, dialog, Menu } from 'electron'
-import { gameManagerMap } from '../index'
 import { sendGameStatusUpdate } from 'backend/utils'
 import { isLinux, isMac } from 'backend/constants/environment'
 import { windowIcon } from 'backend/constants/paths'
 
 import type LogWriter from 'backend/logger/log_writer'
+import { Game } from '../../../common/types/game_manager'
 
 async function getAppSettings(appName: string): Promise<GameSettings> {
   return (
@@ -114,15 +114,13 @@ const openNewBrowserGameWindow = async ({
 }
 
 export async function launchGame(
-  appName: string,
+  game: Game,
   logWriter: LogWriter,
-  gameInfo: GameInfo,
-  runner: Runner,
   args: string[] = []
 ): Promise<boolean> {
-  if (!gameInfo) {
-    return false
-  }
+  const gameInfo = game.getGameInfo()
+  const appName = gameInfo.app_name
+  const runner = gameInfo.runner
 
   let {
     install: { executable }
@@ -153,7 +151,7 @@ export async function launchGame(
   const extraArgsJoined = extraArgs.join(' ')
 
   if (executable) {
-    const isNative = gameManagerMap[runner].isNative(appName)
+    const isNative = game.isNative()
     const {
       success: launchPrepSuccess,
       failureReason: launchPrepFailReason,
@@ -165,7 +163,7 @@ export async function launchGame(
     } = await prepareLaunch(gameSettings, logWriter, gameInfo, isNative)
 
     if (!isNative) {
-      await prepareWineLaunch(runner, appName, logWriter)
+      await prepareWineLaunch(game, logWriter)
     }
 
     const wrappers = setupWrappers(
@@ -189,7 +187,7 @@ export async function launchGame(
 
     sendGameStatusUpdate({
       appName,
-      runner,
+      runner: gameInfo.runner,
       status: 'playing'
     })
 

--- a/src/backend/storeManagers/zoom/games.ts
+++ b/src/backend/storeManagers/zoom/games.ts
@@ -20,7 +20,6 @@ import {
   InstallArgs,
   InstalledInfo,
   LaunchOption,
-  InstallPlatform,
   InstallProgress
 } from 'common/types'
 import { existsSync, rmSync } from 'graceful-fs'
@@ -53,7 +52,7 @@ import { ZoomInstallPlatform, ZoomDownloadFile } from 'common/types/zoom'
 import { t } from 'i18next'
 import { showDialogBoxModalAuto } from '../../dialog/dialog'
 import { sendFrontendMessage } from '../../ipc'
-import { GameManager, RemoveArgs } from 'common/types/game_manager'
+import { Game } from 'common/types/game_manager'
 import { isLinux, isMac, isWindows } from 'backend/constants/environment'
 import { libraryManagerMap } from '..'
 import { isUmuSupported } from 'backend/utils/compatibility_layers'
@@ -62,7 +61,13 @@ import { getUmuId } from 'backend/wiki_game_info/umu/utils'
 import type LogWriter from 'backend/logger/log_writer'
 import { rm, writeFile } from 'node:fs/promises'
 
-export default class ZoomGameManager implements GameManager {
+export default class ZoomGame implements Game {
+  private readonly id: string
+
+  constructor(id: string) {
+    this.id = id
+  }
+
   private async findDosboxExecutable(dir: string): Promise<string | undefined> {
     let list: fs.Dirent[]
     try {
@@ -121,13 +126,13 @@ export default class ZoomGameManager implements GameManager {
     return extra
   }
 
-  getGameInfo(appName: string): GameInfo {
-    const info = libraryManagerMap['zoom'].getGameInfo(appName)
+  getGameInfo(): GameInfo {
+    const info = libraryManagerMap['zoom'].getGameInfo(this.id)
     if (!info) {
       logError(
         [
           'Could not get game info for',
-          `${appName},`,
+          `${this.id},`,
           'returning empty object. Something is probably gonna go wrong soon'
         ],
         LogPrefix.Zoom
@@ -146,94 +151,84 @@ export default class ZoomGameManager implements GameManager {
     return info
   }
 
-  async getSettings(appName: string): Promise<GameSettings> {
+  async getSettings(): Promise<GameSettings> {
     return (
-      GameConfig.get(appName).config ||
-      (await GameConfig.get(appName).getSettings())
+      GameConfig.get(this.id).config ||
+      (await GameConfig.get(this.id).getSettings())
     )
   }
 
-  async importGame(
-    appName: string,
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    folderPath: string,
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    _platform: InstallPlatform
-  ): Promise<ExecResult> {
+  async importGame(): Promise<ExecResult> {
     // The original zoom.py doesn't have an explicit "import" function for installed games.
     // It relies on scanning the library. This function might need to be adapted
     // if Zoom has a way to import already installed games.
     logWarning(
-      `Import game not fully implemented for Zoom: ${appName}`,
+      `Import game not fully implemented for Zoom: ${this.id}`,
       LogPrefix.Zoom
     )
     return { stdout: '', stderr: 'Import not fully implemented' }
   }
 
-  defaultTmpProgress() {
-    return {
-      bytes: '',
-      eta: '',
-      percent: undefined,
-      diskSpeed: undefined,
-      downSpeed: undefined
-    }
-  }
-  private tmpProgress: Record<string, InstallProgress> = {}
+  private defaultTmpProgress = () => ({
+    bytes: '',
+    eta: '',
+    percent: undefined,
+    diskSpeed: undefined,
+    downSpeed: undefined
+  })
+  private tmpProgress: InstallProgress | undefined
 
   onInstallOrUpdateOutput(
-    appName: string,
     action: 'installing' | 'updating',
     data: string,
     total: number
   ) {
     if (data.length === 0) return
 
-    if (!Object.hasOwn(this.tmpProgress, appName)) {
-      this.tmpProgress[appName] = this.defaultTmpProgress()
+    if (!this.tmpProgress) {
+      this.tmpProgress = this.defaultTmpProgress()
     }
-    const progress = this.tmpProgress[appName]
-
     // This part needs to be adapted to parse output from the actual installer.
     // For now, it's a placeholder.
     logDebug(
-      `Installer output for ${appName}: ${data}% (total: ${getFileSize(total)})`,
+      `Installer output for ${this.id}: ${data}% (total: ${getFileSize(total)})`,
       LogPrefix.Zoom
     )
 
-    progress.percent = parseInt(data)
-    if (progress.percent > 100) {
-      progress.percent = 100
+    this.tmpProgress.percent = parseInt(data)
+    if (this.tmpProgress.percent > 100) {
+      this.tmpProgress.percent = 100
     }
-    progress.bytes = 'N/A'
-    progress.eta = 'N/A'
-    progress.downSpeed = 0
-    progress.diskSpeed = 0
+    this.tmpProgress.bytes = 'N/A'
+    this.tmpProgress.eta = 'N/A'
+    this.tmpProgress.downSpeed = 0
+    this.tmpProgress.diskSpeed = 0
 
     sendProgressUpdate({
-      appName: appName,
+      appName: this.id,
       runner: 'zoom',
       status: action,
-      progress: progress
+      progress: this.tmpProgress
     })
   }
 
-  async install(
-    appName: string,
-    { path, platformToInstall, installLanguage }: InstallArgs
-  ): Promise<{
+  async install({
+    path,
+    platformToInstall,
+    installLanguage
+  }: InstallArgs): Promise<{
     status: 'done' | 'error' | 'abort'
     error?: string
   }> {
     logInfo(
-      `Installing ${appName} to ${path} for platform ${platformToInstall}`,
+      `Installing ${this.id} to ${path} for platform ${platformToInstall}`,
       LogPrefix.Zoom
     )
     logInfo(`Installation path: ${path}`, LogPrefix.Zoom)
 
-    const gameInfo = this.getGameInfo(appName)
+    const gameInfo = this.getGameInfo()
     if (!gameInfo || !gameInfo.folder_name) {
-      logError(`Game info not found for ${appName}`, LogPrefix.Zoom)
+      logError(`Game info not found for ${this.id}`, LogPrefix.Zoom)
       return { status: 'error', error: 'Game info not found' }
     }
 
@@ -244,10 +239,10 @@ export default class ZoomGameManager implements GameManager {
     // Fetch installer URL
     const installers: ZoomDownloadFile[] = await libraryManagerMap[
       'zoom'
-    ].getInstallers(installPlatform, appName)
+    ].getInstallers(installPlatform, this.id)
     if (installers.length === 0 || !installers[0].url) {
       logError(
-        `No installer found for ${appName} on ${installPlatform}`,
+        `No installer found for ${this.id} on ${installPlatform}`,
         LogPrefix.Zoom
       )
       return { status: 'error', error: 'No installer found' }
@@ -289,7 +284,6 @@ export default class ZoomGameManager implements GameManager {
               }
 
               this.onInstallOrUpdateOutput(
-                appName,
                 'installing',
                 `${percent}`,
                 totalSize
@@ -360,7 +354,7 @@ export default class ZoomGameManager implements GameManager {
 
       logInfo(`Executing installer: ${executable}`, LogPrefix.Zoom)
 
-      const gameSettings = await this.getSettings(appName)
+      const gameSettings = await this.getSettings()
       await writeFile(
         infFilePath,
         `[Setup]\nLang=english\nDisableWelcomePage=yes\nDisableDirPage=yes\nDisableProgramGroupPage=yes\nDisableReadyPage=yes\n`,
@@ -387,9 +381,9 @@ export default class ZoomGameManager implements GameManager {
         gameInstallPath: path,
         wait: true,
         options: {
-          logMessagePrefix: `Installing ${appName}`,
-          logWriters: [await createGameLogWriter(appName, 'zoom', 'install')],
-          abortId: appName
+          logMessagePrefix: `Installing ${this.id}`,
+          logWriters: [await createGameLogWriter(this.id, 'zoom', 'install')],
+          abortId: this.id
         }
       })
     }
@@ -477,7 +471,7 @@ export default class ZoomGameManager implements GameManager {
           finalExecutable = exes[0]
         } else if (exes.length > 1) {
           // Try to find an exe with the game's name in it
-          const gameInfo = this.getGameInfo(appName)
+          const gameInfo = this.getGameInfo()
           const gameName = gameInfo.title
             .toLowerCase()
             .replace(/[^a-z0-9]/g, '')
@@ -508,7 +502,7 @@ export default class ZoomGameManager implements GameManager {
     }
     await rm(downloadRoot, { recursive: true, force: true })
     if (!finalExecutable) {
-      logError(['Could not find executable for', appName], LogPrefix.Zoom)
+      logError(['Could not find executable for', this.id], LogPrefix.Zoom)
       showDialogBoxModalAuto({
         title: t('box.error.executableNotFound', 'Executable not found'),
         message: t(
@@ -528,7 +522,7 @@ export default class ZoomGameManager implements GameManager {
       install_size: getFileSize(totalSize), // This might need to be the actual installed size, not just installer size
       is_dlc: false,
       version: '1.0', // Placeholder, ideally extracted from installer or API
-      appName: appName,
+      appName: this.id,
       installedDLCs: [],
       language: installLanguage,
       versionEtag: '',
@@ -539,7 +533,7 @@ export default class ZoomGameManager implements GameManager {
     array.push(installedData)
     installedGamesStore.set('installed', array)
     libraryManagerMap['zoom'].refresh()
-    const libraryGame = this.getGameInfo(appName)
+    const libraryGame = this.getGameInfo()
     if (libraryGame) {
       libraryGame.is_installed = true
       libraryGame.install = installedData
@@ -548,16 +542,16 @@ export default class ZoomGameManager implements GameManager {
         'games',
         libraryStore
           .get('games', [])
-          .map((g) => (g.app_name === appName ? libraryGame : g))
+          .map((g) => (g.app_name === this.id ? libraryGame : g))
       )
     }
 
-    logInfo(`Installation of ${appName} completed.`, LogPrefix.Zoom)
+    logInfo(`Installation of ${this.id} completed.`, LogPrefix.Zoom)
     return { status: 'done' }
   }
 
-  isNative(appName: string): boolean {
-    const gameInfo = this.getGameInfo(appName)
+  isNative(): boolean {
+    const gameInfo = this.getGameInfo()
     if (isWindows) {
       return true
     }
@@ -573,22 +567,21 @@ export default class ZoomGameManager implements GameManager {
     return false
   }
 
-  async addShortcuts(appName: string, fromMenu?: boolean) {
-    return addShortcutsUtil(this.getGameInfo(appName), fromMenu)
+  async addShortcuts(fromMenu?: boolean) {
+    return addShortcutsUtil(this, fromMenu)
   }
 
-  async removeShortcuts(appName: string) {
-    return removeShortcutsUtil(this.getGameInfo(appName))
+  async removeShortcuts() {
+    return removeShortcutsUtil(this)
   }
 
   async launch(
-    appName: string,
     logWriter: LogWriter,
     launchArguments?: LaunchOption,
     args: string[] = []
   ): Promise<boolean> {
-    const gameSettings = await this.getSettings(appName)
-    const gameInfo = this.getGameInfo(appName)
+    const gameSettings = await this.getSettings()
+    const gameInfo = this.getGameInfo()
 
     if (
       !gameInfo.install ||
@@ -596,16 +589,12 @@ export default class ZoomGameManager implements GameManager {
       !gameInfo.install.platform ||
       !gameInfo.install.executable
     ) {
-      logError(`Missing install info for ${appName}`, LogPrefix.Zoom)
+      logError(`Missing install info for ${this.id}`, LogPrefix.Zoom)
       return false
     }
 
     if (!existsSync(gameInfo.install.install_path)) {
-      errorHandler({
-        error: 'appears to be deleted',
-        runner: 'zoom',
-        appName: gameInfo.app_name
-      })
+      errorHandler('appears to be deleted', this.id, 'zoom')
       return false
     }
 
@@ -616,12 +605,7 @@ export default class ZoomGameManager implements GameManager {
       gameScopeCommand,
       gameModeBin,
       steamRuntime
-    } = await prepareLaunch(
-      gameSettings,
-      logWriter,
-      gameInfo,
-      this.isNative(appName)
-    )
+    } = await prepareLaunch(gameSettings, logWriter, gameInfo, this.isNative())
     if (!launchPrepSuccess) {
       logWriter.logError(['Launch aborted:', launchPrepFailReason])
       showDialogBoxModalAuto({
@@ -634,11 +618,11 @@ export default class ZoomGameManager implements GameManager {
 
     const commandEnv = {
       ...process.env,
-      ...setupWrapperEnvVars({ appName, appRunner: 'zoom' }),
+      ...setupWrapperEnvVars({ appName: this.id, appRunner: 'zoom' }),
       ...(isWindows
         ? {}
         : setupEnvVars(gameSettings, gameInfo.install.install_path)),
-      ...getKnownFixesEnvVariables(appName, 'zoom')
+      ...getKnownFixesEnvVariables(this.id, 'zoom')
     }
 
     const wrappers = setupWrappers(
@@ -667,10 +651,14 @@ export default class ZoomGameManager implements GameManager {
       })
     }
 
-    sendGameStatusUpdate({ appName, runner: 'zoom', status: 'playing' })
+    sendGameStatusUpdate({
+      appName: this.id,
+      runner: 'zoom',
+      status: 'playing'
+    })
 
-    if (this.isNative(appName)) {
-      const isNativeDosbox = this.isNative(appName) && gameInfo.install.isDosbox
+    if (this.isNative()) {
+      const isNativeDosbox = this.isNative() && gameInfo.install.isDosbox
       const { error, abort } = await callRunner(
         commandParts,
         {
@@ -684,7 +672,7 @@ export default class ZoomGameManager implements GameManager {
           wrappers,
           logMessagePrefix: `Launching ${gameInfo.title}`,
           logWriters: [logWriter],
-          abortId: appName,
+          abortId: this.id,
           cwd: gameInfo.install.install_path
         }
       )
@@ -703,7 +691,7 @@ export default class ZoomGameManager implements GameManager {
         success: wineLaunchPrepSuccess,
         failureReason: wineLaunchPrepFailReason,
         envVars
-      } = await prepareWineLaunch('zoom', appName, logWriter)
+      } = await prepareWineLaunch(this, logWriter)
 
       if (!wineLaunchPrepSuccess) {
         logWriter.logError(['Launch aborted:', wineLaunchPrepFailReason])
@@ -739,7 +727,7 @@ export default class ZoomGameManager implements GameManager {
           wrappers,
           logMessagePrefix: `Launching ${gameInfo.title}`,
           logWriters: [logWriter],
-          abortId: appName
+          abortId: this.id
         }
       })
 
@@ -753,44 +741,32 @@ export default class ZoomGameManager implements GameManager {
     }
   }
 
-  async moveInstall(
-    appName: string,
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    newInstallPath: string
-  ): Promise<{ status: 'done' } | { status: 'error'; error: string }> {
+  async moveInstall(): Promise<
+    { status: 'done' } | { status: 'error'; error: string }
+  > {
     logWarning(
-      `Move install not implemented for Zoom: ${appName}`,
+      `Move install not implemented for Zoom: ${this.id}`,
       LogPrefix.Zoom
     )
     return { status: 'error', error: 'Move install not implemented' }
   }
 
-  async repair(appName: string): Promise<ExecResult> {
-    logWarning(`Repair not implemented for Zoom: ${appName}`, LogPrefix.Zoom)
+  async repair(): Promise<ExecResult> {
+    logWarning(`Repair not implemented for Zoom: ${this.id}`, LogPrefix.Zoom)
     return { stdout: '', stderr: 'Repair not implemented' }
   }
 
-  async syncSaves(
-    appName: string,
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    arg: string,
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    path: string
-  ): Promise<string> {
+  async syncSaves(): Promise<string> {
     logWarning(
-      `Sync saves not implemented for Zoom: ${appName}`,
+      `Sync saves not implemented for Zoom: ${this.id}`,
       LogPrefix.Zoom
     )
     return 'Sync saves not implemented'
   }
 
-  async uninstall({
-    appName,
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    shouldRemovePrefix
-  }: RemoveArgs): Promise<ExecResult> {
+  async uninstall(): Promise<ExecResult> {
     const array = installedGamesStore.get('installed', [])
-    const index = array.findIndex((game) => game.appName === appName)
+    const index = array.findIndex((game) => game.appName === this.id)
     if (index === -1) {
       throw Error("Game isn't installed")
     }
@@ -803,55 +779,42 @@ export default class ZoomGameManager implements GameManager {
     }
     installedGamesStore.set('installed', array)
     libraryManagerMap['zoom'].refresh()
-    const gameInfo = this.getGameInfo(appName)
+    const gameInfo = this.getGameInfo()
     gameInfo.is_installed = false
     gameInfo.install = { is_dlc: false }
-    await removeShortcutsUtil(gameInfo)
-    await removeNonSteamGame({ gameInfo })
+    await removeShortcutsUtil(this)
+    await removeNonSteamGame(this)
     sendFrontendMessage('pushGameToLibrary', gameInfo)
     return { stdout: 'Uninstalled', stderr: '' }
   }
 
-  async update(
-    appName: string,
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    updateOverwrites?: {
-      build?: string
-      branch?: string
-      language?: string
-      dlcs?: string[]
-      dependencies?: string[]
-    }
-  ): Promise<{ status: 'done' | 'error'; error?: string }> {
-    logWarning(`Update not implemented for Zoom: ${appName}`, LogPrefix.Zoom)
+  async update(): Promise<{ status: 'done' | 'error'; error?: string }> {
+    logWarning(`Update not implemented for Zoom: ${this.id}`, LogPrefix.Zoom)
     return { status: 'error', error: 'Update not implemented' }
   }
 
-  async forceUninstall(appName: string): Promise<void> {
+  async forceUninstall(): Promise<void> {
     const installed = installedGamesStore.get('installed', [])
-    const newInstalled = installed.filter((g) => g.appName !== appName)
+    const newInstalled = installed.filter((g) => g.appName !== this.id)
     installedGamesStore.set('installed', newInstalled)
     libraryManagerMap['zoom'].refresh()
-    const gameInfo = this.getGameInfo(appName)
+    const gameInfo = this.getGameInfo()
     gameInfo.is_installed = false
     gameInfo.install = { is_dlc: false }
     sendFrontendMessage('pushGameToLibrary', gameInfo)
   }
 
-  async stop(
-    appName: string /* eslint-disable-next-line @typescript-eslint/no-unused-vars */,
-    stopWine = true
-  ): Promise<void> {
+  async stop(): Promise<void> {
     logWarning(
-      `Stop not fully implemented for Zoom: ${appName}`,
+      `Stop not fully implemented for Zoom: ${this.id}`,
       LogPrefix.Zoom
     )
     // For now, we don't have a specific process to stop for Zoom games
     // If wine is used, it will be handled by the launcher's wine cleanup.
   }
 
-  async isGameAvailable(appName: string): Promise<boolean> {
-    const info = this.getGameInfo(appName)
+  async isGameAvailable(): Promise<boolean> {
+    const info = this.getGameInfo()
     if (!info || !info.is_installed || !info.install.install_path) {
       return false
     }

--- a/src/backend/storeManagers/zoom/library.ts
+++ b/src/backend/storeManagers/zoom/library.ts
@@ -8,6 +8,7 @@ import {
   ZoomFilesResponse,
   ZoomInstallInfo
 } from 'common/types/zoom'
+import ZoomGame from './games'
 
 import {
   getRunnerLogWriter,
@@ -39,6 +40,10 @@ export default class ZoomLibraryManager implements LibraryManager {
       return
 
     await this.refresh()
+  }
+
+  getGame(id: string): ZoomGame {
+    return new ZoomGame(id)
   }
 
   async refresh(): Promise<ExecResult> {

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -46,7 +46,7 @@ import {
 } from '../utils/graphics/vulkan'
 import { lt as semverLt } from 'semver'
 import { createAbortController } from '../utils/aborthandler/aborthandler'
-import { gameManagerMap } from '../storeManagers'
+import { libraryManagerMap } from '../storeManagers'
 import { sendFrontendMessage } from '../ipc'
 import {
   DAYS,
@@ -61,6 +61,7 @@ import {
   isWindows
 } from 'backend/constants/environment'
 import './dxmt'
+import { Game } from '../../common/types/game_manager'
 
 type ReleasesResponse = {
   assets: {
@@ -561,7 +562,9 @@ export const Winetricks = {
     args: string[],
     returnOutput = false
   ) => {
-    const gameSettings = await gameManagerMap[runner].getSettings(appName)
+    const gameSettings = await libraryManagerMap[runner]
+      .getGame(appName)
+      .getSettings()
 
     const { wineVersion } = gameSettings
 
@@ -746,8 +749,8 @@ export const Winetricks = {
       return []
     }
   },
-  listInstalled: async (runner: Runner, appName: string) => {
-    const gameSettings = await gameManagerMap[runner].getSettings(appName)
+  listInstalled: async (game: Game) => {
+    const gameSettings = await game.getSettings()
     const { winePrefix } = await getWineFromProton(gameSettings)
     const winetricksLogPath = join(winePrefix, 'winetricks.log')
     try {
@@ -870,12 +873,13 @@ export async function runWineCommandOnGame(
   appName: string,
   { commandParts, wait = false, protonVerb, startFolder }: WineCommandArgs
 ): Promise<ExecResult> {
-  if (gameManagerMap[runner].isNative(appName)) {
+  const game = libraryManagerMap[runner].getGame(appName)
+  if (game.isNative()) {
     logError('runWineCommand called on native game!', LogPrefix.Gog)
     return { stdout: '', stderr: '' }
   }
-  const { folder_name, install } = gameManagerMap[runner].getGameInfo(appName)
-  const gameSettings = await gameManagerMap[runner].getSettings(appName)
+  const { folder_name, install } = game.getGameInfo()
+  const gameSettings = await game.getSettings()
 
   return runWineCommand({
     gameSettings,

--- a/src/backend/tools/ipc_handler.ts
+++ b/src/backend/tools/ipc_handler.ts
@@ -1,8 +1,8 @@
-import { gameManagerMap, libraryManagerMap } from 'backend/storeManagers'
+import { libraryManagerMap } from 'backend/storeManagers'
 import { addListener, addHandler, sendFrontendMessage } from '../ipc'
 import { Winetricks, runWineCommandOnGame } from '.'
 import path from 'path'
-import { execAsync, sendGameStatusUpdate } from 'backend/utils'
+import { execAsync, getGame, sendGameStatusUpdate } from 'backend/utils'
 import { isWindows } from 'backend/constants/environment'
 
 addHandler(
@@ -23,7 +23,9 @@ addHandler(
 
 // Calls WineCFG or Winetricks. If is WineCFG, use the same binary as wine to launch it to dont update the prefix
 addHandler('callTool', async (event, { tool, exe, appName, runner }) => {
-  const gameSettings = await gameManagerMap[runner].getSettings(appName)
+  const gameSettings = await libraryManagerMap[runner]
+    .getGame(appName)
+    .getSettings()
 
   switch (tool) {
     case 'winetricks':
@@ -72,9 +74,6 @@ addHandler('winetricksAvailable', async (event, runner, appName) => {
 })
 
 addHandler('winetricksInstalled', async (event, runner, appName) => {
-  try {
-    return await Winetricks.listInstalled(runner, appName)
-  } catch {
-    return []
-  }
+  const game = getGame(appName, runner)
+  return Winetricks.listInstalled(game)
 })

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -49,7 +49,7 @@ import { sendFrontendMessage } from './ipc'
 import { GlobalConfig } from './config'
 import { GameConfig } from './game_config'
 import { validWine, runWineCommand } from './launcher'
-import { gameManagerMap, libraryManagerMap } from 'backend/storeManagers'
+import { libraryManagerMap } from 'backend/storeManagers'
 import {
   installWineVersion,
   updateWineVersionInfos,
@@ -85,8 +85,13 @@ import { parse } from '@node-steam/vdf'
 import type LogWriter from 'backend/logger/log_writer'
 import { isRunning } from './downloadmanager/downloadqueue'
 import { isOnline } from './online_monitor'
+import type { Game } from 'common/types/game_manager'
 
 const execAsync = promisify(exec)
+
+function getGame(id: string, runner: Runner): Game {
+  return libraryManagerMap[runner].getGame(id)
+}
 
 /**
  * Compares 2 SemVer strings following "major.minor.patch".
@@ -275,14 +280,8 @@ async function handleExit() {
   app.exit()
 }
 
-type ErrorHandlerMessage = {
-  error?: string
-  appName?: string
-  runner: string
-}
-
-export async function askForceUninstall(runner: Runner, appName: string) {
-  const { title } = gameManagerMap[runner].getGameInfo(appName)
+export async function askForceUninstall(game: Game) {
+  const { title } = game.getGameInfo()
   const { response } = await dialog.showMessageBox({
     type: 'question',
     title,
@@ -294,17 +293,17 @@ export async function askForceUninstall(runner: Runner, appName: string) {
   })
 
   if (response === 1) {
-    await gameManagerMap[runner].forceUninstall(appName)
+    await game.forceUninstall()
   }
   return response
 }
 
-async function errorHandler({
-  error,
-  runner: r,
-  appName
-}: ErrorHandlerMessage): Promise<void> {
-  const plat = r === 'legendary' ? 'Legendary (Epic Games)' : r
+async function errorHandler(
+  error: string,
+  appName: string,
+  runner: Runner
+): Promise<void> {
+  const plat = runner === 'legendary' ? 'Legendary (Epic Games)' : runner
   const deletedFolderMsg = 'appears to be deleted'
   const expiredCredentials = 'No saved credentials'
   const legendaryRegex = /legendary.*\.py/
@@ -321,7 +320,7 @@ async function errorHandler({
   if (ignoreMessages.some((msg) => error.includes(msg))) return
 
   if (error.includes(deletedFolderMsg) && appName) {
-    await askForceUninstall(r.toLocaleLowerCase() as Runner, appName)
+    await askForceUninstall(getGame(appName, runner))
     return
   }
 
@@ -846,10 +845,6 @@ const getCurrentChangelog = async (): Promise<Release | null> => {
     )
     return null
   }
-}
-
-function getInfo(appName: string, runner: Runner): GameInfo {
-  return gameManagerMap[runner].getGameInfo(appName)
 }
 
 // can be removed if legendary and gogdl handle SIGTERM and SIGKILL
@@ -1698,7 +1693,6 @@ export {
   detectVCRedist,
   killPattern,
   shutdownWine,
-  getInfo,
   getShellPath,
   getLatestReleases,
   getWineFromProton,
@@ -1711,7 +1705,8 @@ export {
   calculateEta,
   extractFiles,
   axiosClient,
-  parseSize
+  parseSize,
+  getGame
 }
 
 // Exported only for testing purpose

--- a/src/backend/utils/uninstaller.ts
+++ b/src/backend/utils/uninstaller.ts
@@ -6,7 +6,7 @@ import {
 } from 'backend/constants/paths'
 import { notify } from 'backend/dialog/dialog'
 import { logError, logInfo, LogPrefix } from 'backend/logger'
-import { gameManagerMap } from 'backend/storeManagers'
+import { libraryManagerMap } from 'backend/storeManagers'
 import { sendGameStatusUpdate } from 'backend/utils'
 import { Runner } from 'common/types'
 import { storeMap } from 'common/utils'
@@ -16,7 +16,9 @@ import i18next from 'i18next'
 import { join } from 'path'
 
 export const removePrefix = async (appName: string, runner: Runner) => {
-  const { winePrefix } = await gameManagerMap[runner].getSettings(appName)
+  const { winePrefix } = await libraryManagerMap[runner]
+    .getGame(appName)
+    .getSettings()
   logInfo(`Removing prefix ${winePrefix}`, LogPrefix.Backend)
 
   if (!existsSync(winePrefix)) {
@@ -102,12 +104,13 @@ export const uninstallGameCallback = async (
     status: 'uninstalling'
   })
 
-  const { title } = gameManagerMap[runner].getGameInfo(appName)
+  const game = libraryManagerMap[runner].getGame(appName)
+  const { title } = game.getGameInfo()
 
   let uninstalled = false
 
   try {
-    await gameManagerMap[runner].uninstall({ appName, shouldRemovePrefix })
+    await game.uninstall({ shouldRemovePrefix })
     uninstalled = true
   } catch (error) {
     notify({

--- a/src/backend/wiki_game_info/howlongtobeat/utils.ts
+++ b/src/backend/wiki_game_info/howlongtobeat/utils.ts
@@ -1,7 +1,6 @@
 import axios from 'axios'
 import { logError, logInfo, LogPrefix } from 'backend/logger'
-import { gameManagerMap } from 'backend/storeManagers'
-import { ExtraInfo, GameInfo } from 'common/types'
+import type { Game } from 'common/types/game_manager'
 
 export interface HeroicHowLongToBeatEntry {
   completionist: number
@@ -92,11 +91,14 @@ async function getGameDataById(
 }
 
 async function getGogHLTBGameData(
-  gameInfo: GameInfo,
-  gameExtraInfo: ExtraInfo
+  game: Game
 ): Promise<HeroicHowLongToBeatEntry | null> {
+  const { app_name, title } = game.getGameInfo()
+  const { storeUrl } = await game.getExtraInfo()
+  if (!storeUrl) return null
+
   try {
-    const response = await axios.get(gameExtraInfo.storeUrl!, {
+    const response = await axios.get(storeUrl, {
       headers: {
         'User-Agent':
           'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
@@ -149,12 +151,12 @@ async function getGogHLTBGameData(
       mainExtra,
       completionist,
       gameId: hltbId,
-      gameName: gameInfo.title,
+      gameName: title,
       gameWebLink: `${HLTB_BASE_URL}/game/${hltbId}`
     }
   } catch (error) {
     logError(
-      [`Error fetching HLTB game data for ID ${gameInfo.app_name}:`, error],
+      [`Error fetching HLTB game data for ID ${app_name}:`, error],
       LogPrefix.ExtraGameInfo
     )
     return null
@@ -162,27 +164,27 @@ async function getGogHLTBGameData(
 }
 
 export async function getHowLongToBeat(
-  title: string,
-  gameInfo: GameInfo,
+  game: Game,
   hltbId?: string
 ): Promise<HeroicHowLongToBeatEntry | null> {
-  const gameExtraInfo = await gameManagerMap[gameInfo.runner].getExtraInfo(
-    gameInfo.app_name
-  )
-  if (gameInfo.runner == 'gog' && gameExtraInfo.storeUrl) {
+  const gameInfo = game.getGameInfo()
+  if (gameInfo.runner == 'gog') {
     logInfo(
-      `Getting HowLongToBeat data for ${title} ${gameInfo.app_name} - ${gameInfo.runner}`,
+      `Getting HowLongToBeat data for ${gameInfo.title} ${gameInfo.app_name} - ${gameInfo.runner}`,
       LogPrefix.ExtraGameInfo
     )
 
-    const gameData = await getGogHLTBGameData(gameInfo, gameExtraInfo)
+    const gameData = await getGogHLTBGameData(game)
     if (gameData) {
       return gameData
     }
-    logInfo(`HLTB ID ${hltbId} not found for ${title}`, LogPrefix.ExtraGameInfo)
+    logInfo(
+      `HLTB ID ${hltbId} not found for ${gameInfo.title}`,
+      LogPrefix.ExtraGameInfo
+    )
   } else if (hltbId) {
     logInfo(
-      `Getting HowLongToBeat data for ${title}${hltbId ? ` (ID: ${hltbId})` : ''} - ${gameInfo.runner}`,
+      `Getting HowLongToBeat data for ${gameInfo.title}${hltbId ? ` (ID: ${hltbId})` : ''} - ${gameInfo.runner}`,
       LogPrefix.ExtraGameInfo
     )
 
@@ -190,11 +192,14 @@ export async function getHowLongToBeat(
     if (gameData) {
       return gameData
     }
-    logInfo(`HLTB ID ${hltbId} not found for ${title}`, LogPrefix.ExtraGameInfo)
+    logInfo(
+      `HLTB ID ${hltbId} not found for ${gameInfo.title}`,
+      LogPrefix.ExtraGameInfo
+    )
   }
 
   logInfo(
-    `No HLTB ID available for ${title}, cannot fetch data`,
+    `No HLTB ID available for ${gameInfo.title}, cannot fetch data`,
     LogPrefix.ExtraGameInfo
   )
   return null

--- a/src/backend/wiki_game_info/ipc_handler.ts
+++ b/src/backend/wiki_game_info/ipc_handler.ts
@@ -1,6 +1,7 @@
 import { addHandler } from 'backend/ipc'
 import { getWikiGameInfo } from './wiki_game_info'
+import { getGame } from 'backend/utils'
 
 addHandler('getWikiGameInfo', async (e, title, appName, runner) =>
-  getWikiGameInfo(title, appName, runner)
+  getWikiGameInfo(getGame(appName, runner))
 )

--- a/src/backend/wiki_game_info/wiki_game_info.ts
+++ b/src/backend/wiki_game_info/wiki_game_info.ts
@@ -3,24 +3,22 @@ import { getInfoFromProtonDB } from 'backend/wiki_game_info/protondb/utils'
 import { getSteamDeckComp } from 'backend/wiki_game_info/steamdeck/utils'
 import { wikiGameInfoStore } from './electronStore'
 import { removeSpecialcharacters } from '../utils'
-import { Runner, SteamInfo, WikiInfo } from 'common/types'
+import { SteamInfo, WikiInfo } from 'common/types'
 import { logError, logInfo, LogPrefix } from 'backend/logger'
 import { getInfoFromAppleGamingWiki } from './applegamingwiki/utils'
 import { getHowLongToBeat } from './howlongtobeat/utils'
 import { getInfoFromPCGamingWiki } from './pcgamingwiki/utils'
 import { getUmuId } from './umu/utils'
 import { isLinux, isMac } from 'backend/constants/environment'
-import { gameManagerMap } from 'backend/storeManagers'
+import type { Game } from 'common/types/game_manager'
 
-export async function getWikiGameInfo(
-  title: string,
-  appName: string,
-  runner: Runner
-): Promise<WikiInfo | null> {
-  const gameInfo = gameManagerMap[runner].getGameInfo(appName)
+export async function getWikiGameInfo(game: Game): Promise<WikiInfo | null> {
+  const gameInfo = game.getGameInfo()
+  const appName = gameInfo.app_name
+  const runner = gameInfo.runner
 
   try {
-    title = removeSpecialcharacters(title)
+    const title = removeSpecialcharacters(gameInfo.title)
 
     // check if we have a cached response
     const cachedResponse = wikiGameInfoStore.get(title)
@@ -43,8 +41,7 @@ export async function getWikiGameInfo(
 
     // Get HowLongToBeat data, using gog.com site for GOG games, and HLTB ID from PCGamingWiki if available
     const howlongtobeat = await getHowLongToBeat(
-      title,
-      gameInfo,
+      game,
       pcgamingwiki?.howLongToBeatID
     )
 
@@ -80,7 +77,7 @@ export async function getWikiGameInfo(
     return wikiGameInfo
   } catch (error) {
     logError(
-      [`Was not able to get ExtraGameInfo data for ${title}`, error],
+      [`Was not able to get ExtraGameInfo data for ${gameInfo.title}`, error],
       LogPrefix.ExtraGameInfo
     )
     return null

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -6,7 +6,8 @@ import {
   ExecResult,
   InstallArgs,
   InstallInfo,
-  LaunchOption
+  LaunchOption,
+  GOGAchievement
 } from 'common/types'
 import { GOGCloudSavesLocation } from './gog'
 import type LogWriter from 'backend/logger/log_writer'
@@ -17,66 +18,54 @@ export interface InstallResult {
 }
 
 export type RemoveArgs = {
-  appName: string
   shouldRemovePrefix?: boolean
   deleteFiles?: boolean
 }
 
-export interface GameManager {
-  getSettings: (appName: string) => Promise<GameSettings>
-  getGameInfo: (appName: string) => GameInfo
-  getExtraInfo: (appName: string) => Promise<ExtraInfo>
-  importGame: (
-    appName: string,
-    path: string,
-    platform: InstallPlatform
-  ) => Promise<ExecResult>
+export interface Game {
+  getSettings: () => Promise<GameSettings>
+  getGameInfo: () => GameInfo
+  getExtraInfo: () => Promise<ExtraInfo>
+  importGame: (path: string, platform: InstallPlatform) => Promise<ExecResult>
   onInstallOrUpdateOutput: (
-    appName: string,
     action: 'installing' | 'updating',
     data: string,
     totalDownloadSize: number
   ) => void
-  install: (appName: string, args: InstallArgs) => Promise<InstallResult>
-  isNative: (appName: string) => boolean
-  addShortcuts: (appName: string, fromMenu?: boolean) => Promise<void>
-  removeShortcuts: (appName: string) => Promise<void>
+  install: (args: InstallArgs) => Promise<InstallResult>
+  isNative: () => boolean
+  addShortcuts: (fromMenu?: boolean) => Promise<void>
+  removeShortcuts: () => Promise<void>
   launch: (
-    appName: string,
     logWriter: LogWriter,
     launchArguments?: LaunchOption,
     args?: string[],
     skipVersionCheck?: boolean
   ) => Promise<boolean>
-  moveInstall: (
-    appName: string,
-    newInstallPath: string
-  ) => Promise<InstallResult>
-  repair: (appName: string) => Promise<ExecResult>
+  moveInstall: (newInstallPath: string) => Promise<InstallResult>
+  repair: () => Promise<ExecResult>
   syncSaves: (
-    appName: string,
     arg: string,
     path: string,
     gogSaves?: GOGCloudSavesLocation[]
   ) => Promise<string>
   uninstall: (args: RemoveArgs) => Promise<ExecResult>
-  update: (
-    appName: string,
-    updateOverwrites?: {
-      build?: string
-      branch?: string
-      language?: string
-      dlcs?: string[]
-      dependencies?: string[]
-    }
-  ) => Promise<InstallResult>
-  forceUninstall: (appName: string) => Promise<void>
-  stop: (appName: string, stopWine?: boolean) => Promise<void>
-  isGameAvailable: (appName: string) => Promise<boolean>
+  update: (updateOverwrites?: {
+    build?: string
+    branch?: string
+    language?: string
+    dlcs?: string[]
+    dependencies?: string[]
+  }) => Promise<InstallResult>
+  forceUninstall: () => Promise<void>
+  stop: (stopWine?: boolean) => Promise<void>
+  isGameAvailable: () => Promise<boolean>
+  getAchievements?: (lang: string) => Promise<GOGAchievement[]>
 }
 
 export interface LibraryManager {
   init: () => Promise<void>
+  getGame: (id: string) => Game
   refresh: () => Promise<ExecResult | null>
   getGameInfo: (appName: string, forceReload?: boolean) => GameInfo | undefined
   getInstallInfo: (


### PR DESCRIPTION
Invoking a method on one of the game managers was always a little verbose: Every method took not just its own parameters, but also parameters describing the game's state (effectively that's only an AppName right now, but that may change for other store providers). Instead, there's now one `Game` class instance for every distinct game in the user's library

In practice, code changes in the following way:
Before:
```ts
gameManagerMap[runner].foo(appName, arg1)
gameManagerMap[runner].bar(appName)
gameManagerMap[runner].baz(appName, arg1, arg2)
```
After:
```ts
const game = libraryManagerMap[runner].getGame(appName)
// NOTE: `game` could potentially be passed as a parameter instead of `appName` and `runner`, making the above line unnecessary
game.foo(arg1)
game.bar()
game.baz(arg1, arg2)
```

As I mentioned in #4889, I plan on offloading a lot of `GameInfo` properties into individual methods (so there's not as much a burden on game managers to provide *everything* in `getGameInfo` all at once). Increasing the amount of method calls quickly leads to our before approach (the current code) becoming unreadable due to there being so much duplicate work.

Requires #4889

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [X] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
