### PR TITLE
[UX] Cleanup general logs

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1559,10 +1559,6 @@ async function runWineCommand({
     child.stderr.setEncoding('utf-8')
 
     if (options?.logWriters) {
-      const files = options.logWriters
-        .map((writer) => `"${writer.logFilePath}"`)
-        .join(', ')
-      logDebug(`Logging to file(s) ${files}`, LogPrefix.Backend)
       options.logWriters.forEach((writer) =>
         writer.writeString(
           `Wine Command: ${bin} ${commandParts.join(' ')}\n\nGame Log:\n`
@@ -1737,11 +1733,6 @@ async function callRunner(
       )
       if (appName) await writer.logInfo('Game Output:')
     }
-
-    const files = options.logWriters
-      .map((writer) => `"${writer.logFilePath}"`)
-      .join(', ')
-    logDebug(`Logging to file(s) ${files}`, runner.logPrefix)
   }
 
   // check if the same command is currently running

--- a/src/backend/logger/log_writer.ts
+++ b/src/backend/logger/log_writer.ts
@@ -7,6 +7,8 @@ import { formatLogMessage } from './formatter'
 
 import type { LogOptions } from './types'
 
+import { getLogFilePath, logDebug } from './index'
+
 const LOG_LEVEL_LOGGING_FUNC: Record<LogLevel, (message: string) => unknown> = {
   DEBUG: console.log,
   INFO: console.log,
@@ -24,6 +26,8 @@ export default class LogWriter {
    * have the {@link LogOptions#forceLog} option set aren't logged
    */
   readonly #logsDisabled: boolean
+
+  readonly #isGeneralLog: boolean
 
   /**
    * Whether the log file was already written to by this writer. Used to rotate
@@ -46,6 +50,7 @@ export default class LogWriter {
     this.logFilePath = logFilePath
     this.#outputToOsStreams = outputToOsStreams
     this.#logsDisabled = logsDisabled
+    this.#isGeneralLog = logFilePath === getLogFilePath({})
     this.#wasWrittenTo = false
     this.#isClosed = false
     this.#messageWaitPromise = Promise.resolve()
@@ -89,6 +94,9 @@ export default class LogWriter {
     if (!this.#wasWrittenTo) {
       this.#archiveOldLogFile()
 
+      // print this message only once when a new log file is created and it's not the general log
+      if (!this.#isGeneralLog)
+        logDebug(`Logging to file(s) ${this.logFilePath}`, LogPrefix.Backend)
       const dirname = path.dirname(this.logFilePath)
       await fsPromises.mkdir(dirname, { recursive: true })
     }

--- a/src/backend/storeManagers/zoom/library.ts
+++ b/src/backend/storeManagers/zoom/library.ts
@@ -10,6 +10,7 @@ import {
 } from 'common/types/zoom'
 
 import {
+  getRunnerLogWriter,
   logDebug,
   logError,
   logInfo,
@@ -95,7 +96,8 @@ export async function refresh(): Promise<ExecResult> {
   )
 
   const logContent = `Games List:\n${sortedTitles.join('\n')}\n\nTotal: ${logLines.length}\n`
-  logInfo(logContent, LogPrefix.Zoom)
+  const zoomLogWriter = getRunnerLogWriter('zoom')
+  void zoomLogWriter.logInfo(logContent)
 
   logInfo('Saved games data for Zoom', LogPrefix.Zoom)
 

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -72,14 +72,11 @@ type ReleasesResponse = {
 export async function installOrUpdateTool(tool: Tool) {
   if (tool.os !== process.platform) return
 
-  console.log((await axiosClient.get<ReleasesResponse>(tool.url)).data)
   const {
     data: { assets }
   } = await axiosClient.get<ReleasesResponse>(tool.url)
 
-  console.log(assets)
   let asset = assets[0]
-  console.log(tool)
   if (tool.name === 'dxvk-macOS' && asset.name.includes('-builtin')) {
     // Do not use -builtin asset for dxvk macos
     // TODO: implement proper use of the -builtin using the WINEDLLPATH_PREPEND


### PR DESCRIPTION
This PR has a few changes to cleanup the general logs:
- I had some console.log left from https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5359 printing DXVK-macOS stuff
- The Zoom integration was printing the list of games in the general log instead of a zoom log file
- Lines like `Logging to file(s) ..../Logs/Heroic Games Launcher/runners/legendary.log` were printed many times for each runner, now they are printed only the first time the logs file is written to

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
