### PR TITLE
[UX] Fix incorrect loading state in Wine Manager when library was refreshed

### DIFF
--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -19,6 +19,7 @@ import {
 import { WineVersionInfo, Type, WineManagerUISettings } from 'common/types'
 import { hasHelp } from 'frontend/hooks/hasHelp'
 import classNames from 'classnames'
+import useGlobalState from 'frontend/state/GlobalStateV2'
 
 const WineItem = lazy(
   async () => import('frontend/screens/WineManager/components/WineItem')
@@ -42,9 +43,12 @@ export default function WineManager(): JSX.Element | null {
     </p>
   )
 
-  const { refreshWineVersionInfo, refreshing, platform, isIntelMac } =
-    useContext(ContextProvider)
+  const { platform, isIntelMac } = useContext(ContextProvider)
   const isLinux = platform === 'linux'
+  const { refreshingWineVersions, refreshWineVersions } = useGlobalState.keys(
+    'refreshingWineVersions',
+    'refreshWineVersions'
+  )
 
   const protonge: WineManagerUISettings = {
     type: 'GE-Proton',
@@ -190,12 +194,12 @@ export default function WineManager(): JSX.Element | null {
             {/* refresh button is a tab to make navigation more predictable */}
             <Tab
               title={t('generic.library.refresh', 'Refresh Library')}
-              onClick={() => refreshWineVersionInfo(true)}
+              onClick={() => refreshWineVersions(true)}
               sx={{ minWidth: 0 }}
               icon={
                 <FontAwesomeIcon
                   className={classNames('FormControl__segmentedFaIcon', {
-                    'fa-spin': refreshing
+                    'fa-spin': refreshingWineVersions
                   })}
                   icon={faSyncAlt}
                 />
@@ -218,8 +222,8 @@ export default function WineManager(): JSX.Element | null {
               <span>{t('wine.size', 'Size')}</span>
               <span>{t('wine.actions', 'Action')}</span>
             </div>
-            {refreshing && <UpdateComponent />}
-            {!refreshing &&
+            {refreshingWineVersions && <UpdateComponent />}
+            {!refreshingWineVersions &&
               !!wineVersions.length &&
               wineVersions.map((release) => {
                 return <WineItem key={release.version} {...release} />

--- a/src/frontend/state/ContextProvider.tsx
+++ b/src/frontend/state/ContextProvider.tsx
@@ -42,7 +42,6 @@ const initialContext: ContextType = {
   isIntelMac: false,
   refresh: async () => Promise.resolve(),
   refreshLibrary: async () => Promise.resolve(),
-  refreshWineVersionInfo: async () => Promise.resolve(),
   refreshing: false,
   refreshingInTheBackground: true,
   isRTL: false,

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -19,7 +19,7 @@ import {
   HelpItem
 } from 'frontend/types'
 import { withTranslation } from 'react-i18next'
-import { getGameInfo, getLegendaryConfig, notify } from '../helpers'
+import { getGameInfo, getLegendaryConfig } from '../helpers'
 import { i18n, t, TFunction } from 'i18next'
 
 import ContextProvider from './ContextProvider'
@@ -739,35 +739,6 @@ class GlobalState extends PureComponent<Props> {
     }
   }
 
-  refreshWineVersionInfo = async (fetch: boolean): Promise<void> => {
-    if (this.state.platform === 'win32') {
-      return
-    }
-    window.api.logInfo('Refreshing wine downloader releases')
-    this.setState({ refreshing: true })
-    await window.api
-      .refreshWineVersionInfo(fetch)
-      .then(() => {
-        this.setState({
-          refreshing: false
-        })
-        return
-      })
-      .catch(async () => {
-        this.setState({ refreshing: false })
-        window.api.logError('Sync with upstream releases failed')
-
-        notify({
-          title: 'Wine-Manager',
-          body: t(
-            'notify.refresh.error',
-            "Couldn't fetch releases from upstream, maybe because of Github API restrictions! Try again later."
-          )
-        })
-        return
-      })
-  }
-
   handleGameStatus = async ({
     appName,
     status,
@@ -1121,7 +1092,6 @@ class GlobalState extends PureComponent<Props> {
           isRTL,
           refresh: this.refresh,
           refreshLibrary: this.refreshLibrary,
-          refreshWineVersionInfo: this.refreshWineVersionInfo,
           hiddenGames: {
             list: hiddenGames,
             add: this.hideGame,

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -41,7 +41,6 @@ export interface ContextType {
   isIntelMac: boolean
   refresh: (library: Runner, checkUpdates?: boolean) => Promise<void>
   refreshLibrary: (options: RefreshOptions) => Promise<void>
-  refreshWineVersionInfo: (fetch: boolean) => void
   refreshing: boolean
   refreshingInTheBackground: boolean
   hiddenGames: {


### PR DESCRIPTION
Currently, the `refreshing` global state is used to show both the library "loading" state and the wine manager "loading" state. This means that, when the library is being refreshed, the wine manager shows that "loading" state when nothing is really loading related to the wine manager (and this happens a lot: after a login, after installing a game, after manually refreshing the library, at boot, etc).

And a similar issue happens the other way around, when someone clicks the refresh button in the wine manager, it would set the state that changes the library to show "loading".

This PR fixes that by using 2 different states: `refreshing` (still in the global state, to not change too many things) and `refreshingWineVersions` added as a zustand state (since I was adding this new state I took the opportunity to also move the `refreshWineVersions` function into it to clean up the global state a bit).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
