### PR TITLE
[UX] Allow disabling GOG Presence updates

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -638,6 +638,7 @@
         "default-steam-path": "Default Steam path",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
         "disable_controller": "Disable Heroic navigation using controller",
+        "disable_gog_presence": "Disable GOG Presence updates",
         "disable_logs": "Disable Logs",
         "disablePlaytimeSync": "Disable playtime synchronization",
         "disableUMU": "Disable umu",

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -357,7 +357,8 @@ class GlobalConfigV0 extends GlobalConfig {
       downloadProtonToSteam: false,
       advertiseAvxForRosetta: isMac && defaultWine.type === 'toolkit',
       noTrayIcon: false,
-      showValveProton: false
+      showValveProton: false,
+      disableGOGPresence: false
     }
     // @ts-expect-error TODO: We need to settle on *one* place to define settings defaults
     return settings

--- a/src/backend/storeManagers/gog/presence.ts
+++ b/src/backend/storeManagers/gog/presence.ts
@@ -22,8 +22,15 @@ function setCurrentGame(game: string) {
 
 async function setPresence() {
   try {
-    const { disablePlaytimeSync } = GlobalConfig.get().getSettings()
-    if (disablePlaytimeSync || !GOGUser.isLoggedIn() || !isOnline()) return
+    const { disablePlaytimeSync, disableGOGPresence } =
+      GlobalConfig.get().getSettings()
+    if (
+      disableGOGPresence ||
+      disablePlaytimeSync ||
+      !GOGUser.isLoggedIn() ||
+      !isOnline()
+    )
+      return
     const credentials = await GOGUser.getCredentials()
     if (!credentials) return
 
@@ -58,7 +65,15 @@ async function setPresence() {
 
 async function deletePresence() {
   try {
-    if (!GOGUser.isLoggedIn() || !isOnline()) return
+    const { disablePlaytimeSync, disableGOGPresence } =
+      GlobalConfig.get().getSettings()
+    if (
+      disablePlaytimeSync ||
+      disableGOGPresence ||
+      !GOGUser.isLoggedIn() ||
+      !isOnline()
+    )
+      return
     const credentials = await GOGUser.getCredentials()
     if (!credentials) {
       return

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -112,6 +112,7 @@ export interface AppSettings extends GameSettings {
   disableLogs: boolean
   disableAnimations: boolean
   discordRPC: boolean
+  disableGOGPresence: boolean
   downloadNoHttps: boolean
   downloadProtonToSteam: boolean
   egsLinkedPath: string

--- a/src/frontend/screens/Settings/components/DisableGOGPresence.tsx
+++ b/src/frontend/screens/Settings/components/DisableGOGPresence.tsx
@@ -1,0 +1,22 @@
+import { useTranslation } from 'react-i18next'
+import useSetting from 'frontend/hooks/useSetting'
+import { ToggleSwitch } from 'frontend/components/UI'
+
+const DisableGOGPresence = () => {
+  const { t } = useTranslation()
+  const [disableGOGPresence, setDisableGOGPresence] = useSetting(
+    'disableGOGPresence',
+    false
+  )
+
+  return (
+    <ToggleSwitch
+      htmlId="disableGOGPresence"
+      value={disableGOGPresence}
+      handleChange={() => setDisableGOGPresence(!disableGOGPresence)}
+      title={t('setting.disable_gog_presence', 'Disable GOG Presence updates')}
+    />
+  )
+}
+
+export default DisableGOGPresence

--- a/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/AdvancedSettings/index.tsx
@@ -27,6 +27,7 @@ import {
   ExperimentalFeatures,
   ResetHeroic
 } from '../../components'
+import DisableGOGPresence from '../../components/DisableGOGPresence'
 
 export default function AdvancedSetting() {
   const { config } = useContext(SettingsContext)
@@ -178,6 +179,8 @@ export default function AdvancedSetting() {
       <DownloadNoHTTPS />
 
       <DisableLogs />
+
+      <DisableGOGPresence />
 
       <AllowInstallationBrokenAnticheat />
 


### PR DESCRIPTION
This PR adds an option to disable the GOG presence changes when we open and close heroic.

This is not an essential feature and on mac it makes heroic kinda slow (closing heroic triggers the deletePresence function and running legendary/gogdl binaries takes many seconds, heroic takes like 5 seconds or more just to close when nothing else is happening).

This allows users to disable it if they don't care about showing their presence.

An alternative was to disable the playtime sync, but it was not obvious that the 2 things were related, only clear reading the code (actually, this is a question for @imLinguin, was there a reason to skip the gog presence when playtime sync was disabled?).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
