### PR TITLE
[FIX] Only use fake epic exe when turned on with env variable

### DIFF
--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -890,7 +890,7 @@ export async function launch(
 
   // Use the wrapper EXE to launch games.
   if (
-    commandEnv['USE_FAKE_EPIC_EXE'] === 'true' &&
+    ![undefined, '0', 'false'].includes(commandEnv['USE_FAKE_EPIC_EXE']) &&
     existsSync(fakeEpicExePath)
   ) {
     if (isWindows) {


### PR DESCRIPTION
This reverts a change that is causing issues with Fornite with the fake epic exe wrapper turned on by default.

It changes the logic back to be off by default and only enabled with `USE_FAKE_EPIC_EXE=true` (I'm using `"true"` now while before we were only checking presence, so maybe some user has `USE_FAKE_EPIC_EXE=whatever` and that won't work, but they shouldn't, in the rockstar guide we say to use `"true"` https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki/Rockstar-Games-from-Epic-Games)

EDIT: changed this to support any value except "0" and "false"

"0", "false", and undefined (not setting the env) won't set the fake epic exe

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
