### PR TITLE
[Fix] False positive "an error has occurred" messages on bleeding-edge Linux distros

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -290,14 +290,18 @@ async function errorHandler({
   const deletedFolderMsg = 'appears to be deleted'
   const expiredCredentials = 'No saved credentials'
   const legendaryRegex = /legendary.*\.py/
-  // this message appears on macOS when no Crossover was found in the system but its a false alarm
-  const ignoreCrossoverMessage = 'IndexError: list index out of range'
+  const ignoreMessages = [
+    // this message appears on macOS when no Crossover was found in the system, but it's a false alarm
+    'IndexError: list index out of range',
+    // Happens with the Zipapp build of Legendary on Linux, if the user updates
+    // dependencies requests relies on
+    'RequestsDependencyWarning'
+  ]
 
   if (!error) return
 
-  if (error.includes(ignoreCrossoverMessage)) {
-    return
-  }
+  if (ignoreMessages.some((msg) => error.includes(msg))) return
+
   if (error.includes(deletedFolderMsg) && appName) {
     const runner = r.toLocaleLowerCase() as Runner
     const { title } = gameManagerMap[runner].getGameInfo(appName)


### PR DESCRIPTION
Our generic "error handler" is a little sensitive, which caused it to trigger on this output:
```
legendary version "0.20.41", codename "Freeman Pontifex (Heroic)"
/opt/Heroic/resources/app.asar.unpacked/build/bin/x64/linux/./legendary/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.3) or chardet (6.0.0.post1)/charset_normalizer (3.4.4) doesn't match a supported version!
```

This warning is thrown since users on Linux can update some dependencies independently of Legendary/Heroic, causing slightly-too-new versions to be used. I don't think this alone is an issue however, so we should just ignore it

85d3fc186b0d7ce45d6e7f59b31fb3ce2e028804 just changes whitespace, 938642ae16b09c7bf539096c050cec4ad9cdff14 is the main change

Can't test this, contacting some affected users to test

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
