### PR TITLE
[Fix] Missing extra info due to HLTB failure

### DIFF
--- a/src/backend/wiki_game_info/howlongtobeat/utils.ts
+++ b/src/backend/wiki_game_info/howlongtobeat/utils.ts
@@ -1,7 +1,8 @@
 import { logError, logInfo, LogPrefix } from 'backend/logger'
-import { HowLongToBeat } from 'howlongtobeat-js'
+import { HowLongToBeat, HowLongToBeatEntry } from 'howlongtobeat-js'
 
-export interface HowLongToBeatEntry {
+// this is a subset of the HowLongToBeatEntry type without some fields
+export interface HeroicHowLongToBeatEntry {
   completionist: number
   mainStory: number
   mainExtra: number
@@ -14,10 +15,20 @@ export interface HowLongToBeatEntry {
 
 export async function getHowLongToBeat(
   title: string
-): Promise<HowLongToBeatEntry | null> {
+): Promise<HeroicHowLongToBeatEntry | null> {
   logInfo(`Getting HowLongToBeat data for ${title}`, LogPrefix.ExtraGameInfo)
   const hltb = new HowLongToBeat(0.4)
-  const info = await hltb.search(title)
+  let info: HowLongToBeatEntry[] | null = null
+  try {
+    info = await hltb.search(title)
+  } catch (error) {
+    logError(
+      [`Error searching HLTB data for ${title}:`, error],
+      LogPrefix.ExtraGameInfo
+    )
+    return null
+  }
+
   if (!info || info.length === 0) {
     logError(
       `No HowLongToBeat data found for ${title}`,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -16,7 +16,7 @@ import {
 } from './types/zoom'
 import { TitleBarOverlay } from 'electron'
 import { ChildProcess } from 'child_process'
-import type { HowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
+import type { HeroicHowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
 import type { Path } from 'backend/schemas'
 import type LogWriter from 'backend/logger/log_writer'
 
@@ -699,7 +699,7 @@ export interface SteamInfo {
 export interface WikiInfo {
   pcgamingwiki: PCGamingWikiInfo | null
   applegamingwiki: AppleGamingWikiInfo | null
-  howlongtobeat: HowLongToBeatEntry | null
+  howlongtobeat: HeroicHowLongToBeatEntry | null
   gamesdb: GamesDBInfo | null
   steamInfo: SteamInfo | null
   umuId: string | null

--- a/src/frontend/components/UI/WikiGameInfo/components/HowLongToBeat/index.tsx
+++ b/src/frontend/components/UI/WikiGameInfo/components/HowLongToBeat/index.tsx
@@ -1,10 +1,10 @@
 import { useTranslation } from 'react-i18next'
 import './index.scss'
-import type { HowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
+import type { HeroicHowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
 import { createNewWindow } from 'frontend/helpers'
 
 type Props = {
-  info: HowLongToBeatEntry
+  info: HeroicHowLongToBeatEntry
 }
 
 export default function HowLongToBeat({ info }: Props) {


### PR DESCRIPTION
Some time ago, the requests to the HLTB service started failing. Since we are using a `Promise.all` function, this failure caused all the other game info results to be ignored and the extra info was not shown at all even for the data we could get.

I renamed the `HowLongToBeatEntry` type to `HeroicHowLongToBeatEntry` cause it was conflicting with the type from `howlongtobeat-js`, we care about fewer things in the one we use.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
