### PR TITLE
[UX] Prevent multiple Play clicks

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -120,6 +120,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
     error: boolean
     message: unknown
   }>({ error: false, message: '' })
+  const [playClicked, setPlayClicked] = useState(false)
 
   const anticheatInfo = hasAnticheatInfo(gameInfo)
 
@@ -242,6 +243,12 @@ export default React.memo(function GamePage(): JSX.Element | null {
     })
   }, [appName])
 
+  useEffect(() => {
+    // when the user clicks the Play button, we disable it so the user can't click it again
+    // once we receive the "launching" status update we can safely unset this state
+    if (status === 'launching') setPlayClicked(false)
+  }, [status])
+
   function handleUpdate() {
     if (gameInfo.runner !== 'sideload')
       updateGame({ appName, runner, gameInfo })
@@ -308,7 +315,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
         importing: isImporting,
         installingWinetricksPackages: isInstallingWinetricksPackages,
         installingRedist: isInstallingRedist,
-        launching: isLaunching,
+        launching: isLaunching || playClicked,
         linux: isLinux,
         linuxNative: isLinuxNative,
         mac: isMac,
@@ -533,6 +540,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       return sendKill(appName, gameInfo.runner)
     }
 
+    setPlayClicked(true)
     await launch({
       appName,
       t,
@@ -541,6 +549,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       hasUpdate,
       showDialogModal
     })
+    setPlayClicked(false)
   }
 
   async function handleInstall(is_installed: boolean) {


### PR DESCRIPTION
When a user clicks the Play button in the game details page, it only changes to "Launching" when we get the "launching" (or other status) status change from the backend.

Because of this, if it takes a long time for the backend to send this state, there's no feedback to the user that something is happening and it makes it look like the button didn't work, leading users to click again.

I think this started in 2.19 (I don't recall seeing this delay before).

Anyway, we already do something like this in the GameCard component (this delay does not happen in the library screen), we set a state when the button is clicked and use that to disable the button.

For this PR I also had to include that useEffect that unsets `playClicked` when the status changes to launching because it was affecting other states of that button.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
