### PR TITLE
Center Loading/UpdateComponent when the app is loading for the first time

### DIFF
--- a/src/frontend/index.scss
+++ b/src/frontend/index.scss
@@ -99,3 +99,10 @@ body {
   margin-inline: var(--space-xs) 0;
   color: var(--text-secondary);
 }
+
+#root:has(> .UpdateComponent) {
+  height: 100vh;
+  & > .UpdateComponent {
+    height: 100vh;
+  }
+}


### PR DESCRIPTION
This is a small fix for an issue I noticed after merging https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4808

The initial `Loading` state while the application loads was not centered in the window, it was aligned to the top. This fixes that.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
