### PR TITLE
Also consider "ThirdPartyManagedProvider" attribute when checking for a third party store

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -544,7 +544,8 @@ function loadFile(app_name: string): boolean {
   const FolderName = customAttributes?.FolderName
   const canRunOffline = customAttributes?.CanRunOffline?.value === 'true'
   const thirdPartyManagedApp =
-    customAttributes?.ThirdPartyManagedApp?.value || undefined
+    customAttributes?.ThirdPartyManagedApp?.value ||
+    customAttributes?.ThirdPartyManagedProvider?.value
 
   if (dlcItemList) {
     dlcItemList.forEach((v: { releaseInfo: { appId: string }[] }) => {

--- a/src/common/types/legendary.ts
+++ b/src/common/types/legendary.ts
@@ -105,7 +105,15 @@ type CustomAttributeType =
   | 'extraLaunchOption_001_Args'
   | 'extraLaunchOption_001_Name'
   | 'ThirdPartyManagedApp'
+  | 'ThirdPartyManagedProvider'
   | 'AdditionalCommandLine'
+  | 'GameID'
+  | 'MainWindowProcessName'
+  | 'RegistryKey'
+  | 'RegistryPath'
+  | 'neverUpdate'
+  | 'partnerLinkId'
+  | 'partnerLinkType'
 
 interface CustomAttributeValue {
   type: 'STRING'


### PR DESCRIPTION
It seems some newer Ubisoft games set this instead of "ThirdPartyManagedApp". This caused us to attempt to get install info for those games, which will of course never work

Relevant Discord thread: https://discord.com/channels/812703221789097985/1466907169008910480

Can't test this, waiting for OP to confirm fix

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
