### PR TITLE
[UI] Make game sub-menu use Dropdown component 

### DIFF
--- a/src/frontend/components/UI/CategoryFilter/index.tsx
+++ b/src/frontend/components/UI/CategoryFilter/index.tsx
@@ -71,8 +71,8 @@ export default function CategoryFilter() {
 
   return (
     <Dropdown
-      buttonClass="selectStyle"
-      className="categoriesFilter"
+      buttonClass="selectContainer"
+      containerClassName="categoriesFilter"
       data-tour="library-categories"
       title={t('header.categories', 'Categories')}
       popUpOnHover

--- a/src/frontend/components/UI/Dropdown/index.scss
+++ b/src/frontend/components/UI/Dropdown/index.scss
@@ -41,7 +41,6 @@
     transition: all 200ms;
     pointer-events: none;
     opacity: 0;
-    max-height: 0;
     overflow: hidden;
     gap: 0.3rem;
     padding: var(--space-sm);

--- a/src/frontend/components/UI/Dropdown/index.scss
+++ b/src/frontend/components/UI/Dropdown/index.scss
@@ -1,5 +1,21 @@
 .dropdownContainer {
   position: relative;
+  border-radius: var(--space-3xs);
+  width: 100%;
+  height: 40px;
+  display: flex;
+  justify-content: space-around;
+  background: var(--input-background);
+  box-shadow: 0px 0px 0px 3px var(--search-bar-border, var(--input-background));
+  font-weight: normal;
+  font-size: var(--text-md);
+  color: var(--text-secondary);
+  border: none;
+  background-repeat: no-repeat;
+  margin: 0;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 
   .button {
     padding-inline: 2rem;
@@ -18,7 +34,7 @@
     right: 0px;
     min-width: 250px;
     display: flex;
-    border-radius: var(--space-xs);
+    border-radius: var(--space-3xs);
     flex-direction: column;
     background: var(--background);
     opacity: 0;

--- a/src/frontend/components/UI/Dropdown/index.tsx
+++ b/src/frontend/components/UI/Dropdown/index.tsx
@@ -1,31 +1,39 @@
-import { ReactNode, useState } from 'react'
+import { ReactNode, useContext, useState } from 'react'
 import './index.scss'
+import ContextProvider from 'frontend/state/ContextProvider'
 
 type Props = {
   title?: ReactNode | string
   children: ReactNode
-  className?: string
+  containerClassName?: string
   buttonClass?: string
+  dropdownClassName?: string
   popUpOnHover?: boolean
 }
 
 export default function Dropdown({
   title,
   children,
-  className,
+  containerClassName,
   buttonClass,
+  dropdownClassName,
   popUpOnHover = false
 }: Props) {
   const [isExpanded, setIsExpanded] = useState(false)
+  const { activeController } = useContext(ContextProvider)
 
   const handlePopup = (state: 'enter' | 'leave') => {
     // if no pop up behavior is wanted, ignore mouse movements
     if (!popUpOnHover) return
+
+    // popup behaviour is disabled for gamepads
+    if (activeController) return
+
     setIsExpanded(state === 'enter')
   }
 
   return (
-    <div className={`dropdownContainer ${className || ''}`}>
+    <div className={`dropdownContainer ${containerClassName || ''}`}>
       <button
         onMouseEnter={() => handlePopup('enter')}
         onMouseLeave={() => handlePopup('leave')}
@@ -46,7 +54,7 @@ export default function Dropdown({
         onMouseLeave={() => handlePopup('leave')}
         onBlur={() => setIsExpanded(false)}
         onFocus={() => setIsExpanded(true)}
-        className={`dropdown ${isExpanded ? 'expanded' : 'collapsed'}`}
+        className={`dropdown ${dropdownClassName || ''} ${isExpanded ? 'expanded' : 'collapsed'}`}
       >
         {children}
       </div>

--- a/src/frontend/components/UI/LibraryFilters/index.tsx
+++ b/src/frontend/components/UI/LibraryFilters/index.tsx
@@ -174,9 +174,9 @@ export default function LibraryFilters() {
 
   return (
     <Dropdown
-      buttonClass="selectStyle"
+      buttonClass="selectContainer"
       title={t('header.filters', 'Filters')}
-      className="libraryFilters"
+      containerClassName="libraryFilters"
       data-tour="library-filters"
       popUpOnHover
     >

--- a/src/frontend/components/UI/SearchBar/index.scss
+++ b/src/frontend/components/UI/SearchBar/index.scss
@@ -9,7 +9,7 @@
 
   &:focus-within {
     box-shadow: 0px 0px 0px 3px
-      var(--search-bar-border, var(--input-backgroundd));
+      var(--search-bar-border, var(--input-background));
   }
 
   .autoComplete {

--- a/src/frontend/components/UI/SelectField/index.css
+++ b/src/frontend/components/UI/SelectField/index.css
@@ -3,6 +3,32 @@
   grid-template-areas: 'label' 'select';
 }
 
+.selectContainer {
+  grid-area: select;
+  background: var(--input-background);
+  font-weight: normal;
+  font-size: var(--text-md);
+  color: var(--text-secondary);
+  border: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--text-secondary) 50%),
+    linear-gradient(135deg, var(--text-secondary) 50%, transparent 50%),
+    linear-gradient(to right, #ccc, #ccc);
+  background-position:
+    calc(100% - 20px) calc(50% + 1px),
+    calc(100% - 15px) calc(50% + 1px),
+    calc(100% - 40px) 50%;
+  background-size:
+    5px 5px,
+    5px 5px,
+    1px 70%;
+  background-repeat: no-repeat;
+  min-width: 100px;
+  text-indent: var(--space-sm);
+  padding-inline-end: 4rem;
+  white-space: nowrap;
+}
+
 .selectStyle,
 .selectFieldWrapper .MuiOutlinedInput-root {
   border-radius: var(--space-3xs);

--- a/src/frontend/screens/Game/GamePage/components/DotsMenu.tsx
+++ b/src/frontend/screens/Game/GamePage/components/DotsMenu.tsx
@@ -1,8 +1,6 @@
 import { useContext, useState } from 'react'
 import GameContext from '../../GameContext'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import GameSubMenu from '../../GameSubMenu'
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
 import { GameInfo } from 'common/types'
 import {
   Dialog,
@@ -33,33 +31,27 @@ const DotsMenu = ({ gameInfo, handleUpdate }: Props) => {
 
   return (
     <>
-      <div className="game-actions">
-        <button className="toggle">
-          <FontAwesomeIcon icon={faEllipsisV} />
-        </button>
-
-        <GameSubMenu
-          appName={appName}
-          isInstalled={is_installed}
-          title={title}
-          storeUrl={
-            gameExtraInfo?.storeUrl ||
-            ('store_url' in gameInfo && gameInfo.store_url !== undefined
-              ? gameInfo.store_url
-              : '')
-          }
-          changelog={gameExtraInfo?.changelog}
-          runner={gameInfo.runner}
-          handleUpdate={handleUpdate}
-          handleChangeLog={() => setShowChangelog(true)}
-          disableUpdate={is.installing || is.updating}
-          onShowRequirements={
-            hasRequirements ? () => setShowRequirements(true) : undefined
-          }
-          onShowModifyInstall={() => setShowModifyInstallModal(true)}
-          gameInfo={gameInfo}
-        />
-      </div>
+      <GameSubMenu
+        appName={appName}
+        isInstalled={is_installed}
+        title={title}
+        storeUrl={
+          gameExtraInfo?.storeUrl ||
+          ('store_url' in gameInfo && gameInfo.store_url !== undefined
+            ? gameInfo.store_url
+            : '')
+        }
+        changelog={gameExtraInfo?.changelog}
+        runner={gameInfo.runner}
+        handleUpdate={handleUpdate}
+        handleChangeLog={() => setShowChangelog(true)}
+        disableUpdate={is.installing || is.updating}
+        onShowRequirements={
+          hasRequirements ? () => setShowRequirements(true) : undefined
+        }
+        onShowModifyInstall={() => setShowModifyInstallModal(true)}
+        gameInfo={gameInfo}
+      />
 
       {showRequirements && (
         <Dialog showCloseButton onClose={() => setShowRequirements(false)}>

--- a/src/frontend/screens/Game/GamePage/index.css
+++ b/src/frontend/screens/Game/GamePage/index.css
@@ -478,7 +478,7 @@
   .settings-icon {
     width: 44px;
     position: relative;
-    padding: 6px;
+    padding: 9px;
     color: var(--navbar-inactive);
     background-color: var(--navbar-background);
     border-radius: 10px;

--- a/src/frontend/screens/Game/GameSubMenu/index.css
+++ b/src/frontend/screens/Game/GameSubMenu/index.css
@@ -18,6 +18,47 @@
   }
 }
 
+.game-submenu-container {
+  height: 39px;
+  width: 39px;
+  display: flex;
+  border-radius: var(--space-xs);
+}
+
+.game-submenu-button {
+  background: var(--input-background);
+  border: none;
+  align-items: center;
+  display: flex;
+  flex-grow: 1;
+}
+
+.game-submenu-icon {
+  color: var(--text-default);
+  padding-left: var(--space-2xs);
+  padding-right: var(--space-2xs);
+  height: 24px;
+  display: flex;
+  flex-grow: 1;
+}
+
+.dropdown.game-submenu-dropdown {
+  .button {
+    background-color: var(--background);
+    align-self: flex-start;
+    padding-left: 0;
+
+    svg {
+      margin-right: var(--space-xs);
+    }
+  }
+
+  /* store page has different setup */
+  a.button.is-link {
+    margin-left: var(--space-xs);
+  }
+}
+
 .dots {
   position: absolute;
   right: 46px;

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -27,9 +27,8 @@ import {
   ShoppingCart as ShoppingCartIcon
 } from '@mui/icons-material'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
+import { faEllipsisV, faWineGlass  } from '@fortawesome/free-solid-svg-icons'
 import { faLinux, faSteam } from '@fortawesome/free-brands-svg-icons'
-import { faWineGlass } from '@fortawesome/free-solid-svg-icons'
 import Dropdown from 'frontend/components/UI/Dropdown'
 
 interface Props {

--- a/src/frontend/screens/Game/GameSubMenu/index.tsx
+++ b/src/frontend/screens/Game/GameSubMenu/index.tsx
@@ -1,20 +1,15 @@
 import './index.css'
-
 import { useCallback, useContext, useEffect, useState } from 'react'
-
 import { GameInfo, GameStatus, Runner } from 'common/types'
-
 import { createNewWindow, repair } from 'frontend/helpers'
 import { useTranslation } from 'react-i18next'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { NavLink } from 'react-router-dom'
-
 import { CircularProgress, SvgIcon } from '@mui/material'
 import UninstallModal from 'frontend/components/UI/UninstallModal'
 import GameContext from '../GameContext'
 import { openInstallGameModal } from 'frontend/state/InstallGameModal'
 import useGlobalState from 'frontend/state/GlobalStateV2'
-
 import {
   ArrowUpward as ArrowUpwardIcon,
   CheckCircle as CheckCircleIcon,
@@ -32,8 +27,10 @@ import {
   ShoppingCart as ShoppingCartIcon
 } from '@mui/icons-material'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
 import { faLinux, faSteam } from '@fortawesome/free-brands-svg-icons'
 import { faWineGlass } from '@fortawesome/free-solid-svg-icons'
+import Dropdown from 'frontend/components/UI/Dropdown'
 
 interface Props {
   appName: string
@@ -272,7 +269,15 @@ export default function GamesSubmenu({
 
   return (
     <>
-      <div className="gameTools subMenuContainer">
+      <Dropdown
+        containerClassName="game-submenu-container"
+        buttonClass="game-submenu-button"
+        dropdownClassName="game-submenu-dropdown"
+        popUpOnHover
+        title={
+          <FontAwesomeIcon className="game-submenu-icon" icon={faEllipsisV} />
+        }
+      >
         {showUninstallModal && (
           <UninstallModal
             appName={appName}
@@ -281,180 +286,178 @@ export default function GamesSubmenu({
             isDlc={false}
           />
         )}
-        <div className={`submenu`}>
-          {isInstalled && (
-            <>
-              {isSideloaded && (
-                <button
-                  onClick={async () => handleEdit()}
-                  className="link button is-text is-link buttonWithIcon"
-                >
-                  <EditIcon />
-                  {t('button.sideload.edit', 'Edit App/Game')}
-                </button>
-              )}{' '}
+        {isInstalled && (
+          <>
+            {isSideloaded && (
               <button
-                onClick={() => handleShortcuts()}
+                onClick={async () => handleEdit()}
                 className="link button is-text is-link buttonWithIcon"
               >
-                <ShortcutIcon />
-                {hasShortcuts
-                  ? t('submenu.removeShortcut', 'Remove shortcuts')
-                  : t('submenu.addShortcut', 'Add shortcut')}
+                <EditIcon />
+                {t('button.sideload.edit', 'Edit App/Game')}
               </button>
-              <button
-                onClick={async () => setShowUninstallModal(true)}
-                className="link button is-text is-link buttonWithIcon"
-                disabled={is.playing}
-              >
-                <DeleteIcon />
-                {t('button.uninstall', 'Uninstall')}
-              </button>{' '}
-              {!isSideloaded && !isThirdPartyManaged && (
-                <button
-                  onClick={async () => handleUpdate()}
-                  className="link button is-text is-link buttonWithIcon"
-                  disabled={disableUpdate}
-                >
-                  <ArrowUpwardIcon />
-                  {t('button.force_update', 'Force Update if Available')}
-                </button>
-              )}{' '}
-              {!isSideloaded && !isThirdPartyManaged && (
-                <button
-                  onClick={async () => handleMoveInstall()}
-                  className="link button is-text is-link buttonWithIcon"
-                >
-                  <DriveFileMoveIcon />
-                  {t('submenu.move', 'Move Game')}
-                </button>
-              )}{' '}
-              {!isSideloaded && !isThirdPartyManaged && (
-                <button
-                  onClick={async () => handleChangeInstall()}
-                  className="link button is-text is-link buttonWithIcon"
-                >
-                  <FindInPageIcon />
-                  {t('submenu.change', 'Change Install Location')}
-                </button>
-              )}{' '}
-              {!isSideloaded && !isThirdPartyManaged && (
-                <button
-                  onClick={async () => handleRepair(appName)}
-                  className="link button is-text is-link buttonWithIcon"
-                >
-                  <CheckCircleIcon />
-                  {t('submenu.verify', 'Verify and Repair')}
-                </button>
-              )}{' '}
-              {isLinux &&
-                runner === 'legendary' &&
-                (eosOverlayRefresh ? (
-                  refreshCircle()
-                ) : (
-                  <button
-                    className="link button is-text is-link buttonWithIcon"
-                    onClick={handleEosOverlay}
-                  >
-                    <PictureInPictureIcon />
-                    {eosOverlayEnabled
-                      ? t('submenu.disableEosOverlay', 'Disable EOS Overlay')
-                      : t('submenu.enableEosOverlay', 'Enable EOS Overlay')}
-                  </button>
-                ))}
-            </>
-          )}
-          {steamRefresh ? (
-            refreshCircle()
-          ) : (
+            )}{' '}
             <button
-              onClick={async () => handleAddToSteam()}
+              onClick={() => handleShortcuts()}
               className="link button is-text is-link buttonWithIcon"
             >
-              <SvgIcon>
-                <FontAwesomeIcon icon={faSteam} />
-              </SvgIcon>
-              {addedToSteam
-                ? t('submenu.removeFromSteam', 'Remove from Steam')
-                : t('submenu.addToSteam', 'Add to Steam')}
+              <ShortcutIcon tabIndex={-1} />
+              {hasShortcuts
+                ? t('submenu.removeShortcut', 'Remove shortcuts')
+                : t('submenu.addShortcut', 'Add shortcut')}
             </button>
-          )}
+            <button
+              onClick={async () => setShowUninstallModal(true)}
+              className="link button is-text is-link buttonWithIcon"
+              disabled={is.playing}
+            >
+              <DeleteIcon tabIndex={-1} />
+              {t('button.uninstall', 'Uninstall')}
+            </button>{' '}
+            {!isSideloaded && !isThirdPartyManaged && (
+              <button
+                onClick={async () => handleUpdate()}
+                className="link button is-text is-link buttonWithIcon"
+                disabled={disableUpdate}
+              >
+                <ArrowUpwardIcon tabIndex={-1} />
+                {t('button.force_update', 'Force Update if Available')}
+              </button>
+            )}{' '}
+            {!isSideloaded && !isThirdPartyManaged && (
+              <button
+                onClick={async () => handleMoveInstall()}
+                className="link button is-text is-link buttonWithIcon"
+              >
+                <DriveFileMoveIcon tabIndex={-1} />
+                {t('submenu.move', 'Move Game')}
+              </button>
+            )}{' '}
+            {!isSideloaded && !isThirdPartyManaged && (
+              <button
+                onClick={async () => handleChangeInstall()}
+                className="link button is-text is-link buttonWithIcon"
+              >
+                <FindInPageIcon tabIndex={-1} />
+                {t('submenu.change', 'Change Install Location')}
+              </button>
+            )}{' '}
+            {!isSideloaded && !isThirdPartyManaged && (
+              <button
+                onClick={async () => handleRepair(appName)}
+                className="link button is-text is-link buttonWithIcon"
+              >
+                <CheckCircleIcon tabIndex={-1} />
+                {t('submenu.verify', 'Verify and Repair')}
+              </button>
+            )}{' '}
+            {isLinux &&
+              runner === 'legendary' &&
+              (eosOverlayRefresh ? (
+                refreshCircle()
+              ) : (
+                <button
+                  className="link button is-text is-link buttonWithIcon"
+                  onClick={handleEosOverlay}
+                >
+                  <PictureInPictureIcon tabIndex={-1} />
+                  {eosOverlayEnabled
+                    ? t('submenu.disableEosOverlay', 'Disable EOS Overlay')
+                    : t('submenu.enableEosOverlay', 'Enable EOS Overlay')}
+                </button>
+              ))}
+          </>
+        )}
+        {steamRefresh ? (
+          refreshCircle()
+        ) : (
           <button
-            onClick={() => openGameCategoriesModal(gameInfo)}
+            onClick={async () => handleAddToSteam()}
             className="link button is-text is-link buttonWithIcon"
           >
-            <FormatListBulletedIcon />
-            {t('submenu.categories', 'Categories')}
+            <SvgIcon tabIndex={-1}>
+              <FontAwesomeIcon icon={faSteam} />
+            </SvgIcon>
+            {addedToSteam
+              ? t('submenu.removeFromSteam', 'Remove from Steam')
+              : t('submenu.addToSteam', 'Add to Steam')}
           </button>
-          {!isSideloaded && storeUrl && (
-            <NavLink
-              className="link button is-text is-link buttonWithIcon"
-              to={`/store-page?store-url=${storeUrl}`}
-            >
-              <ShoppingCartIcon />
-              {t('submenu.store')}
-            </NavLink>
-          )}
-          {!isSideloaded && !!changelog?.length && (
-            <button
-              onClick={() => handleChangeLog()}
-              className="link button is-text is-link buttonWithIcon"
-            >
-              <InfoIcon />
-              {t('button.changelog', 'Show Changelog')}
-            </button>
-          )}{' '}
-          {!isSideloaded && isLinux && (
-            <button
-              onClick={() => createNewWindow(protonDBurl)}
-              className="link button is-text is-link buttonWithIcon"
-            >
-              <SvgIcon>
-                <FontAwesomeIcon icon={faLinux} />
-              </SvgIcon>
-              {t('submenu.protondb', 'Check Compatibility')}
-            </button>
-          )}
-          {onShowRequirements && (
-            <button
-              onClick={async () => onShowRequirements()}
-              className="link button is-text is-link buttonWithIcon"
-            >
-              <DesktopAccessDisabledIcon />
-              {t('game.requirements', 'Requirements')}
-            </button>
-          )}
-          {showModifyItem && (
-            <button
-              onClick={async () => onShowModifyInstall()}
-              className="link button is-text is-link buttonWithIcon"
-            >
-              <RepartitionIcon />
-              {t('game.modify', 'Modify Installation')}
-            </button>
-          )}
-          {isInstalled && (
-            <button
-              onClick={async () => onBrowseFiles()}
-              className="link button is-text is-link buttonWithIcon"
-            >
-              <FolderIcon />
-              {t('button.browse_files', 'Browse Files')}
-            </button>
-          )}
-          {hasWine && (
-            <button
-              onClick={async () => onBrowsePrefix()}
-              className="link button is-text is-link buttonWithIcon"
-            >
-              <SvgIcon>
-                <FontAwesomeIcon icon={faWineGlass} />
-              </SvgIcon>
-              {t('button.browse_wine_prefix', 'Browse Wine Prefix')}
-            </button>
-          )}
-        </div>
-      </div>
+        )}
+        <button
+          onClick={() => openGameCategoriesModal(gameInfo)}
+          className="link button is-text is-link buttonWithIcon"
+        >
+          <FormatListBulletedIcon tabIndex={-1} />
+          {t('submenu.categories', 'Categories')}
+        </button>
+        {!isSideloaded && storeUrl && (
+          <NavLink
+            className="link button is-text is-link buttonWithIcon"
+            to={`/store-page?store-url=${storeUrl}`}
+          >
+            <ShoppingCartIcon tabIndex={-1} />
+            {t('submenu.store')}
+          </NavLink>
+        )}
+        {!isSideloaded && !!changelog?.length && (
+          <button
+            onClick={() => handleChangeLog()}
+            className="link button is-text is-link buttonWithIcon"
+          >
+            <InfoIcon tabIndex={-1} />
+            {t('button.changelog', 'Show Changelog')}
+          </button>
+        )}{' '}
+        {!isSideloaded && isLinux && (
+          <button
+            onClick={() => createNewWindow(protonDBurl)}
+            className="link button is-text is-link buttonWithIcon"
+          >
+            <SvgIcon tabIndex={-1}>
+              <FontAwesomeIcon icon={faLinux} />
+            </SvgIcon>
+            {t('submenu.protondb', 'Check Compatibility')}
+          </button>
+        )}
+        {onShowRequirements && (
+          <button
+            onClick={async () => onShowRequirements()}
+            className="link button is-text is-link buttonWithIcon"
+          >
+            <DesktopAccessDisabledIcon tabIndex={-1} />
+            {t('game.requirements', 'Requirements')}
+          </button>
+        )}
+        {showModifyItem && (
+          <button
+            onClick={async () => onShowModifyInstall()}
+            className="link button is-text is-link buttonWithIcon"
+          >
+            <RepartitionIcon tabIndex={-1} />
+            {t('game.modify', 'Modify Installation')}
+          </button>
+        )}
+        {isInstalled && (
+          <button
+            onClick={async () => onBrowseFiles()}
+            className="link button is-text is-link buttonWithIcon"
+          >
+            <FolderIcon tabIndex={-1} />
+            {t('button.browse_files', 'Browse Files')}
+          </button>
+        )}
+        {hasWine && (
+          <button
+            onClick={async () => onBrowsePrefix()}
+            className="link button is-text is-link buttonWithIcon"
+          >
+            <SvgIcon tabIndex={-1}>
+              <FontAwesomeIcon icon={faWineGlass} />
+            </SvgIcon>
+            {t('button.browse_wine_prefix', 'Browse Wine Prefix')}
+          </button>
+        )}
+      </Dropdown>
     </>
   )
 }


### PR DESCRIPTION
This is a follow-up to a previous PR to add in dropdown components. Made some more extensions and modifications to make that more usable, and changed the dropdown in the game card to now use the same component. This gives us several advantages, but the biggest one is just better usability with gamepad, as well as more standardisation in UI over several screens. 

I've also modified the default behaviour for the dropdowns with a gamepad. Instead of the dropdown appearing when focusing, it will now only allow opening and closing by clicking it. Mouse behavior is unchanged, just the behavior with a gamepad.

Here's a before and after:

Before:


https://github.com/user-attachments/assets/f930db0c-e05e-40db-8f0e-83ce77c57a74



After:


https://github.com/user-attachments/assets/5cff8a74-a770-479d-9fbc-dabe9e44f0a8



Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
