### PR TITLE
[UX] Do not color logs to avoid confusing lines

### DIFF
--- a/src/frontend/screens/Settings/sections/LogSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/LogSettings/index.tsx
@@ -23,48 +23,22 @@ interface LogBoxProps {
 const LogBox: React.FC<LogBoxProps> = ({ logFileContent }) => {
   const { t } = useTranslation()
   const maxLines = 1000
-  let sliced = false
   let lines = logFileContent.split('\n')
   if (lines.length > maxLines) {
-    lines = ['...', ...lines.slice(-maxLines)]
-    sliced = true
+    const truncatedHint = t(
+      'settings.log.long-log-hint',
+      'Log truncated, last 1000 lines are shown!'
+    )
+    lines = [
+      truncatedHint,
+      '...',
+      ...lines.slice(maxLines),
+      '...',
+      truncatedHint
+    ]
   }
 
-  return (
-    <>
-      {sliced && (
-        <span className="setting long-log-hint">
-          {t(
-            'settings.log.long-log-hint',
-            'Log truncated, last 1000 lines are shown!'
-          )}
-        </span>
-      )}
-      <span className="setting log-box">
-        {lines.map((line, key) => {
-          if (line.toLowerCase().includes(' err')) {
-            return (
-              <p key={key} className="log-error">
-                {line}
-              </p>
-            )
-          } else if (line.toLowerCase().includes(' warn')) {
-            return (
-              <p key={key} className="log-warning">
-                {line}
-              </p>
-            )
-          } else {
-            return (
-              <p key={key} className="log-info">
-                {line}
-              </p>
-            )
-          }
-        })}
-      </span>
-    </>
-  )
+  return <pre className="setting log-box">{lines.join('\n')}</pre>
 }
 
 export default function LogSettings() {


### PR DESCRIPTION
Currently, we are coloring the warning and error messages in the logs, but the coloring mostly flags errors and warnings that we know can be completely ignored but it gives users the notion that they need to solve them when an game fails to run.

Like... this is for a game that worked just fine for me:
<img width="936" height="470" alt="Captura de pantalla 2026-01-17 a la(s) 8 51 44 p  m" src="https://github.com/user-attachments/assets/0fb0d51f-bfa2-477e-85ec-7da3c92e5546" />

There's a lot more error messages that can be ignored in general and most of us know after all the time providing support but it can be really confusing for others.

But for a user trying to get a game to run, all these red error messages are completely misleading and can make them waste a lot of time.

And I added one more change that should help support: many users copy/paste the content of the log dialog not knowing when it's truncated (we show a not-too-visible message about it being truncated)

I changed it a bit to include the message as part of the logs, so it's way easier to notice, either when they select the content or paste it somewhere, and now it's shown both at the beginning and at the end of the truncated log

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
