### PR TITLE
[UX] Tell users to manually upload log if upload button failed

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -732,6 +732,7 @@
                 },
                 "error": {
                     "content": "Failed to upload log file. Check Heroic's general log for details",
+                    "manual_upload": "Click the \"SHOW LOG FILE IN FOLDER\" button and upload the \"launch.log\" file manually to Discord or any online file sharing service.",
                     "title": "Upload failed"
                 },
                 "header": "Uploaded log files",

--- a/src/frontend/components/UI/Dialog/index.css
+++ b/src/frontend/components/UI/Dialog/index.css
@@ -108,6 +108,10 @@
   padding: 0 var(--dialog-margin-horizontal) var(--dialog-gap);
 }
 
+.log-upload-result {
+  max-width: 500px !important;
+}
+
 .Dialog__footer {
   display: flex;
   gap: 16px;

--- a/src/frontend/components/UI/LogFileUploadDialog/index.tsx
+++ b/src/frontend/components/UI/LogFileUploadDialog/index.tsx
@@ -76,10 +76,18 @@ export default function LogUploadDialog() {
     if (error)
       return [
         t('setting.log.upload.error.title', 'Upload failed'),
-        t(
-          'setting.log.upload.error.content',
-          "Failed to upload log file. Check Heroic's general log for details"
-        ),
+        <>
+          {t(
+            'setting.log.upload.error.content',
+            "Failed to upload log file. Check Heroic's general log for details"
+          )}
+          <br />
+          <br />
+          {t(
+            'setting.log.upload.error.manual_upload',
+            'Click the "SHOW LOG FILE IN FOLDER" button and upload the "launch.log" file manually to Discord or any online file sharing service.'
+          )}
+        </>,
         <>
           <button onClick={onClose} className={'button is-secondary'}>
             {t('box.ok')}
@@ -106,7 +114,11 @@ export default function LogUploadDialog() {
   if (!uploadLogFileProps) return <></>
 
   return (
-    <Dialog onClose={onClose} showCloseButton={false}>
+    <Dialog
+      onClose={onClose}
+      showCloseButton={false}
+      className="log-upload-result"
+    >
       <DialogHeader>{dialogTitle}</DialogHeader>
       <DialogContent>{dialogContent}</DialogContent>
       <DialogFooter>{dialogFooter}</DialogFooter>


### PR DESCRIPTION
Closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5170

During support, it's really common for users to share a screenshot or say the upload of logs didn't work. And it's always the same answer that they have to click SHOW LOG FILE IN FOLDER and upload launch.log manually somewhere.

This adds that comment in that same dialog, saving time for everyone.

<img width="530" height="294" alt="image" src="https://github.com/user-attachments/assets/7b224f65-9c6e-47c0-ae2d-9818960c91c0" />

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
