### PR TITLE
[UX/FEAT] Add an "Import Game" button as alt function on the gamepage

### DIFF
--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -19,12 +19,18 @@ import useSetting from 'frontend/hooks/useSetting'
 interface Props {
   gameInfo: GameInfo
   handlePlay: (gameInfo: GameInfo) => Promise<void>
+  handleImport: () => void
   handleInstall: (
     is_installed: boolean
   ) => Promise<void | { status: 'done' | 'error' | 'abort' }>
 }
 
-const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
+const MainButton = ({
+  gameInfo,
+  handlePlay,
+  handleInstall,
+  handleImport
+}: Props) => {
   const { t } = useTranslation('gamepage')
   const { is } = useContext(GameContext)
   const [verboseLogs, setVerboseLogs] = useSetting('verboseLogs', true)
@@ -159,6 +165,24 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
 
   const is_installed = gameInfo.is_installed
 
+  function altInstallAction() {
+    if (is_installed || is.queued || is.installing || is.notInstallable) {
+      return <></>
+    }
+
+    return (
+      <button className="button altPlay is-secondary">
+        <ArrowBackIosNew />
+        <a className="button" onClick={handleImport}>
+          <span className="buttonWithIcon">
+            <Download />
+            {t('button.import', 'Import Game')}
+          </span>
+        </a>
+      </button>
+    )
+  }
+
   return (
     <div className="playButtons">
       {is_installed && !is.queued && !is.uninstalling && (
@@ -201,34 +225,37 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
         </>
       )}
       {(!is_installed || is.queued) && (
-        <button
-          onClick={async () => handleInstall(is_installed)}
-          disabled={
-            is.playing ||
-            is.updating ||
-            is.reparing ||
-            is.moving ||
-            is.uninstalling ||
-            is.notSupportedGame ||
-            is.notInstallable
-          }
-          autoFocus={true}
-          className={classNames(
-            'button',
-            {
-              'is-primary': is_installed,
-              'is-tertiary':
-                is.notAvailable ||
-                is.installing ||
-                is.queued ||
-                is.notInstallable,
-              'is-secondary': !is_installed && !is.queued
-            },
-            'mainBtn'
-          )}
-        >
-          {getButtonLabel()}
-        </button>
+        <>
+          <button
+            onClick={async () => handleInstall(is_installed)}
+            disabled={
+              is.playing ||
+              is.updating ||
+              is.reparing ||
+              is.moving ||
+              is.uninstalling ||
+              is.notSupportedGame ||
+              is.notInstallable
+            }
+            autoFocus={true}
+            className={classNames(
+              'button',
+              {
+                'is-primary': is_installed,
+                'is-tertiary':
+                  is.notAvailable ||
+                  is.installing ||
+                  is.queued ||
+                  is.notInstallable,
+                'is-secondary': !is_installed && !is.queued
+              },
+              'mainBtn'
+            )}
+          >
+            {getButtonLabel()}
+          </button>
+          {altInstallAction()}
+        </>
       )}
     </div>
   )

--- a/src/frontend/screens/Game/GamePage/index.css
+++ b/src/frontend/screens/Game/GamePage/index.css
@@ -294,8 +294,8 @@
             a {
               display: none;
               position: absolute;
-              bottom: 100%;
-              right: -10px;
+              bottom: 106%;
+              right: 0px;
               white-space: nowrap;
             }
 

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -437,6 +437,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                           gameInfo={gameInfo}
                           handlePlay={handlePlay}
                           handleInstall={handleInstall}
+                          handleImport={handleImport}
                         />
                       </div>
                       {wikiLink}
@@ -566,6 +567,24 @@ export default React.memo(function GamePage(): JSX.Element | null {
       progress,
       t,
       showDialogModal: showDialogModal
+    })
+  }
+
+  function handleImport() {
+    return install({
+      gameInfo,
+      installPath: 'import',
+      isInstalling: false,
+      previousProgress: null,
+      progress: {
+        ...progress,
+        bytes: '',
+        eta: '',
+        percent: 0,
+        downSpeed: 0
+      },
+      t,
+      showDialogModal
     })
   }
 })


### PR DESCRIPTION
Small change on the Download Button on the game page to show the import game option as an alternative action.

<img width="314" height="195" alt="image" src="https://github.com/user-attachments/assets/87d2bdcc-1782-4189-be88-8eb58ae703be" />


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
