### PR TITLE
Fix spelling: 'Exitting' -> 'Exiting'

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -242,7 +242,7 @@ async function initializeWindow(): Promise<BrowserWindow> {
     const { exitToTray, noTrayIcon } = GlobalConfig.get().getSettings()
 
     if (exitToTray && !noTrayIcon) {
-      logInfo('Exitting to tray instead of quitting', LogPrefix.Backend)
+      logInfo('Exiting to tray instead of quitting', LogPrefix.Backend)
       return mainWindow.hide()
     }
 


### PR DESCRIPTION
'Exiting' should only have one 't' (reference: [The Free Dictionary](https://www.thefreedictionary.com/exit)).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)
