### PR TITLE
[UX] Download known fixes even before downloading a game

### DIFF
--- a/src/backend/anticheat/ipc_handler.ts
+++ b/src/backend/anticheat/ipc_handler.ts
@@ -1,7 +1,7 @@
 import { backendEvents } from 'backend/backend_events'
 import { addHandler } from '../ipc'
 import { downloadAntiCheatData, gameAnticheatInfo } from './utils'
-import { isMac } from 'backend/constants/environment'
+import { isMac, isWindows } from 'backend/constants/environment'
 import { logDebug, LogPrefix } from 'backend/logger'
 
 // we use the game's `namespace` value here, it's the value that can be easily fetch by AreWeAnticheatYet
@@ -10,6 +10,8 @@ addHandler('getAnticheatInfo', async (e, appNamespace) =>
 )
 
 backendEvents.on('releasesInfoReady', (releasesInfo) => {
+  if (isWindows) return
+
   logDebug('Releases info ready, checking anticheat data', LogPrefix.Backend)
   void downloadAntiCheatData(
     isMac

--- a/src/backend/anticheat/utils.ts
+++ b/src/backend/anticheat/utils.ts
@@ -6,17 +6,7 @@ import { axiosClient } from 'backend/utils'
 import { join } from 'node:path'
 import { appFolder } from 'backend/constants/paths'
 import { isMac, isWindows } from 'backend/constants/environment'
-import { createHash } from 'node:crypto'
-import { createReadStream } from 'graceful-fs'
-import { finished } from 'node:stream/promises'
-
-async function createMD5(filePath: string) {
-  const hash = createHash('md5')
-  const rStream = createReadStream(filePath)
-  rStream.pipe(hash)
-  await finished(rStream)
-  return hash.digest('hex')
-}
+import { createMD5 } from 'backend/utils/releases'
 
 const anticheatDataPath = join(appFolder, 'areweanticheatyet.json')
 

--- a/src/backend/constants/paths.ts
+++ b/src/backend/constants/paths.ts
@@ -32,7 +32,6 @@ export const heroicIconFolder = join(appFolder, 'icons')
 export const heroicInstallPath = join(userHome, 'Games', 'Heroic')
 const defaultWinePrefixDir = join(userHome, 'Games', 'Heroic', 'Prefixes')
 export const defaultWinePrefix = join(defaultWinePrefixDir, 'default')
-export const fixesPath = join(appFolder, 'fixes')
 
 export const publicDir = resolve(
   __dirname,

--- a/src/backend/downloadmanager/utils.ts
+++ b/src/backend/downloadmanager/utils.ts
@@ -1,19 +1,13 @@
 import { gameManagerMap } from 'backend/storeManagers'
 import { logError, LogPrefix, logWarning } from 'backend/logger'
-import {
-  downloadFile,
-  isEpicServiceOffline,
-  sendGameStatusUpdate
-} from '../utils'
-import { DMStatus, InstallParams, Runner } from 'common/types'
+import { isEpicServiceOffline, sendGameStatusUpdate } from '../utils'
+import { DMStatus, InstallParams } from 'common/types'
 import i18next from 'i18next'
 import { notify, showDialogBoxModalAuto } from '../dialog/dialog'
 import { isOnline } from '../online_monitor'
 import pathModule from 'path'
-import { existsSync, mkdirSync, rmSync } from 'graceful-fs'
-import { storeMap } from 'common/utils'
+import { existsSync, rmSync } from 'graceful-fs'
 import { gogdlConfigPath } from 'backend/storeManagers/gog/constants'
-import { fixesPath } from 'backend/constants/paths'
 
 async function installQueueElement(params: InstallParams): Promise<{
   status: DMStatus
@@ -82,8 +76,6 @@ async function installQueueElement(params: InstallParams): Promise<{
   }
 
   try {
-    downloadFixesFor(appName, runner)
-
     const { status, error } = await gameManagerMap[runner].install(appName, {
       path: path.replaceAll("'", ''),
       installDlcs,
@@ -183,15 +175,6 @@ async function updateQueueElement(params: InstallParams): Promise<{
       status: 'done'
     })
   }
-}
-
-async function downloadFixesFor(appName: string, runner: Runner) {
-  const url = `https://raw.githubusercontent.com/Heroic-Games-Launcher/known-fixes/main/${storeMap[runner]}/${appName}-${storeMap[runner]}.json`
-  const dest = pathModule.join(fixesPath, `${appName}-${storeMap[runner]}.json`)
-  if (!existsSync(fixesPath)) {
-    mkdirSync(fixesPath, { recursive: true })
-  }
-  downloadFile({ url, dest, ignoreFailure: true })
 }
 
 export { installQueueElement, updateQueueElement }

--- a/src/backend/known_fixes/ipc_handler.ts
+++ b/src/backend/known_fixes/ipc_handler.ts
@@ -1,0 +1,13 @@
+import { backendEvents } from 'backend/backend_events'
+import { addHandler } from '../ipc'
+import { downloadFileIfNeeded, getKnownFixesFor } from './utils'
+import { logDebug, LogPrefix } from 'backend/logger'
+
+addHandler('getKnownFixes', (e, appName, runner) =>
+  getKnownFixesFor(appName, runner)
+)
+
+backendEvents.on('releasesInfoReady', (releasesInfo) => {
+  logDebug('Releases info ready, checking known fixes data', LogPrefix.Backend)
+  void downloadFileIfNeeded(releasesInfo.knownFixesSha)
+})

--- a/src/backend/known_fixes/utils.ts
+++ b/src/backend/known_fixes/utils.ts
@@ -1,13 +1,13 @@
 import { KnownFixesFile, Runner } from 'common/types'
-import { existsSync, readFileSync } from 'graceful-fs'
+import { createWriteStream, existsSync, readFileSync } from 'graceful-fs'
 import { storeMap } from 'common/utils'
 import { appFolder } from 'backend/constants/paths'
 import { logDebug, logInfo, LogPrefix, logWarning } from 'backend/logger'
 import { createMD5 } from 'backend/utils/releases'
 import { runOnceWhenOnline } from 'backend/online_monitor'
 import { axiosClient } from 'backend/utils'
-import { writeFile } from 'fs/promises'
 import { join } from 'path'
+import { pipeline } from 'stream/promises'
 
 const fixesPath = join(appFolder, 'known_fixes.json')
 
@@ -17,10 +17,10 @@ export function getKnownFixesFor(appName: string, runner: Runner) {
 
   try {
     const fixesContent = JSON.parse(
-      readFileSync(fixesPath).toString()
+      readFileSync(fixesPath, 'utf-8')
     ) as KnownFixesFile
 
-    return fixesContent[storeMap[runner] as keyof KnownFixesFile][appName]
+    return fixesContent[storeMap[runner]][appName]
   } catch (error) {
     // if we fail to download the json file, it can be malformed causing
     // JSON.parse to throw an exception
@@ -49,12 +49,9 @@ export async function downloadFileIfNeeded(latestFileHash: string) {
       'https://raw.githubusercontent.com/Heroic-Games-Launcher/known-fixes/main/known_fixes.json'
 
     try {
-      const { data } = await axiosClient.get<string>(url, {
-        responseType: 'text',
-        transformResponse: [(d) => d] // disable JSON parsing
-      })
-
-      await writeFile(fixesPath, data)
+      const response = await axiosClient.get(url, { responseType: 'stream' })
+      const fileStream = createWriteStream(fixesPath)
+      await pipeline(response.data, fileStream)
       logInfo(`Known Fixes data downloaded`, LogPrefix.Backend)
     } catch (error) {
       logWarning(

--- a/src/backend/known_fixes/utils.ts
+++ b/src/backend/known_fixes/utils.ts
@@ -1,0 +1,66 @@
+import { KnownFixesFile, Runner } from 'common/types'
+import { existsSync, readFileSync } from 'graceful-fs'
+import { storeMap } from 'common/utils'
+import { appFolder } from 'backend/constants/paths'
+import { logDebug, logInfo, LogPrefix, logWarning } from 'backend/logger'
+import { createMD5 } from 'backend/utils/releases'
+import { runOnceWhenOnline } from 'backend/online_monitor'
+import { axiosClient } from 'backend/utils'
+import { writeFile } from 'fs/promises'
+import { join } from 'path'
+
+const fixesPath = join(appFolder, 'known_fixes.json')
+
+export function getKnownFixesFor(appName: string, runner: Runner) {
+  if (runner === 'sideload') return null
+  if (!existsSync(fixesPath)) return null
+
+  try {
+    const fixesContent = JSON.parse(
+      readFileSync(fixesPath).toString()
+    ) as KnownFixesFile
+
+    return fixesContent[storeMap[runner] as keyof KnownFixesFile][appName]
+  } catch (error) {
+    // if we fail to download the json file, it can be malformed causing
+    // JSON.parse to throw an exception
+    logWarning(['Known fixes could not be loaded, ignoring.', error])
+    return null
+  }
+}
+
+export async function downloadFileIfNeeded(latestFileHash: string) {
+  if (process.env.CI === 'e2e') return
+
+  const localFileHash = await createMD5(fixesPath)
+
+  if (latestFileHash && localFileHash === latestFileHash) {
+    logDebug('Known Fixes data did not change. Skipping.', LogPrefix.Backend)
+    return
+  }
+
+  logDebug(
+    'Known Fixes data changed. Downloading latest file.',
+    LogPrefix.Backend
+  )
+
+  runOnceWhenOnline(async () => {
+    const url =
+      'https://raw.githubusercontent.com/Heroic-Games-Launcher/known-fixes/main/known_fixes.json'
+
+    try {
+      const { data } = await axiosClient.get<string>(url, {
+        responseType: 'text',
+        transformResponse: [(d) => d] // disable JSON parsing
+      })
+
+      await writeFile(fixesPath, data)
+      logInfo(`Known Fixes data downloaded`, LogPrefix.Backend)
+    } catch (error) {
+      logWarning(
+        `Failed download of Known Fixes data: ${error}`,
+        LogPrefix.Backend
+      )
+    }
+  })
+}

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -12,7 +12,6 @@ import {
   WineCommandArgs,
   SteamRuntime,
   GameSettings,
-  KnowFixesInfo,
   LaunchParams,
   StatusPromise
 } from 'common/types'
@@ -65,7 +64,6 @@ import {
   deleteAbortController
 } from './utils/aborthandler/aborthandler'
 import { download, isInstalled } from './wine/runtimes/runtimes'
-import { storeMap } from 'common/utils'
 import { runWineCommandOnGame } from './storeManagers/legendary/games'
 import { getMainWindow } from './main_window'
 import { sendFrontendMessage } from './ipc'
@@ -79,7 +77,6 @@ import { tsStore } from './constants/key_value_stores'
 import {
   defaultUmuPath,
   defaultWinePrefix,
-  fixesPath,
   flatpakHome,
   galaxyCommunicationExePath,
   gamesConfigPath,
@@ -103,6 +100,7 @@ import { gameAnticheatInfo } from './anticheat/utils'
 import type { PartialDeep } from 'type-fest'
 import type LogWriter from './logger/log_writer'
 import { isEnabled } from './storeManagers/legendary/eos_overlay/eos_overlay'
+import { getKnownFixesFor } from './known_fixes/utils'
 
 let powerDisplayId: number | null
 
@@ -1009,27 +1007,8 @@ async function prepareWineLaunch(
   return { success: true, envVars: envVars }
 }
 
-export function readKnownFixes(appName: string, runner: Runner) {
-  const fixPath = join(fixesPath, `${appName}-${storeMap[runner]}.json`)
-
-  if (!existsSync(fixPath)) return null
-
-  try {
-    const fixesContent = JSON.parse(
-      readFileSync(fixPath).toString()
-    ) as KnowFixesInfo
-
-    return fixesContent
-  } catch (error) {
-    // if we fail to download the json file, it can be malformed causing
-    // JSON.parse to throw an exception
-    logWarning(`Known fixes could not be applied, ignoring.\n${error}`)
-    return null
-  }
-}
-
 async function installFixes(appName: string, runner: Runner) {
-  const knownFixes = readKnownFixes(appName, runner)
+  const knownFixes = getKnownFixesFor(appName, runner)
 
   if (!knownFixes) return
 
@@ -1067,7 +1046,7 @@ async function installFixes(appName: string, runner: Runner) {
 }
 
 function getKnownFixesEnvVariables(appName: string, runner: Runner) {
-  const knownFixes = readKnownFixes(appName, runner)
+  const knownFixes = getKnownFixesFor(appName, runner)
 
   return knownFixes?.envVariables || {}
 }

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -78,12 +78,7 @@ import {
   logWarning
 } from './logger'
 import { gameInfoStore } from 'backend/storeManagers/legendary/electronStores'
-import {
-  launchEventCallback,
-  readKnownFixes,
-  runWineCommand,
-  validWine
-} from './launcher'
+import { launchEventCallback, runWineCommand, validWine } from './launcher'
 import { initQueue } from './downloadmanager/downloadqueue'
 import {
   initOnlineMonitor,
@@ -1379,10 +1374,6 @@ addListener('changeGameVersionPinnedStatus', (e, appName, runner, status) => {
   libraryManagerMap[runner].changeVersionPinnedStatus(appName, status)
 })
 
-addHandler('getKnownFixes', (e, appName, runner) =>
-  readKnownFixes(appName, runner)
-)
-
 addHandler('wine.isValidVersion', async (e, wineVersion: WineInstallation) =>
   validWine(wineVersion)
 )
@@ -1400,6 +1391,7 @@ import './logger/ipc_handler'
 import './wine/manager/ipc_handler'
 import './shortcuts/ipc_handler'
 import './anticheat/ipc_handler'
+import './known_fixes/ipc_handler'
 import './storeManagers/legendary/eos_overlay/ipc_handler'
 import './wine/runtimes/ipc_handler'
 import './downloadmanager/ipc_handler'

--- a/src/backend/utils/releases.ts
+++ b/src/backend/utils/releases.ts
@@ -1,5 +1,4 @@
 import { backendEvents } from 'backend/backend_events'
-import { isWindows } from 'backend/constants/environment'
 import { LogPrefix, logWarning } from 'backend/logger'
 import { runOnceWhenOnline } from 'backend/online_monitor'
 import { axiosClient } from 'backend/utils'
@@ -11,7 +10,6 @@ import { finished } from 'node:stream/promises'
 // fetch latest versions of wine/proton/gptk and anticheat data if needed
 export const fetchLastestReleases = () => {
   if (process.env.CI === 'e2e') return
-  if (isWindows) return
 
   runOnceWhenOnline(async () => {
     const url =

--- a/src/backend/utils/releases.ts
+++ b/src/backend/utils/releases.ts
@@ -5,7 +5,7 @@ import { axiosClient } from 'backend/utils'
 import { ReleasesInfo } from 'common/types'
 import { createHash } from 'node:crypto'
 import { createReadStream, existsSync } from 'graceful-fs'
-import { finished } from 'node:stream/promises'
+import { pipeline } from 'node:stream/promises'
 
 // fetch latest versions of wine/proton/gptk and anticheat data if needed
 export const fetchLastestReleases = () => {
@@ -32,7 +32,6 @@ export async function createMD5(filePath: string) {
 
   const hash = createHash('md5')
   const rStream = createReadStream(filePath)
-  rStream.pipe(hash)
-  await finished(rStream)
+  await pipeline(rStream, hash)
   return hash.digest('hex')
 }

--- a/src/backend/utils/releases.ts
+++ b/src/backend/utils/releases.ts
@@ -4,6 +4,9 @@ import { LogPrefix, logWarning } from 'backend/logger'
 import { runOnceWhenOnline } from 'backend/online_monitor'
 import { axiosClient } from 'backend/utils'
 import { ReleasesInfo } from 'common/types'
+import { createHash } from 'node:crypto'
+import { createReadStream, existsSync } from 'graceful-fs'
+import { finished } from 'node:stream/promises'
 
 // fetch latest versions of wine/proton/gptk and anticheat data if needed
 export const fetchLastestReleases = () => {
@@ -24,4 +27,14 @@ export const fetchLastestReleases = () => {
       )
     }
   })
+}
+
+export async function createMD5(filePath: string) {
+  if (!existsSync(filePath)) return ''
+
+  const hash = createHash('md5')
+  const rStream = createReadStream(filePath)
+  rStream.pipe(hash)
+  await finished(rStream)
+  return hash.digest('hex')
 }

--- a/src/backend/utils/uninstaller.ts
+++ b/src/backend/utils/uninstaller.ts
@@ -1,11 +1,10 @@
 import { GlobalConfig } from 'backend/config'
-import { fixesPath, gamesConfigPath } from 'backend/constants/paths'
+import { gamesConfigPath } from 'backend/constants/paths'
 import { notify } from 'backend/dialog/dialog'
 import { logError, logInfo, LogPrefix } from 'backend/logger'
 import { gameManagerMap } from 'backend/storeManagers'
 import { sendGameStatusUpdate } from 'backend/utils'
 import { Runner } from 'common/types'
-import { storeMap } from 'common/utils'
 import { Event } from 'electron'
 import { existsSync, readdirSync, rmSync } from 'graceful-fs'
 import i18next from 'i18next'
@@ -54,13 +53,6 @@ export const removePrefix = async (appName: string, runner: Runner) => {
 
   // if we got here, we are safe to delete this folder
   rmSync(winePrefix, { recursive: true })
-}
-
-const removeFixFile = (appName: string, runner: Runner) => {
-  const fixFilePath = join(fixesPath, `${appName}-${storeMap[runner]}.json`)
-  if (existsSync(fixFilePath)) {
-    rmSync(fixFilePath)
-  }
 }
 
 const removeSettingsAndLogs = (appName: string) => {
@@ -112,7 +104,6 @@ export const uninstallGameCallback = async (
     if (shouldRemoveSetting) {
       removeSettingsAndLogs(appName)
     }
-    removeFixFile(appName, runner)
 
     notify({ title, body: i18next.t('notify.uninstalled') })
     logInfo('Finished uninstalling', LogPrefix.Backend)

--- a/src/backend/wine/manager/ipc_handler.ts
+++ b/src/backend/wine/manager/ipc_handler.ts
@@ -10,6 +10,7 @@ import type { WineManagerStatus } from 'common/types'
 import { notify } from '../../dialog/dialog'
 import { t } from 'i18next'
 import { backendEvents } from 'backend/backend_events'
+import { isWindows } from 'backend/constants/environment'
 
 addHandler('installWineVersion', async (e, release) => {
   const onProgress = (state: WineManagerStatus) => {
@@ -59,6 +60,8 @@ addHandler('removeWineVersion', async (e, release) => {
 })
 
 backendEvents.on('releasesInfoReady', (releasesInfo) => {
+  if (isWindows) return
+
   logDebug('Releases info ready, checking wine releases', LogPrefix.Backend)
   void updateWineListsIfOutdated(releasesInfo)
 })

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -819,13 +819,20 @@ export type InstallInfo =
   | ZoomInstalledInfo
   | ZoomInstallInfo
 
-export interface KnowFixesInfo {
+export interface KnownFixesInfo {
   title: string
   notes?: Record<string, string>
   winetricks?: string[]
   runInPrefix?: string[]
   envVariables?: Record<string, string>
   wikiLink?: string
+}
+
+export interface KnownFixesFile {
+  amazon: Record<string, KnownFixesInfo>
+  epic: Record<string, KnownFixesInfo>
+  gog: Record<string, KnownFixesInfo>
+  zoom: Record<string, KnownFixesInfo>
 }
 
 export interface UploadedLogData {
@@ -863,4 +870,5 @@ export type ReleasesInfo = Record<
     shaMac: string
     shaLinux: string
   }
+  knownFixesSha: string
 }

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -22,7 +22,7 @@ import type {
   InstallInfo,
   InstallParams,
   InstallPlatform,
-  KnowFixesInfo,
+  KnownFixesInfo,
   LaunchOption,
   LaunchParams,
   MoveGameArgs,
@@ -247,7 +247,7 @@ interface AsyncIPCFunctions {
   removeFromSteam: (appName: string, runner: Runner) => Promise<void>
   isAddedToSteam: (appName: string, runner: Runner) => Promise<boolean>
   getAnticheatInfo: (appNamespace: string) => Promise<AntiCheatInfo | null>
-  getKnownFixes: (appName: string, runner: Runner) => KnowFixesInfo | null
+  getKnownFixes: (appName: string, runner: Runner) => KnownFixesInfo | null
   getEosOverlayStatus: () => {
     isInstalled: boolean
     version?: string

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,9 +1,9 @@
 import { Runner } from './types'
 
-export const storeMap: { [key in Runner]: string | undefined } = {
+export const storeMap = {
   legendary: 'epic',
   gog: 'gog',
   nile: 'amazon',
   sideload: undefined,
   zoom: 'zoom'
-}
+} as const satisfies Record<Runner, string | undefined>

--- a/src/frontend/hooks/hasKnownFixes.ts
+++ b/src/frontend/hooks/hasKnownFixes.ts
@@ -1,16 +1,6 @@
-import { useEffect, useState } from 'react'
-import { KnownFixesInfo, Runner } from 'common/types'
+import { useAwaited } from './useAwaited'
+import { Runner } from 'common/types'
 
 export const useKnownFixes = (appName: string, runner: Runner) => {
-  const [knownFixes, setKnownFixes] = useState<KnownFixesInfo | null>(null)
-
-  useEffect(() => {
-    void window.api
-      .getKnownFixes(appName, runner)
-      .then((info: KnownFixesInfo | null) => {
-        setKnownFixes(info)
-      })
-  }, [appName, runner])
-
-  return knownFixes
+  return useAwaited(window.api.getKnownFixes, appName, runner)
 }

--- a/src/frontend/hooks/hasKnownFixes.ts
+++ b/src/frontend/hooks/hasKnownFixes.ts
@@ -1,17 +1,16 @@
 import { useEffect, useState } from 'react'
-import { KnowFixesInfo, Runner } from 'common/types'
+import { KnownFixesInfo, Runner } from 'common/types'
 
-export const hasKnownFixes = (appName: string, runner: Runner) => {
-  const [knownFixes, setKnownFixes] = useState<KnowFixesInfo | null>(null)
+export const useKnownFixes = (appName: string, runner: Runner) => {
+  const [knownFixes, setKnownFixes] = useState<KnownFixesInfo | null>(null)
 
   useEffect(() => {
-    window.api
+    void window.api
       .getKnownFixes(appName, runner)
-      .then((info: KnowFixesInfo | null) => {
-        console.log({ info })
+      .then((info: KnownFixesInfo | null) => {
         setKnownFixes(info)
       })
-  }, [appName])
+  }, [appName, runner])
 
   return knownFixes
 }

--- a/src/frontend/hooks/useAwaited.ts
+++ b/src/frontend/hooks/useAwaited.ts
@@ -1,17 +1,15 @@
 import { useEffect, useState } from 'react'
 
-export function useAwaited<T>(getter: () => Promise<T>): T | null
-export function useAwaited<T>(getter: () => Promise<T>, defaultValue: T): T
-export function useAwaited<T>(
-  getter: () => Promise<T>,
-  defaultValue: T | null = null
+export function useAwaited<T, Args extends unknown[]>(
+  getter: (...args: Args) => Promise<T>,
+  ...args: Args
 ): T | null {
-  const [value, setValue] = useState<T | null>(defaultValue)
+  const [value, setValue] = useState<T | null>(null)
 
   useEffect(() => {
     // This is `setValue` as long as the component requesting the value is mounted
     let setValueIfMounted = setValue
-    getter().then(setValueIfMounted)
+    void getter(...args).then(setValueIfMounted)
     return () => {
       // TODO: Send signal to BE to abort the promise
       setValueIfMounted = () => {
@@ -19,7 +17,7 @@ export function useAwaited<T>(
         // requesting it no longer exists
       }
     }
-  }, [])
+  }, [getter, args])
 
   return value
 }

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -68,7 +68,7 @@ import { hasAnticheatInfo } from 'frontend/hooks/hasAnticheatInfo'
 import { hasHelp } from 'frontend/hooks/hasHelp'
 import Genres from './components/Genres'
 import ReleaseDate from './components/ReleaseDate'
-import { hasKnownFixes } from 'frontend/hooks/hasKnownFixes'
+import { useKnownFixes } from 'frontend/hooks/hasKnownFixes'
 import { openInstallGameModal } from 'frontend/state/InstallGameModal'
 import useSettingsContext from 'frontend/hooks/useSettingsContext'
 import SettingsContext from 'frontend/screens/Settings/SettingsContext'
@@ -139,7 +139,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
   const anticheatInfo = hasAnticheatInfo(gameInfo)
 
-  const knownFixes = hasKnownFixes(appName, runner)
+  const knownFixes = useKnownFixes(appName, runner)
 
   const isWin = platform === 'win32'
   const isLinux = platform === 'linux'


### PR DESCRIPTION
This PR changes the logic used to fetch game known fixes. Instead of downloading the info per-game during the game's installation, we now download a json file with all the known fixes at boot from https://github.com/Heroic-Games-Launcher/known-fixes/blob/main/known_fixes.json (it's only 16kb and it's only updated eventually only if we add new fixes, so nothing to worry at this point)

This has a lot of advantages both for the end user and for us:
- we can display the wiki links even for games that are not installed, this is really useful so users can find important information before installing a game (like if they want to install a Rockstar game on Mac, they can read they'll need the paid Crossover, so they can avoid downloading the game if they don't have it)
- we don't need to add extra code to the download manager, and we also don't need to remove the file when uninstalling a game
- now with the new method to get releases info from a single repo that reduces the number of requests we do at boot, this file will only be updated if needed based on the md5 of the local file and the md5 of the latest version (before we were trying to download a known fixes file for every game installation and we didn't know if there was a fix or not until we tried)
- with the previous logic, users would only get the known fixes updated for a game by reinstalling the game, now they get the fixes updated when they open heroic if there's anything new
- the pattern is more consistent with how we handle anticheat data (that is kinda similar metadata for games from another source) and the code is more contained in it's own module now
- this also solves a bug where Heroic wouldn't download known fixes for imported games!

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
