### PR TITLE
[FIX] Pick executable inside .app using metadata

### DIFF
--- a/src/backend/storeManagers/index.ts
+++ b/src/backend/storeManagers/index.ts
@@ -106,12 +106,13 @@ export function getTargetExePath(
 
   // we can't execute a `.app` file directly
   // we have to use the path of the script inside the .app directory
-  if (executable && isMac && executable.endsWith('.app')) {
+  if (isMac) {
     try {
       // look for the `CFBundleExecutable` key and the next value
       const plistContent = readFileSync(
-        join(executable, 'Contents', 'Info.plist')
-      ).toString()
+        join(executable, 'Contents', 'Info.plist'),
+        'utf-8'
+      )
       const matchResult = plistContent.match(
         /<key>CFBundleExecutable<\/key>\n\s+<string>(.*)<\/string>/m
       )

--- a/src/backend/storeManagers/index.ts
+++ b/src/backend/storeManagers/index.ts
@@ -14,8 +14,12 @@ import { GameManager, LibraryManager } from 'common/types/game_manager'
 import { logInfo, RunnerToLogPrefixMap } from 'backend/logger'
 
 import { addToQueue } from 'backend/downloadmanager/downloadqueue'
-import { DMQueueElement, GameInfo, Runner } from 'common/types'
+import { DMQueueElement, GameInfo, GameSettings, Runner } from 'common/types'
 import { GlobalConfig } from 'backend/config'
+import LogWriter from 'backend/logger/log_writer'
+import { isMac } from 'backend/constants/environment'
+import { readFileSync } from 'fs'
+import { join } from 'path'
 type GameManagerMap = {
   [key in Runner]: GameManager
 }
@@ -88,4 +92,42 @@ export async function initStoreManagers() {
   await NileLibraryManager.initNileLibraryManager()
   if (GlobalConfig.get().getSettings().experimentalFeatures?.zoomPlatform)
     await ZoomLibraryManager.initZoomLibraryManager()
+}
+
+export function getTargetExePath(
+  gameInfo: GameInfo,
+  gameSettings: GameSettings,
+  logWriter: LogWriter
+) {
+  const executable = gameSettings.targetExe || gameInfo.install.executable
+
+  if (!executable) return executable
+  if (!executable.endsWith('.app')) return executable
+
+  // we can't execute a `.app` file directly
+  // we have to use the path of the script inside the .app directory
+  if (executable && isMac && executable.endsWith('.app')) {
+    try {
+      // look for the `CFBundleExecutable` key and the next value
+      const plistContent = readFileSync(
+        join(executable, 'Contents', 'Info.plist')
+      ).toString()
+      const matchResult = plistContent.match(
+        /<key>CFBundleExecutable<\/key>\n\s+<string>(.*)<\/string>/m
+      )
+      if (matchResult) {
+        // this is standarized inside .app bundles
+        const newPath = join(executable, 'Contents', 'MacOS', matchResult[1])
+        logWriter.logInfo(
+          `Replaced ${executable} alternative executable with ${newPath}`
+        )
+        return newPath
+      }
+    } catch (error) {
+      logWriter.logError('Error finding executable inside .app')
+      logWriter.logError(error)
+    }
+  }
+
+  return executable
 }

--- a/src/backend/storeManagers/sideload/library.ts
+++ b/src/backend/storeManagers/sideload/library.ts
@@ -1,11 +1,9 @@
 import { ExecResult, GameInfo } from 'common/types'
-import { readdirSync } from 'graceful-fs'
-import { dirname, join } from 'path'
+import { dirname } from 'path'
 import { libraryStore } from './electronStores'
 import { logWarning } from 'backend/logger'
 import { addShortcuts } from 'backend/shortcuts/shortcuts/shortcuts'
 import { sendFrontendMessage } from 'backend/ipc'
-import { isMac } from 'backend/constants/environment'
 
 export function addNewApp({
   app_name,
@@ -37,18 +35,6 @@ export function addNewApp({
     description,
     customUserAgent,
     launchFullScreen
-  }
-
-  if (isMac && executable?.endsWith('.app')) {
-    const macAppExecutable = readdirSync(
-      join(executable, 'Contents', 'MacOS')
-    )[0]
-    game.install.executable = join(
-      executable,
-      'Contents',
-      'MacOS',
-      macAppExecutable
-    )
   }
 
   const current = libraryStore.get('games', [])

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -28,7 +28,7 @@ import {
   deleteAbortController
 } from '../../utils/aborthandler/aborthandler'
 import { BrowserWindow, dialog, Menu } from 'electron'
-import { gameManagerMap } from '../index'
+import { gameManagerMap, getTargetExePath } from '../index'
 import { sendGameStatusUpdate } from 'backend/utils'
 import { isLinux, isMac } from 'backend/constants/environment'
 import { windowIcon } from 'backend/constants/paths'
@@ -129,19 +129,7 @@ export async function launchGame(
     return false
   }
 
-  let {
-    install: { executable }
-  } = gameInfo
-
   const { browserUrl, customUserAgent, launchFullScreen } = gameInfo
-
-  const gameSettingsOverrides = await GameConfig.get(appName).getSettings()
-  if (
-    gameSettingsOverrides.targetExe !== undefined &&
-    gameSettingsOverrides.targetExe !== ''
-  ) {
-    executable = gameSettingsOverrides.targetExe
-  }
 
   if (browserUrl) {
     return openNewBrowserGameWindow({
@@ -153,6 +141,7 @@ export async function launchGame(
   }
 
   const gameSettings = await getAppSettings(appName)
+  let executable = getTargetExePath(gameInfo, gameSettings, logWriter)
   const { launcherArgs } = gameSettings
   const extraArgs = [...shlex.split(launcherArgs ?? ''), ...args]
   const extraArgsJoined = extraArgs.join(' ')


### PR DESCRIPTION
Currently, when we sideload a native mac app/game, the code is picking the first file it finds in the `Contents/MacOS` directory but the first file is not necessarily the one that should be executed.

This PR changes that to use the plist file metadata to read the `CFBundleExecutable` metadata to know what file should be used.

This has a few more benefits:
- users pick the .app and we show that in the settings (current logic is to replace the .app config to the detected file which is kinda confusing for the user to see a path inside the .app in the input, now it happens on the fly when launching)
- this will be needed for this PR https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4608/changes#diff-69e9f792ff44c2d37e460ca5076ab07248dd5ac260a056ac8c2cff4870afee58R97 to run games without wine
- this also helps with native mac games from the zoom platform

I tested running a sideloaded native, non-native, and browser game, they all worked fine.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
