### PR TITLE
[UI] Simplify filters and categories

### DIFF
--- a/src/frontend/components/UI/CategoryFilter/index.tsx
+++ b/src/frontend/components/UI/CategoryFilter/index.tsx
@@ -24,47 +24,16 @@ export default function CategoryFilter() {
     }
   }
 
-  const setCategoryOnly = (category: string) => {
-    setCurrentCustomCategories([category])
-  }
+  const resetCategories = () => setCurrentCustomCategories([])
 
-  const selectAll = () => {
-    setCurrentCustomCategories(
-      ['preset_uncategorized'].concat(customCategories.listCategories())
-    )
-  }
-
-  const toggleWithOnly = (
-    toggle: JSX.Element,
-    onOnlyClicked: () => void,
-    category: string
-  ) => {
-    return (
-      <div className="toggleWithOnly" key={category}>
-        {toggle}
-        <button className="only" onClick={() => onOnlyClicked()}>
-          {t('header.only', 'only')}
-        </button>
-      </div>
-    )
-  }
-
-  const categoryToggle = (categoryName: string, categoryValue?: string) => {
-    const toggle = (
-      <ToggleSwitch
-        htmlId={categoryValue || categoryName}
-        handleChange={() => toggleCategory(categoryValue || categoryName)}
-        value={currentCustomCategories.includes(categoryValue || categoryName)}
-        title={categoryName}
-      />
-    )
-
-    const onOnlyClick = () => {
-      setCategoryOnly(categoryValue || categoryName)
-    }
-
-    return toggleWithOnly(toggle, onOnlyClick, categoryValue || categoryName)
-  }
+  const categoryToggle = (categoryName: string, categoryValue?: string) => (
+    <ToggleSwitch
+      htmlId={categoryValue || categoryName}
+      handleChange={() => toggleCategory(categoryValue || categoryName)}
+      value={currentCustomCategories.includes(categoryValue || categoryName)}
+      title={categoryName}
+    />
+  )
 
   const categoriesList = customCategories.listCategories()
 
@@ -94,9 +63,9 @@ export default function CategoryFilter() {
         <button
           type="reset"
           className="button is-primary"
-          onClick={() => selectAll()}
+          onClick={() => resetCategories()}
         >
-          {t('header.select_all', 'Select All')}
+          {t('header.reset', 'Reset')}
         </button>
         <button
           className="button is-secondary is-small"

--- a/src/frontend/components/UI/LibraryFilters/index.css
+++ b/src/frontend/components/UI/LibraryFilters/index.css
@@ -60,29 +60,6 @@
       box-shadow: 4px 5px 5px 7px rgba(0, 0, 0, 0.2);
     }
   }
-
-  .toggleWithOnly {
-    display: flex;
-
-    & label {
-      flex-grow: 1;
-    }
-    .only {
-      opacity: 0.01;
-      background: none;
-      border: none;
-      color: var(--text);
-      text-decoration: underline;
-      cursor: pointer;
-      &:hover {
-        color: var(--accent);
-      }
-    }
-    &:hover .only,
-    &:focus-within .only {
-      opacity: 1;
-    }
-  }
 }
 
 body.isRTL .libraryFilters .dropdown {

--- a/src/frontend/components/UI/LibraryFilters/index.tsx
+++ b/src/frontend/components/UI/LibraryFilters/index.tsx
@@ -136,7 +136,7 @@ export default function LibraryFilters() {
       browser: false
     })
     setShowHidden(false)
-    setShowNonAvailable(true)
+    setShowNonAvailable(false)
     setShowFavourites(false)
     setShowInstalledOnly(false)
     setShowSupportOfflineOnly(false)


### PR DESCRIPTION
Simplified the filters and categories logic, because I think it's significantly simpler to select the filters we actively want over de-selecting those we don't want. This will also work make gamepad navigation even simpler. 

An example use case, since I use a Mac I might want to filter by only Mac games. Previously, to do that I would have to de-select "Windows" and "Browser". Now I can just select Mac. If I do want multiple filters it is more work to select them, but since they're filters, I think most people would prefer to be more restrictive by default. The same thinking applies to Categories as well :)

Here's a video of it in action, I didn't capture the categories but it's exactly the same logi:

<details>

https://github.com/user-attachments/assets/1809c560-9526-4aba-bb70-d8d6331a0512

https://github.com/user-attachments/assets/e24b6651-01e3-4461-a7fc-112de0801c60

</details>

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
