### PR TITLE
[FIX] Fix inconcistent login state switching stores

### DIFF
--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -377,6 +377,7 @@ export default function WebView() {
       )}
       {loading.refresh && <UpdateComponent message={loading.message} />}
       <webview
+        key={store}
         ref={webviewRef}
         className="WebView__webview"
         partition={`persist:${startUrl === epicLoginUrl ? 'epicstore' : store}`}


### PR DESCRIPTION
This PR fixes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5257

The issue was that we use different partitions for the webview and when react re-renders the page it does NOT change the partition if the webview is already rendered. So starting with a store sets a partition and then changing to another store keeps the previous partition, but when changing to another screen and going back to stores, the webview is rendered from scratch and the partition is set.

This PR adds the `key` attribute so whenever we change the store, the webview is completely re-rendered, setting the correct partition.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
