### PR TITLE
[UX] Log if a game does not support offlineMode but offlineMode is on

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -790,6 +790,8 @@ async function prepareWineLaunch(
   failureReason?: string
   envVars?: Record<string, string>
 }> {
+  const gameInfo = gameManagerMap[runner].getGameInfo(appName)
+
   const gameSettings =
     GameConfig.get(appName).config ||
     (await GameConfig.get(appName).getSettings())
@@ -850,6 +852,12 @@ async function prepareWineLaunch(
       checkEOSOverlayStatusPromise.then(
         (enabled) => `EOS Overlay: ${enabled ? 'Enabled' : 'Not enabled'}`
       )
+    )
+  }
+
+  if (gameSettings.offlineMode && !gameInfo.canRunOffline) {
+    void logWriter.logWarning(
+      "Warning: 'offlineMode' is turned on but the game does not support offline mode. Disable 'offlineMode' in the game's settings."
     )
   }
 
@@ -968,9 +976,7 @@ async function prepareWineLaunch(
     await download('battleye_runtime')
   }
 
-  const { folder_name: installFolderName } =
-    gameManagerMap[runner].getGameInfo(appName)
-  const envVars = setupWineEnvVars(gameSettings, installFolderName)
+  const envVars = setupWineEnvVars(gameSettings, gameInfo.folder_name)
 
   return { success: true, envVars: envVars }
 }


### PR DESCRIPTION
Closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4727

We see pretty often in support threads that users have offlineMode turned on for online games. We already show a warning in the Settings modal when offlineMode is turned on for a game that reports not supporting it, but users may ignore it and we may not notice it when checking logs.

This PR makes it more explicit: if a game does not  `canRunOffline` and `offlineMode` is turned on, we show a warning in the logs so it's more obvious and clear.


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
