### PR TITLE
[UI] Fix text wrapping for CJK fonts

### DIFF
--- a/src/frontend/components/UI/TwoColTableInput/index.css
+++ b/src/frontend/components/UI/TwoColTableInput/index.css
@@ -19,6 +19,7 @@
   font-size: var(--text-lg);
   padding: var(--space-xs-fixed);
   text-align: start;
+  white-space: nowrap;
 }
 
 /* using max and min width on purpose, width doesn't work as expected on these */


### PR DESCRIPTION
Before:
<img width="678" height="211" alt="屏幕截图 2026-02-06 110159" src="https://github.com/user-attachments/assets/48280614-c07c-45b4-8aa7-7b27cf86a7d6" />
<img width="681" height="230" alt="屏幕截图 2026-02-06 110254" src="https://github.com/user-attachments/assets/3abeb806-f490-40db-b09c-40792476af27" />
After:
<img width="683" height="198" alt="屏幕截图 2026-02-06 142821" src="https://github.com/user-attachments/assets/6224efb8-87b9-4223-b5de-a239ce4566d9" />
<img width="675" height="149" alt="屏幕截图 2026-02-06 142848" src="https://github.com/user-attachments/assets/34851eb7-761b-43d7-80f7-4c952dbb92ed" />

