### PR TITLE
[Feat] Automatically pause and resume downloads based connectivity status

### DIFF
--- a/src/backend/online_monitor.ts
+++ b/src/backend/online_monitor.ts
@@ -126,6 +126,14 @@ export const initOnlineMonitor = () => {
   })
 }
 
+export const onConnectivityChange = (
+  callback: (status: ConnectivityStatus) => unknown
+) => {
+  connectivityEmitter.on('online', () => callback('online'))
+  connectivityEmitter.on('offline', () => callback('offline'))
+  connectivityEmitter.on('check-online', () => callback('check-online'))
+}
+
 export const runOnceWhenOnline = (callback: () => unknown) => {
   if (isOnline()) {
     callback()


### PR DESCRIPTION
This adds a new method that can be used anywhere to cause an effect based on the connectivity status. Here I am using it to handle the Queue and auto-pause the downloads if the system gets offline and then resume them when online.

Should fix: #5363 

## How to test

### Scenario: Go Offline during download

1. Start a download.
2. Disconnect or change Wi-fi
3. Result: Download should pause.
4. Restore Connectivity to 'online'.
5. Result: Download should resume automatically.

### Scenario: Manual pause while offline

1. Manually click pause.
2. Gets offline
3. Gets online -> download should NOT auto-resume.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
