### PR TITLE
Add explicit gamescope enable toggle

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -359,7 +359,8 @@
             "gameWidth": "The width resolution used by the game. A 16:9 aspect ratio is assumed by gamescope.",
             "upscaleHeight": "The height resolution used by gamescope. A 16:9 aspect ratio is assumed.",
             "upscaleMethod": "The upscaling method gamescope should use.",
-            "upscaleWidth": "The width resolution used by gamescope. A 16:9 aspect ratio is assumed."
+            "upscaleWidth": "The width resolution used by gamescope. A 16:9 aspect ratio is assumed.",
+            "resolution-info": "When enabling gamescope but not enabling upscaling, game resolution is set to the dimensions of the current primary monitor."
         },
         "general": "Sync with EGL if you have a working installation of the Epic Games Launcher elsewhere and want to import your games to avoid downloading them again.",
         "mangohud": "MangoHUD is an overlay that displays and monitors FPS, temperatures, CPU/GPU load and other system resources.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -360,7 +360,7 @@
             "upscaleHeight": "The height resolution used by gamescope. A 16:9 aspect ratio is assumed.",
             "upscaleMethod": "The upscaling method gamescope should use.",
             "upscaleWidth": "The width resolution used by gamescope. A 16:9 aspect ratio is assumed.",
-            "resolution-info": "When enabling gamescope but not enabling upscaling, game resolution is set to the dimensions of the current primary monitor."
+            "autores-info": "Game resolution is set to the dimensions of the current primary monitor."
         },
         "general": "Sync with EGL if you have a working installation of the Epic Games Launcher elsewhere and want to import your games to avoid downloading them again.",
         "mangohud": "MangoHUD is an overlay that displays and monitors FPS, temperatures, CPU/GPU load and other system resources.",
@@ -696,6 +696,7 @@
             "enableGamescope": "Enable Gamescope",
             "enableLimiter": "Enable FPS Limiter",
             "enableUpscaling": "Enables Upscaling",
+            "enableAutoRes": "Enable Automatic Resolution",
             "missingMsg": "We could not find gamescope on the PATH. Install it or add it to the PATH.",
             "warningFlatpak": "We could not find a compatible version of Gamescope. Install Gamescope's flatpak package with runtime {{runtimeVersion}} and restart Heroic."
         },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -692,6 +692,7 @@
         "gamemode": "Use GameMode (Feral Game Mode needs to be installed)",
         "gamescope": {
             "enableForceGrabCursor": "Enable Force Grab Cursor",
+            "enableGamescope": "Enable Gamescope",
             "enableLimiter": "Enable FPS Limiter",
             "enableUpscaling": "Enables Upscaling",
             "missingMsg": "We could not find gamescope on the PATH. Install it or add it to the PATH.",

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -591,10 +591,11 @@ async function prepareLaunch(
   }
 
   if (
-    gameSettings.gamescope?.enable ||
-    ((gameSettings.gamescope?.enableLimiter ||
-      gameSettings.gamescope?.enableUpscaling) &&
-      !isSteamDeckGameMode)
+    (gameSettings.gamescope?.enable !== null
+      ? gameSettings.gamescope?.enable
+      : gameSettings.gamescope?.enableLimiter ||
+        gameSettings.gamescope?.enableUpscaling) &&
+    !isSteamDeckGameMode
   ) {
     const gameScopeBin = await searchForExecutableOnPath('gamescope')
     if (!gameScopeBin) {

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -21,6 +21,7 @@ import {
 import i18next from 'i18next'
 import { existsSync, mkdirSync } from 'graceful-fs'
 import { join, dirname, isAbsolute } from 'path'
+import { screen } from 'electron'
 
 import {
   constructAndUpdateRPC,
@@ -659,6 +660,10 @@ async function prepareLaunch(
         if (gameSettings.gamescope.windowType === 'borderless') {
           gameScopeCommand.push('-b')
         }
+      } else {
+        const { width, height } = screen.getPrimaryDisplay().workAreaSize
+        gameScopeCommand.push('-w', width.toString())
+        gameScopeCommand.push('-h', height.toString())
       }
 
       if (gameSettings.gamescope.enableLimiter) {

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -661,7 +661,7 @@ async function prepareLaunch(
         if (gameSettings.gamescope.windowType === 'borderless') {
           gameScopeCommand.push('-b')
         }
-      } else {
+      } else if (gameSettings.gamescope.enableAutoRes) {
         const { width, height } = screen.getPrimaryDisplay().workAreaSize
         gameScopeCommand.push('-w', width.toString())
         gameScopeCommand.push('-h', height.toString())

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -590,9 +590,10 @@ async function prepareLaunch(
   }
 
   if (
-    (gameSettings.gamescope?.enableLimiter ||
+    gameSettings.gamescope?.enable ||
+    ((gameSettings.gamescope?.enableLimiter ||
       gameSettings.gamescope?.enableUpscaling) &&
-    !isSteamDeckGameMode
+      !isSteamDeckGameMode)
   ) {
     const gameScopeBin = await searchForExecutableOnPath('gamescope')
     if (!gameScopeBin) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -782,6 +782,7 @@ export interface WindowProps extends Electron.Rectangle {
 }
 
 interface GameScopeSettings {
+  enable: boolean
   enableUpscaling: boolean
   enableLimiter: boolean
   enableForceGrabCursor: boolean

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -783,6 +783,7 @@ export interface WindowProps extends Electron.Rectangle {
 
 interface GameScopeSettings {
   enable: boolean | null
+  enableAutoRes: boolean | null
   enableUpscaling: boolean
   enableLimiter: boolean
   enableForceGrabCursor: boolean

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -782,7 +782,7 @@ export interface WindowProps extends Electron.Rectangle {
 }
 
 interface GameScopeSettings {
-  enable: boolean
+  enable: boolean | null
   enableUpscaling: boolean
   enableLimiter: boolean
   enableForceGrabCursor: boolean

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -135,6 +135,12 @@ const Gamescope = () => {
           }
           title={t('setting.gamescope.enableGamescope', 'Enable Gamescope')}
         />
+        <InfoIcon
+          text={t(
+            'help.gamescope.resolution-info',
+            'When enabling gamescope but not enabling upscaling, game resolution is set to the dimensions of the current primary monitor.'
+          )}
+        />
       </div>
     )
   }

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -17,6 +17,7 @@ const Gamescope = () => {
   const isLinux = platform === 'linux'
   const [gamescope, setGamescope] = useSetting('gamescope', {
     enable: null,
+    enableAutoRes: null,
     enableUpscaling: false,
     enableLimiter: false,
     enableForceGrabCursor: false,
@@ -135,12 +136,6 @@ const Gamescope = () => {
           }
           title={t('setting.gamescope.enableGamescope', 'Enable Gamescope')}
         />
-        <InfoIcon
-          text={t(
-            'help.gamescope.resolution-info',
-            'When enabling gamescope but not enabling upscaling, game resolution is set to the dimensions of the current primary monitor.'
-          )}
-        />
       </div>
     )
   }
@@ -153,6 +148,28 @@ const Gamescope = () => {
     <div className="gamescopeSettings">
       {/* Enable Upscale */}
       {renderGamescopeToggle()}
+      <div className="toggleRow">
+        <ToggleSwitch
+          htmlId="gamescopeAutoResToggle"
+          value={gamescope.enableAutoRes || false}
+          handleChange={() =>
+            setGamescope({
+              ...gamescope,
+              enableAutoRes: !gamescope.enableAutoRes
+            })
+          }
+          title={t(
+            'setting.gamescope.enableAutoRes',
+            'Enable Automatic Resolution'
+          )}
+        />
+        <InfoIcon
+          text={t(
+            'help.gamescope.autores-info',
+            'Game resolution is set to the dimensions of the current primary monitor.'
+          )}
+        />
+      </div>
       <div className="toggleRow">
         <ToggleSwitch
           htmlId="gamescopeUpscaleToggle"

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -16,6 +16,7 @@ const Gamescope = () => {
   const { platform } = useContext(ContextProvider)
   const isLinux = platform === 'linux'
   const [gamescope, setGamescope] = useSetting('gamescope', {
+    enable: false,
     enableUpscaling: false,
     enableLimiter: false,
     enableForceGrabCursor: false,
@@ -120,9 +121,32 @@ const Gamescope = () => {
     }
   ]
 
+  const renderGamescopeToggle = () => {
+    return (
+      <div className="toggleRow">
+        <ToggleSwitch
+          htmlId="gamescopeToggle"
+          value={gamescope.enable || false}
+          handleChange={() =>
+            setGamescope({
+              ...gamescope,
+              enable: !gamescope.enable
+            })
+          }
+          title={t('setting.gamescope.enableGamescope', 'Enable Gamescope')}
+        />
+      </div>
+    )
+  }
+
+  if (!gamescope.enable) {
+    return renderGamescopeToggle()
+  }
+
   return (
     <div className="gamescopeSettings">
       {/* Enable Upscale */}
+      {renderGamescopeToggle()}
       <div className="toggleRow">
         <ToggleSwitch
           htmlId="gamescopeUpscaleToggle"

--- a/src/frontend/screens/Settings/components/Gamescope.tsx
+++ b/src/frontend/screens/Settings/components/Gamescope.tsx
@@ -16,7 +16,7 @@ const Gamescope = () => {
   const { platform } = useContext(ContextProvider)
   const isLinux = platform === 'linux'
   const [gamescope, setGamescope] = useSetting('gamescope', {
-    enable: false,
+    enable: null,
     enableUpscaling: false,
     enableLimiter: false,
     enableForceGrabCursor: false,


### PR DESCRIPTION
Explicit enabling/disabling of gamescope for when some games misbehave due to compositor-specific behavior. Launches with primary display dimensions if not upscaling.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ✔️ ] Tested the feature and it's working on a current and clean install.
- [ ✔️ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ✔️ ] Created / Updated Tests (If necessary)
- [ ✔️ ] Created / Updated documentation (If necessary)
