### PR TITLE
[FIX] Lookup OfferImage images in metadata

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -570,9 +570,13 @@ function loadFile(app_name: string): boolean {
       : customAttributes?.CloudSaveFolder?.value) ?? ''
   const installFolder = FolderName ? FolderName.value : app_name
 
-  const gameBox = keyImages.find(({ type }) => type === 'DieselGameBox')
+  const gameBox = keyImages.find(
+    ({ type }) => type === 'DieselGameBox' || type === 'OfferImageWide'
+  )
 
-  const gameBoxTall = keyImages.find(({ type }) => type === 'DieselGameBoxTall')
+  const gameBoxTall = keyImages.find(
+    ({ type }) => type === 'DieselGameBoxTall' || type === 'OfferImageTall'
+  )
 
   const gameBoxStore = keyImages.find(
     ({ type }) => type === 'DieselStoreFrontTall'


### PR DESCRIPTION
Looks like images in the metadata of early access games can have different keys than the `DieselGameBox` ones we look for currently. We have to look for `OfferImageWide` an `OfferImageTall` too.

This is what it looks like for Path of Exile 2:

```
    "keyImages": [
      {
        "height": 1600,
        "md5": "7262fe7eb7693daae6af25dfc5188383",
        "size": 377431,
        "type": "OfferImageTall",
        "uploadedDate": "2025-12-08T18:10:39.646Z",
        "url": "https://cdn1.epicgames.com/item/58a18be6bbba41a0bf52b014bb81d33b/EGS_PathofExile2_GrindingGearGames_S2_1200x1600-7262fe7eb7693daae6af25dfc5188383",
        "width": 1200
      },
      {
        "height": 1440,
        "md5": "56206c309622e9cdb8bb0560085c5a9c",
        "size": 569662,
        "type": "OfferImageWide",
        "uploadedDate": "2025-12-08T18:10:43.601Z",
        "url": "https://cdn1.epicgames.com/item/58a18be6bbba41a0bf52b014bb81d33b/EGS_PathofExile2_GrindingGearGames_S1_2560x1440-56206c309622e9cdb8bb0560085c5a9c",
        "width": 2560
      }
    ]
```


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
