### PR TITLE
[UX] Fix mix between default prefixes dir and shared prefix dir

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -23,10 +23,11 @@ import { configStore } from './constants/key_value_stores'
 import { isFlatpak, isLinux, isMac, isWindows } from './constants/environment'
 import {
   configPath,
-  defaultWinePrefix,
+  sharedWinePrefix,
   gamesConfigPath,
   heroicInstallPath,
-  userHome
+  userHome,
+  defaultWinePrefixDir
 } from './constants/paths'
 import { join } from 'path'
 import { spawnSync } from 'child_process'
@@ -293,6 +294,10 @@ class GlobalConfigV0 extends GlobalConfig {
     let settings = JSON.parse(readFileSync(configPath, 'utf-8'))
     const defaultSettings = settings.defaultSettings as AppSettings
 
+    // keep old setting value for backwards compatibility, always use defaultWinePrefixDir in new code
+    if (!defaultSettings.defaultWinePrefixDir)
+      defaultSettings.defaultWinePrefixDir = defaultSettings.defaultWinePrefix
+
     // fix relative paths
     const winePrefix = !isWindows
       ? defaultSettings?.winePrefix?.replace('~', userHome)
@@ -300,7 +305,7 @@ class GlobalConfigV0 extends GlobalConfig {
 
     settings = {
       ...this.getFactoryDefaults(),
-      ...settings.defaultSettings,
+      ...defaultSettings,
       winePrefix
     } as AppSettings
 
@@ -328,7 +333,8 @@ class GlobalConfigV0 extends GlobalConfig {
       defaultInstallPath: heroicInstallPath,
       libraryTopSection: 'disabled',
       defaultSteamPath: getSteamCompatFolder(),
-      defaultWinePrefix: defaultWinePrefix,
+      defaultWinePrefix: defaultWinePrefixDir,
+      defaultWinePrefixDir: defaultWinePrefixDir,
       hideChangelogsOnStartup: false,
       language: 'en',
       maxWorkers: 0,
@@ -339,7 +345,7 @@ class GlobalConfigV0 extends GlobalConfig {
       showFps: false,
       useGameMode: isFlatpak,
       wineCrossoverBottle: 'Heroic',
-      winePrefix: isWindows ? '' : defaultWinePrefix,
+      winePrefix: isWindows ? '' : sharedWinePrefix,
       wineVersion: defaultWine,
       enableEsync: true,
       enableFsync: isLinux,

--- a/src/backend/constants/paths.ts
+++ b/src/backend/constants/paths.ts
@@ -30,7 +30,13 @@ export const configPath = join(appFolder, 'config.json')
 export const gamesConfigPath = join(appFolder, 'GamesConfig')
 export const heroicIconFolder = join(appFolder, 'icons')
 export const heroicInstallPath = join(userHome, 'Games', 'Heroic')
-const defaultWinePrefixDir = join(userHome, 'Games', 'Heroic', 'Prefixes')
+export const defaultWinePrefixDir = join(
+  userHome,
+  'Games',
+  'Heroic',
+  'Prefixes'
+)
+export const sharedWinePrefix = join(defaultWinePrefixDir, 'shared')
 export const defaultWinePrefix = join(defaultWinePrefixDir, 'default')
 export const fixesPath = join(appFolder, 'fixes')
 

--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -8,7 +8,7 @@ import { currentGameConfigVersion } from 'backend/constants/others'
 import { isMac, isWindows } from './constants/environment'
 import {
   configPath,
-  defaultWinePrefix,
+  sharedWinePrefix,
   gamesConfigPath,
   userHome
 } from './constants/paths'
@@ -303,7 +303,7 @@ class GameConfigV0 extends GameConfig {
         defaultSettings.wineCrossoverBottle = wineCrossoverBottle
       }
 
-      defaultSettings.winePrefix = winePrefix || defaultWinePrefix
+      defaultSettings.winePrefix = winePrefix || sharedWinePrefix
 
       // fix winePrefix if needed
       if (gameSettings.winePrefix?.includes('~')) {

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -77,7 +77,7 @@ import { addRecentGame } from './recent_games/recent_games'
 import { tsStore } from './constants/key_value_stores'
 import {
   defaultUmuPath,
-  defaultWinePrefix,
+  sharedWinePrefix,
   fixesPath,
   flatpakHome,
   galaxyCommunicationExePath,
@@ -1413,7 +1413,7 @@ export async function validWine(
 export async function verifyWinePrefix(
   settings: GameSettings
 ): Promise<{ res: ExecResult }> {
-  const { winePrefix = defaultWinePrefix, wineVersion } = settings
+  const { winePrefix = sharedWinePrefix, wineVersion } = settings
 
   const isValidWine = await validWine(wineVersion)
 

--- a/src/backend/utils/uninstaller.ts
+++ b/src/backend/utils/uninstaller.ts
@@ -1,5 +1,9 @@
 import { GlobalConfig } from 'backend/config'
-import { fixesPath, gamesConfigPath } from 'backend/constants/paths'
+import {
+  defaultWinePrefix,
+  fixesPath,
+  gamesConfigPath
+} from 'backend/constants/paths'
 import { notify } from 'backend/dialog/dialog'
 import { logError, logInfo, LogPrefix } from 'backend/logger'
 import { gameManagerMap } from 'backend/storeManagers'
@@ -21,7 +25,7 @@ export const removePrefix = async (appName: string, runner: Runner) => {
   }
 
   // folder exists, do some sanity checks before deleting it
-  const { defaultInstallPath, defaultWinePrefix } =
+  const { defaultInstallPath, sharedWinePrefix } =
     GlobalConfig.get().getSettings()
 
   if (winePrefix === defaultInstallPath) {
@@ -31,6 +35,14 @@ export const removePrefix = async (appName: string, runner: Runner) => {
     return
   }
 
+  if (winePrefix === sharedWinePrefix) {
+    logInfo(
+      `Can't delete folder ${winePrefix}, prefix folder is the shared prefix directory ${sharedWinePrefix}`
+    )
+    return
+  }
+
+  // keep this check for backwards compatibility
   if (winePrefix === defaultWinePrefix) {
     logInfo(
       `Can't delete folder ${winePrefix}, prefix folder is the default prefix directory ${defaultWinePrefix}`

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -105,7 +105,9 @@ export interface AppSettings extends GameSettings {
   darkTrayIcon: boolean
   defaultInstallPath: string
   defaultSteamPath: string
-  defaultWinePrefix: string
+  sharedWinePrefix: string
+  defaultWinePrefix: string // only here for backwards compatibility, don't use in new code
+  defaultWinePrefixDir: string
   disableController: boolean
   disablePlaytimeSync: boolean
   disableSmoothScrolling: boolean

--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -119,8 +119,8 @@ export default function SideloadDialog({
   // Suggest default Wine prefix if we're adding a new app
   useEffect(() => {
     if (editMode) return
-    window.api.requestAppSettings().then(({ defaultWinePrefix }) => {
-      const suggestedWinePrefix = `${defaultWinePrefix}/${title}`
+    window.api.requestAppSettings().then(({ defaultWinePrefixDir }) => {
+      const suggestedWinePrefix = `${defaultWinePrefixDir}/${title}`
       setWinePrefix(suggestedWinePrefix)
     })
   }, [title, editMode])

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -49,7 +49,7 @@ export default function WineSelector({
   React.useEffect(() => {
     const getAppSettings = async () => {
       const {
-        defaultWinePrefix: prefixFolder,
+        defaultWinePrefixDir,
         wineVersion,
         winePrefix: defaultPrefix,
         wineCrossoverBottle: defaultBottle
@@ -71,7 +71,7 @@ export default function WineSelector({
       } else {
         const dirName =
           removeSpecialcharacters(title) || removeSpecialcharacters(appName)
-        const suggestedWinePrefix = `${prefixFolder}/${dirName}`
+        const suggestedWinePrefix = `${defaultWinePrefixDir}/${dirName}`
         setWinePrefix(suggestedWinePrefix)
         setWineVersion(wineVersion || undefined)
       }

--- a/src/frontend/screens/Settings/components/WinePrefix.tsx
+++ b/src/frontend/screens/Settings/components/WinePrefix.tsx
@@ -14,11 +14,8 @@ const WinePrefix = () => {
 
   const isWin = platform === 'win32'
 
-  const [defaultWinePrefix] = useSetting('defaultWinePrefix', '')
-  const [winePrefix, setWinePrefix] = useSetting(
-    'winePrefix',
-    defaultWinePrefix + '/default'
-  )
+  const [sharedWinePrefix] = useSetting('sharedWinePrefix', '')
+  const [winePrefix, setWinePrefix] = useSetting('winePrefix', sharedWinePrefix)
 
   if (isWin || wineVersion.type === 'crossover') {
     return <></>

--- a/src/frontend/screens/Settings/components/WinePrefixesBasePath.tsx
+++ b/src/frontend/screens/Settings/components/WinePrefixesBasePath.tsx
@@ -11,28 +11,28 @@ const WinePrefixesBasePath = () => {
   const { isDefault } = useContext(SettingsContext)
   const isWindows = platform === 'win32'
 
+  const [defaultWinePrefixDir, setDefaultWinePrefixDir] = useSetting(
+    'defaultWinePrefixDir',
+    ''
+  )
+
   if (!isDefault || isWindows) {
     return <></>
   }
-
-  const [defaultWinePrefix, setDefaultWinePrefix] = useSetting(
-    'defaultWinePrefix',
-    ''
-  )
 
   return (
     <PathSelectionBox
       htmlId="selectDefaultWinePrefix"
       label={t('setting.defaultWinePrefix', 'Set Folder for new Wine Prefixes')}
-      path={defaultWinePrefix}
-      onPathChange={setDefaultWinePrefix}
+      path={defaultWinePrefixDir}
+      onPathChange={setDefaultWinePrefixDir}
       type="directory"
       pathDialogTitle={t(
         'toolbox.settings.wineprefix',
         'Select a Folder for new Wine Prefixes'
       )}
       noDeleteButton
-      pathDialogDefaultPath={defaultWinePrefix}
+      pathDialogDefaultPath={defaultWinePrefixDir}
     />
   )
 }

--- a/src/frontend/screens/Settings/sections/SyncSaves/index.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/index.tsx
@@ -22,8 +22,8 @@ const SyncSaves = () => {
     false
   )
 
-  const [defaultWinePrefix] = useSetting('defaultWinePrefix', '')
-  const [winePrefix] = useSetting('winePrefix', defaultWinePrefix + '/default')
+  const [sharedWinePrefix] = useSetting('sharedWinePrefix', '')
+  const [winePrefix] = useSetting('winePrefix', sharedWinePrefix)
 
   const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
 


### PR DESCRIPTION
This PR makes the final changes so it closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3274

This renames the variables and setting keys we use to make it more clear that one is the default prefixes folder (where prefixes are created inside) and the default (now `shared`) wine prefix dir (the one used with the "Use shared Wine prefix").

The new setting value is only applied for new installation or if a user resets Heroic, for existing users this should not change anything (it means that if they already have the base prefixes dir as .../default it will continue like that and prefixes will be created inside it, to not break things for them).

Similar thing happens with the `default` wine prefix config, now it's renamed to `sharedWinePrefix` so it matches better the `Use shared Wine prefix` option. For existing user we still show the previous value they have (they probably have .../default) and for new users we show .../shared instead.

This will solve this issue where users end up with `.../Prefixes/default` as a prefix and also `.../Prefixes/default/some game prefix here` as other prefixes inside that one.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
