### PR TITLE
[UX] Warn about installation in progress when exiting Heroic

### DIFF
--- a/src/backend/downloadmanager/downloadqueue.ts
+++ b/src/backend/downloadmanager/downloadqueue.ts
@@ -319,5 +319,6 @@ export {
   getQueueInformation,
   cancelCurrentDownload,
   pauseCurrentDownload,
-  resumeCurrentDownload
+  resumeCurrentDownload,
+  isRunning
 }

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -83,6 +83,7 @@ import {
 import { parse } from '@node-steam/vdf'
 
 import type LogWriter from 'backend/logger/log_writer'
+import { isRunning } from './downloadmanager/downloadqueue'
 
 const execAsync = promisify(exec)
 
@@ -238,7 +239,7 @@ async function handleExit() {
 
   await gogPresence.deletePresence()
 
-  if (isLocked && mainWindow) {
+  if ((isLocked || isRunning()) && mainWindow) {
     const { response } = await showMessageBox(mainWindow, {
       buttons: [i18next.t('box.no'), i18next.t('box.yes')],
       message: i18next.t(
@@ -252,9 +253,11 @@ async function handleExit() {
       return
     }
 
-    // This is very hacky and can be removed if gogdl
-    // and legendary handle SIGTERM and SIGKILL
-    const possibleChildren = ['legendary', 'gogdl']
+    // This is very hacky and can be removed if bineries handle SIGTERM and SIGKILL
+    // FIXME: we should keep track of what we are doing and kill just that
+    // this is really dangerous cause we can be killing other processes unrelated
+    // to what we are doing x_x
+    const possibleChildren = ['legendary', 'gogdl', 'nile']
     possibleChildren.forEach((procName) => {
       try {
         killPattern(procName)


### PR DESCRIPTION
We used to have this feature but at some point it got lost.

When closing Heroic, if a download is in progress we warn the user first instead of just closing Heroic.

Currently, since that code we used to have is not running, closing Heroic mid download does not kill the current downloads and the continue running in the background.

This PR does NOT fix what happens if Heroic is killed (like with `kill -9`), because that's an extreme case where we can't really show a warning to the user (and I don't really know what's the solution there).

This closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4617

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
