### PR TITLE
[FIX] Clean up release notes by removing URLs and usernames

### DIFF
--- a/flathub/update-flathub.ts
+++ b/flathub/update-flathub.ts
@@ -175,12 +175,14 @@ async function main() {
   for (const [i, releaseComponent_i] of releaseNotesComponents.entries()) {
     if (i === 0) continue
     if (!releaseComponent_i.startsWith('*')) continue
-    if (releaseComponent_i.includes('http')) continue
 
+    // Remove URLs and "@username" from the release note text
     const li = releaseComponent_i
       .replace(/\n/g, '')
       .replace(/\r/g, '')
       .replace(/\t/g, '')
+      .replace(/https?:\/\/[^\s]+/g, '') // Remove URLs
+      .replace(/by\s+@[\w-]+/gi, '') // Remove "by @username"
       .slice(1)
       .trim()
 
@@ -196,7 +198,9 @@ async function main() {
 
   const componentsTag = heroicXmlJson[1].component
   // Locate the 'releases' element within the 'componentsTag'
-  const releasesTag = componentsTag.find((val) => val.releases !== undefined)
+  const releasesTag = componentsTag.find(
+    (val: { releases?: unknown }) => val.releases !== undefined
+  )
 
   // Proceed to find the <ul> element as before
   const releaseListTag = releasesTag?.releases[0].release[0].description[1]


### PR DESCRIPTION
The XML is never being updated if on the line with the change there is a URL so now it should clean the URL and remove the username.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
