### PR TITLE
Add DevSkim security scan workflow

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -1,0 +1,27 @@
+name: DevSkim
+
+on:
+  pull_request:
+    branches: ['main']
+  schedule:
+    - cron: '40 5 * * 2'
+
+jobs:
+  scan:
+    name: DevSkim
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run DevSkim scanner
+        uses: microsoft/DevSkim-Action@v1
+
+      - name: Upload DevSkim scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: devskim-results.sarif


### PR DESCRIPTION
- Add DevSkim CI job that runs on PRs to main and weekly (Tue 05:40 UTC).
- Minimal permissions (actions/contents read, security-events write); uploads SARIF to the Security tab via github/codeql-action/upload-sarif.
- Uses microsoft/DevSkim-Action@v1 and actions/checkout@v4. (Renovate will pin SHAs if configured #5116; can pin manually if preferred.)

---

Testing/impact: Workflow-only change; no runtime code touched.
