### PR TITLE
[FIX] Dropdown vertical scroll

### DIFF
--- a/src/frontend/components/UI/Dropdown/index.scss
+++ b/src/frontend/components/UI/Dropdown/index.scss
@@ -10,6 +10,7 @@
     opacity: 1;
     max-height: 70vh;
     box-shadow: 4px 5px 5px 7px rgba(0, 0, 0, 0.2);
+    overflow-y: auto;
   }
 
   .dropdown {


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5221

There's a regression in the latest release, if a list of categories is long enough, if it doesn't fit the screen it cannot be scrolled anymore.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
