### PR TITLE
[Fix] Only show the "Allow using Valve Proton builds to run games" toggle on Linux

### DIFF
--- a/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
@@ -47,6 +47,7 @@ export default function AdvancedSetting() {
   const { libraryStatus, platform } = useContext(ContextProvider)
   const { t } = useTranslation()
   const isWindows = platform === 'win32'
+  const isLinux = platform === 'linux'
 
   useEffect(() => {
     // set copied to clipboard status to true if it's not already set to true
@@ -180,7 +181,7 @@ export default function AdvancedSetting() {
 
       <AllowInstallationBrokenAnticheat />
 
-      <ShowValveProton />
+      {isLinux && <ShowValveProton />}
 
       <hr />
 


### PR DESCRIPTION
The toggle doesn't do anything on Windows & macOS, so don't show it there

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
