### PR TITLE
[FIX] Change DXVK macos fix from previous release

### DIFF
--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -67,11 +67,14 @@ type ReleasesResponse = {
 export async function installOrUpdateTool(tool: Tool) {
   if (tool.os !== process.platform) return
 
+  console.log((await axiosClient.get<ReleasesResponse>(tool.url)).data)
   const {
     data: { assets }
   } = await axiosClient.get<ReleasesResponse>(tool.url)
 
+  console.log(assets)
   let asset = assets[0]
+  console.log(tool)
   if (tool.name === 'dxvk-macOS' && asset.name.includes('-builtin')) {
     // Do not use -builtin asset for dxvk macos
     // TODO: implement proper use of the -builtin using the WINEDLLPATH_PREPEND
@@ -186,7 +189,10 @@ export const DXVK = {
       },
       {
         name: 'dxvk-macOS',
-        url: 'https://api.github.com/repos/Gcenx/DXVK-macOS/releases/latest',
+        // url: 'https://api.github.com/repos/Gcenx/DXVK-macOS/releases/latest',
+        // TODO: go back to using latest once we implement the WINEDLLPATH_PREPEND
+        // env variable for dxvk-macos and dxmt
+        url: 'https://api.github.com/repos/Gcenx/DXVK-macOS/releases/tags/v1.10.3-20230507-repack',
         os: 'darwin'
       }
     ]


### PR DESCRIPTION
My change from https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5342 was wrong. While it fixed the initial error installing DXVK, I was confused on how to use it and missed the part of gcenx's message that said it was NOT meant to be used in the way it was used before.

So... I'm reverting that change that checks alternative paths and instead I added a workaround to use a fixed version of DXVK and a specific asset so it works correctly.

I added some TODOs to migrate to the -builtin asset later (I'll do that so it works with both DXMT and DXVK eventually).

I can confirm now DXVK works fine, which is kinda the only option for intel mac.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
