### PR TITLE
[UX] Hide main window when quitting

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -237,8 +237,6 @@ async function handleExit() {
   const isLocked = existsSync(join(gamesConfigPath, 'lock'))
   const mainWindow = getMainWindow()
 
-  await gogPresence.deletePresence()
-
   if ((isLocked || isRunning()) && mainWindow) {
     const { response } = await showMessageBox(mainWindow, {
       buttons: [i18next.t('box.no'), i18next.t('box.yes')],
@@ -269,6 +267,10 @@ async function handleExit() {
     // Kill all child processes
     callAllAbortControllers()
   }
+
+  mainWindow?.hide()
+  await gogPresence.deletePresence()
+
   app.exit()
 }
 


### PR DESCRIPTION
When quitting, we wait for the GOG presence to be updated before calling `app.exit()`. This introduces a noticeable delay between clicking the close button in Heroic & the main window actually being closed.
To be a little more responsive, we can hide the main window once we know we don't need it anymore. Heroic will of course keep running for a short while after the window is closed, but that should be fine

Somewhat a sister PR to https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5249, although this may be safer to merge

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
