### PR TITLE
[Zoom] Fix installation of mac-native games from Zoom Platform

### DIFF
--- a/src/backend/storeManagers/zoom/library.ts
+++ b/src/backend/storeManagers/zoom/library.ts
@@ -32,14 +32,14 @@ const library: Map<string, GameInfo> = new Map()
 const installedGames: Map<string, InstalledInfo> = new Map()
 
 export async function initZoomLibraryManager() {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return
 
   await refresh()
 }
 
 export async function refresh(): Promise<ExecResult> {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return { stdout: '', stderr: 'Zoom Support disabled' }
 
   libraryCache.clear()
@@ -103,7 +103,7 @@ export async function refresh(): Promise<ExecResult> {
 }
 
 async function getZoomLibrary(): Promise<ZoomGameInfo[]> {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return []
 
   const cachedGames = libraryCache.get('library')
@@ -137,7 +137,7 @@ async function getZoomLibrary(): Promise<ZoomGameInfo[]> {
 }
 
 export function zoomToUnifiedInfo(zoomGame: ZoomGameInfo): GameInfo {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return {} as GameInfo
 
   const object: GameInfo = {
@@ -168,14 +168,14 @@ export function zoomToUnifiedInfo(zoomGame: ZoomGameInfo): GameInfo {
 }
 
 export function getGameInfo(slug: string): GameInfo | undefined {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return
 
   return library.get(slug) || getInstallAndGameInfo(slug)
 }
 
 export function getInstallAndGameInfo(slug: string): GameInfo | undefined {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return
 
   const lib = libraryStore.get('games', [])
@@ -197,7 +197,7 @@ export async function getInstallInfo(
   appName: string,
   installPlatform = 'windows'
 ): Promise<ZoomInstallInfo | undefined> {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return
 
   logInfo(
@@ -258,7 +258,7 @@ export async function getInstallInfo(
 }
 
 export function refreshInstalled() {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return
 
   const installedArray = installedGamesStore.get('installed', [])
@@ -272,7 +272,7 @@ export function refreshInstalled() {
 }
 
 export async function getExtras(appName: string) {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return { extras: [] }
 
   logDebug(`Fetching extras for Zoom ID ${appName}`, LogPrefix.Zoom)
@@ -312,7 +312,7 @@ export async function getInstallers(
   platform: string,
   appName: string
 ): Promise<ZoomDownloadFile[]> {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return []
 
   logDebug(
@@ -364,7 +364,7 @@ export async function changeGameInstallPath(
   appName: string,
   newInstallPath: string
 ): Promise<void> {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return
 
   const cachedGameData = library.get(appName)
@@ -387,7 +387,7 @@ export async function changeGameInstallPath(
 }
 
 export function installState() {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return
 
   logWarning(
@@ -397,7 +397,7 @@ export function installState() {
 }
 
 export function changeVersionPinnedStatus(appName: string, status: boolean) {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return
 
   const game = library.get(appName)
@@ -422,7 +422,7 @@ export function changeVersionPinnedStatus(appName: string, status: boolean) {
 }
 
 export async function listUpdateableGames(): Promise<string[]> {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return []
 
   logWarning('listUpdateableGames not implemented for Zoom', LogPrefix.Zoom)
@@ -430,7 +430,7 @@ export async function listUpdateableGames(): Promise<string[]> {
 }
 
 export function updateGameInLibrary(game: GameInfo) {
-  if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
+  if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return
 
   if (library.has(game.app_name)) {

--- a/src/backend/storeManagers/zoom/library.ts
+++ b/src/backend/storeManagers/zoom/library.ts
@@ -160,7 +160,9 @@ export function zoomToUnifiedInfo(zoomGame: ZoomGameInfo): GameInfo {
     is_installed: false,
     save_folder: '',
     canRunOffline: true, // Assuming DRM-free as per zoom.py
-    is_mac_native: zoomGame.operating_systems.includes('osx'),
+    is_mac_native:
+      zoomGame.operating_systems.includes('osx') ||
+      zoomGame.operating_systems.includes('mac'),
     is_linux_native: zoomGame.operating_systems.includes('linux'),
     thirdPartyManagedApp: undefined
   }
@@ -200,8 +202,11 @@ export async function getInstallInfo(
   if (!GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     return
 
+  const normalizedInstallPlatform =
+    installPlatform === 'osx' ? 'mac' : installPlatform
+
   logInfo(
-    `Getting install info for ${appName} on ${installPlatform}`,
+    `Getting install info for ${appName} on ${normalizedInstallPlatform}`,
     LogPrefix.Zoom
   )
 
@@ -215,11 +220,12 @@ export async function getInstallInfo(
     const filesRequest: ZoomFilesResponse = await ZoomUser.makeRequest(
       `${apiUrl}/li/game/${appName}/files`
     )
-    const files = filesRequest[installPlatform as keyof ZoomFilesResponse] || []
+    const files =
+      filesRequest[normalizedInstallPlatform as keyof ZoomFilesResponse] || []
 
     if (files.length === 0) {
       logWarning(
-        `No installer files found for ${appName} on platform ${installPlatform}`,
+        `No installer files found for ${appName} on platform ${normalizedInstallPlatform}`,
         LogPrefix.Zoom
       )
       return

--- a/src/common/types/zoom.ts
+++ b/src/common/types/zoom.ts
@@ -1,6 +1,6 @@
 import { LaunchOption } from 'common/types'
 
-export type ZoomInstallPlatform = 'windows' | 'linux'
+export type ZoomInstallPlatform = 'windows' | 'linux' | 'mac'
 
 export interface ZoomCredentials {
   access_token: string

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -292,7 +292,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       return <ErrorComponent message={message} />
     }
 
-    const isMacNative = ['osx', 'Mac'].includes(installPlatform ?? '')
+    const isMacNative = ['osx', 'Mac', 'mac'].includes(installPlatform ?? '')
     const isLinuxNative = ['linux', 'Linux'].includes(installPlatform ?? '')
 
     // create setting context functions

--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -226,6 +226,7 @@ export default function SideloadDialog({
         ]
       case 'osx':
       case 'Mac':
+      case 'mac':
         return [
           { name: 'Apps', extensions: ['App'] },
           { name: 'Other Binaries', extensions: ['sh', 'py', 'bin'] },

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -615,7 +615,8 @@ class GlobalState extends PureComponent<Props> {
       this.setState({
         zoom: {
           library: [],
-          username: userInfo?.username
+          username: userInfo?.username,
+          enabled: true
         }
       })
 
@@ -630,7 +631,8 @@ class GlobalState extends PureComponent<Props> {
     this.setState({
       zoom: {
         library: [],
-        username: null
+        username: null,
+        enabled: true
       }
     })
     console.log('Logging out from zoom')
@@ -700,7 +702,8 @@ class GlobalState extends PureComponent<Props> {
       },
       zoom: {
         library: zoomLibrary,
-        username: zoom.username
+        username: zoom.username,
+        enabled: zoom.enabled
       },
       amazon: {
         library: amazonLibrary,
@@ -925,7 +928,8 @@ class GlobalState extends PureComponent<Props> {
         this.setState({
           zoom: {
             library: [...library],
-            username: this.state.zoom.username
+            username: this.state.zoom.username,
+            enabled: true
           }
         })
       }


### PR DESCRIPTION
This PR fixes installing games from Zoom on a Mac.

Note that games are NOT playable with this PR, there's an issue when we try to launch `.app` files directly that is addressed in this other PR https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4608/changes#diff-69e9f792ff44c2d37e460ca5076ab07248dd5ac260a056ac8c2cff4870afee58R94

Once that other PR is merged we can fix launching native mac games from zoom. This PR only fixes the installation.

Since this is still all experimental and we clarify only linux I think it's fine to have this with a partial fix to install it correctly and later another fix to actually run the file in another PR.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
