### PR TITLE
[Fix] Gruvbox Dark on-screen keyboard button color

### DIFF
--- a/src/frontend/themes.scss
+++ b/src/frontend/themes.scss
@@ -214,7 +214,8 @@ body.gruvbox_dark {
   --primary-hover: #83a598;
   --danger: #9e2c28;
   --danger-hover: #f05d4d;
-  --anticheat-denied: #9e2c28 --anticheat-broken: #af3a03;
+  --anticheat-denied: #9e2c28;
+  --anticheat-broken: #af3a03;
   --anticheat-running: #076678;
   --anticheat-supported: #79740e;
   --anticheat-planned: #8f3f71;


### PR DESCRIPTION
Before:
<img width="2050" height="1330" alt="image" src="https://github.com/user-attachments/assets/74f6d75e-6ba8-4750-9007-f6def436de73" />

After:
<img width="2050" height="1330" alt="image" src="https://github.com/user-attachments/assets/a9d68fec-03af-4414-9cc0-c62bd21c7652" />

It's not exactly pretty (our themes need some love in general IMO), but at least it's usable for now

Resolves #4932

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
