### PR TITLE
Update desktop filename to fix generic icon on AppImage

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -64,7 +64,7 @@ linux:
   icon: build/icon.icns
   desktop:
     entry:
-      Name: Heroic Games Launcher
+      Name: Heroic
       Comment[de]: Ein OSS-Spielelauncher für GOG, Epic Games und Amazon Games
       Comment[pl]: Otwartoźródłowy launcher dla GOG, Epic Games i Amazon Games
       Comment[fr]: Un lanceur de jeux open source pour GOG, Epic Games et Amazon Games

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "heroic_games_launcher",
+  "name": "heroic",
   "version": "2.19.1",
   "versionNames": {
     "stable": "Punk 01 - Shaka",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "heroic",
+  "name": "heroic_games_launcher",
   "version": "2.19.1",
   "versionNames": {
     "stable": "Punk 01 - Shaka",


### PR DESCRIPTION
A mismatch between the app_id (`heroic`) and the filename for desktop file (`heroic_games_launcher.desktop`) creates this generic Wayland icon instead of the Heroic icon. First I tried to change the filename to contain the scope to Linux only, but I couldn't figure out where it's set (closest was executableName on electron-builder.yml). I also tried to change the appId only for Linux, but the only field that worked was the root packageName.

Get app id: `WAYLAND_DEBUG=1 ./Heroic-*.AppImage 2>&1 | grep set_app_id`
Extract files from AppImage to investigate: `./Heroic-*.AppImage --appimage-extract`

This problem doesn't happen on the Flatpak version.

Let me know if there's a better solution to this or if it can potentially break other builds.

### Before:
<img width="2796" height="1936" alt="before" src="https://github.com/user-attachments/assets/87e343f9-5a81-44a7-9b02-f341d8fc8415" />
<img width="3840" height="2040" alt="before-2" src="https://github.com/user-attachments/assets/fef72917-6849-4234-bfba-14aabbbbf039" />

### After:
<img width="2796" height="1936" alt="after" src="https://github.com/user-attachments/assets/f1d66a6b-dc7f-4d3d-a07e-102a90893b1d" />
<img width="3838" height="2030" alt="after-2" src="https://github.com/user-attachments/assets/aec16707-d576-42d2-8a92-78b08c498288" />
