### PR TITLE
[UI] Remove Extra System Requirements option from Game Sub Menu

### DIFF
--- a/src/frontend/screens/Game/GamePage/components/DotsMenu.tsx
+++ b/src/frontend/screens/Game/GamePage/components/DotsMenu.tsx
@@ -29,8 +29,6 @@ const DotsMenu = ({ gameInfo, handleUpdate }: Props) => {
 
   const { is_installed, title } = gameInfo
 
-  const hasRequirements = (gameExtraInfo?.reqs || []).length > 0
-
   return (
     <>
       <div className="game-actions">
@@ -53,9 +51,6 @@ const DotsMenu = ({ gameInfo, handleUpdate }: Props) => {
           handleUpdate={handleUpdate}
           handleChangeLog={() => setShowChangelog(true)}
           disableUpdate={is.installing || is.updating}
-          onShowRequirements={
-            hasRequirements ? () => setShowRequirements(true) : undefined
-          }
           onShowModifyInstall={() => setShowModifyInstallModal(true)}
           gameInfo={gameInfo}
         />

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -19,7 +19,6 @@ import {
   ArrowUpward as ArrowUpwardIcon,
   CheckCircle as CheckCircleIcon,
   Delete as DeleteIcon,
-  DesktopAccessDisabled as DesktopAccessDisabledIcon,
   DriveFileMove as DriveFileMoveIcon,
   Edit as EditIcon,
   FindInPage as FindInPageIcon,
@@ -45,7 +44,6 @@ interface Props {
   handleUpdate: () => void
   handleChangeLog: () => void
   disableUpdate: boolean
-  onShowRequirements?: () => void
   onShowModifyInstall?: () => void
   gameInfo: GameInfo
 }
@@ -60,7 +58,6 @@ export default function GamesSubmenu({
   handleUpdate,
   handleChangeLog,
   disableUpdate,
-  onShowRequirements,
   onShowModifyInstall,
   gameInfo
 }: Props) {

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -415,15 +415,6 @@ export default function GamesSubmenu({
               {t('submenu.protondb', 'Check Compatibility')}
             </button>
           )}
-          {onShowRequirements && (
-            <button
-              onClick={async () => onShowRequirements()}
-              className="link button is-text is-link buttonWithIcon"
-            >
-              <DesktopAccessDisabledIcon />
-              {t('game.requirements', 'Requirements')}
-            </button>
-          )}
           {showModifyItem && (
             <button
               onClick={async () => onShowModifyInstall()}


### PR DESCRIPTION
There's already a System Requirements section in the Tab view. Thus, it doesn't help to keep the same option in the sub menu.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
