### PR TITLE
[Fix] Don't fail to check for updates if there isn't a beta release

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -770,18 +770,17 @@ const getLatestReleases = async (): Promise<Release[]> => {
   logInfo('Checking for new Heroic Updates', LogPrefix.Backend)
 
   try {
-    const { data: releases } = await axiosClient.get(GITHUB_API)
-    const latestStable: Release = releases.filter(
-      (rel: Release) => rel.prerelease === false
-    )[0]
-    const latestBeta: Release = releases.filter(
-      (rel: Release) => rel.prerelease === true
-    )[0]
+    const { data: releases } = await axiosClient.get<Release[]>(GITHUB_API)
+    const latestStable = releases
+      .filter((rel) => rel.prerelease === false)
+      .at(0)
+    const latestBeta = releases.filter((rel) => rel.prerelease === true).at(0)
 
     const current = app.getVersion()
 
-    const thereIsNewStable = semverGt(latestStable.tag_name, current)
-    const thereIsNewBeta = semverGt(latestBeta.tag_name, current)
+    const thereIsNewStable =
+      latestStable && semverGt(latestStable.tag_name, current)
+    const thereIsNewBeta = latestBeta && semverGt(latestBeta.tag_name, current)
 
     if (thereIsNewStable) {
       newReleases.push({ ...latestStable, type: 'stable' })


### PR DESCRIPTION
The update check currently fails with this error:
```
(23:35:38) [ERROR]:   [Backend]:         Error when checking for Heroic updates TypeError: Cannot read properties of undefined (reading 'tag_name')
    at Fm (.../HeroicGamesLauncher/src/backend/utils.ts:784:48)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at Session.<anonymous> (node:electron/js2c/browser_init:2:107280)
```
This is because there isn't a beta release in the list of releases returned by the GitHub API at all (it only returns the last 30 entries)

To resolve this, don't assume we always have a `[0]` element here:

https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/bcc0e37a125268c3e8eb50c89fd74b336cf29a65/src/backend/utils.ts#L779

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
