### PR TITLE
[Fix] "Environment variables" table not splitting key/value on `=`

### DIFF
--- a/src/frontend/components/UI/TwoColTableInput/index.tsx
+++ b/src/frontend/components/UI/TwoColTableInput/index.tsx
@@ -69,10 +69,10 @@ export function TableInput({
     if (
       // if there's a connector, try to split the key
       connector &&
-      newVarValue.includes(connector) &&
+      newVarName.includes(connector) &&
       !newVarValue
     ) {
-      const [key, value] = newVarValue.split(connector)
+      const [key, value] = newVarName.split(connector)
       setNewVarName(key)
       setNewVarValue(value)
     } else {


### PR DESCRIPTION
Could've sworn we already had a PR to fix this, but apparently not?

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
