### PR TITLE
[UX] Add Proton-Sarek to wine manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Heroic would not be possible without the work done in many other projects:
 - Nile: https://github.com/imLinguin/nile
 - Comet: https://github.com/imLinguin/comet
 - GE-Proton: https://github.com/GloriousEggroll/proton-ge-custom
+- Proton-Sarek: https://github.com/pythonlover02/Proton-Sarek
 - umu-launcher: https://github.com/Open-Wine-Components/umu-launcher
 - DXVK: https://github.com/doitsujin/dxvk
 - VKD3D: https://github.com/HansKristian-Work/vkd3d-proton

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1024,6 +1024,7 @@
     },
     "wineExplanation": {
         "proton-ge": "GE-Proton is a Proton variant created by Glorious Eggroll. It is meant to be used along with the umu launcher (default in Heroic).",
+        "proton-sarek": "Proton-Sarek is a Proton variant created by pythonlover02. It is meant to be used with GPUs that do not support Vulkan 1.3+.",
         "wine-ge": "Wine-GE-Proton is a Wine variant created by Glorious Eggroll. It has been deprecated in favor of GE-Proton with the umu launcher."
     },
     "winetricks": {

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -815,7 +815,7 @@ function getDxvkUrl(): string {
   }
   if (any_gpu_supports_version([1, 1, 0])) {
     logInfo(
-      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to DXVK 1.10.3',
+      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to DXVK 1.10.3 for Wine, or use Proton-Sarek.',
       LogPrefix.ToolInstaller
     )
     return 'https://api.github.com/repos/doitsujin/dxvk/releases/tags/v1.10.3'
@@ -851,7 +851,7 @@ function getVkd3dUrl(): string {
   }
   if (any_gpu_supports_version([1, 1, 0])) {
     logInfo(
-      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to VKD3D 2.6',
+      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to VKD3D 2.6 for Wine, or use Proton-Sarek.',
       LogPrefix.ToolInstaller
     )
     return 'https://api.github.com/repos/Heroic-Games-Launcher/vkd3d-proton/releases/tags/v2.6'

--- a/src/backend/wine/manager/downloader/constants.ts
+++ b/src/backend/wine/manager/downloader/constants.ts
@@ -25,3 +25,7 @@ export const WINESTAGINGMACOS_URL =
 /// Url to Game Porting Toolkit from Gcenx github release page
 export const GPTK_URL =
   'https://api.github.com/repos/Gcenx/game-porting-toolkit/releases'
+
+/// Url for Proton Sarek github release page
+export const PROTON_SAREK_URL =
+  'https://api.github.com/repos/pythonlover02/Proton-Sarek/releases'

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -16,7 +16,8 @@ import {
   WINELUTRIS_URL,
   WINECROSSOVER_URL,
   WINESTAGINGMACOS_URL,
-  GPTK_URL
+  GPTK_URL,
+  PROTON_SAREK_URL
 } from './constants'
 import { VersionInfo, Repositorys, WineVersionInfo } from 'common/types'
 import {
@@ -143,6 +144,21 @@ async function getAvailableVersions({
           count: count
         })
           .then((fetchedReleases: VersionInfo[]) => {
+            releases.push(...fetchedReleases)
+          })
+          .catch((error: Error) => {
+            logError(error, LogPrefix.WineDownloader)
+          })
+        break
+      }
+      case Repositorys.PROTONSAREK: {
+        await fetchReleases({
+          url: PROTON_SAREK_URL,
+          type: 'Proton-Sarek',
+          count: count
+        })
+          .then((fetchedReleases: VersionInfo[]) => {
+            console.log(fetchedReleases)
             releases.push(...fetchedReleases)
           })
           .catch((error: Error) => {

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -42,6 +42,9 @@ function getLatestLocalVersions(): Record<string, string | undefined> {
         ?.date,
       latestGEProton: localWines.find(
         (wine) => wine.version === 'GE-Proton-latest'
+      )?.date,
+      latestProtonSarek: localWines.find(
+        (wine) => wine.version === 'Proton-Sarek-latest'
       )?.date
     }
   }
@@ -104,6 +107,14 @@ export function updateWineListsIfOutdated(releasesData: ReleasesInfo) {
       )
     )
       repositoriesToFetch.push(Repositorys.WINEGE)
+
+    if (
+      localVersionIsOlder(
+        latestLocalVersions.latestProtonSarek,
+        releasesData['proton-sarek']
+      )
+    )
+      repositoriesToFetch.push(Repositorys.PROTONSAREK)
   }
 
   if (isMac) {
@@ -155,7 +166,7 @@ async function updateWineVersionInfos(
             Repositorys.WINESTAGINGMACOS,
             Repositorys.GPTK
           ]
-        : [Repositorys.WINEGE, Repositorys.PROTONGE]
+        : [Repositorys.WINEGE, Repositorys.PROTONGE, Repositorys.PROTONSAREK]
     }
 
     await getAvailableVersions({

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -739,6 +739,7 @@ export type Type =
   | 'Wine-GE'
   | 'GE-Proton'
   | 'Proton'
+  | 'Proton-Sarek'
   | 'Wine-Lutris'
   | 'Wine-Kron4ek'
   | 'Wine-Crossover'
@@ -775,7 +776,8 @@ export enum Repositorys {
   WINELUTRIS,
   WINECROSSOVER,
   WINESTAGINGMACOS,
-  GPTK
+  GPTK,
+  PROTONSAREK
 }
 
 export type WineManagerStatus =
@@ -850,6 +852,7 @@ export type ReleasesInfo = Record<
   | 'game-porting-toolkit'
   | 'wine-staging'
   | 'wine-crossover'
+  | 'proton-sarek'
   | 'dxvk'
   | 'dxvk-mac'
   | 'dxmt'

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -91,6 +91,7 @@ export default function WineManager(): JSX.Element | null {
     WineManagerUISettings[]
   >([
     protonge,
+    { type: 'Proton-Sarek', value: 'protonsarek', enabled: isLinux },
     { type: 'Wine-GE', value: 'winege', enabled: isLinux },
     gamePortingToolkit,
     wineCrossover,
@@ -157,6 +158,16 @@ export default function WineManager(): JSX.Element | null {
             {t(
               'wineExplanation.proton-ge',
               'GE-Proton is a Proton variant created by Glorious Eggroll. It is meant to be used along with the umu launcher (default in Heroic).'
+            )}
+          </div>
+        )
+      case 'Proton-Sarek':
+        return (
+          <div className="infoBox">
+            <FontAwesomeIcon icon={faCheck} color={'green'} />
+            {t(
+              'wineExplanation.proton-sarek',
+              'Proton-Sarek is a Proton variant created by pythonlover02. It is meant to be used with GPUs that do not support Vulkan 1.3+.'
             )}
           </div>
         )


### PR DESCRIPTION
This PR add Proton-Sarek to the Wine Manager

I also updated the releases-info repo to include this https://github.com/Heroic-Games-Launcher/releases-info/blob/main/release-data.json#L18

I tested:
- installing different versions of proton-sarek
- running a game with different versions of proton-sarek

It seems to be fine running through umu but let me know if it should be disabled for this

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
