### PR TITLE
[UX] Cleanup game logs, add config file path

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -81,6 +81,7 @@ import {
   fixesPath,
   flatpakHome,
   galaxyCommunicationExePath,
+  gamesConfigPath,
   runtimePath,
   userHome
 } from './constants/paths'
@@ -330,6 +331,12 @@ function filterGameSettingsForLog(
 ): PartialDeep<GameSettings> {
   const gameSettings: PartialDeep<GameSettings> =
     structuredClone(originalSettings)
+
+  // this is irrelevant for support
+  delete gameSettings.enableQuickSavesMenu
+  // if this is visible, it means verboseLogs is true, no need to print it
+  delete gameSettings.verboseLogs
+
   // remove gamescope settings if it's disabled
   if (gameSettings.gamescope) {
     if (!gameSettings.gamescope.enableLimiter) {
@@ -412,6 +419,9 @@ function filterGameSettingsForLog(
         if (wineType.type === 'wine') {
           delete gameSettings.wineCrossoverBottle
           delete gameSettings.advertiseAvxForRosetta
+          if (wineType.name?.includes('DXMT')) {
+            delete gameSettings.autoInstallDxvk
+          }
         }
 
         if (wineType.type === 'toolkit') {
@@ -431,6 +441,9 @@ function filterGameSettingsForLog(
       delete gameSettings.winePrefix
       delete gameSettings.wineCrossoverBottle
       delete gameSettings.advertiseAvxForRosetta
+      delete gameSettings.autoInstallDxvk
+      delete gameSettings.autoInstallDxvkNvapi
+      delete gameSettings.autoInstallVkd3d
     }
   }
 
@@ -537,6 +550,8 @@ async function prepareLaunch(
   await logWriter.logInfo([
     'Game Settings:',
     filterGameSettingsForLog(gameSettings, !native),
+    '\n',
+    `Stored at: ${join(gamesConfigPath, gameInfo.app_name + '.json')}`,
     '\n\n'
   ])
 


### PR DESCRIPTION
This PR does 3 things:
- cleanup some of the logs for Mac games (some settings are displayed for games where it makes no sense, like DXVK for native games or when using wine with DXMT)
- cleanup some logs in general (no need for the cloud saves quick menu and verboseLogs settings listed there, they add noise and no value for support)
- added the config file path to the logs, can be useful during support

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
