### PR TITLE
Ignore special characters while searching and filtering

### DIFF
--- a/src/frontend/components/UI/LibrarySearchBar/index.tsx
+++ b/src/frontend/components/UI/LibrarySearchBar/index.tsx
@@ -5,6 +5,7 @@ import { GameInfo, Runner } from 'common/types'
 import SearchBar from '../SearchBar'
 import { useTranslation } from 'react-i18next'
 import LibraryContext from 'frontend/screens/Library/LibraryContext'
+import { normalizeTitle } from 'frontend/helpers/library'
 
 function fixFilter(text: string) {
   const regex = new RegExp(/([?\\|*|+|(|)|[|]|])+/, 'g')
@@ -25,6 +26,11 @@ export default function LibrarySearchBar() {
   const navigate = useNavigate()
   const { t } = useTranslation()
 
+  const normalizedFilterText = useMemo(
+    () => normalizeTitle(fixFilter(filterText)),
+    [filterText]
+  )
+
   const list = useMemo(() => {
     return [
       ...(epic.library ?? []),
@@ -37,11 +43,18 @@ export default function LibrarySearchBar() {
       .filter((el) => {
         return (
           !el.install.is_dlc &&
-          new RegExp(fixFilter(filterText), 'i').test(el.title)
+          normalizeTitle(el.title).includes(normalizedFilterText)
         )
       })
       .sort((g1, g2) => (g1.title < g2.title ? -1 : 1))
-  }, [amazon.library, epic.library, gog.library, zoom.library, filterText])
+  }, [
+    amazon.library,
+    epic.library,
+    gog.library,
+    sideloadedLibrary,
+    zoom.library,
+    normalizedFilterText
+  ])
 
   const handleClick = (game: GameInfo) => {
     handleSearch('')

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -240,6 +240,10 @@ const updateGame = (args: UpdateParams) => {
   return window.api.updateGame(args)
 }
 
+export const normalizeTitle = (title: string) => {
+  return title.replace(/[^\w\s]/g, '').toLowerCase()
+}
+
 export const epicCategories = ['all', 'legendary', 'epic']
 export const gogCategories = ['all', 'gog']
 export const sideloadedCategories = ['all', 'sideload']


### PR DESCRIPTION
Previously when typing "Baldurs Gate" into the search bar you would get no result. That's because the Game is actually called "Baldur's Gate" the same is true for "Stalker" since the games start with "S.T.A.L.K.E.R.".
So with this patch we ignore all non word characters while searching or filtering.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
