### PR TITLE
[SIDELOAD]: add support for proton_shortcuts

### DIFF
--- a/src/backend/schemas.ts
+++ b/src/backend/schemas.ts
@@ -3,7 +3,10 @@ import path from 'path'
 
 const Path = z
   .string()
-  .refine((val) => path.parse(val).root, 'Path is not valid')
+  .refine(
+    (val) => path.parse(val).root || val.match(/^[A-Z]:(\\|\/)/),
+    'Path is not valid'
+  )
   .brand('Path')
 type Path = z.infer<typeof Path>
 

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -77,7 +77,14 @@ export async function launch(
   launchArguments?: LaunchOption,
   args: string[] = []
 ): Promise<boolean> {
-  return launchGame(appName, logWriter, getGameInfo(appName), 'sideload', args)
+  return launchGame(
+    appName,
+    logWriter,
+    getGameInfo(appName),
+    'sideload',
+    launchArguments,
+    args
+  )
 }
 
 export async function stop(appName: string): Promise<void> {

--- a/src/backend/storeManagers/sideload/library.ts
+++ b/src/backend/storeManagers/sideload/library.ts
@@ -1,11 +1,16 @@
-import { ExecResult, GameInfo } from 'common/types'
+import { ExecResult, GameInfo, LaunchOption } from 'common/types'
 import { readdirSync } from 'graceful-fs'
 import { dirname, join } from 'path'
 import { libraryStore } from './electronStores'
-import { logWarning } from 'backend/logger'
+import { logError, logWarning } from 'backend/logger'
 import { addShortcuts } from 'backend/shortcuts/shortcuts/shortcuts'
 import { sendFrontendMessage } from 'backend/ipc'
 import { isMac } from 'backend/constants/environment'
+import { getSettings } from './games'
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { parse as iniParse } from 'ini'
+import { DesktopEntry } from 'common/types/shortcuts'
+import { Path } from 'backend/schemas'
 
 export function addNewApp({
   app_name,
@@ -114,7 +119,48 @@ export async function getInstallInfo(): Promise<undefined> {
   return undefined
 }
 
-export const getLaunchOptions = () => []
+export async function getLaunchOptions(
+  appName: string
+): Promise<LaunchOption[]> {
+  const gameSettings = await getSettings(appName)
+  if (gameSettings.wineVersion.type !== 'proton') return []
+  if (!gameSettings.winePrefix) return []
+
+  const protonShortcutsPath = join(
+    gameSettings.winePrefix,
+    'drive_c/proton_shortcuts'
+  )
+  const launchOptions: LaunchOption[] = []
+  try {
+    const dir = await readdir(protonShortcutsPath, { encoding: 'utf-8' })
+    const files = dir.filter((f) => f.endsWith('.desktop'))
+    for (const file of files) {
+      const contents = await readFile(join(protonShortcutsPath, file), {
+        encoding: 'utf-8'
+      })
+      const desktopFile = iniParse(contents)
+      const desktopEntry = desktopFile['Desktop Entry'] as DesktopEntry
+
+      if (
+        desktopEntry.Path &&
+        !(await stat(desktopEntry.Path).catch(() => false))
+      )
+        continue
+
+      const execPath = desktopEntry.Exec.replace(/\\(.)/g, '$1')
+      launchOptions.push({
+        type: 'altExe',
+        name: desktopEntry.Name,
+        executable: await Path.parseAsync(execPath)
+      })
+    }
+  } catch (err) {
+    logError(['Failed to parse proton shortcuts', err])
+    return []
+  }
+
+  return launchOptions
+}
 
 export function changeVersionPinnedStatus() {
   logWarning(

--- a/src/backend/storeManagers/sideload/library.ts
+++ b/src/backend/storeManagers/sideload/library.ts
@@ -128,7 +128,7 @@ export async function getLaunchOptions(
 
   const protonShortcutsPath = join(
     gameSettings.winePrefix,
-    'drive_c/proton_shortcuts'
+    'pfx/drive_c/proton_shortcuts'
   )
   const launchOptions: LaunchOption[] = []
   try {

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -1,4 +1,4 @@
-import { GameInfo, GameSettings, Runner } from 'common/types'
+import { GameInfo, GameSettings, LaunchOption, Runner } from 'common/types'
 import { GameConfig } from '../../game_config'
 import {
   createGameLogWriter,
@@ -123,6 +123,7 @@ export async function launchGame(
   logWriter: LogWriter,
   gameInfo: GameInfo,
   runner: Runner,
+  launchArguments?: LaunchOption,
   args: string[] = []
 ): Promise<boolean> {
   if (!gameInfo) {
@@ -134,6 +135,10 @@ export async function launchGame(
   } = gameInfo
 
   const { browserUrl, customUserAgent, launchFullScreen } = gameInfo
+
+  if (launchArguments && 'executable' in launchArguments) {
+    executable = launchArguments.executable
+  }
 
   const gameSettingsOverrides = await GameConfig.get(appName).getSettings()
   if (

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -54,6 +54,7 @@ interface BaseLaunchOption {
 // Option to launch an alternative executable instead
 interface AltExeLaunchOption {
   type: 'altExe'
+  name?: string
   executable: Path
 }
 

--- a/src/common/types/shortcuts.ts
+++ b/src/common/types/shortcuts.ts
@@ -1,0 +1,7 @@
+export interface DesktopEntry {
+  Name: string
+  Exec: string
+  Icon?: string
+  StartupWMClass?: string
+  Path?: string
+}

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -432,7 +432,7 @@ async function checkLaunchOptionsAndLaunch({
           label = option.dlcTitle
           break
         case 'altExe':
-          label = option.executable
+          label = option.name ?? option.executable
           break
       }
 

--- a/src/frontend/hooks/useLaunchOptions.ts
+++ b/src/frontend/hooks/useLaunchOptions.ts
@@ -66,9 +66,7 @@ export const useLaunchOptions = ({
         case 'dlc':
           return 'dlcTitle' in option ? option.dlcTitle : 'DLC'
         case 'altExe':
-          return 'executable' in option
-            ? option.executable
-            : 'Alternative Executable'
+          return option.name ?? option.executable
         default:
           return 'Launch Option'
       }


### PR DESCRIPTION
this functionality can be easily extended to other providers, however I think only zoom will benefit most from this. 
In order for shortcuts to appear in Heroic, an app needs to register something in start menu. In EA App desktop and menu shortcuts are one option.

The `proton_shortcuts` feature was originally meant for Steam to support running arbitrary executables like mods in prefixes of games and being able to display launch options for new additions

I have modified executable path constraints to support Windows paths, as well as added a name field for altExe option

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
