### PR TITLE
[Refactor] Move playtime tracking to a dedicated Zustand store in the Frontend, and a dedicated class in the Backend

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -98,18 +98,18 @@
         "changelogFor": "Changelog for {{gameTitle}}",
         "downloadSize": "Download Size",
         "extra_info": "Extra info",
-        "firstPlayed": "First Played",
+        "firstPlayed": "First Played: {{firstPlayedDateStr}}",
         "getting-download-size": "Getting download size",
         "getting-install-size": "Getting install size",
         "install_info": "Install info",
         "installSize": "Install Size",
         "language": "Language",
-        "lastPlayed": "Last Played",
+        "lastPlayed": "Last Played: {{lastPlayedDateStr}}",
         "modify": "Modify Installation",
         "neverPlayed": "Never",
         "platform": "Select Platform Version to Install",
         "requirements": "System Requirements",
-        "totalPlayed": "Time Played"
+        "totalPlayed": "Time Played: {{totalPlayed}}"
     },
     "gamecard": {
         "moving": "Moving",

--- a/src/backend/backend_events.ts
+++ b/src/backend/backend_events.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events'
 
 import type TypedEventEmitter from 'typed-emitter'
-import type { GameStatus, RecentGame } from 'common/types'
+import type { Runner, GameStatus, RecentGame, Playtime } from 'common/types'
 
 type BackendEvents = {
   gameStatusUpdate: (payload: GameStatus) => void
@@ -12,6 +12,17 @@ type BackendEvents = {
     oldValue: unknown
     newValue: unknown
   }) => void
+  playSessionEnded: (
+    game_id: string,
+    runner: Runner,
+    session_start_date: Date
+  ) => void
+  playtimeUpdate: (
+    game_id: string,
+    runner: Runner,
+    newPlaytime: Playtime
+  ) => void
+
   [key: `progressUpdate-${string}`]: (progress: GameStatus) => void
 }
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -154,6 +154,7 @@ import {
 } from './constants/paths'
 import { supportedLanguages } from 'common/languages'
 import MigrationSystem from './migration'
+import PlaytimeManager from './playtime'
 
 app.commandLine?.appendSwitch('ozone-platform-hint', 'auto')
 if (isLinux) app.commandLine?.appendSwitch('--gtk-version', '3')
@@ -332,6 +333,7 @@ if (!gotTheLock) {
     initLogger()
 
     await MigrationSystem.get().applyMigrations()
+    PlaytimeManager.get().init()
 
     initOnlineMonitor()
     initStoreManagers()
@@ -1377,3 +1379,4 @@ import './wiki_game_info/ipc_handler'
 import './recent_games/ipc_handler'
 import './tools/ipc_handler'
 import './progress_bar'
+import './playtime/ipc_handler'

--- a/src/backend/playtime/index.ts
+++ b/src/backend/playtime/index.ts
@@ -1,0 +1,72 @@
+import { backendEvents } from 'backend/backend_events'
+import { tsStore } from 'backend/constants/key_value_stores'
+
+import type { Playtime, Runner } from 'common/types'
+
+const defaultPlaytime: Playtime = {
+  totalPlayed: 0
+}
+
+export default class PlaytimeManager {
+  static #instance: PlaytimeManager
+
+  static get(): PlaytimeManager {
+    if (!this.#instance) this.#instance = new PlaytimeManager()
+    return this.#instance
+  }
+
+  init() {
+    backendEvents.on(
+      'playSessionEnded',
+      (game_id, runner, session_start_date) => {
+        this.#onPlaySessionEnded(game_id, runner, session_start_date)
+      }
+    )
+  }
+
+  getPlaytime(game_id: string, runner: Runner): Playtime {
+    // Add Runner to GameID-only keys. Ideally we'd do this with a migration,
+    // but the migration system runs too early (so we can't rely on finding
+    // games in the library at that point)
+    const playtime_no_runner = tsStore.get_nodefault(game_id) as
+      | Playtime
+      | undefined
+    if (playtime_no_runner) {
+      tsStore.set(`${game_id}_${runner}`, playtime_no_runner)
+      tsStore.delete(game_id)
+    }
+
+    return tsStore.get(`${game_id}_${runner}`, structuredClone(defaultPlaytime))
+  }
+
+  updatePlaytime(game_id: string, runner: Runner, playtime: Playtime): void {
+    tsStore.set(`${game_id}_${runner}`, playtime)
+    backendEvents.emit('playtimeUpdate', game_id, runner, playtime)
+  }
+
+  #onPlaySessionEnded(
+    game_id: string,
+    runner: Runner,
+    session_start_date: Date
+  ): void {
+    const session_end_date = new Date()
+    const past_playtime = this.getPlaytime(game_id, runner)
+
+    let new_playtime = structuredClone(past_playtime)
+    if (!new_playtime.firstPlayed) {
+      new_playtime = {
+        ...past_playtime,
+        firstPlayed: session_start_date.toISOString(),
+        lastPlayed: session_end_date.toISOString()
+      }
+    } else {
+      new_playtime.lastPlayed = session_end_date.toISOString()
+    }
+
+    const session_playtime =
+      (session_end_date.getTime() - session_start_date.getTime()) / 1000 / 60
+    new_playtime.totalPlayed += session_playtime
+
+    this.updatePlaytime(game_id, runner, new_playtime)
+  }
+}

--- a/src/backend/playtime/ipc_handler.ts
+++ b/src/backend/playtime/ipc_handler.ts
@@ -1,0 +1,13 @@
+import { addListener, sendFrontendMessage } from '../ipc'
+import { backendEvents } from '../backend_events'
+
+import PlaytimeManager from '.'
+
+addListener('playtime.get', (e, game_id, runner) => {
+  const playtime = PlaytimeManager.get().getPlaytime(game_id, runner)
+  sendFrontendMessage('playtime.update', game_id, runner, playtime)
+})
+
+backendEvents.on('playtimeUpdate', (game_id, runner, newPlaytime) => {
+  sendFrontendMessage('playtime.update', game_id, runner, newPlaytime)
+})

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -6,12 +6,9 @@ import { getMainWindow } from './main_window'
 import { sendFrontendMessage } from './ipc'
 import { gameManagerMap } from './storeManagers'
 import { launchEventCallback } from './launcher'
-import { z } from 'zod'
 import { windowIcon } from './constants/paths'
-import { Path } from './schemas'
+import { Path, Runners } from './schemas'
 import { isCLINoGui } from './constants/environment'
-
-const RUNNERS = z.enum(['legendary', 'gog', 'nile', 'sideload'])
 
 export function handleProtocol(args: string[]) {
   const urlStr = args.find((arg) => arg.startsWith('heroic://'))
@@ -69,7 +66,7 @@ async function handleLaunch(url: URL) {
   }
 
   let runner: Runner | undefined
-  const runnerParse = RUNNERS.safeParse(runnerStr)
+  const runnerParse = Runners.safeParse(runnerStr)
   if (runnerParse.success) {
     runner = runnerParse.data
   }
@@ -144,7 +141,7 @@ function findGame(
   if (runner) return gameManagerMap[runner].getGameInfo(appName)
 
   // If no runner is specified, search for the game in all runners and return the first one found
-  for (const runner of RUNNERS.options) {
+  for (const runner of Runners.options) {
     const maybeGameInfo = gameManagerMap[runner].getGameInfo(appName)
     if (maybeGameInfo.app_name) return maybeGameInfo
   }

--- a/src/backend/schemas.ts
+++ b/src/backend/schemas.ts
@@ -7,4 +7,6 @@ const Path = z
   .brand('Path')
 type Path = z.infer<typeof Path>
 
-export { Path }
+const Runners = z.enum(['legendary', 'gog', 'nile', 'zoom', 'sideload'])
+
+export { Path, Runners }

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -23,8 +23,8 @@ import i18next from 'i18next'
 import { notify, showDialogBoxModalAuto } from '../../dialog/dialog'
 import { GlobalConfig } from '../../config'
 import { getWikiGameInfo } from 'backend/wiki_game_info/wiki_game_info'
-import { tsStore } from 'backend/constants/key_value_stores'
 import { isAppImage, isFlatpak, isWindows } from 'backend/constants/environment'
+import PlaytimeManager from '../../playtime'
 
 const getSteamUserdataDir = async () => {
   const { defaultSteamPath } = GlobalConfig.get().getSettings()
@@ -316,9 +316,11 @@ async function addNonSteamGame(props: {
     newEntry.Devkit = false
     newEntry.DevkitOverrideAppID = false
 
-    const lastPlayed = tsStore.get_nodefault(
-      `${props.gameInfo.app_name}.lastPlayed`
+    const playtime = PlaytimeManager.get().getPlaytime(
+      props.gameInfo.app_name,
+      props.gameInfo.runner
     )
+    const lastPlayed = playtime.lastPlayed
     if (lastPlayed) {
       newEntry.LastPlayTime = new Date(lastPlayed)
     } else {

--- a/src/common/typedefs/dom-additions.ts
+++ b/src/common/typedefs/dom-additions.ts
@@ -32,6 +32,73 @@ declare global {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Navigator/windowControlsOverlay) */
     readonly windowControlsOverlay: WindowControlsOverlay
   }
+
+  // A loose typedef of Intl.DurationFormat
+  // Can be removed once <https://github.com/microsoft/TypeScript/issues/60608> is closed
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Intl {
+    interface DurationFormatOptionsStyleRegistry {
+      long: never
+      short: never
+      narrow: never
+      digital: never
+    }
+
+    type DurationFormatOptionsStyle = keyof DurationFormatOptionsStyleRegistry
+
+    interface DurationFormatOptions {
+      localeMatcher?: 'lookup' | 'best fit' | undefined
+      numberingSystem?: string | undefined
+      style?: DurationFormatOptionsStyle | undefined
+      years?: 'long' | 'short' | 'narrow' | undefined
+      yearsDisplay?: 'always' | 'auto' | undefined
+      months?: 'long' | 'short' | 'narrow' | undefined
+      monthsDisplay?: 'always' | 'auto' | undefined
+      weeks?: 'long' | 'short' | 'narrow' | undefined
+      weeksDisplay?: 'always' | 'auto' | undefined
+      days?: 'long' | 'short' | 'narrow' | undefined
+      daysDisplay?: 'always' | 'auto' | undefined
+      hours?: 'long' | 'short' | 'narrow' | 'numeric' | '2-digit' | undefined
+      hoursDisplay?: 'always' | 'auto' | undefined
+      minutes?: 'long' | 'short' | 'narrow' | 'numeric' | '2-digit' | undefined
+      minutesDisplay?: 'always' | 'auto' | undefined
+      seconds?: 'long' | 'short' | 'narrow' | 'numeric' | '2-digit' | undefined
+      secondsDisplay?: 'always' | 'auto' | undefined
+      milliseconds?: 'long' | 'short' | 'narrow' | 'numeric' | undefined
+      millisecondsDisplay?: 'always' | 'auto' | undefined
+      microseconds?: 'long' | 'short' | 'narrow' | 'numeric' | undefined
+      microsecondsDisplay?: 'always' | 'auto' | undefined
+      nanoseconds?: 'long' | 'short' | 'narrow' | 'numeric' | undefined
+      nanosecondsDisplay?: 'always' | 'auto' | undefined
+      fractionalDigits?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+    }
+
+    interface DurationFormatConstructor {
+      new (
+        locales: LocalesArgument,
+        options?: DurationFormatOptions
+      ): DurationFormat
+    }
+
+    interface DurationFormatObject {
+      years?: number
+      months?: number
+      weeks?: number
+      days?: number
+      hours?: number
+      minutes?: number
+      seconds?: number
+      milliseconds?: number
+      microseconds?: number
+      nanoseconds?: number
+    }
+
+    interface DurationFormat {
+      format(value: DurationFormatObject): string
+    }
+
+    const DurationFormat: DurationFormatConstructor
+  }
 }
 
 export {}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -816,3 +816,24 @@ export interface RunnerCommandStub {
   stdout?: string
   stderr?: string
 }
+
+interface PlaytimeBase {
+  // Total playtime in minutes
+  totalPlayed: number
+}
+
+interface PlaytimeWithoutFirstAndLastPlayed extends PlaytimeBase {
+  firstPlayed?: undefined
+  lastPlayed?: undefined
+}
+
+interface PlaytimeWithFirstAndLastPlayed extends PlaytimeBase {
+  // ISO Date string of first recorded game launch
+  firstPlayed: string
+  // ISO Date string of last recorded game launch
+  lastPlayed: string
+}
+
+export type Playtime =
+  | PlaytimeWithFirstAndLastPlayed
+  | PlaytimeWithoutFirstAndLastPlayed

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -1,7 +1,7 @@
 import Store from 'electron-store'
 import { Get } from 'type-fest'
 
-import {
+import type {
   WineVersionInfo,
   InstalledInfo,
   UserInfo,
@@ -15,7 +15,9 @@ import {
   WikiInfo,
   GameInfo,
   WindowProps,
-  UploadedLogData
+  UploadedLogData,
+  Playtime,
+  Runner
 } from 'common/types'
 import { UserData } from 'common/types/gog'
 import { NileUserData } from './nile'
@@ -61,16 +63,7 @@ export interface StoreStructure {
   zoomInstalledGamesStore: {
     installed: InstalledInfo[]
   }
-  timestampStore: {
-    [K: string]: {
-      firstPlayed: string
-      lastPlayed: string
-      totalPlayed: number
-    }
-  }
-  fontsStore: {
-    fonts: string[]
-  }
+  timestampStore: Record<`${string}_${Runner}`, Playtime>
   gogConfigStore: {
     userData: UserData
     credentials?: GOGLoginData

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -25,6 +25,7 @@ import type {
   LaunchOption,
   LaunchParams,
   MoveGameArgs,
+  Playtime,
   RecentGame,
   Release,
   Runner,
@@ -119,6 +120,7 @@ interface SyncIPCFunctions {
     status: boolean
   ) => void
   logoutZoom: () => void
+  'playtime.get': (game_id: string, runner: Runner) => void
 }
 
 /*
@@ -350,6 +352,11 @@ interface FrontendMessages {
   logFileUploaded: (url: string, data: UploadedLogData) => void
   logFileUploadDeleted: (url: string) => void
   progressUpdate: (progress: GameStatus) => void
+  'playtime.update': (
+    game_id: string,
+    runner: Runner,
+    playtime: Playtime
+  ) => void
 
   // Used inside tests, so we can be a bit lenient with the type checking here
   message: (...params: unknown[]) => void

--- a/src/frontend/helpers/electronStores.ts
+++ b/src/frontend/helpers/electronStores.ts
@@ -161,11 +161,6 @@ const nileConfigStore = new TypeCheckedStoreFrontend('nileConfigStore', {
   cwd: 'nile_store'
 })
 
-const timestampStore = new TypeCheckedStoreFrontend('timestampStore', {
-  cwd: 'store',
-  name: 'timestamp'
-})
-
 const sideloadLibrary = new TypeCheckedStoreFrontend('sideloadedStore', {
   cwd: 'sideload_apps',
   name: 'library'
@@ -182,7 +177,6 @@ export {
   gogInstalledGamesStore,
   gogConfigStore,
   libraryStore,
-  timestampStore,
   sideloadLibrary,
   wineDownloaderInfoStore,
   downloadManagerStore,

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -428,7 +428,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
                       <Description />
                       {!notInstallable && (
-                        <TimeContainer runner={runner} game={appName} />
+                        <TimeContainer runner={runner} game_id={appName} />
                       )}
                       <GameStatus
                         gameInfo={gameInfo}

--- a/src/frontend/state/Playtime.ts
+++ b/src/frontend/state/Playtime.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+import { useShallow } from 'zustand/react/shallow'
+
+import type { Playtime, Runner } from 'common/types'
+
+type StoreType = Record<`${string}_${Runner}`, Playtime>
+
+const usePlaytimeRaw = create<StoreType>()(() => ({}))
+
+window.api.playtime.updateSlot((e, game_id, runner, playtime) => {
+  const key = `${game_id}_${runner}`
+  usePlaytimeRaw.setState({ [key]: playtime })
+})
+
+export const usePlaytime = <T>(
+  selector: Parameters<typeof useShallow<StoreType, T>>[0]
+) => usePlaytimeRaw(useShallow(selector))

--- a/src/preload/api/misc.ts
+++ b/src/preload/api/misc.ts
@@ -102,3 +102,8 @@ export const deleteUploadedLogFile = makeHandlerInvoker('deleteUploadedLogFile')
 export const logFileUploadedSlot = frontendListenerSlot('logFileUploaded')
 export const logFileUploadDeletedSlot = frontendListenerSlot('logFileUploadDeleted')
 export const isIntelMac = makeHandlerInvoker('isIntelMac')
+
+export const playtime = {
+  get: makeListenerCaller('playtime.get'),
+  updateSlot: frontendListenerSlot('playtime.update')
+}


### PR DESCRIPTION
This implements the changes I've mentioned here: <https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5014#pullrequestreview-3465730597>

The Frontend now uses a Zustand store to house playtime information. If the playtime changes, the Backend sends updates to it & the Frontend just re-renders automatically

Playtime tracking in the Backend is done automatically with a new `playSessionEnded` event, emitted at the end of `launchCallback`. A new `PlaytimeManager` class listens to this event and updates playtime accordingly. The GOG library manager also listens to this event to sync the playtime with GOG

In the process, I've made some housekeeping changes:
- Playtime store keys are now of type `${string}_${Runner}`, to avoid game ID collisions
  - This is mentioned in the code, but just to have it here as well: This *doesn't* use the migration system, since the system runs too early
- The strings shown to the user now get the playtime number / first/last play date as parameters, so other locales may change their position
- First/last play dates are generated using a locale-aware `Intl.DateTimeFormat` (it used the system locale before, which may not be the locale the user configured)
- Total playtime is formatted using a `Intl.DurationFormat` to present the duration in a more friendly format, and now includes seconds
  - I've had to write a typedef for `DurationFormat` for this, since it's not in TypeScript yet (for some reason)

TODO:

- [ ] Fetch playtime from GOG's servers again. Ideally I'd like to do this after https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4889 is merged, since that'd involve touching the `LibraryManager` type

Notes:
- The playtime updates could've used the `gameStatusUpdate` event instead, but it seems we currently emit the `done` status multiple times. Cleaning that up may cause side-effects, so I left it alone for now

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
