### PR TITLE
[UI] Set html's "lang" attribute to the current language

### DIFF
--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -36,6 +36,7 @@ storage.removeItem('nonAvailableGames')
 const languageCode: string =
   configStore.get_nodefault('language') ?? storage.getItem('language') ?? 'en'
 configStore.set('language', languageCode)
+document.querySelector('html')?.setAttribute('lang', languageCode)
 
 window.setCustomCSS = (cssString: string) => {
   const style = document.createElement('style')

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -256,6 +256,7 @@ class GlobalState extends PureComponent<Props> {
 
   setLanguage = (newLanguage: string) => {
     this.setState({ language: newLanguage })
+    document.querySelector('html')?.setAttribute('lang', newLanguage)
   }
 
   setTheme = (newThemeName: string) => {


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5248#issuecomment-3814442701

With the correct `lang` attribute value when we use the `text-transform` CSS property it will properly handle accents and special characters for the current language.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
