### PR TITLE
[UX] Fix PATH on mac for intel homebrew and macports when checking winetricks deps

### DIFF
--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -54,7 +54,12 @@ import {
 } from '../utils/inet/downloader'
 import { getUmuPath, isUmuSupported } from 'backend/utils/compatibility_layers'
 import { toolsPath, userHome } from 'backend/constants/paths'
-import { isLinux, isMac, isWindows } from 'backend/constants/environment'
+import {
+  isIntelMac,
+  isLinux,
+  isMac,
+  isWindows
+} from 'backend/constants/environment'
 import './dxmt'
 
 export async function installOrUpdateTool(tool: Tool) {
@@ -609,7 +614,9 @@ export const Winetricks = {
         WINESERVER: wineServer,
         WINE: wineBin,
         WINE64: wineBin,
-        PATH: `/opt/homebrew/bin:${process.env.PATH}`
+        PATH: isIntelMac
+          ? `/opt/local/bin:/usr/local/bin:${process.env.PATH}`
+          : `/opt/local/bin:/opt/homebrew/bin:${process.env.PATH}`
       }
 
       const envs = isMac ? macEnvs : linuxEnvs


### PR DESCRIPTION
Based on the comments and suggestions from https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2439

We currently only add the Apple Silicon directory of Homebrew but not the one it uses on Intel macs, and there's also the option to install some of the dependencies using Macports.

This enables the support of both cases.

Closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2439

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
