### PR TITLE
[FIX] Check alternative folders when installing DXVK

### DIFF
--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -238,9 +238,17 @@ export const DXVK = {
     const toolPathx32 = `${toolsPath}/${tool}/${globalVersion}/${
       tool === 'vkd3d' ? 'x86' : 'x32'
     }`
-    const dlls32 = readdirSync(toolPathx32)
+    const toolPathx32Alt = `${toolsPath}/${tool}/${globalVersion}/i386-windows`
+    let dlls32: string[] = []
+    if (existsSync(toolPathx32)) dlls32 = readdirSync(toolPathx32)
+    else if (existsSync(toolPathx32Alt)) dlls32 = readdirSync(toolPathx32Alt)
+
     const toolPathx64 = `${toolsPath}/${tool}/${globalVersion}/x64`
-    const dlls64 = readdirSync(toolPathx64)
+    const toolPathx64Alt = `${toolsPath}/${tool}/${globalVersion}/x86_64-windows`
+    let dlls64: string[] = []
+    if (existsSync(toolPathx64)) readdirSync(toolPathx64)
+    else if (existsSync(toolPathx64Alt)) dlls64 = readdirSync(toolPathx64Alt)
+
     const currentVersionCheck = `${winePrefix}/current_${tool}`
     let currentVersion = ''
 


### PR DESCRIPTION
Latest changes in the DXVK macos repo made the installation of DXVK fail because we are looking only for the `x32` and `x64` directories and the new asset has the folders `i386-windows` and `x86_64-windows` instead.

This PR fixes that by checking if the folders exists and falling back to the new folder name if the previous does not exist.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
