### PR TITLE
[UX] Default windows version of games even if linux native available

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -177,17 +177,11 @@ export default React.memo(function GamePage(): JSX.Element | null {
         const {
           install,
           thirdPartyManagedApp,
-          is_linux_native = undefined,
           is_mac_native = undefined
         } = { ...gameInfo }
 
         const installPlatform =
-          install.platform ||
-          (is_linux_native && isLinux
-            ? 'linux'
-            : is_mac_native && isMac
-              ? 'Mac'
-              : 'Windows')
+          install.platform || (is_mac_native && isMac ? 'Mac' : 'Windows')
 
         if (
           runner !== 'sideload' &&

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -89,10 +89,6 @@ function InstallModal({ appName, runner, gameInfo = null }: Props) {
   )
 
   const getDefaultplatform = (): InstallPlatform => {
-    if (isLinux && gameInfo?.is_linux_native) {
-      return 'linux'
-    }
-
     if (isMac && gameInfo?.is_mac_native) {
       return 'Mac'
     }


### PR DESCRIPTION
Many users install the native linux version of games because it's the default, but we have seen over time that linux versions are not always the best option (either because they depend on old libraries, or because some GOG features like cloud saves won't work).

This PR changes this to always asume Windows as the default for installation (and for install info fetching). Users can always pick the linux version if they really want it, but making windows the default will help more.

I didn't change the native version for macos since, in my experience, they work pretty well and in some cases better than the windows version.

This closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4918 (the issue there was the game reporting linux as an option, but failing to fetch linux install info)

This closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4089 (in that issue there's a suggestion about making this a configuration, but I don't want to add yet another advanced feature, most of the times the linux version is just worse)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
