### PR TITLE
[Fix] Improve handling of installation progress to avoid UI lag

### DIFF
--- a/src/frontend/components/UI/DLCList/DLC/index.tsx
+++ b/src/frontend/components/UI/DLCList/DLC/index.tsx
@@ -29,7 +29,7 @@ const DLC = ({ dlc, runner, mainAppInfo, onClose }: Props) => {
   const [dlcInfo, setDlcInfo] = useState<GameInfo | null>(null)
   const [dlcSize, setDlcSize] = useState<number>(0)
   const [refreshing, setRefreshing] = useState(true)
-  const [progress] = hasProgress(app_name)
+  const [progress] = hasProgress(dlc.app_name, runner)
 
   const isInstalled = dlcInfo?.is_installed
 

--- a/src/frontend/components/UI/Sidebar/components/CurrentDownload/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/CurrentDownload/index.tsx
@@ -19,7 +19,7 @@ type Props = {
 }
 
 export default React.memo(function CurrentDownload({ appName, runner }: Props) {
-  const [progress] = hasProgress(appName)
+  const [progress] = hasProgress(appName, runner)
   const [gameTitle, setGameTitle] = useState('')
   const { libraryStatus } = useContext(ContextProvider)
   const { t } = useTranslation()
@@ -75,7 +75,7 @@ export default React.memo(function CurrentDownload({ appName, runner }: Props) {
             />
           </Box>
           <Box sx={{ minWidth: 35 }}>
-            <Typography variant="body2">{`${Math.round(
+            <Typography variant="body2">{`${Math.ceil(
               progress.percent || 0
             )}%`}</Typography>
           </Box>

--- a/src/frontend/hooks/hasStatus.ts
+++ b/src/frontend/hooks/hasStatus.ts
@@ -5,13 +5,10 @@ import { hasProgress } from './hasProgress'
 import { useTranslation } from 'react-i18next'
 import { getStatusLabel, handleNonAvailableGames } from './constants'
 
-export function hasStatus(
-  appName: string,
-  gameInfo?: GameInfo,
-  gameSize?: string
-) {
+export function hasStatus(gameInfo: GameInfo, gameSize?: string) {
+  const appName = gameInfo.app_name
   const { libraryStatus, epic, gog } = React.useContext(ContextProvider)
-  const [progress] = hasProgress(appName)
+  const [progress] = hasProgress(gameInfo.app_name, gameInfo.runner)
   const [newGameInfo, setNewGameInfo] = React.useState<GameInfo | undefined>(
     gameInfo
   )

--- a/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/DownloadManagerItem/index.tsx
@@ -87,7 +87,7 @@ const DownloadManagerItem = ({
     install: { is_dlc }
   } = gameInfo || {}
 
-  const [progress] = hasProgress(appName)
+  const [progress] = hasProgress(appName, runner)
   const { status } = element
   const finished = status === 'done'
   const canceled = status === 'error' || (status === 'abort' && !current)

--- a/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
+++ b/src/frontend/screens/DownloadManager/components/ProgressHeader/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { AreaChart, Area, ResponsiveContainer } from 'recharts'
 import { Box, LinearProgress, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
-import { DownloadManagerState } from 'common/types'
+import { DownloadManagerState, Runner } from 'common/types'
 
 interface Point {
   download: number
@@ -19,10 +19,11 @@ const roundToNearestHundredth = function (val: number | undefined) {
 export default function ProgressHeader(props: {
   appName: string
   state: DownloadManagerState
+  runner: Runner
 }) {
   const sampleSize = 100
   const { t } = useTranslation()
-  const [progress] = hasProgress(props.appName)
+  const [progress] = hasProgress(props.appName, props.runner)
   const [avgSpeed, setAvgDownloadSpeed] = useState<Point[]>(
     Array<Point>(sampleSize).fill({ download: 0, disk: 0 })
   )

--- a/src/frontend/screens/DownloadManager/index.tsx
+++ b/src/frontend/screens/DownloadManager/index.tsx
@@ -111,6 +111,7 @@ export default React.memo(function DownloadManager(): JSX.Element | null {
           <ProgressHeader
             state={state}
             appName={currentElement?.params?.appName ?? ''}
+            runner={currentElement?.params?.runner ?? 'legendary'}
           />
           {currentElement && (
             <div className="downloadManager">

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -101,10 +101,10 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const [gameInfo, setGameInfo] = useState(locationGameInfo)
   const [gameSettings, setGameSettings] = useState<GameSettings | null>(null)
 
-  const { status, folder, statusContext } = hasStatus(appName, gameInfo)
+  const { status, folder, statusContext } = hasStatus(gameInfo)
   const gameAvailable = gameInfo.is_installed && status !== 'notAvailable'
 
-  const [progress, previousProgress] = hasProgress(appName)
+  const [progress, previousProgress] = hasProgress(appName, runner)
 
   const [extraInfo, setExtraInfo] = useState<ExtraInfo | null>(
     gameInfo.extra || null

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -126,12 +126,12 @@ const GameCard = ({
   const isInstallable =
     gameInfo.installable === undefined || gameInfo.installable // If it's undefined we assume it's installable
 
-  const [progress, previousProgress] = hasProgress(appName)
+  const [progress, previousProgress] = hasProgress(appName, runner)
   const { install_size: size = '0' } = {
     ...gameInstallInfo
   }
 
-  const { status, folder, label } = hasStatus(appName, gameInfo, size)
+  const { status, folder, label } = hasStatus(gameInfo, size)
 
   const isBrowserGame = gameInfo.install.platform === 'Browser'
 

--- a/src/frontend/state/InstallProgress.ts
+++ b/src/frontend/state/InstallProgress.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+import { useShallow } from 'zustand/react/shallow'
+
+import type { InstallProgress, Runner } from 'common/types'
+
+type StoreType = Record<`${string}_${Runner}`, InstallProgress>
+
+const useInstallProgressRaw = create<StoreType>()(() => ({}))
+
+window.api.onProgressUpdate((e, { appName, progress, runner }) => {
+  const key = `${appName}_${runner}`
+  useInstallProgressRaw.setState({ [key]: progress })
+})
+
+export const useInstallProgress = <T>(
+  selector: Parameters<typeof useShallow<StoreType, T>>[0]
+) => useInstallProgressRaw(useShallow(selector))


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5046

Currently, the `hasProgress` hook is adding one event listener for the `onProgressUpdate` for every card in the library (adding hundreds of event listeners for big libraries!). This is causing really noticeable lag while an installation is in progress for every upgrade progress event (steps to reproduce in the linked issue).

This PR fixes that with a few changes:
- now the event listener is added only once in thew new zustand state (code is based on https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5034 to keep track of each game installation by key to avoid a lot of re-renders)
- the `hasProgress` hook now updates its state only when the given appName+runner progress changes

Some extra things:
- The `hasProgress` hook only depended on the appName before, I added the runner too cause different stores may end up with the same appName id in some edge cases
- The `CurrentDownload` component was using `Math.round` while the game card was using `Math.ceil` to show the progress, this caused the numbers to be different, now they both use `Math.ceil`
- The `hasStatus` hook was receiving both the appName AND the gameInfo, with the gameInfo we already have the appName so I removed that param

With the changes in this PR, you can see there's no lag at all when the install progress is updated.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
