### PR TITLE
Add Windows ARM 64 Native Build Support

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v4
       with:
-        standalone: ${{ runner.os == 'Windows' }}
+        standalone: ${{ runner.os == 'Windows' && runner.arch != 'ARM64' }}
     - uses: actions/setup-node@v6
       with:
         node-version-file: 'package.json'

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -19,14 +19,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2025, ubuntu-24.04, macos-15]
+        include:
+          - os: windows-2025
+            arch: x64
+          - os: windows-11-arm
+            arch: arm64
+          - os: ubuntu-24.04
+            arch: x64
+          - os: macos-15
+            arch: x64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-deps
-      - name: Build Windows Portable version
-        run: pnpm dist:win portable
-        if: runner.os == 'Windows'
+      - name: Build Windows x64 Portable version
+        run: pnpm dist:win portable --x64
+        if: matrix.os == 'windows-2025'
+      - name: Build Windows ARM64 Portable version
+        run: pnpm dist:win portable --arm64
+        if: matrix.os == 'windows-11-arm'
       - name: Build macOS x64 & arm64 versions
         run: pnpm dist:mac --x64 --arm64 --publish=never
         env:
@@ -47,12 +58,14 @@ jobs:
       - name: Upload built version
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ (matrix.os == 'windows-2025'  && 'win-portable'  ) ||
-                    (matrix.os == 'macos-15'      && 'mac-x64'       ) ||
-                    (matrix.os == 'ubuntu-24.04'  && 'linux-AppImage-x64') }}
-          path: ${{ (matrix.os == 'windows-2025'  && 'dist/Heroic*.exe'      ) ||
-                    (matrix.os == 'macos-15'      && 'dist/Heroic*x64.dmg'   ) ||
-                    (matrix.os == 'ubuntu-24.04'  && 'dist/Heroic*x86_64.AppImage') }}
+          name: ${{ (matrix.os == 'windows-2025'  && 'win-x64-portable'  ) ||
+                    (matrix.os == 'windows-11-arm' && 'win-arm64-portable') ||
+                    (matrix.os == 'macos-15'       && 'mac-x64'           ) ||
+                    (matrix.os == 'ubuntu-24.04'   && 'linux-AppImage-x64') }}
+          path: ${{ (matrix.os == 'windows-2025'  && 'dist/Heroic*.exe'           ) ||
+                    (matrix.os == 'windows-11-arm' && 'dist/Heroic*.exe'           ) ||
+                    (matrix.os == 'macos-15'       && 'dist/Heroic*x64.dmg'        ) ||
+                    (matrix.os == 'ubuntu-24.04'   && 'dist/Heroic*x86_64.AppImage') }}
           retention-days: 14
           if-no-files-found: error
           compression-level: 3

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,7 +28,9 @@ win:
     - nsis
   files:
     - build/bin/${arch}/win32/*
-    - build/bin/x64/win32/*
+    - build/bin/x64/win32/nile.exe
+    - build/bin/x64/win32/GalaxyCommunication.exe
+    - build/bin/x64/win32/EpicGamesLauncher.exe
 
 portable:
   artifactName: ${productName}-${version}-Portable-${arch}.${ext}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -26,7 +26,9 @@ win:
   icon: build/win_icon.ico
   target:
     - nsis
-  files: build/bin/${arch}/win32/*
+  files:
+    - build/bin/${arch}/win32/*
+    - build/bin/x64/win32/*
 
 portable:
   artifactName: ${productName}-${version}-Portable-${arch}.${ext}

--- a/meta/downloadHelperBinaries.ts
+++ b/meta/downloadHelperBinaries.ts
@@ -150,9 +150,7 @@ async function downloadNile() {
     },
     arm64: {
       linux: 'nile_linux_arm64',
-      darwin: 'nile_macOS_arm64',
-      // No native ARM64 Windows build; x64 runs under Windows emulation
-      win32: 'nile_windows_x86_64.exe'
+      darwin: 'nile_macOS_arm64'
     }
   })
 }
@@ -167,10 +165,7 @@ async function downloadComet() {
         x64: {
           win32: 'GalaxyCommunication-dummy.exe'
         },
-        arm64: {
-          // No native ARM64 build; x64 runs under Windows emulation
-          win32: 'GalaxyCommunication-dummy.exe'
-        }
+        arm64: {}
       }
     ),
     downloadGithubAssets('comet', 'imLinguin/comet', RELEASE_TAGS['comet'], {
@@ -197,10 +192,7 @@ async function downloadEpicIntegration() {
       x64: {
         win32: 'EpicGamesLauncher.exe'
       },
-      arm64: {
-        // No native ARM64 build; x64 runs under Windows emulation
-        win32: 'EpicGamesLauncher.exe'
-      }
+      arm64: {}
     }
   )
 }

--- a/meta/downloadHelperBinaries.ts
+++ b/meta/downloadHelperBinaries.ts
@@ -114,7 +114,8 @@ async function downloadLegendary() {
       },
       arm64: {
         linux: 'legendary_linux_arm64',
-        darwin: 'legendary_macOS_arm64'
+        darwin: 'legendary_macOS_arm64',
+        win32: 'legendary_windows_arm64.exe'
       }
     }
   )
@@ -133,7 +134,8 @@ async function downloadGogdl() {
       },
       arm64: {
         linux: 'gogdl_linux_arm64',
-        darwin: 'gogdl_macOS_arm64'
+        darwin: 'gogdl_macOS_arm64',
+        win32: 'gogdl_windows_arm64.exe'
       }
     }
   )
@@ -148,7 +150,9 @@ async function downloadNile() {
     },
     arm64: {
       linux: 'nile_linux_arm64',
-      darwin: 'nile_macOS_arm64'
+      darwin: 'nile_macOS_arm64',
+      // No native ARM64 Windows build; x64 runs under Windows emulation
+      win32: 'nile_windows_x86_64.exe'
     }
   })
 }
@@ -163,7 +167,10 @@ async function downloadComet() {
         x64: {
           win32: 'GalaxyCommunication-dummy.exe'
         },
-        arm64: {}
+        arm64: {
+          // No native ARM64 build; x64 runs under Windows emulation
+          win32: 'GalaxyCommunication-dummy.exe'
+        }
       }
     ),
     downloadGithubAssets('comet', 'imLinguin/comet', RELEASE_TAGS['comet'], {
@@ -174,7 +181,8 @@ async function downloadComet() {
       },
       arm64: {
         darwin: 'comet-aarch64-apple-darwin',
-        linux: 'comet-aarch64-unknown-linux-gnu'
+        linux: 'comet-aarch64-unknown-linux-gnu',
+        win32: 'comet-aarch64-pc-windows-msvc.exe'
       }
     })
   ])
@@ -189,7 +197,10 @@ async function downloadEpicIntegration() {
       x64: {
         win32: 'EpicGamesLauncher.exe'
       },
-      arm64: {}
+      arm64: {
+        // No native ARM64 build; x64 runs under Windows emulation
+        win32: 'EpicGamesLauncher.exe'
+      }
     }
   )
 }

--- a/src/backend/constants/paths.ts
+++ b/src/backend/constants/paths.ts
@@ -41,11 +41,11 @@ export const publicDir = resolve(
 )
 
 export const fakeEpicExePath = fixAsarPath(
-  join(publicDir, 'bin', 'x64', 'win32', 'EpicGamesLauncher.exe')
+  join(publicDir, 'bin', process.arch, 'win32', 'EpicGamesLauncher.exe')
 )
 
 export const galaxyCommunicationExePath = fixAsarPath(
-  join(publicDir, 'bin', 'x64', 'win32', 'GalaxyCommunication.exe')
+  join(publicDir, 'bin', process.arch, 'win32', 'GalaxyCommunication.exe')
 )
 
 export const webviewPreloadPath = fixAsarPath(

--- a/src/backend/constants/paths.ts
+++ b/src/backend/constants/paths.ts
@@ -40,12 +40,16 @@ export const publicDir = resolve(
   app.isPackaged || process.env.CI === 'e2e' ? '' : '../public'
 )
 
+// On Windows the exe lives under the build's own arch; on Mac/Linux it is
+// always the x64 binary (run through Wine), matching electron-builder.yml.
+const winBinArch = process.platform === 'win32' ? process.arch : 'x64'
+
 export const fakeEpicExePath = fixAsarPath(
-  join(publicDir, 'bin', process.arch, 'win32', 'EpicGamesLauncher.exe')
+  join(publicDir, 'bin', winBinArch, 'win32', 'EpicGamesLauncher.exe')
 )
 
 export const galaxyCommunicationExePath = fixAsarPath(
-  join(publicDir, 'bin', process.arch, 'win32', 'GalaxyCommunication.exe')
+  join(publicDir, 'bin', winBinArch, 'win32', 'GalaxyCommunication.exe')
 )
 
 export const webviewPreloadPath = fixAsarPath(

--- a/src/backend/constants/paths.ts
+++ b/src/backend/constants/paths.ts
@@ -40,16 +40,12 @@ export const publicDir = resolve(
   app.isPackaged || process.env.CI === 'e2e' ? '' : '../public'
 )
 
-// On Windows the exe lives under the build's own arch; on Mac/Linux it is
-// always the x64 binary (run through Wine), matching electron-builder.yml.
-const winBinArch = process.platform === 'win32' ? process.arch : 'x64'
-
 export const fakeEpicExePath = fixAsarPath(
-  join(publicDir, 'bin', winBinArch, 'win32', 'EpicGamesLauncher.exe')
+  join(publicDir, 'bin', 'x64', 'win32', 'EpicGamesLauncher.exe')
 )
 
 export const galaxyCommunicationExePath = fixAsarPath(
-  join(publicDir, 'bin', winBinArch, 'win32', 'GalaxyCommunication.exe')
+  join(publicDir, 'bin', 'x64', 'win32', 'GalaxyCommunication.exe')
 )
 
 export const webviewPreloadPath = fixAsarPath(

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -429,6 +429,9 @@ function splitPathAndName(fullPath: string): { dir: string; bin: string } {
 }
 
 function archSpecificBinary(binaryName: string) {
+  // On Windows the helper binaries have .exe extension
+  if (process.platform === 'win32') binaryName += '.exe'
+
   // Try to use the arch-native binary first, if that doesn't exist fall back to
   // the x64 version (assume a compatibility layer like box64 is installed)
   const archSpecificPath = join(


### PR DESCRIPTION
Add a native Windows ARM64 build using the windows-11-arm GitHub-hosted runner to the existing CI workflow.

With the rising popularity of Windows ARM 64 devices, such as the latest Surface / Snapdragon X laptops, and soon to be released Snapdragon X2 devices and Nvidia N1X SOC users are increasingly expecting native applications.

Closes #4079
Closes #2209

## Changes

### Build Workflow

#### [MODIFIED] .github/workflows/build-base.yml

- Add `windows-11-arm` to the matrix as a fourth entry
- Add a Windows ARM64 build step: `pnpm dist:win portable --arm64`
- Add artifact upload for the ARM64 portable EXE (`win-arm64-portable`)
- Make the existing Windows build step explicit with `--x64`

#### [MODIFIED] .github/actions/install-deps/action.yml

- pnpm/action-setup uses standalone mode on Windows, which downloads an x64-only standalone pnpm binary. This doesn't work on the ARM64 runner.

- Changed standalone: ${{ runner.os == 'Windows' }} → standalone: ${{ runner.os == 'Windows' && runner.arch != 'ARM64' }}. The ARM64 runner will instead install pnpm via corepack/npm using the pre-installed Node.js on the runner.
 
#### [MODIFIED] meta/downloadHelperBinaries.ts

- **Legendary**: Add `arm64.win32: 'legendary_windows_arm64.exe'`
- **GOGdl**: Add `arm64.win32: 'gogdl_windows_arm64.exe'`
- **Nile**: Add `arm64.win32: 'nile_windows_x86_64.exe'` (x64 fallback, runs under emulation)
- **Comet**: Add `arm64.win32: 'comet-aarch64-pc-windows-msvc.exe'`
- **GalaxyCommunication**: Add `arm64.win32: 'GalaxyCommunication-dummy.exe'` (x64, runs under emulation)
- **EpicGamesLauncher**: Add `arm64.win32: 'EpicGamesLauncher.exe'` (x64, runs under emulation)

#### [MODIFIED] src/backend/constants/paths.ts

- Fix paths for EpicGamesLauncher.exe/GalaxyCommunication.exe to look under the proper folder binaries folder on Windows ARM

#### [MODIFIED] src/backend/utils.ts

- Fix primary search for binaries to include .exe extension, was always failing and falling back to x64 binary folder which didn't exist on Windows ARM

My test computer is a Lenovo Yoga Slim 7x using a Snapdragon X Elite processor running Windows 11 ARM Pro 25H2.

I've just successfully tested logging into Epic, GOG and Amazon. I installed an game from Epic and was able to play it. 

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
