### PR TITLE
[chore] Update all github actions to latest versions

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -3,12 +3,13 @@ description: 'Installs dependencies (Node itself, node_modules, node-gyp, helper
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v3
-      with:
-        node-version: '20'
-    - uses: pnpm/action-setup@v3
+    - uses: pnpm/action-setup@v4
       with:
         standalone: ${{ runner.os == 'Windows' }}
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: 'package.json'
+        cache: 'pnpm'
     - name: Install node-gyp
       run: pnpm add --global node-gyp
       shell: bash

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -20,7 +20,7 @@ jobs:
         os: [windows-2025, ubuntu-24.04, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-deps
       - name: Build Windows Portable version
         run: pnpm dist:win portable
@@ -43,7 +43,7 @@ jobs:
         run: pnpm dist:linux AppImage --x64 --arm64 --publish=never
         if: runner.os == 'Linux'
       - name: Upload built version
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ (matrix.os == 'windows-2025'  && 'win-portable'  ) ||
                     (matrix.os == 'macos-15'      && 'mac-x64'       ) ||
@@ -55,7 +55,7 @@ jobs:
           if-no-files-found: error
           compression-level: 3
       - name: Upload linux ARM version
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux-AppImage-arm64
           path: dist/Heroic*arm64.AppImage
@@ -64,7 +64,7 @@ jobs:
           compression-level: 3
         if: runner.os == 'Linux'
       - name: Upload macOS ARM version
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mac-arm64
           path: dist/Heroic*arm64.dmg

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.0
+        uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -9,7 +9,7 @@ jobs:
   codecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-deps
       - name: Check Typescript syntax
         run: pnpm codecheck

--- a/.github/workflows/create-pr-from-stable.yml
+++ b/.github/workflows/create-pr-from-stable.yml
@@ -7,7 +7,7 @@ jobs:
   stableToMain:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: main
       - name: Reset stable branch
@@ -15,7 +15,7 @@ jobs:
           git fetch origin stable:stable
           git reset --hard stable
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: stable_to_main
           commit-message: Sync latest stable changes with main

--- a/.github/workflows/draft-release-linux.yml
+++ b/.github/workflows/draft-release-linux.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - run: sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-deps
       - run: pnpm release:linux
         env:

--- a/.github/workflows/draft-release-mac.yml
+++ b/.github/workflows/draft-release-mac.yml
@@ -22,10 +22,10 @@ jobs:
   draft-releases:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-deps
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - run: python3 -m pip install castlabs-evs
       - run: pnpm release:mac

--- a/.github/workflows/draft-release-windows.yml
+++ b/.github/workflows/draft-release-windows.yml
@@ -10,11 +10,11 @@ jobs:
   draft-releases:
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-deps
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - run: python3 -m pip install castlabs-evs
       - run: pnpm release:win
         env:

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -18,7 +18,7 @@ jobs:
       options: --privileged
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: ./.github/actions/install-deps
       - name: Build artifacts.
         run: pnpm dist:linux appimage --publish=never

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-deps
       - name: Lint code.
         run: pnpm lint

--- a/.github/workflows/release_aur.yml
+++ b/.github/workflows/release_aur.yml
@@ -70,7 +70,7 @@ jobs:
         if: ${{ success() }}
 
       - name: Publish AUR package
-        uses: KSXGitHub/github-actions-deploy-aur@v2.7.2
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
         with:
           pkgname: heroic-games-launcher-bin
           pkgbuild: ./PKGBUILD

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -30,7 +30,7 @@ jobs:
       - name: echo ref name.
         run: echo "tag name ${{ github.ref_name }}"
       - name: Checkout repository.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - uses: ./.github/actions/install-deps
       - name: Reconfigure git to use HTTP authentication
         run: >

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - uses: ./.github/actions/install-deps
       - name: Test CI
         run: pnpm test:ci
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - uses: ./.github/actions/install-deps
       - name: Fix ownership and mode
         run: sudo chown root /home/runner/work/HeroicGamesLauncher/HeroicGamesLauncher/node_modules/electron/dist/chrome-sandbox && sudo chmod 4755 /home/runner/work/HeroicGamesLauncher/HeroicGamesLauncher/node_modules/electron/dist/chrome-sandbox

--- a/.github/workflows/update-bug-template-on-release.yml
+++ b/.github/workflows/update-bug-template-on-release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Get Latest Release Version
         id: get_latest_release

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "email": "heroicgameslauncher@protonmail.com"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">=22"
   },
-  "packageManager": "pnpm@10.9.0",
+  "packageManager": "pnpm@10.26.2",
   "scripts": {
     "start": "electron-vite dev --watch",
     "debug:react": "pnpm start & react-devtools",


### PR DESCRIPTION
The vast majority of the updates are to ensure compatibility with the latest github runner images, which default to NodeJS 24 instead of 20.

There is also a minor change to the install-deps action to install pnpm before node as that is what the node action recommends. Updated the versions of NodeJS and pnpm in package.json to make sure the setup actions (and developer tools) grab versions that match Electron 36.

Also enabled pnpm package caching to take advantage of new features in the node action and hopefully reduce build times.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
