### PR TITLE
[UX] Hint at 4-char codes in preferred language

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -582,7 +582,7 @@
         "custom_themes_path": "Select the path to look for custom CSS files",
         "dxvkfpsvalue": "Positive integer value (e.g. 30, 60, ...)",
         "egs-prefix": "Prefix where EGS is installed",
-        "prefered_language": "2-char code (i.e.: \"en\" or \"fr\")"
+        "prefered_language": "2-char or 4-char code (i.e.: \"fr\" or \"pt-BR\")"
     },
     "platforms": {
         "browser": "Browser",

--- a/src/frontend/screens/Settings/components/PreferedLanguage.tsx
+++ b/src/frontend/screens/Settings/components/PreferedLanguage.tsx
@@ -36,7 +36,7 @@ const PreferedLanguage = () => {
       htmlId="prefered-language"
       placeholder={t(
         'placeholder.prefered_language',
-        '2-char code (i.e.: "en" or "fr")'
+        '2-char or 4-char code (i.e.: "fr" or "pt-BR")'
       )}
       value={languageCode}
       onChange={handleLanguageCode}


### PR DESCRIPTION
Preferred language option helper text says 2-char code (i.e.: "en" or "fr") but it could also be 4-chars (pt-BR or es-ES). Let's fix it.

Fixes #5401 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)