### PR TITLE
[FIX] Power and display sleep blocking logic

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -535,32 +535,34 @@ process.on('uncaughtException', async (err) => {
   })
 })
 
-let powerId: number | null
-let displaySleepId: number | null
+let powerId: number | undefined
+let displaySleepId: number | undefined
 
 addListener('lock', (e, playing: boolean) => {
-  if (!playing && (!powerId || !powerSaveBlocker.isStarted(powerId))) {
+  const isSleepBlocked = powerId !== undefined
+  const isDisplaySleepBlocked = displaySleepId !== undefined
+
+  if (!playing && !isSleepBlocked) {
     logInfo('Preventing machine to sleep', LogPrefix.Backend)
     powerId = powerSaveBlocker.start('prevent-app-suspension')
   }
 
-  if (
-    playing &&
-    (!displaySleepId || !powerSaveBlocker.isStarted(displaySleepId))
-  ) {
+  if (playing && !isDisplaySleepBlocked) {
     logInfo('Preventing display to sleep', LogPrefix.Backend)
     displaySleepId = powerSaveBlocker.start('prevent-display-sleep')
   }
 })
 
 addListener('unlock', () => {
-  if (powerId && powerSaveBlocker.isStarted(powerId)) {
+  if (powerId !== undefined) {
     logInfo('Stopping Power Saver Blocker', LogPrefix.Backend)
     powerSaveBlocker.stop(powerId)
+    powerId = undefined
   }
-  if (displaySleepId && powerSaveBlocker.isStarted(displaySleepId)) {
+  if (displaySleepId !== undefined) {
     logInfo('Stopping Display Sleep Blocker', LogPrefix.Backend)
     powerSaveBlocker.stop(displaySleepId)
+    displaySleepId = undefined
   }
 })
 


### PR DESCRIPTION
The issue here is that  `powerId` can be the number zero, so since we are just checking for `!powerId` it was being incremented and the ZERO one was never being stopped.

Also, the `isStarted` method from Electron appears to be broken because it always returns false, even if there is a process opened. Was able to confirm this by adding several logs across the code.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
