### PR TITLE
[UI] Show update badge on gamecard only if controller is connected

### DIFF
--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -423,6 +423,8 @@ const GameCard = ({
   }
 
   const showSettingsButton = isInstalled && !isUninstalling && !isBrowserGame
+  const showUpdateBadge =
+    hasUpdate && !isUpdating && !isQueued && activeController
 
   return (
     <div>
@@ -441,7 +443,7 @@ const GameCard = ({
           data-tour={dataTour}
         >
           {haveStatus && <span className="gameCardStatus">{label}</span>}
-          {hasUpdate && !isUpdating && !isQueued && activeController && (
+          {showUpdateBadge && (
             <span className="gameCardUpdateBadge">
               {t('status.hasUpdates')}
             </span>


### PR DESCRIPTION

<img width="606" height="406" alt="Screenshot_20260224_154026" src="https://github.com/user-attachments/assets/069b8db0-f694-4dd3-bc3a-dd0c9c1c9abc" />

<img width="587" height="381" alt="Screenshot_20260224_154013" src="https://github.com/user-attachments/assets/6436d30c-56dc-4e12-92c0-3ab0d865921f" />


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
