### PR TITLE
[Fix] Get current flatpak runtime so it's not hardcoded

### DIFF
--- a/src/backend/constants/environment.ts
+++ b/src/backend/constants/environment.ts
@@ -8,7 +8,7 @@ interface Manifest {
 
 function readFlatpakRuntimeVersion() {
   try {
-    const manifestContent = readFileSync('/app/manifest.json').toString()
+    const manifestContent = readFileSync('/app/manifest.json', 'utf8')
     const manifest = JSON.parse(manifestContent) as Manifest
     return manifest['runtime-version']
   } catch (error) {


### PR DESCRIPTION
So, I ran this:

```bash
flatpak run --command=bash com.heroicgameslauncher.hgl
cat /app/manifest.json
```

and it prints a lot of the flatpak metadata for heroic, starting with:

```json
{
  "id" : "com.heroicgameslauncher.hgl",
  "runtime" : "org.freedesktop.Platform",
  "runtime-version" : "25.08",
  "runtime-commit" : "de826b812cbcd018885f245c76a218d31762a1c03bc60f4af897a2681562c899",
  "sdk" : "org.freedesktop.Sdk",
  "sdk-commit" : "87329bcc381871a8a04dfbba15c8303321ac729b09bd26919d7b2e0d1120d739",
  "base" : "org.electronjs.Electron2.BaseApp",
  "base-version" : "25.08",
  "base-commit" : "3242bb61fa04b9114d23f9a204f0479c2704b6a498e8f92abfa3d9132dbd263b",
  "command" : "heroic-run",
  "modules" : [
    ...
```

We can read that file to get the current runtime version so the constant that we use in other places is not missing.

closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4791

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
