### PR TITLE
Add pnpm audit workflow

### DIFF
--- a/.github/workflows/pnpm-audit.yml
+++ b/.github/workflows/pnpm-audit.yml
@@ -29,14 +29,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: pnpm audit (high+ only, report-only)
+      - name: pnpm audit (report all severities)
         run: |
-          pnpm audit --prod --audit-level=high > audit-report.txt
+          pnpm audit --prod > audit-report.txt || true
+
+      - name: pnpm audit (enforce high+)
+        run: pnpm audit --prod --audit-level=high
 
       - name: Publish audit summary
         if: always()
         run: |
-          echo "### pnpm audit (high+ only)" >> "$GITHUB_STEP_SUMMARY"
+          echo "### pnpm audit (full report)" >> "$GITHUB_STEP_SUMMARY"
           echo >> "$GITHUB_STEP_SUMMARY"
           if [ -s audit-report.txt ]; then
             cat audit-report.txt >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
- Add pnpm audit workflow on PRs to main/stable and weekly (Wed 04:15 UTC).
- Use Node 20 and pnpm 10.9.0 (pnpm cache) with pnpm install --frozen-lockfile.
- Run two audits: full pnpm audit --prod (captured to summary) and enforcing pnpm audit --prod --audit-level=high (fails on high/critical). Summary always shows all severities.
- Minimal permissions (contents: read). Actions tag-pinned; Renovate will handle digest pinning #5116.

---

Testing/impact: Workflow-only change; no runtime code touched.
