### PR TITLE
[FIX] Use correct partition and clear data on epic logout

### DIFF
--- a/src/backend/storeManagers/legendary/user.ts
+++ b/src/backend/storeManagers/legendary/user.ts
@@ -70,6 +70,7 @@ export class LegendaryUser {
     await ses.clearCache()
     await ses.clearAuthCache()
     await ses.clearHostResolverCache()
+    await ses.clearData()
     configStore.delete('userInfo')
     clearCache('legendary')
   }

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -379,7 +379,7 @@ export default function WebView() {
       <webview
         ref={webviewRef}
         className="WebView__webview"
-        partition={`persist:${store}`}
+        partition={`persist:${startUrl === epicLoginUrl ? 'epicstore' : store}`}
         src={startUrl}
         allowpopups={trueAsStr}
         preload={webviewPreloadPath}


### PR DESCRIPTION
There's a bug that users can't logout from the epic account to log into a new one, it keeps reloging you in with the previous acount.

The issue was that `store` during the login is `undefined` and ends up using a partition called `undefined`, but then the logout of epic clears a partition called `epicstore`.

This PR fixes that by:
- using `epicstore` as the partition name if we are logging in
- also clearing the Data of the partition

I think there might be a similar issue with Amazon from this report https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5052 but I don't have an Amazon account to check.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
