### PR TITLE
[Fix] Incorrect virtual keyboard button when zoomed

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -568,6 +568,7 @@ interface GamepadActionArgsWithoutMetadata {
     | 'esc'
     | 'tab'
     | 'shiftTab'
+    | 'keyboardClick'
   metadata?: undefined
 }
 

--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -59,7 +59,8 @@ export const initGamepad = () => {
     leftClick: { triggeredAt: {}, repeatDelay: false },
     esc: { triggeredAt: {}, repeatDelay: false },
     tab: { triggeredAt: {}, repeatDelay: false },
-    shiftTab: { triggeredAt: {}, repeatDelay: false }
+    shiftTab: { triggeredAt: {}, repeatDelay: false },
+    keyboardClick: { triggeredAt: {}, repeatDelay: false }
   }
 
   // check if an action should be triggered
@@ -122,8 +123,7 @@ export const initGamepad = () => {
           } else if (isGameCard()) {
             action = 'mainAction'
           } else if (VirtualKeyboardController.isButtonFocused()) {
-            // simulate a left click on a virtual keyboard button
-            action = 'leftClick'
+            action = 'keyboardClick'
           } else if (isTextInput()) {
             // open virtual keyboard if focusing a text input
             VirtualKeyboardController.initOrFocus()
@@ -203,6 +203,13 @@ export const initGamepad = () => {
 
       if (action === 'mainAction') {
         currentElement()?.click()
+      } else if (action === 'keyboardClick') {
+        // we have to do this for the keyboard because:
+        // simulated clicks break when zoomed in
+        // normal `.click()` calls don't work because the buttons are divs
+        const button = currentElement()
+        const buttonCode = button?.dataset.skbtn
+        if (buttonCode) VirtualKeyboardController.typeCharacter(buttonCode)
       } else {
         // we have to tell Electron to simulate key presses
         // so the spatial navigation works

--- a/src/frontend/helpers/virtualKeyboard.ts
+++ b/src/frontend/helpers/virtualKeyboard.ts
@@ -79,5 +79,8 @@ export const VirtualKeyboardController = {
   },
   space: () => {
     typeInInput(' ')
+  },
+  typeCharacter: (char: string) => {
+    typeInInput(char)
   }
 }


### PR DESCRIPTION
Closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4933

Using electron's simulated clicks broke when the UI was zoomed in, "clicking" the wrong button.

This PR fixes that by handling keyboard "click" differently, instead of clicking it we get the key code and type it in the input field.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
