### PR TITLE
[Fix] Workaround Steam Input virtual gamepad not detected by deprecated Win…

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1282,6 +1282,23 @@ function setupWineEnvVars(gameSettings: GameSettings, gameId = '0') {
   ) {
     ret.ROSETTA_ADVERTISE_AVX = '1'
   }
+  // Workaround for Steam Input virtual gamepad not working for games launched through HGL from Steam
+  // using deprecated WineGE/ProtonGE releases (<= 8.x) following SDL behavior change on version >= 2.30
+  // (included with flatpak Freedesktop runtime 24.08 or newer)
+  // https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4708
+  // https://github.com/libsdl-org/SDL/issues/14410
+  // https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1818
+  if (
+    isLinux &&
+    /(GE|Wine|Proton)-(Proton[7-8]|[4-7].*-GE|GE-4.[0-9]*)/.test(
+      wineVersion.name
+    )
+  ) {
+    ret.SteamVirtualGamepadInfo = ''
+    logWarning(
+      `Deprecated Wine-GE/Proton-GE release (<= 8.x) detected. Applying workaround for Steam Input virtual gamepad detection.`
+    )
+  }
   return ret
 }
 


### PR DESCRIPTION
This PR implements a workaround for Steam Input virtual gamepad not working for games launched through HGL from Steam using deprecated WineGE/ProtonGE releases (<= 8.x) following SDL behavior change on version >= 2.30  (included with flatpak Freedesktop runtime 24.08 or newer).
The workaround consists of setting `SteamVirtualGamepadInfo = ""` environment variable  at runtime if Wine version is WineGE or ProtonGE <= 8.x. Newer versions of ProtonGE (at least 10.x) are not affected.
For custom Wine version other than the ones that can be downloaded directly from HGL, users can configure the environment variable for each title, as needed.

The issue affects not only the flatpak release but also AppImage and other releases, when running on a system with SDL version >= 2.30.
While the issue may be resolved in a future SDL version (it's not clear yet), I think for the time being is good if the problem is mitigated from HGL since users running LTS distros (e.g. Debian) may not get the SDL fix for a while.

Reference:
https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4708
https://github.com/libsdl-org/SDL/issues/14410
https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1818

Fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4708.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x ] Tested the feature and it's working on a current and clean install.
- [x ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
