### PR TITLE
[UI/UX] Improve Environmental Table settings and a few others

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -220,6 +220,13 @@
         "remove-category": "Remove Category",
         "warning": "Warning"
     },
+    "common": {
+        "cancel": "Cancel",
+        "clear_all": "Clear All",
+        "confirm": "Confirm",
+        "save": "Save",
+        "warning": "Warning"
+    },
     "controller": {
         "hints": {
             "back": "Back",
@@ -517,13 +524,14 @@
     },
     "options": {
         "advanced": {
-            "key": "Variable Name",
             "placeHolderKey": "NAME",
             "placeHolderValue": "E.g.: Path/To/ExtraFiles",
-            "title": "Environment Variables",
-            "value": "Value"
+            "title": "Environment Variables"
         },
         "env_variables": {
+            "add_new": "Add New Variable",
+            "bulk_edit": "Bulk Edit",
+            "clear_all_confirm": "Are you sure you want to clear all environment variables?",
             "error": {
                 "empty_key": "Variable names can't be empty",
                 "equal_sign_in_key": "Variable names can't contain the \"=\" sign",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -531,9 +531,11 @@
         "env_variables": {
             "add_new": "Add New Variable",
             "bulk_edit": "Bulk Edit",
+            "bulk_edit_error": "Some variables are incorrect. Please check that all lines follow the KEY=VALUE format and neither is empty.",
             "clear_all_confirm": "Are you sure you want to clear all environment variables?",
             "error": {
                 "empty_key": "Variable names can't be empty",
+                "empty_value": "Value can't be empty",
                 "equal_sign_in_key": "Variable names can't contain the \"=\" sign",
                 "space_in_key": "Variable names can't contain spaces"
             },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -871,6 +871,7 @@
             "warning": "This game does not explicitly allow offline mode, turn this on at your own risk. The game may not work."
         },
         "open-config-file": "Open Config File",
+        "open-game-settings-file-hint": "Click to open game settings file",
         "reset-heroic": "Reset Heroic",
         "saves": {
             "gog_linux_native_warning": "Linux native games do not support GOG's Cloud Saves feature. Use the Windows version instead.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -221,9 +221,13 @@
         "warning": "Warning"
     },
     "common": {
+        "add": "Add",
         "cancel": "Cancel",
         "clear_all": "Clear All",
         "confirm": "Confirm",
+        "duplicate": "Duplicate",
+        "edit": "Edit",
+        "remove": "Remove",
         "save": "Save",
         "warning": "Warning"
     },
@@ -525,17 +529,17 @@
     "options": {
         "advanced": {
             "placeHolderKey": "NAME",
-            "placeHolderValue": "E.g.: Path/To/ExtraFiles",
+            "placeHolderValue": "VALUE",
             "title": "Environment Variables"
         },
         "env_variables": {
             "add_new": "Add New Variable",
             "bulk_edit": "Bulk Edit",
-            "bulk_edit_error": "Some variables are incorrect. Please check that all lines follow the KEY=VALUE format and neither is empty.",
+            "bulk_edit_error": "Some variables are incorrect. Please check that all lines follow the KEY=VALUE format.",
             "clear_all_confirm": "Are you sure you want to clear all environment variables?",
             "error": {
+                "duplicate_key": "A variable with this name already exists",
                 "empty_key": "Variable names can't be empty",
-                "empty_value": "Value can't be empty",
                 "equal_sign_in_key": "Variable names can't contain the \"=\" sign",
                 "space_in_key": "Variable names can't contain spaces"
             },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -529,7 +529,7 @@
     "options": {
         "advanced": {
             "placeHolderKey": "NAME",
-            "placeHolderValue": "VALUE",
+            "placeHolderV": "VALUE",
             "title": "Environment Variables"
         },
         "env_variables": {

--- a/src/frontend/components/UI/SvgButton/index.css
+++ b/src/frontend/components/UI/SvgButton/index.css
@@ -6,3 +6,9 @@
   margin: 0;
   color: var(--text-default);
 }
+
+.svg-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  filter: grayscale(1);
+}

--- a/src/frontend/screens/Settings/components/BulkEditModal.tsx
+++ b/src/frontend/screens/Settings/components/BulkEditModal.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import { EnviromentVariable } from 'common/types'
+
+interface BulkEditModalProps {
+  initialValue: string
+  onSave: (envs: EnviromentVariable[]) => void
+  onCancel: () => void
+  t: (key: string, fallback?: string) => string
+}
+
+const BulkEditModal = ({
+  initialValue,
+  onSave,
+  onCancel,
+  t
+}: BulkEditModalProps) => {
+  const [currentText, setCurrentText] = useState(initialValue)
+  const [error, setError] = useState('')
+
+  const handleSave = () => {
+    const lines = currentText.split('\n')
+    const envMap = new Map<string, string>()
+    let hasError = false
+
+    lines.forEach((line) => {
+      const trimmedLine = line.trim()
+      if (!trimmedLine) return
+
+      if (trimmedLine.includes('=')) {
+        const [key, ...rest] = trimmedLine.split('=')
+        const trimmedKey = key.trim()
+        const trimmedVal = rest.join('=').trim()
+
+        if (!trimmedKey || !trimmedVal) {
+          hasError = true
+        } else {
+          envMap.set(trimmedKey, trimmedVal)
+        }
+      } else {
+        hasError = true
+      }
+    })
+
+    if (hasError) {
+      setError(
+        t(
+          'options.env_variables.bulk_edit_error',
+          'Some variables are incorrect. Please check that all lines follow the KEY=VALUE format and neither is empty.'
+        )
+      )
+      return
+    }
+
+    const newEnvs: EnviromentVariable[] = Array.from(envMap).map(
+      ([key, value]) => ({ key, value })
+    )
+    onSave(newEnvs)
+  }
+
+  return (
+    <div className="bulk-edit-wrapper">
+      <textarea
+        className="bulk-edit-textarea"
+        defaultValue={initialValue}
+        onChange={(e) => {
+          setCurrentText(e.target.value)
+          setError('')
+        }}
+        placeholder="KEY=VALUE"
+      />
+      {error && (
+        <div className="env-var-error" style={{ marginTop: '10px' }}>
+          {error}
+        </div>
+      )}
+      <div className="bulk-edit-actions">
+        <button
+          className="SvgButton"
+          onClick={onCancel}
+          style={{
+            padding: '8px 16px',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            background: 'var(--background-darker)',
+            color: 'var(--text-color)',
+            border: 'none'
+          }}
+        >
+          {t('common.cancel', 'Cancel')}
+        </button>
+        <button
+          className="SvgButton"
+          onClick={handleSave}
+          style={{
+            padding: '8px 16px',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            background: 'var(--accent)',
+            color: 'white',
+            border: 'none'
+          }}
+        >
+          {t('common.save', 'Save')}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default BulkEditModal

--- a/src/frontend/screens/Settings/components/BulkEditModal.tsx
+++ b/src/frontend/screens/Settings/components/BulkEditModal.tsx
@@ -74,32 +74,10 @@ const BulkEditModal = ({
         </div>
       )}
       <div className="bulk-edit-actions">
-        <button
-          className="SvgButton"
-          onClick={onCancel}
-          style={{
-            padding: '8px 16px',
-            borderRadius: '4px',
-            cursor: 'pointer',
-            background: 'var(--background-darker)',
-            color: 'var(--text-color)',
-            border: 'none'
-          }}
-        >
+        <button onClick={onCancel} className="button is-secondary">
           {t('common.cancel', 'Cancel')}
         </button>
-        <button
-          className="SvgButton"
-          onClick={handleSave}
-          style={{
-            padding: '8px 16px',
-            borderRadius: '4px',
-            cursor: 'pointer',
-            background: 'var(--accent)',
-            color: 'white',
-            border: 'none'
-          }}
-        >
+        <button onClick={handleSave} className="button is-primary">
           {t('common.save', 'Save')}
         </button>
       </div>

--- a/src/frontend/screens/Settings/components/BulkEditModal.tsx
+++ b/src/frontend/screens/Settings/components/BulkEditModal.tsx
@@ -31,7 +31,7 @@ const BulkEditModal = ({
         const trimmedKey = key.trim()
         const trimmedVal = rest.join('=').trim()
 
-        if (!trimmedKey || !trimmedVal) {
+        if (!trimmedKey) {
           hasError = true
         } else {
           envMap.set(trimmedKey, trimmedVal)

--- a/src/frontend/screens/Settings/components/BulkEditModal.tsx
+++ b/src/frontend/screens/Settings/components/BulkEditModal.tsx
@@ -1,54 +1,56 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { EnviromentVariable } from 'common/types'
+import { validateEnvKey } from './EnvVariableRow'
 
 interface BulkEditModalProps {
-  initialValue: string
+  initialEnvs: EnviromentVariable[]
   onSave: (envs: EnviromentVariable[]) => void
   onCancel: () => void
-  t: (key: string, fallback?: string) => string
 }
 
 const BulkEditModal = ({
-  initialValue,
+  initialEnvs,
   onSave,
-  onCancel,
-  t
+  onCancel
 }: BulkEditModalProps) => {
-  const [currentText, setCurrentText] = useState(initialValue)
+  const { t } = useTranslation()
+  const initialText = useMemo(
+    () => initialEnvs.map((env) => `${env.key}=${env.value}`).join('\n'),
+    [initialEnvs]
+  )
+  const [currentText, setCurrentText] = useState(initialText)
   const [error, setError] = useState('')
 
   const handleSave = () => {
     const lines = currentText.split('\n')
     const envMap = new Map<string, string>()
-    let hasError = false
 
-    lines.forEach((line) => {
+    for (const line of lines) {
       const trimmedLine = line.trim()
-      if (!trimmedLine) return
+      if (!trimmedLine) continue
 
-      if (trimmedLine.includes('=')) {
-        const [key, ...rest] = trimmedLine.split('=')
-        const trimmedKey = key.trim()
-        const trimmedVal = rest.join('=').trim()
-
-        if (!trimmedKey) {
-          hasError = true
-        } else {
-          envMap.set(trimmedKey, trimmedVal)
-        }
-      } else {
-        hasError = true
-      }
-    })
-
-    if (hasError) {
-      setError(
-        t(
-          'options.env_variables.bulk_edit_error',
-          'Some variables are incorrect. Please check that all lines follow the KEY=VALUE format and neither is empty.'
+      if (!trimmedLine.includes('=')) {
+        setError(
+          t(
+            'options.env_variables.bulk_edit_error',
+            'Some variables are incorrect. Please check that all lines follow the KEY=VALUE format.'
+          )
         )
-      )
-      return
+        return
+      }
+
+      const [key, ...rest] = trimmedLine.split('=')
+      const trimmedKey = key.trim()
+      const trimmedVal = rest.join('=').trim()
+
+      const keyError = validateEnvKey(trimmedKey, t)
+      if (keyError) {
+        setError(keyError)
+        return
+      }
+
+      envMap.set(trimmedKey, trimmedVal)
     }
 
     const newEnvs: EnviromentVariable[] = Array.from(envMap).map(
@@ -61,18 +63,14 @@ const BulkEditModal = ({
     <div className="bulk-edit-wrapper">
       <textarea
         className="bulk-edit-textarea"
-        defaultValue={initialValue}
+        defaultValue={initialText}
         onChange={(e) => {
           setCurrentText(e.target.value)
           setError('')
         }}
         placeholder="KEY=VALUE"
       />
-      {error && (
-        <div className="env-var-error" style={{ marginTop: '10px' }}>
-          {error}
-        </div>
-      )}
+      {error && <div className="env-var-error">{error}</div>}
       <div className="bulk-edit-actions">
         <button onClick={onCancel} className="button is-secondary">
           {t('common.cancel', 'Cancel')}

--- a/src/frontend/screens/Settings/components/EnvVariableRow.tsx
+++ b/src/frontend/screens/Settings/components/EnvVariableRow.tsx
@@ -122,7 +122,7 @@ const EnvVariableRow = ({ env, onSave, onRemove, onDuplicate }: Props) => {
             onChange={(val) => {
               setEditValue(val)
             }}
-            placeholder={t('options.advanced.placeHolderValue', 'VALUE')}
+            placeholder={t('options.advanced.placeHolderV', 'VALUE')}
           />
         </div>
       ) : (

--- a/src/frontend/screens/Settings/components/EnvVariableRow.tsx
+++ b/src/frontend/screens/Settings/components/EnvVariableRow.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { SvgButton, TextInputField } from 'frontend/components/UI'
+import { EnviromentVariable } from 'common/types'
+import EditIcon from '@mui/icons-material/Edit'
+import DeleteIcon from '@mui/icons-material/Delete'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import CheckIcon from '@mui/icons-material/Check'
+import CloseIcon from '@mui/icons-material/Close'
+
+export const validateEnvKey = (
+  key: string,
+  t: (k: string, fallback: string) => string
+): string => {
+  const trimmedKey = key.trim()
+  if (!trimmedKey) {
+    return t(
+      'options.env_variables.error.empty_key',
+      "Variable names can't be empty"
+    )
+  }
+  if (trimmedKey.match(/=/)) {
+    return t(
+      'options.env_variables.error.equal_sign_in_key',
+      `Variable names can't contain the "=" sign`
+    )
+  }
+  if (trimmedKey.match(/ /)) {
+    return t(
+      'options.env_variables.error.space_in_key',
+      `Variable names can't contain spaces`
+    )
+  }
+  return ''
+}
+
+interface Props {
+  env: EnviromentVariable
+  onSave: (newKey: string, newValue: string) => string | null
+  onRemove: () => void
+  onDuplicate: () => void
+}
+
+const EnvVariableRow = ({ env, onSave, onRemove, onDuplicate }: Props) => {
+  const { t } = useTranslation()
+  const [isEditing, setIsEditing] = useState(false)
+  const [editKey, setEditKey] = useState(env.key)
+  const [editValue, setEditValue] = useState(env.value)
+  const [error, setError] = useState('')
+  const rowRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (isEditing) {
+      const input = rowRef.current?.querySelector<HTMLInputElement>(
+        '.env-var-edit-fields input'
+      )
+      input?.focus()
+    }
+  }, [isEditing])
+
+  const focusEditButton = () => {
+    const btn = rowRef.current?.querySelector<HTMLButtonElement>(
+      '.env-var-row-actions .svg-button'
+    )
+    btn?.focus()
+  }
+
+  const startEdit = () => {
+    setEditKey(env.key)
+    setEditValue(env.value)
+    setError('')
+    setIsEditing(true)
+  }
+
+  const cancelEdit = () => {
+    setIsEditing(false)
+    setError('')
+    setTimeout(focusEditButton, 0)
+  }
+
+  const saveEdit = () => {
+    const validationError = validateEnvKey(editKey, t)
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+    const saveError = onSave(editKey.trim(), editValue.trim())
+    if (saveError) {
+      setError(saveError)
+      return
+    }
+    setIsEditing(false)
+    setError('')
+    setTimeout(focusEditButton, 0)
+  }
+
+  return (
+    <div ref={rowRef} className="env-var-row">
+      {isEditing ? (
+        <div className="env-var-edit-fields">
+          <TextInputField
+            htmlId={`edit-key-${env.key}`}
+            value={editKey}
+            onChange={(val) => {
+              let nextKey = val
+              let nextValue = editValue
+              if (val.includes('=') && !editValue) {
+                const [key, ...rest] = val.split('=')
+                nextKey = key
+                nextValue = rest.join('=')
+                setEditValue(nextValue)
+              }
+              setEditKey(nextKey)
+              setError(validateEnvKey(nextKey, t))
+            }}
+            placeholder={t('options.advanced.placeHolderKey', 'NAME')}
+          />
+          <span className="env-var-connector">=</span>
+          <TextInputField
+            htmlId={`edit-value-${env.key}`}
+            value={editValue}
+            onChange={(val) => {
+              setEditValue(val)
+            }}
+            placeholder={t('options.advanced.placeHolderValue', 'VALUE')}
+          />
+        </div>
+      ) : (
+        <div className="env-var-info">
+          <span className="env-var-key" title={env.key}>
+            {env.key}
+          </span>
+          <span className="env-var-connector">=</span>
+          <span className="env-var-value" title={env.value}>
+            {env.value}
+          </span>
+        </div>
+      )}
+
+      {error && <div className="env-var-error">{error}</div>}
+
+      <div className="env-var-row-actions">
+        {isEditing ? (
+          <>
+            <SvgButton
+              onClick={saveEdit}
+              title={t('common.save', 'Save')}
+              disabled={!editKey.trim()}
+            >
+              <CheckIcon style={{ color: 'var(--success)' }} fontSize="large" />
+            </SvgButton>
+            <SvgButton
+              onClick={cancelEdit}
+              title={t('common.cancel', 'Cancel')}
+            >
+              <CloseIcon style={{ color: 'var(--danger)' }} fontSize="large" />
+            </SvgButton>
+          </>
+        ) : (
+          <>
+            <SvgButton onClick={startEdit} title={t('common.edit', 'Edit')}>
+              <EditIcon
+                style={{ color: 'var(--text-default)' }}
+                fontSize="large"
+              />
+            </SvgButton>
+            <SvgButton
+              onClick={onDuplicate}
+              title={t('common.duplicate', 'Duplicate')}
+            >
+              <ContentCopyIcon
+                style={{ color: 'var(--text-default)' }}
+                fontSize="large"
+              />
+            </SvgButton>
+            <SvgButton onClick={onRemove} title={t('common.remove', 'Remove')}>
+              <DeleteIcon style={{ color: 'var(--danger)' }} fontSize="large" />
+            </SvgButton>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default EnvVariableRow

--- a/src/frontend/screens/Settings/components/EnvVariablesTable.css
+++ b/src/frontend/screens/Settings/components/EnvVariablesTable.css
@@ -140,6 +140,7 @@
 
 .bulk-edit-textarea {
   width: 100%;
+  min-width: 500px;
   min-height: 300px;
   background: var(--background);
   border: 1px solid var(--accent);
@@ -154,4 +155,16 @@
   color: var(--danger);
   font-size: var(--text-xs);
   margin-bottom: var(--space-xs-fixed);
+}
+
+.bulk-edit-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.bulk-edit-actions {
+  display: flex;
+  gap: var(--space-sm-fixed);
+  margin-top: var(--space-md-fixed);
+  justify-content: flex-end;
 }

--- a/src/frontend/screens/Settings/components/EnvVariablesTable.css
+++ b/src/frontend/screens/Settings/components/EnvVariablesTable.css
@@ -1,0 +1,157 @@
+.env-vars-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md-fixed);
+  width: 100%;
+}
+
+.env-vars-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-md-fixed);
+  margin-bottom: var(--space-xs-fixed);
+}
+
+.env-vars-title {
+  font-size: var(--text-lg);
+  color: var(--accent);
+  margin: 0;
+}
+
+.env-vars-actions {
+  display: flex;
+  gap: var(--space-sm-fixed);
+  align-items: center;
+}
+
+.env-vars-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs-fixed);
+}
+
+.env-var-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm-fixed);
+  padding: var(--space-xs-fixed) var(--space-sm-fixed);
+  background: var(--input-background);
+  border-radius: var(--border-radius-sm);
+  transition: background 0.2s;
+  min-height: 48px;
+}
+
+.env-var-row:hover {
+  background: var(--background-darker);
+}
+
+.env-var-info {
+  display: grid;
+  grid-template-columns: 1fr auto 1.5fr;
+  flex-grow: 1;
+  gap: var(--space-sm-fixed);
+  align-items: center;
+  overflow: hidden;
+}
+
+.env-var-key {
+  font-weight: bold;
+  color: var(--accent);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.env-var-connector {
+  color: var(--text-muted);
+  font-weight: bold;
+}
+
+.env-var-value {
+  color: var(--text-color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.env-var-edit-fields {
+  display: flex;
+  flex-grow: 1;
+  gap: var(--space-xs-fixed);
+  align-items: center;
+}
+
+.env-var-edit-fields .Field {
+  margin: 0;
+  flex-grow: 1;
+}
+
+.env-var-row-actions {
+  display: flex;
+  gap: var(--space-2xs-fixed);
+  opacity: 0.2;
+  transition: opacity 0.2s;
+  align-items: center;
+}
+
+.env-var-row:hover .env-var-row-actions {
+  opacity: 1;
+}
+
+.env-var-add-section {
+  margin-top: var(--space-sm-fixed);
+  padding: var(--space-md-fixed);
+  border: 1px dashed var(--accent);
+  border-radius: var(--border-radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm-fixed);
+}
+
+.env-var-add-title {
+  font-weight: bold;
+  color: var(--accent);
+  font-size: var(--text-md);
+}
+
+.env-var-add-inputs {
+  display: flex;
+  gap: var(--space-sm-fixed);
+  align-items: center;
+}
+
+.env-var-add-inputs .Field {
+  flex-grow: 1;
+  margin: 0;
+}
+
+.env-var-add-inputs .env-var-connector {
+  flex-shrink: 0;
+}
+
+.env-var-save-hint {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs-fixed);
+}
+
+.bulk-edit-textarea {
+  width: 100%;
+  min-height: 300px;
+  background: var(--background);
+  border: 1px solid var(--accent);
+  color: var(--text-color);
+  padding: var(--space-sm-fixed);
+  font-family: monospace;
+  border-radius: var(--border-radius-sm);
+  resize: vertical;
+}
+
+.env-var-error {
+  color: var(--danger);
+  font-size: var(--text-xs);
+  margin-bottom: var(--space-xs-fixed);
+}

--- a/src/frontend/screens/Settings/components/EnvVariablesTable.css
+++ b/src/frontend/screens/Settings/components/EnvVariablesTable.css
@@ -168,3 +168,9 @@
   margin-top: var(--space-md-fixed);
   justify-content: flex-end;
 }
+
+.env-vars-container .svg-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  filter: grayscale(1);
+}

--- a/src/frontend/screens/Settings/components/EnvVariablesTable.css
+++ b/src/frontend/screens/Settings/components/EnvVariablesTable.css
@@ -15,7 +15,6 @@
 
 .env-vars-title {
   font-size: var(--text-lg);
-  color: var(--accent);
   margin: 0;
 }
 
@@ -57,19 +56,19 @@
 
 .env-var-key {
   font-weight: bold;
-  color: var(--accent);
+  color: var(--text-default);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .env-var-connector {
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-weight: bold;
 }
 
 .env-var-value {
-  color: var(--text-color);
+  color: var(--text-default);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -80,11 +79,6 @@
   flex-grow: 1;
   gap: var(--space-xs-fixed);
   align-items: center;
-}
-
-.env-var-edit-fields .Field {
-  margin: 0;
-  flex-grow: 1;
 }
 
 .env-var-row-actions {
@@ -103,16 +97,13 @@
 .env-var-add-section {
   margin-top: var(--space-sm-fixed);
   padding: var(--space-md-fixed);
-  border: 1px dashed var(--accent);
+  border: 1px dashed var(--divider, var(--text-secondary));
   border-radius: var(--border-radius-sm);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm-fixed);
 }
 
 .env-var-add-title {
   font-weight: bold;
-  color: var(--accent);
+  color: var(--text-default);
   font-size: var(--text-md);
 }
 
@@ -122,30 +113,17 @@
   align-items: center;
 }
 
-.env-var-add-inputs .Field {
-  flex-grow: 1;
-  margin: 0;
-}
-
 .env-var-add-inputs .env-var-connector {
   flex-shrink: 0;
 }
 
-.env-var-save-hint {
-  font-size: var(--text-sm);
-  color: var(--text-muted);
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs-fixed);
-}
-
 .bulk-edit-textarea {
   width: 100%;
-  min-width: 500px;
+  max-width: 100%;
   min-height: 300px;
   background: var(--background);
-  border: 1px solid var(--accent);
-  color: var(--text-color);
+  border: 1px solid var(--divider, var(--text-secondary));
+  color: var(--text-default);
   padding: var(--space-sm-fixed);
   font-family: monospace;
   border-radius: var(--border-radius-sm);
@@ -154,8 +132,6 @@
 
 .env-var-error {
   color: var(--danger);
-  font-size: var(--text-xs);
-  margin-bottom: var(--space-xs-fixed);
 }
 
 .bulk-edit-wrapper {
@@ -168,10 +144,4 @@
   gap: var(--space-sm-fixed);
   margin-top: var(--space-md-fixed);
   justify-content: flex-end;
-}
-
-.env-vars-container .svg-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-  filter: grayscale(1);
 }

--- a/src/frontend/screens/Settings/components/EnvVariablesTable.css
+++ b/src/frontend/screens/Settings/components/EnvVariablesTable.css
@@ -95,6 +95,7 @@
   align-items: center;
 }
 
+.env-var-row:focus-within,
 .env-var-row:hover .env-var-row-actions {
   opacity: 1;
 }

--- a/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
+++ b/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
@@ -1,34 +1,172 @@
+import { useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { InfoBox } from 'frontend/components/UI'
-import {
-  ColumnProps,
-  TableInput
-} from 'frontend/components/UI/TwoColTableInput'
+import { InfoBox, TextInputField, SvgButton } from 'frontend/components/UI'
 import { EnviromentVariable } from 'common/types'
 import useSetting from 'frontend/hooks/useSetting'
+import ContextProvider from 'frontend/state/ContextProvider'
+import EditIcon from '@mui/icons-material/Edit'
+import DeleteIcon from '@mui/icons-material/Delete'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import SaveIcon from '@mui/icons-material/Save'
+import ClearAllIcon from '@mui/icons-material/ClearAll'
+import ListAltIcon from '@mui/icons-material/ListAlt'
+import CloseIcon from '@mui/icons-material/Close'
+import AddBoxIcon from '@mui/icons-material/AddBox'
+import './EnvVariablesTable.css'
 
 const EnvVariablesTable = () => {
   const { t } = useTranslation()
-
+  const { showDialogModal } = useContext(ContextProvider)
   const [environmentOptions, setEnvironmentOptions] = useSetting(
     'enviromentOptions',
     []
   )
 
-  const getEnvironmentVariables = () => {
-    const columns: ColumnProps[] = []
-    environmentOptions.forEach((env) =>
-      columns.push({ key: env.key, value: env.value })
-    )
-    return columns
+  const [editingIndex, setEditingIndex] = useState<number | null>(null)
+  const [editKey, setEditKey] = useState('')
+  const [editValue, setEditValue] = useState('')
+  const [newKey, setNewKey] = useState('')
+  const [newValue, setNewValue] = useState('')
+  const [keyError, setKeyError] = useState('')
+
+  const validateKey = (key: string): string => {
+    if (key.match(/=/)) {
+      return t(
+        'options.env_variables.error.equal_sign_in_key',
+        `Variable names can't contain the "=" sign`
+      )
+    }
+    if (key.match(/ /)) {
+      return t(
+        'options.env_variables.error.space_in_key',
+        `Variable names can't contain spaces`
+      )
+    }
+    return ''
   }
 
-  const onEnvVariablesChange = (cols: ColumnProps[]) => {
-    const envs: EnviromentVariable[] = []
-    cols.forEach((col) =>
-      envs.push({ key: col.key.trim(), value: col.value.trim() })
-    )
-    setEnvironmentOptions(envs)
+  const handleAdd = () => {
+    const error = validateKey(newKey)
+    if (error) {
+      setKeyError(error)
+      return
+    }
+    if (!newKey.trim()) {
+      setKeyError(
+        t(
+          'options.env_variables.error.empty_key',
+          "Variable names can't be empty"
+        )
+      )
+      return
+    }
+
+    const updated = [
+      ...environmentOptions,
+      { key: newKey.trim(), value: newValue.trim() }
+    ]
+    setEnvironmentOptions(updated)
+    setNewKey('')
+    setNewValue('')
+    setKeyError('')
+  }
+
+  const handleRemove = (index: number) => {
+    const updated = environmentOptions.filter((_, i) => i !== index)
+    setEnvironmentOptions(updated)
+  }
+
+  const handleDuplicate = (index: number) => {
+    const item = environmentOptions[index]
+    const updated = [
+      ...environmentOptions,
+      { key: `${item.key}_COPY`, value: item.value }
+    ]
+    setEnvironmentOptions(updated)
+  }
+
+  const handleEdit = (index: number) => {
+    setEditingIndex(index)
+    setEditKey(environmentOptions[index].key)
+    setEditValue(environmentOptions[index].value)
+  }
+
+  const handleSaveEdit = (index: number) => {
+    const error = validateKey(editKey)
+    if (error) {
+      setKeyError(error)
+      return
+    }
+    const updated = [...environmentOptions]
+    updated[index] = { key: editKey.trim(), value: editValue.trim() }
+    setEnvironmentOptions(updated)
+    setEditingIndex(null)
+    setKeyError('')
+  }
+
+  const handleClearAll = () => {
+    showDialogModal({
+      title: t('common.warning', 'Warning'),
+      message: t(
+        'options.env_variables.clear_all_confirm',
+        'Are you sure you want to clear all environment variables?'
+      ),
+      buttons: [
+        {
+          text: t('common.cancel', 'Cancel'),
+          onClick: () => {}
+        },
+        {
+          text: t('common.confirm', 'Confirm'),
+          onClick: () => setEnvironmentOptions([])
+        }
+      ]
+    })
+  }
+
+  const openBulkEdit = () => {
+    const bulkText = environmentOptions
+      .map((env) => `${env.key}=${env.value}`)
+      .join('\n')
+
+    let currentText = bulkText
+
+    showDialogModal({
+      title: t('options.env_variables.bulk_edit', 'Bulk Edit'),
+      message: (
+        <textarea
+          className="bulk-edit-textarea"
+          defaultValue={bulkText}
+          onChange={(e) => {
+            currentText = e.target.value
+          }}
+          placeholder="KEY=VALUE"
+        />
+      ),
+      buttons: [
+        {
+          text: t('common.cancel', 'Cancel'),
+          onClick: () => {}
+        },
+        {
+          text: t('common.save', 'Save'),
+          onClick: () => {
+            const lines = currentText.split('\n')
+            const newEnvs: EnviromentVariable[] = []
+            lines.forEach((line) => {
+              if (line.includes('=')) {
+                const [key, ...rest] = line.split('=')
+                newEnvs.push({
+                  key: key.trim(),
+                  value: rest.join('=').trim()
+                })
+              }
+            })
+            setEnvironmentOptions(newEnvs)
+          }
+        }
+      ]
+    })
   }
 
   const envVariablesInfo = (
@@ -46,50 +184,138 @@ const EnvVariablesTable = () => {
   )
 
   return (
-    <TableInput
-      label={t('options.advanced.title', 'Environment Variables')}
-      htmlId={'enviromentOptions'}
-      header={{
-        key: t('options.advanced.key', 'Variable Name'),
-        value: t('options.advanced.value', 'Value')
-      }}
-      rows={getEnvironmentVariables()}
-      onChange={onEnvVariablesChange}
-      connector="="
-      validation={(key: string, value: string) => {
-        let keyError = ''
-        const valueError = ''
+    <div className="env-vars-container">
+      <div className="env-vars-header">
+        <h3 className="env-vars-title">
+          {t('options.advanced.title', 'Environment Variables')}
+        </h3>
+        <div className="env-vars-actions">
+          <SvgButton
+            onClick={openBulkEdit}
+            title={t('options.env_variables.bulk_edit', 'Bulk Edit')}
+          >
+            <ListAltIcon style={{ color: 'var(--accent)' }} fontSize="large" />
+          </SvgButton>
+          <SvgButton
+            onClick={handleClearAll}
+            title={t('common.clear_all', 'Clear All')}
+          >
+            <ClearAllIcon style={{ color: 'var(--danger)' }} fontSize="large" />
+          </SvgButton>
+        </div>
+      </div>
 
-        if (key.match(/=/)) {
-          keyError = t(
-            'options.env_variables.error.equal_sign_in_key',
-            `Variable names can't contain the "=" sign`
-          )
-        } else if (key.match(/ /)) {
-          keyError = t(
-            'options.env_variables.error.space_in_key',
-            `Variable names can't contain spaces`
-          )
-        }
+      <div className="env-vars-list">
+        {environmentOptions.map((env) => {
+          const index = environmentOptions.findIndex((e) => e === env)
+          const isEditing = editingIndex === index
 
-        if (value && !key) {
-          keyError = t(
-            'options.env_variables.error.empty_key',
-            `Variable names can't be empty`
-          )
-        }
+          return (
+            <div key={`${env.key}-${index}`} className="env-var-row">
+              {isEditing ? (
+                <div className="env-var-edit-fields">
+                  <TextInputField
+                    htmlId={`edit-key-${index}`}
+                    value={editKey}
+                    onChange={setEditKey}
+                    placeholder="NAME"
+                    extraClass={keyError ? 'error' : ''}
+                  />
+                  <span className="env-var-connector">=</span>
+                  <TextInputField
+                    htmlId={`edit-value-${index}`}
+                    value={editValue}
+                    onChange={setEditValue}
+                    placeholder="VALUE"
+                  />
+                </div>
+              ) : (
+                <div className="env-var-info">
+                  <span className="env-var-key" title={env.key}>
+                    {env.key}
+                  </span>
+                  <span className="env-var-connector">=</span>
+                  <span className="env-var-value" title={env.value}>
+                    {env.value}
+                  </span>
+                </div>
+              )}
 
-        return [keyError, valueError]
-      }}
-      inputPlaceHolder={{
-        key: t('options.advanced.placeHolderKey', 'NAME'),
-        value: t(
-          'options.advanced.placeHolderValue',
-          'E.g.: Path/To/ExtraFiles'
-        )
-      }}
-      afterInput={envVariablesInfo}
-    />
+              <div className="env-var-row-actions">
+                {isEditing ? (
+                  <>
+                    <SvgButton onClick={() => handleSaveEdit(index)}>
+                      <SaveIcon
+                        style={{ color: 'var(--success)' }}
+                        fontSize="large"
+                      />
+                    </SvgButton>
+                    <SvgButton onClick={() => setEditingIndex(null)}>
+                      <CloseIcon
+                        style={{ color: 'var(--danger)' }}
+                        fontSize="large"
+                      />
+                    </SvgButton>
+                  </>
+                ) : (
+                  <>
+                    <SvgButton onClick={() => handleEdit(index)}>
+                      <EditIcon
+                        style={{ color: 'var(--accent)' }}
+                        fontSize="large"
+                      />
+                    </SvgButton>
+                    <SvgButton onClick={() => handleDuplicate(index)}>
+                      <ContentCopyIcon
+                        style={{ color: 'var(--accent)' }}
+                        fontSize="large"
+                      />
+                    </SvgButton>
+                    <SvgButton onClick={() => handleRemove(index)}>
+                      <DeleteIcon
+                        style={{ color: 'var(--danger)' }}
+                        fontSize="large"
+                      />
+                    </SvgButton>
+                  </>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {keyError && <div className="env-var-error">{keyError}</div>}
+
+      <div className="env-var-add-section">
+        <span className="env-var-add-title">
+          {t('options.env_variables.add_new', 'Add New Variable')}
+        </span>
+        <div className="env-var-add-inputs">
+          <TextInputField
+            htmlId="new-env-key"
+            value={newKey}
+            onChange={(val) => {
+              setNewKey(val)
+              setKeyError('')
+            }}
+            placeholder={t('options.advanced.placeHolderKey', 'NAME')}
+          />
+          <span className="env-var-connector">=</span>
+          <TextInputField
+            htmlId="new-env-value"
+            value={newValue}
+            onChange={setNewValue}
+            placeholder={t('options.advanced.placeHolderValue', 'VALUE')}
+          />
+          <SvgButton onClick={handleAdd} className="is-primary">
+            <AddBoxIcon style={{ color: 'var(--success)' }} fontSize="large" />
+          </SvgButton>
+        </div>
+      </div>
+
+      {envVariablesInfo}
+    </div>
   )
 }
 

--- a/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
+++ b/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
@@ -254,7 +254,10 @@ const EnvVariablesTable = () => {
               <div className="env-var-row-actions">
                 {isEditing ? (
                   <>
-                    <SvgButton onClick={() => handleSaveEdit(index)}>
+                    <SvgButton
+                      onClick={() => handleSaveEdit(index)}
+                      disabled={!editKey.trim() || !editValue.trim()}
+                    >
                       <SaveIcon
                         style={{ color: 'var(--success)' }}
                         fontSize="large"

--- a/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
+++ b/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
@@ -52,12 +52,6 @@ const EnvVariablesTable = () => {
         `Variable names can't contain spaces`
       )
     }
-    if (!trimmedValue) {
-      return t(
-        'options.env_variables.error.empty_value',
-        "Value can't be empty"
-      )
-    }
     return ''
   }
 
@@ -338,7 +332,7 @@ const EnvVariablesTable = () => {
           <SvgButton
             onClick={handleAdd}
             className="is-primary"
-            disabled={!newKey.trim() || !newValue.trim()}
+            disabled={!newKey.trim()}
           >
             <AddBoxIcon style={{ color: 'var(--success)' }} fontSize="large" />
           </SvgButton>

--- a/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
+++ b/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
@@ -215,7 +215,7 @@ const EnvVariablesTable = () => {
             onChange={(val) => {
               setNewValue(val)
             }}
-            placeholder={t('options.advanced.placeHolderValue', 'VALUE')}
+            placeholder={t('options.advanced.placeHolderV', 'VALUE')}
           />
           <SvgButton
             onClick={handleAdd}

--- a/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
+++ b/src/frontend/screens/Settings/components/EnvVariablesTable.tsx
@@ -3,17 +3,13 @@ import { useTranslation } from 'react-i18next'
 import { InfoBox, TextInputField, SvgButton } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import ContextProvider from 'frontend/state/ContextProvider'
-import EditIcon from '@mui/icons-material/Edit'
-import DeleteIcon from '@mui/icons-material/Delete'
-import ContentCopyIcon from '@mui/icons-material/ContentCopy'
-import SaveIcon from '@mui/icons-material/Save'
 import ClearAllIcon from '@mui/icons-material/ClearAll'
 import ListAltIcon from '@mui/icons-material/ListAlt'
-import CloseIcon from '@mui/icons-material/Close'
 import AddBoxIcon from '@mui/icons-material/AddBox'
 import './EnvVariablesTable.css'
 
 import BulkEditModal from './BulkEditModal'
+import EnvVariableRow, { validateEnvKey } from './EnvVariableRow'
 
 const EnvVariablesTable = () => {
   const { t } = useTranslation()
@@ -23,40 +19,12 @@ const EnvVariablesTable = () => {
     []
   )
 
-  const [editingIndex, setEditingIndex] = useState<number | null>(null)
-  const [editKey, setEditKey] = useState('')
-  const [editValue, setEditValue] = useState('')
   const [newKey, setNewKey] = useState('')
   const [newValue, setNewValue] = useState('')
   const [formError, setFormError] = useState('')
 
-  const validateEnv = (key: string, value: string): string => {
-    const trimmedKey = key.trim()
-    const trimmedValue = value.trim()
-
-    if (!trimmedKey) {
-      return t(
-        'options.env_variables.error.empty_key',
-        "Variable names can't be empty"
-      )
-    }
-    if (trimmedKey.match(/=/)) {
-      return t(
-        'options.env_variables.error.equal_sign_in_key',
-        `Variable names can't contain the "=" sign`
-      )
-    }
-    if (trimmedKey.match(/ /)) {
-      return t(
-        'options.env_variables.error.space_in_key',
-        `Variable names can't contain spaces`
-      )
-    }
-    return ''
-  }
-
   const handleAdd = () => {
-    const error = validateEnv(newKey, newValue)
+    const error = validateEnvKey(newKey, t)
     if (error) {
       setFormError(error)
       return
@@ -65,7 +33,6 @@ const EnvVariablesTable = () => {
     const trimmedKey = newKey.trim()
     const trimmedValue = newValue.trim()
 
-    // Overwrite if exists
     const existingIndex = environmentOptions.findIndex(
       (env) => env.key === trimmedKey
     )
@@ -84,37 +51,48 @@ const EnvVariablesTable = () => {
   }
 
   const handleRemove = (index: number) => {
-    const updated = environmentOptions.filter((_, i) => i !== index)
-    setEnvironmentOptions(updated)
+    setEnvironmentOptions(environmentOptions.filter((_, i) => i !== index))
+  }
+
+  const generateUniqueCopyKey = (baseKey: string): string => {
+    const existingKeys = new Set(environmentOptions.map((env) => env.key))
+    const baseCopyKey = `${baseKey}_COPY`
+    if (!existingKeys.has(baseCopyKey)) return baseCopyKey
+
+    let counter = 2
+    while (existingKeys.has(`${baseKey}_COPY${counter}`)) {
+      counter += 1
+    }
+    return `${baseKey}_COPY${counter}`
   }
 
   const handleDuplicate = (index: number) => {
     const item = environmentOptions[index]
-    const updated = [
+    const newCopyKey = generateUniqueCopyKey(item.key)
+    setEnvironmentOptions([
       ...environmentOptions,
-      { key: `${item.key}_COPY`, value: item.value }
-    ]
-    setEnvironmentOptions(updated)
+      { key: newCopyKey, value: item.value }
+    ])
   }
 
-  const handleEdit = (index: number) => {
-    setEditingIndex(index)
-    setEditKey(environmentOptions[index].key)
-    setEditValue(environmentOptions[index].value)
-    setFormError('')
-  }
-
-  const handleSaveEdit = (index: number) => {
-    const error = validateEnv(editKey, editValue)
-    if (error) {
-      setFormError(error)
-      return
+  const handleSaveEdit = (
+    index: number,
+    newKey: string,
+    newValue: string
+  ): string | null => {
+    const duplicateIndex = environmentOptions.findIndex(
+      (env, i) => i !== index && env.key === newKey
+    )
+    if (duplicateIndex >= 0) {
+      return t(
+        'options.env_variables.error.duplicate_key',
+        'A variable with this name already exists'
+      )
     }
     const updated = [...environmentOptions]
-    updated[index] = { key: editKey.trim(), value: editValue.trim() }
+    updated[index] = { key: newKey, value: newValue }
     setEnvironmentOptions(updated)
-    setEditingIndex(null)
-    setFormError('')
+    return null
   }
 
   const handleClearAll = () => {
@@ -138,16 +116,11 @@ const EnvVariablesTable = () => {
   }
 
   const openBulkEdit = () => {
-    const bulkText = environmentOptions
-      .map((env) => `${env.key}=${env.value}`)
-      .join('\n')
-
     showDialogModal({
       title: t('options.env_variables.bulk_edit', 'Bulk Edit'),
       message: (
         <BulkEditModal
-          initialValue={bulkText}
-          t={t}
+          initialEnvs={environmentOptions}
           onCancel={() => showDialogModal({ showDialog: false })}
           onSave={(envs) => {
             setEnvironmentOptions(envs)
@@ -176,19 +149,23 @@ const EnvVariablesTable = () => {
   return (
     <div className="env-vars-container">
       <div className="env-vars-header">
-        <h3 className="env-vars-title">
+        <label className="env-vars-title">
           {t('options.advanced.title', 'Environment Variables')}
-        </h3>
+        </label>
         <div className="env-vars-actions">
           <SvgButton
             onClick={openBulkEdit}
             title={t('options.env_variables.bulk_edit', 'Bulk Edit')}
           >
-            <ListAltIcon style={{ color: 'var(--accent)' }} fontSize="large" />
+            <ListAltIcon
+              style={{ color: 'var(--text-default)' }}
+              fontSize="large"
+            />
           </SvgButton>
           <SvgButton
             onClick={handleClearAll}
             title={t('common.clear_all', 'Clear All')}
+            disabled={environmentOptions.length === 0}
           >
             <ClearAllIcon style={{ color: 'var(--danger)' }} fontSize="large" />
           </SvgButton>
@@ -196,105 +173,17 @@ const EnvVariablesTable = () => {
       </div>
 
       <div className="env-vars-list">
-        {environmentOptions.map((env) => {
-          const index = environmentOptions.findIndex((e) => e === env)
-          const isEditing = editingIndex === index
-
-          return (
-            <div key={`${env.key}-${index}`} className="env-var-row">
-              {isEditing ? (
-                <div className="env-var-edit-fields">
-                  <TextInputField
-                    htmlId={`edit-key-${index}`}
-                    value={editKey}
-                    onChange={(val) => {
-                      if (val.includes('=') && !editValue) {
-                        const [key, ...rest] = val.split('=')
-                        setEditKey(key)
-                        setEditValue(rest.join('='))
-                      } else {
-                        setEditKey(val)
-                      }
-                      setFormError(validateEnv(val, editValue))
-                    }}
-                    placeholder="NAME"
-                    extraClass={
-                      formError && editingIndex === index ? 'error' : ''
-                    }
-                  />
-                  <span className="env-var-connector">=</span>
-                  <TextInputField
-                    htmlId={`edit-value-${index}`}
-                    value={editValue}
-                    onChange={(val) => {
-                      setEditValue(val)
-                      setFormError(validateEnv(editKey, val))
-                    }}
-                    placeholder="VALUE"
-                  />
-                </div>
-              ) : (
-                <div className="env-var-info">
-                  <span className="env-var-key" title={env.key}>
-                    {env.key}
-                  </span>
-                  <span className="env-var-connector">=</span>
-                  <span className="env-var-value" title={env.value}>
-                    {env.value}
-                  </span>
-                </div>
-              )}
-
-              <div className="env-var-row-actions">
-                {isEditing ? (
-                  <>
-                    <SvgButton
-                      onClick={() => handleSaveEdit(index)}
-                      disabled={!editKey.trim() || !editValue.trim()}
-                    >
-                      <SaveIcon
-                        style={{ color: 'var(--success)' }}
-                        fontSize="large"
-                      />
-                    </SvgButton>
-                    <SvgButton
-                      onClick={() => {
-                        setEditingIndex(null)
-                        setFormError('')
-                      }}
-                    >
-                      <CloseIcon
-                        style={{ color: 'var(--danger)' }}
-                        fontSize="large"
-                      />
-                    </SvgButton>
-                  </>
-                ) : (
-                  <>
-                    <SvgButton onClick={() => handleEdit(index)}>
-                      <EditIcon
-                        style={{ color: 'var(--accent)' }}
-                        fontSize="large"
-                      />
-                    </SvgButton>
-                    <SvgButton onClick={() => handleDuplicate(index)}>
-                      <ContentCopyIcon
-                        style={{ color: 'var(--accent)' }}
-                        fontSize="large"
-                      />
-                    </SvgButton>
-                    <SvgButton onClick={() => handleRemove(index)}>
-                      <DeleteIcon
-                        style={{ color: 'var(--danger)' }}
-                        fontSize="large"
-                      />
-                    </SvgButton>
-                  </>
-                )}
-              </div>
-            </div>
-          )
-        })}
+        {environmentOptions.map((env, index) => (
+          <EnvVariableRow
+            key={`${env.key}-${index}`}
+            env={env}
+            onSave={(newKey, newValue) =>
+              handleSaveEdit(index, newKey, newValue)
+            }
+            onRemove={() => handleRemove(index)}
+            onDuplicate={() => handleDuplicate(index)}
+          />
+        ))}
       </div>
 
       <div className="env-var-add-section">
@@ -306,18 +195,18 @@ const EnvVariablesTable = () => {
             htmlId="new-env-key"
             value={newKey}
             onChange={(val) => {
+              let nextKey = val
+              let nextValue = newValue
               if (val.includes('=') && !newValue) {
                 const [key, ...rest] = val.split('=')
-                setNewKey(key)
-                setNewValue(rest.join('='))
-                setFormError(validateEnv(key, rest.join('=')))
-              } else {
-                setNewKey(val)
-                setFormError(validateEnv(val, newValue))
+                nextKey = key
+                nextValue = rest.join('=')
+                setNewValue(nextValue)
               }
+              setNewKey(nextKey)
+              setFormError(validateEnvKey(nextKey, t))
             }}
             placeholder={t('options.advanced.placeHolderKey', 'NAME')}
-            extraClass={formError && editingIndex === null ? 'error' : ''}
           />
           <span className="env-var-connector">=</span>
           <TextInputField
@@ -325,7 +214,6 @@ const EnvVariablesTable = () => {
             value={newValue}
             onChange={(val) => {
               setNewValue(val)
-              setFormError(validateEnv(newKey, val))
             }}
             placeholder={t('options.advanced.placeHolderValue', 'VALUE')}
           />
@@ -333,13 +221,12 @@ const EnvVariablesTable = () => {
             onClick={handleAdd}
             className="is-primary"
             disabled={!newKey.trim()}
+            title={t('common.add', 'Add')}
           >
             <AddBoxIcon style={{ color: 'var(--success)' }} fontSize="large" />
           </SvgButton>
         </div>
-        {formError && editingIndex === null && (
-          <div className="env-var-error">{formError}</div>
-        )}
+        {formError && <div className="env-var-error">{formError}</div>}
       </div>
 
       {envVariablesInfo}

--- a/src/frontend/screens/Settings/index.css
+++ b/src/frontend/screens/Settings/index.css
@@ -95,6 +95,15 @@
   color: #5a5e5f;
 }
 
+.appName > span {
+  cursor: pointer;
+  transition: 300ms;
+}
+
+.appName > span:hover {
+  color: var(--text-secondary);
+}
+
 .save > .material-icons {
   font-size: var(--text-2xl);
   margin-inline-start: 6px;

--- a/src/frontend/screens/Settings/index.css
+++ b/src/frontend/screens/Settings/index.css
@@ -95,12 +95,19 @@
   color: #5a5e5f;
 }
 
-.appName > span {
+.appNameButton {
   cursor: pointer;
   transition: 300ms;
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  user-select: all;
 }
 
-.appName > span:hover {
+.appNameButton:hover,
+.appNameButton:focus-visible {
   color: var(--text-secondary);
 }
 

--- a/src/frontend/screens/Settings/sections/FooterInfo/index.tsx
+++ b/src/frontend/screens/Settings/sections/FooterInfo/index.tsx
@@ -12,7 +12,16 @@ export default function FooterInfo() {
       {!isDefault && (
         <span className="appName">
           AppName: &nbsp;
-          <span style={{ userSelect: 'all' }}> {appName}</span>
+          <span
+            style={{ userSelect: 'all' }}
+            title={t(
+              'settings.open-game-settings-file-hint',
+              'Click to open game settings file'
+            )}
+            onClick={() => window.api.showConfigFileInFolder(appName)}
+          >
+            {appName}
+          </span>
         </span>
       )}
     </div>

--- a/src/frontend/screens/Settings/sections/FooterInfo/index.tsx
+++ b/src/frontend/screens/Settings/sections/FooterInfo/index.tsx
@@ -6,22 +6,25 @@ export default function FooterInfo() {
   const { t } = useTranslation()
   const { isDefault, appName } = useContext(SettingsContext)
 
+  const openConfigFile = () => window.api.showConfigFileInFolder(appName)
+
   return (
     <div>
       <span className="save">{t('info.settings')}</span>
       {!isDefault && (
         <span className="appName">
           AppName: &nbsp;
-          <span
-            style={{ userSelect: 'all' }}
+          <button
+            type="button"
+            className="appNameButton"
             title={t(
               'settings.open-game-settings-file-hint',
               'Click to open game settings file'
             )}
-            onClick={() => window.api.showConfigFileInFolder(appName)}
+            onClick={openConfigFile}
           >
             {appName}
-          </span>
+          </button>
         </span>
       )}
     </div>


### PR DESCRIPTION
This improves the UI of the Environmental Table setting on the game settings that is being broken for a while now and also add some new options for Copy, builk edit and clear all.

Another small feat is to open the game settings file when clicking the appname on the game settings.

https://github.com/user-attachments/assets/d533676e-6685-442c-a465-9f2f846a9309

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
