### PR TITLE
Windows setup asks user where to install Heroic

### DIFF
--- a/.idea/indexLayout.xml
+++ b/.idea/indexLayout.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="UserContentModel">
-    <attachedFolders />
-    <explicitIncludes />
-    <explicitExcludes />
-  </component>
-</project>


### PR DESCRIPTION
Closes #3388 

Added some properties to NSIS in the Electron Builder to ask the Windows user where they wish to install Heroic instead of automatically installing in localappdata.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
