### PR TITLE
[Fix] Add missing `decodeURIComponent` for args and alt exe protocol arguments

### DIFF
--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -54,9 +54,13 @@ async function handleLaunch(url: URL) {
     // `heroic://launch?appName=Quail&runner=legendary&arg=foo&arg=bar`
     appName = url.searchParams.get('appName')
     runnerStr = url.searchParams.get('runner')
-    args = url.searchParams.getAll('arg')
-    const altExeParse = Path.safeParse(url.searchParams.get('altExe'))
-    if (altExeParse.success) altExe = altExeParse.data
+    args = url.searchParams.getAll('arg').map(decodeURIComponent)
+
+    const altExeParameter = url.searchParams.get('altExe')
+    if (altExeParameter) {
+      const altExeParse = Path.safeParse(decodeURIComponent(altExeParameter))
+      if (altExeParse.success) altExe = altExeParse.data
+    }
   }
 
   if (!appName) {


### PR DESCRIPTION
When handling a `heroic://` protocol, we did not call `decodeURIComponent` on the `arg` or `altExe` parameters, which meant clients will likely not be able to use these options correctly. Trying to add a `/` to either option wouldn't work for example, which is especially problematic for the alt EXE parameter (since that expects a non-relative path, which will always include `/` or `\`)

Heroic itself does not use these options, and I'm not aware of any clients that do at the moment (although the Nexus Mods app will soon), so there's not really anything to test here. You can try passing something like `heroic://launch?appName=Salt&runner=legendary&arg=%2Fpath%20with%2Fspaces` to Heroic & see it properly decode `/` and ` `

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
