### PR TITLE
[UI] Fix GamePage scaling on larger displays

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.css
+++ b/src/frontend/screens/Game/GamePage/index.css
@@ -6,7 +6,6 @@
   gap: var(--space-md);
   border-radius: 10px;
   height: 100%;
-  max-width: 2400px;
   grid-template-areas:
     'header header'
     'main extra'
@@ -93,8 +92,6 @@
     flex-direction: column;
     width: 100%;
     height: 100%;
-    max-height: 1100px;
-    max-width: 1200px;
     overflow-y: auto;
     overflow-x: hidden;
     align-items: flex-start;
@@ -108,7 +105,6 @@
 
   .extraInfoWrapper {
     grid-area: extra;
-    max-width: 850px;
     gap: 1rem;
   }
 


### PR DESCRIPTION
this is to fix scaling issues on larger displays

Either remove the lines or change them to 100% so the UI scales properly on all displays
in #4626 there were changes made to limit the size, I'm not sure why when the elements don't really spread that far away from each other.
regular examples
<img width="2560" height="1390" alt="before" src="https://github.com/user-attachments/assets/4c341ab9-e587-4731-9d8d-ae5d546d962a" />
<img width="2560" height="1390" alt="after" src="https://github.com/user-attachments/assets/56381b3b-956e-4269-a8f1-053dbd40b397" />
extreme examples
<img width="4285" height="811" alt="before2" src="https://github.com/user-attachments/assets/b5dab276-34ae-4775-9e3f-f922f7197207" />
<img width="4086" height="944" alt="after2" src="https://github.com/user-attachments/assets/00b1d587-3964-4bd9-b32e-d1bf6c72bbdc" />

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
