### PR TITLE
[UI] Small fix, make update component take entire screen

### DIFF
--- a/src/frontend/components/UI/UpdateComponent/index.css
+++ b/src/frontend/components/UI/UpdateComponent/index.css
@@ -1,5 +1,5 @@
 .UpdateComponent {
-  height: 100%;
+  height: 100vh;
   font-size: var(--text-xl);
   color: var(--text-default);
   display: flex;


### PR DESCRIPTION
<--- Put the description here --->
Noticed the loading component was just in the top part of the screen, this addresses the issue. 
Before: 

<img width="874" height="808" alt="imagem" src="https://github.com/user-attachments/assets/da5b45ca-3cfa-4507-95b5-aace359babed" />

After:

<img width="865" height="806" alt="imagem" src="https://github.com/user-attachments/assets/3aba4551-3cae-4e87-91e6-0dc68d9a5bcb" />

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
