### PR TITLE
Added translation on the PLAY button in the last recently played game

### DIFF
--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -249,7 +249,7 @@ const GameCard = ({
           title={`${t('label.playing.start')} (${title})`}
           disabled={disabled}
         >
-          {justPlayed ? <span>PLAY</span> : <PlayIcon />}
+          {justPlayed ? <span>{t('button.play', 'PLAY')}</span> : <PlayIcon />}
         </SvgButton>
       )
     } else {


### PR DESCRIPTION
Currently the PLAY button on the last recently played game cannot be translated, this PR adds the possibility of translation.

Fixes #3972

<img width="1117" height="437" alt="image" src="https://github.com/user-attachments/assets/8b4dbf8d-7fb7-4291-b50d-fc4312265c25" />


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
