### PR TITLE
[Refactor] Reduce the number of requests that we do at boot time

### DIFF
--- a/src/backend/anticheat/ipc_handler.ts
+++ b/src/backend/anticheat/ipc_handler.ts
@@ -1,7 +1,19 @@
+import { backendEvents } from 'backend/backend_events'
 import { addHandler } from '../ipc'
-import { gameAnticheatInfo } from './utils'
+import { downloadAntiCheatData, gameAnticheatInfo } from './utils'
+import { isMac } from 'backend/constants/environment'
+import { logDebug, LogPrefix } from 'backend/logger'
 
 // we use the game's `namespace` value here, it's the value that can be easily fetch by AreWeAnticheatYet
 addHandler('getAnticheatInfo', async (e, appNamespace) =>
   gameAnticheatInfo(appNamespace)
 )
+
+backendEvents.on('releasesInfoReady', (releasesInfo) => {
+  logDebug('Releases info ready, checking anticheat data', LogPrefix.Backend)
+  void downloadAntiCheatData(
+    isMac
+      ? releasesInfo.anticheatFiles.shaMac
+      : releasesInfo.anticheatFiles.shaLinux
+  )
+})

--- a/src/backend/anticheat/utils.ts
+++ b/src/backend/anticheat/utils.ts
@@ -1,17 +1,43 @@
 import { writeFile, readFile } from 'fs/promises'
-import { logInfo, LogPrefix, logWarning } from 'backend/logger'
+import { logDebug, logInfo, LogPrefix, logWarning } from 'backend/logger'
 import { AntiCheatInfo } from 'common/types'
 import { runOnceWhenOnline } from '../online_monitor'
 import { axiosClient } from 'backend/utils'
 import { join } from 'node:path'
 import { appFolder } from 'backend/constants/paths'
 import { isMac, isWindows } from 'backend/constants/environment'
+import { createHash } from 'node:crypto'
+import { createReadStream } from 'graceful-fs'
+import { finished } from 'node:stream/promises'
+
+async function createMD5(filePath: string) {
+  const hash = createHash('md5')
+  const rStream = createReadStream(filePath)
+  rStream.pipe(hash)
+  await finished(rStream)
+  return hash.digest('hex')
+}
 
 const anticheatDataPath = join(appFolder, 'areweanticheatyet.json')
 
-function downloadAntiCheatData() {
+async function downloadAntiCheatData(latestFileHash?: string) {
   if (process.env.CI === 'e2e') return
   if (isWindows) return
+
+  const localFileHash = await createMD5(anticheatDataPath)
+
+  if (latestFileHash && localFileHash === latestFileHash) {
+    logDebug(
+      'AreWeAnticheatYet data did not change. Skipping.',
+      LogPrefix.Backend
+    )
+    return
+  }
+
+  logDebug(
+    'AreWeAnticheatYet data changed. Downloading latest file.',
+    LogPrefix.Backend
+  )
 
   runOnceWhenOnline(async () => {
     const url = isMac
@@ -19,8 +45,12 @@ function downloadAntiCheatData() {
       : 'https://raw.githubusercontent.com/Starz0r/AreWeAntiCheatYet/HEAD/games.json'
 
     try {
-      const { data } = await axiosClient.get(url)
-      await writeFile(anticheatDataPath, JSON.stringify(data, null, 2))
+      const { data } = await axiosClient.get<string>(url, {
+        responseType: 'text',
+        transformResponse: [(d) => d] // disable JSON parsing
+      })
+
+      await writeFile(anticheatDataPath, data)
       logInfo(`AreWeAntiCheatYet data downloaded`, LogPrefix.Backend)
     } catch (error) {
       logWarning(

--- a/src/backend/backend_events.ts
+++ b/src/backend/backend_events.ts
@@ -1,7 +1,12 @@
 import EventEmitter from 'events'
 
 import type TypedEventEmitter from 'typed-emitter'
-import type { GameStatus, RecentGame, WineVersionInfo } from 'common/types'
+import type {
+  GameStatus,
+  RecentGame,
+  ReleasesInfo,
+  WineVersionInfo
+} from 'common/types'
 
 type BackendEvents = {
   gameStatusUpdate: (payload: GameStatus) => void
@@ -15,6 +20,7 @@ type BackendEvents = {
   [key: `progressUpdate-${string}`]: (progress: GameStatus) => void
   wineVersionInstalled: (versionInfo: WineVersionInfo, path: string) => void
   wineVersionUninstalled: (versionInfo: WineVersionInfo) => void
+  releasesInfoReady: (releasesInfo: ReleasesInfo) => void
 }
 
 // This can be used to emit/listen to events to decouple components

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1,5 +1,5 @@
 import { initImagesCache } from './images_cache'
-import { downloadAntiCheatData } from './anticheat/utils'
+import { fetchLastestReleases } from './utils/releases'
 import { DiskSpaceData, StatusPromise, WineInstallation } from 'common/types'
 import * as path from 'path'
 import {
@@ -111,7 +111,6 @@ import {
   initStoreManagers,
   libraryManagerMap
 } from './storeManagers'
-import { updateWineVersionInfos } from './wine/manager/utils'
 import { addNewApp } from './storeManagers/sideload/library'
 import {
   getGameOverride,
@@ -204,16 +203,6 @@ async function initializeWindow(): Promise<BrowserWindow> {
       checkRosettaInstall()
     }
   }, 2500)
-
-  if (!isWindows && !isCLINoGui) {
-    setTimeout(async () => {
-      try {
-        await updateWineVersionInfos(true)
-      } catch (error) {
-        logError(error, LogPrefix.Backend)
-      }
-    }, 5000)
-  }
 
   const globalConf = GlobalConfig.get().getSettings()
 
@@ -457,7 +446,7 @@ if (!gotTheLock) {
       backendEvents.emit('languageChanged')
     })
 
-    downloadAntiCheatData()
+    fetchLastestReleases()
 
     initTrayIcon(mainWindow)
 

--- a/src/backend/utils/releases.ts
+++ b/src/backend/utils/releases.ts
@@ -1,0 +1,27 @@
+import { backendEvents } from 'backend/backend_events'
+import { isWindows } from 'backend/constants/environment'
+import { LogPrefix, logWarning } from 'backend/logger'
+import { runOnceWhenOnline } from 'backend/online_monitor'
+import { axiosClient } from 'backend/utils'
+import { ReleasesInfo } from 'common/types'
+
+// fetch latest versions of wine/proton/gptk and anticheat data if needed
+export const fetchLastestReleases = () => {
+  if (process.env.CI === 'e2e') return
+  if (isWindows) return
+
+  runOnceWhenOnline(async () => {
+    const url =
+      'https://raw.githubusercontent.com/Heroic-Games-Launcher/releases-info/refs/heads/main/release-data.json'
+
+    try {
+      const { data } = await axiosClient.get<ReleasesInfo>(url)
+      backendEvents.emit('releasesInfoReady', data)
+    } catch (error) {
+      logWarning(
+        `Failed download of information about latest releases: ${error}`,
+        LogPrefix.Backend
+      )
+    }
+  })
+}

--- a/src/backend/wine/manager/ipc_handler.ts
+++ b/src/backend/wine/manager/ipc_handler.ts
@@ -2,12 +2,14 @@ import { addHandler, sendFrontendMessage } from 'backend/ipc'
 import {
   installWineVersion,
   removeWineVersion,
+  updateWineListsIfOutdated,
   updateWineVersionInfos
 } from './utils'
-import { logError, LogPrefix } from 'backend/logger'
+import { logDebug, logError, LogPrefix } from 'backend/logger'
 import type { WineManagerStatus } from 'common/types'
 import { notify } from '../../dialog/dialog'
 import { t } from 'i18next'
+import { backendEvents } from 'backend/backend_events'
 
 addHandler('installWineVersion', async (e, release) => {
   const onProgress = (state: WineManagerStatus) => {
@@ -54,4 +56,9 @@ addHandler('refreshWineVersionInfo', async (e, fetch?) => {
 addHandler('removeWineVersion', async (e, release) => {
   const result = await removeWineVersion(release)
   if (result) notify({ title: release.version, body: t('notify.uninstalled') })
+})
+
+backendEvents.on('releasesInfoReady', (releasesInfo) => {
+  logDebug('Releases info ready, checking wine releases', LogPrefix.Backend)
+  void updateWineListsIfOutdated(releasesInfo)
 })

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -5,7 +5,12 @@
 
 import { existsSync, mkdirSync, rmSync } from 'graceful-fs'
 import { logError, logInfo, LogPrefix, logWarning } from 'backend/logger'
-import { WineVersionInfo, Repositorys, WineManagerStatus } from 'common/types'
+import {
+  WineVersionInfo,
+  Repositorys,
+  WineManagerStatus,
+  ReleasesInfo
+} from 'common/types'
 
 import { getAvailableVersions, installVersion } from './downloader/main'
 import { sendFrontendMessage } from '../../ipc'
@@ -15,7 +20,7 @@ import {
   deleteAbortController
 } from 'backend/utils/aborthandler/aborthandler'
 import { toolsPath } from 'backend/constants/paths'
-import { isMac } from 'backend/constants/environment'
+import { isLinux, isMac, isWindows } from 'backend/constants/environment'
 import { GlobalConfig } from '../../config'
 import { join } from 'path'
 import { backendEvents } from 'backend/backend_events'
@@ -28,8 +33,113 @@ export const wineDownloaderInfoStore = new TypeCheckedStoreBackend(
   }
 )
 
+function getLatestLocalVersions(): Record<string, string | undefined> {
+  const localWines = wineDownloaderInfoStore.get('wine-releases', [])
+
+  if (isLinux) {
+    return {
+      latestWineGE: localWines.find((wine) => wine.version === 'Wine-GE-latest')
+        ?.date,
+      latestGEProton: localWines.find(
+        (wine) => wine.version === 'GE-Proton-latest'
+      )?.date
+    }
+  }
+
+  if (isMac) {
+    return {
+      latestWineCrossover: localWines.find(
+        (wine) => wine.version === 'Wine-Crossover-latest'
+      )?.date,
+      latestWineStaging: localWines.find(
+        (wine) => wine.version === 'Wine-Staging-macOS-latest'
+      )?.date,
+      latestGPTK: localWines.find(
+        (wine) => wine.version === 'Game-Porting-Toolkit-latest'
+      )?.date
+    }
+  }
+
+  return {}
+}
+
+// compare dates only of local version is present
+function localVersionIsOlder(
+  localDate: string | undefined,
+  latestRelease: { published_at: string; tag: string }
+) {
+  if (!localDate) return false
+
+  return (
+    Date.parse(localDate) <
+    Date.parse(latestRelease.published_at.replace(/T.*/, ''))
+  )
+}
+
+// Fetch the latest releases of the different translation layers but only
+// if we don't already have the latest version locally
+//
+// Note that this updates the list of releases of a given repo if and only if
+// we already have a list for that given repo
+export function updateWineListsIfOutdated(releasesData: ReleasesInfo) {
+  if (isWindows) return
+
+  const latestLocalVersions = getLatestLocalVersions()
+  const repositoriesToFetch = []
+
+  // compare dates to know which repositories to fetch
+  if (isLinux) {
+    if (
+      localVersionIsOlder(
+        latestLocalVersions.latestGEProton,
+        releasesData['ge-proton']
+      )
+    )
+      repositoriesToFetch.push(Repositorys.PROTONGE)
+
+    if (
+      localVersionIsOlder(
+        latestLocalVersions.latestWineGE,
+        releasesData['wine-ge']
+      )
+    )
+      repositoriesToFetch.push(Repositorys.WINEGE)
+  }
+
+  if (isMac) {
+    if (
+      localVersionIsOlder(
+        latestLocalVersions.latestWineCrossover,
+        releasesData['wine-crossover']
+      )
+    )
+      repositoriesToFetch.push(Repositorys.WINECROSSOVER)
+
+    if (
+      localVersionIsOlder(
+        latestLocalVersions.latestWineStaging,
+        releasesData['wine-staging']
+      )
+    )
+      repositoriesToFetch.push(Repositorys.WINESTAGINGMACOS)
+
+    if (
+      localVersionIsOlder(
+        latestLocalVersions.latestGPTK,
+        releasesData['game-porting-toolkit']
+      )
+    )
+      repositoriesToFetch.push(Repositorys.GPTK)
+  }
+
+  if (repositoriesToFetch.length > 0) {
+    void updateWineVersionInfos(true, repositoriesToFetch)
+  }
+}
+
 async function updateWineVersionInfos(
   fetch = false,
+  repositorys: Repositorys[] | null = null,
   count = 50
 ): Promise<WineVersionInfo[]> {
   let releases: WineVersionInfo[] = []
@@ -38,25 +148,31 @@ async function updateWineVersionInfos(
   if (fetch) {
     logInfo('Fetching upstream information...', LogPrefix.WineDownloader)
 
-    const repositorys = isMac
-      ? [
-          Repositorys.WINECROSSOVER,
-          Repositorys.WINESTAGINGMACOS,
-          Repositorys.GPTK
-        ]
-      : [Repositorys.WINEGE, Repositorys.PROTONGE]
+    if (repositorys === null) {
+      repositorys = isMac
+        ? [
+            Repositorys.WINECROSSOVER,
+            Repositorys.WINESTAGINGMACOS,
+            Repositorys.GPTK
+          ]
+        : [Repositorys.WINEGE, Repositorys.PROTONGE]
+    }
 
     await getAvailableVersions({
       repositorys,
       count
     }).then((response) => (releases = response as WineVersionInfo[]))
 
+    let releasesToStore: WineVersionInfo[] = []
+
     if (wineDownloaderInfoStore.has('wine-releases')) {
       const old_releases = wineDownloaderInfoStore.get('wine-releases', [])
 
       old_releases.forEach((old) => {
+        releasesToStore.push(old)
+
         const index = releases.findIndex((release) => {
-          if (release.type === 'GE-Proton') {
+          if (isLinux && release.type === 'GE-Proton') {
             // The "Proton" prefix got dropped from the version string. We still
             // want to detect old versions though
             if (`Proton-${release.version}` === old.version) return true
@@ -68,7 +184,7 @@ async function updateWineVersionInfos(
             )
               return true
           }
-          return release?.version === old?.version
+          return release.version === old.version
         })
 
         if (old.installDir !== undefined && existsSync(old?.installDir)) {
@@ -85,10 +201,27 @@ async function updateWineVersionInfos(
         }
       })
 
-      wineDownloaderInfoStore.delete('wine-releases')
+      // here we are adding new elements to the list and replacing the `-latest`
+      releases.forEach((release) => {
+        const foundIndex = releasesToStore.findIndex(
+          (oldRelease) =>
+            oldRelease.version === release.version ||
+            oldRelease.version === `Proton-${release.version}`
+        )
+        if (foundIndex === -1) {
+          releasesToStore.push(release)
+        } else if (release.version.endsWith('-latest')) {
+          releasesToStore[foundIndex] = release
+        }
+      })
+    } else {
+      releasesToStore = releases
     }
 
-    wineDownloaderInfoStore.set('wine-releases', releases)
+    wineDownloaderInfoStore.set(
+      'wine-releases',
+      releasesToStore.sort((a, b) => Date.parse(b.date) - Date.parse(a.date))
+    )
   } else {
     logInfo('Read local information ...', LogPrefix.WineDownloader)
     if (wineDownloaderInfoStore.has('wine-releases')) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -826,3 +826,24 @@ export interface RunnerCommandStub {
   stdout?: string
   stderr?: string
 }
+
+export type ReleasesInfo = Record<
+  | 'ge-proton'
+  | 'wine-ge'
+  | 'game-porting-toolkit'
+  | 'wine-staging'
+  | 'wine-crossover'
+  | 'dxvk'
+  | 'dxvk-mac'
+  | 'dxmt'
+  | 'vkd3d',
+  {
+    tag: string
+    published_at: string
+  }
+> & {
+  anticheatFiles: {
+    shaMac: string
+    shaLinux: string
+  }
+}


### PR DESCRIPTION
The idea of this PR is to introduce a new way of fetching the latest releases of things so we can avoid doing a lot of unnecessary requests to GitHub when the app starts.

I created this repo https://github.com/Heroic-Games-Launcher/releases-info that runs daily and generates a JSON file with a lot of information about the different tools we use: wine-ge, ge-proton, gptk, dxvk, vkd3d, anticheat files, etc

The main idea is that, at boot, we only fetch that file, and we can get information about the latest releases and versions of the different components and then compare with what we already have locally, and only then fetch the files or version from GitHub if we identify there's something new to fetch.

Updates for DXVK, VKD3D, DXVK mac, and DXMT are not implemented in this PR though. For DXVK/VKD3D I still need to figure out what's the best way. For DXMT we currently don't support it but I'm planning to add support for it soon and I'll be using this new feature to keep that updated.

EDIT: one more thing about this... eventually we could automate the releases-info.json file to be sent to some CDN to avoid GitHub completely on boot unless needed, I think for now it's good enough to reduce the number of requests, but we can investigate that if there's still some issues related to rate limiting

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
