### PR TITLE
Add OSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,15 +10,16 @@ on:
   # Optional branch protection trigger
   branch_protection_rule:
 
-permissions:
-  contents: read
-  security-events: write
-  id-token: write
+permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- Add OSSF Scorecard workflow running on PRs to main, weekly (Mon 03:30 UTC), and branch protection rule.
- Minimal permissions: contents: read, security-events: write, id-token: write.
- Steps: checkout, run ossf/scorecard-action@v2.4.3, upload SARIF to Code Scanning, and attach results as an artifact.
- Actions are tag-pinned; Renovate will handle digest pinning if configured (#5116).

---

Testing/impact: Workflow-only change; no runtime code touched.