### PR TITLE
[UX] Show link to instructions to install winetricks deps on macos

### DIFF
--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -635,23 +635,7 @@ export const Winetricks = {
         }
       }, 1000)
 
-      // check if winetricks dependencies are installed
-      const dependencies = ['7z', 'cabextract', 'zenity', 'unzip', 'curl']
-      dependencies.forEach(async (dependency) => {
-        try {
-          await execAsync(`which ${dependency}`, { ...execOptions, env: envs })
-        } catch {
-          appendMessage(
-            `${dependency} not installed! Winetricks might fail to install some packages or even open`
-          )
-          logWarning(
-            [
-              `${dependency} not installed! Winetricks might fail to install some packages or even open`
-            ],
-            LogPrefix.WineTricks
-          )
-        }
-      })
+      Winetricks.checkDependencies(envs, appendMessage)
 
       logInfo(`Running ${winetricks} ${args.join(' ')}`, LogPrefix.WineTricks)
 
@@ -760,6 +744,30 @@ export const Winetricks = {
     } finally {
       installingComponent = ''
       sendFrontendMessage('installing-winetricks-component', '')
+    }
+  },
+  checkDependencies: async (
+    envs: Record<string, string>,
+    appendMessage: (message: string) => void
+  ) => {
+    // check if winetricks dependencies are installed
+    const dependencies = ['7z', 'cabextract', 'zenity', 'unzip', 'curl']
+    const missingDeps: string[] = []
+    for (const dependency of dependencies) {
+      try {
+        await execAsync(`which ${dependency}`, { ...execOptions, env: envs })
+      } catch {
+        missingDeps.push(dependency)
+        const message = `${dependency} not installed! Winetricks might fail to install some packages or even open`
+        appendMessage(message)
+        logWarning([message], LogPrefix.WineTricks)
+      }
+    }
+
+    if (missingDeps.length > 0 && isMac) {
+      const message = `Check https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki/Using-Heroic-on-a-Mac-computer#winetricks-setup to install the missing dependencies.`
+      appendMessage(message)
+      logWarning([message], LogPrefix.WineTricks)
     }
   }
 }


### PR DESCRIPTION
This PR adds a bit more info when we shows the missing `winetricks` dependencies messages in the Winetricks dialog.

Now we also print a link to the wiki for mac users to learn how to install those dependencies which is not clear in general and users and up asking in Discord or GitHub.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
