### PR TITLE
[Fix] TimeContainer conflicts

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -421,9 +421,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                       />
 
                       <Description />
-                      {!notInstallable && (
-                        <TimeContainer runner={runner} game={appName} />
-                      )}
+                      {!notInstallable && <TimeContainer gameInfo={gameInfo} />}
                       <GameStatus
                         gameInfo={gameInfo}
                         progress={progress}

--- a/src/frontend/screens/Game/TimeContainer/index.tsx
+++ b/src/frontend/screens/Game/TimeContainer/index.tsx
@@ -8,18 +8,18 @@ import { timestampStore } from 'frontend/helpers/electronStores'
 import './index.css'
 import PopoverComponent from 'frontend/components/UI/PopoverComponent'
 import { AvTimer } from '@mui/icons-material'
-import { Runner } from 'common/types'
+import { GameInfo } from 'common/types'
 import { hasStatus } from 'frontend/hooks/hasStatus'
 
 type Props = {
-  runner: Runner
-  game: string
+  gameInfo: GameInfo
 }
 
-function TimeContainer({ runner, game }: Props) {
+function TimeContainer({ gameInfo }: Props) {
+  const { app_name: game, runner } = gameInfo
   const { t } = useTranslation('gamepage')
   const [tsInfo, setTsInfo] = useState(timestampStore.get_nodefault(game))
-  const { status } = hasStatus(game)
+  const { status } = hasStatus(gameInfo)
 
   useEffect(() => {
     // update local stored time after playing


### PR DESCRIPTION
This PR didn't have any conflict https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/commit/a95fde1a31a07de1f39f3cc11c9f2cd6c7c7a8d5

But it was merged after my PR https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5048/files that changed the signature of the `hasStatus` hook.

I wonder if we should have a git rule to ensure the PRs are always rebased on top of the latest main to allow merging them? that could catch this type of issue.

This is also addressed in https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5087 but I'd rather have this fix in one PR that is not changing the dependencies so we can merge this independently and unlock all other PRs

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
