### PR TITLE
[UI] Tabs in Game Page now more accessible with gamepad and keyboard

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.css
+++ b/src/frontend/screens/Game/GamePage/index.css
@@ -30,7 +30,7 @@
 
   .MuiTab-labelIcon {
     min-height: unset;
-    align-items: flex-start;
+    align-items: center;
   }
 
   & > p {
@@ -655,7 +655,6 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
-  margin-bottom: var(--space-md);
 
   .gameInfoTabs {
     align-items: center;
@@ -681,14 +680,6 @@
 
     .MuiTabs-flexContainer {
       border-bottom: none;
-    }
-  }
-
-  .tabButton {
-    border-radius: var(--space-lg);
-
-    & .MuiTabs-indicator {
-      display: none;
     }
   }
 

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -452,7 +452,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                           value={currentTab}
                           onChange={(e, newVal) => setCurrentTab(newVal)}
                           aria-label="gameinfo tabs"
-                          variant="scrollable"
+                          selectionFollowsFocus
                         >
                           <Tab
                             className="tabButton"


### PR DESCRIPTION
Noticed that the tabs in the game page were simultaneously not displaying focus correctly, and also not handling input very well. This is particularly bad when navigating with a keyboard or gamepad where you kinda lose track of where you are and what you're doing. Apparently, this was being caused because of the "scrollable" variant not playing nicely with the tabs. I also modified the tabs to add the `selectionFollowFocus` because I feel like it lends itself very well to navigation / gamepad driven inputs. 

Before: 

https://github.com/user-attachments/assets/885965af-8c7c-446b-9c14-4acdce83a794


After:


https://github.com/user-attachments/assets/185a83bd-3d95-447b-afb4-7c96b6b23b7f


Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
