### PR TITLE
[Mac] Update DXMT in installed Wines if new version detected

### DIFF
--- a/src/backend/tools/dxmt.ts
+++ b/src/backend/tools/dxmt.ts
@@ -14,6 +14,7 @@ import {
   writeFileSync
 } from 'graceful-fs'
 import { toolsPath } from 'backend/constants/paths'
+import { wineDownloaderInfoStore } from 'backend/wine/manager/utils'
 
 const DXMT = {
   getLatest: () => {
@@ -40,59 +41,11 @@ const DXMT = {
     const wineFilePath = join(installDir, versionInfo.version)
     const wineCopyFilePath = `${wineFilePath}-DXMT`
     try {
-      // copy wine
       cpSync(wineFilePath, wineCopyFilePath, { recursive: true })
 
-      // copy dxmt files inside wine
-      const globalVersion = readFileSync(join(toolsPath, 'dxmt', 'latest_dxmt'))
-        .toString()
-        .split('\n')[0]
+      DXMT.copyLatestDXMTFiles(wineCopyFilePath)
 
-      const toolPath = join(toolsPath, 'dxmt', globalVersion)
-      const wineInternalPath = join(
-        wineCopyFilePath,
-        'Contents',
-        'Resources',
-        'wine',
-        'lib',
-        'wine'
-      )
-
-      const filesToCopy = [
-        'x86_64-windows/d3d10core.dll',
-        'x86_64-windows/d3d11.dll',
-        'x86_64-windows/dxgi.dll',
-        'x86_64-windows/nvapi64.dll',
-        'x86_64-windows/nvngx.dll',
-        'x86_64-windows/winemetal.dll',
-        'x86_64-unix/winemetal.so',
-        'i386-windows/d3d10core.dll',
-        'i386-windows/d3d11.dll',
-        'i386-windows/dxgi.dll',
-        'i386-windows/winemetal.dll'
-      ]
-
-      filesToCopy.forEach((file) => {
-        logDebug(
-          `Copying ${join(toolPath, file)} in ${join(wineInternalPath, file)}`,
-          LogPrefix.ToolInstaller
-        )
-        copyFileSync(join(toolPath, file), join(wineInternalPath, file))
-      })
-
-      // rename version in info.plist
-      const infoFilePath = join(wineCopyFilePath, 'Contents', 'Info.plist')
-      let content = readFileSync(infoFilePath, 'utf8')
-      content = content.replace(
-        /(<key>CFBundleShortVersionString<\/key>\n.*<string>)(.*)(<\/string>)/m,
-        '$1$2-DXMT$3'
-      )
-      content = content.replace(
-        /(<key>CFBundleVersion<\/key>\n.*<string>)(.*)(<\/string>)/m,
-        '$1$2-DXMT$3'
-      )
-
-      writeFileSync(infoFilePath, content)
+      DXMT.addDXMTSuffixInPlist(wineCopyFilePath)
     } catch (error) {
       logError(
         `Error copying wine staging for DXMT version ${error}`,
@@ -102,6 +55,11 @@ const DXMT = {
         rmSync(wineCopyFilePath, { recursive: true })
       }
     }
+  },
+  getCurrentDXMTVersion: () => {
+    return readFileSync(join(toolsPath, 'dxmt', 'latest_dxmt'))
+      .toString()
+      .split('\n')[0]
   },
   deleteWineCopy: async (versionInfo: WineVersionInfo) => {
     const dxmtVersionPath = `${versionInfo.installDir}-DXMT`
@@ -116,6 +74,57 @@ const DXMT = {
         )
       }
     }
+  },
+
+  copyLatestDXMTFiles: (pathToWine: string) => {
+    const dxmtVersion = DXMT.getCurrentDXMTVersion()
+
+    const pathToDXMT = join(toolsPath, 'dxmt', dxmtVersion)
+
+    const wineInternalPath = join(
+      pathToWine,
+      'Contents',
+      'Resources',
+      'wine',
+      'lib',
+      'wine'
+    )
+
+    const filesToCopy = [
+      'x86_64-windows/d3d10core.dll',
+      'x86_64-windows/d3d11.dll',
+      'x86_64-windows/dxgi.dll',
+      'x86_64-windows/nvapi64.dll',
+      'x86_64-windows/nvngx.dll',
+      'x86_64-windows/winemetal.dll',
+      'x86_64-unix/winemetal.so',
+      'i386-windows/d3d10core.dll',
+      'i386-windows/d3d11.dll',
+      'i386-windows/dxgi.dll',
+      'i386-windows/winemetal.dll'
+    ]
+
+    filesToCopy.forEach((file) => {
+      logDebug(
+        `Copying ${join(pathToDXMT, file)} in ${join(wineInternalPath, file)}`,
+        LogPrefix.ToolInstaller
+      )
+      copyFileSync(join(pathToDXMT, file), join(wineInternalPath, file))
+    })
+  },
+  addDXMTSuffixInPlist: (pathToWine: string) => {
+    const infoFilePath = join(pathToWine, 'Contents', 'Info.plist')
+    let content = readFileSync(infoFilePath, 'utf8')
+    content = content.replace(
+      /(<key>CFBundleShortVersionString<\/key>\n.*<string>)(.*)(<\/string>)/m,
+      '$1$2-DXMT$3'
+    )
+    content = content.replace(
+      /(<key>CFBundleVersion<\/key>\n.*<string>)(.*)(<\/string>)/m,
+      '$1$2-DXMT$3'
+    )
+
+    writeFileSync(infoFilePath, content)
   }
 }
 
@@ -130,4 +139,28 @@ backendEvents.on('wineVersionUninstalled', async (versionInfo) => {
   if (isMac && !isIntelMac && versionInfo.type === 'Wine-Staging-macOS') {
     await DXMT.deleteWineCopy(versionInfo)
   }
+})
+
+// Update DXMT version in `*-DXMT` wines if new version available
+backendEvents.on('releasesInfoReady', async (releasesInfo) => {
+  // TODO: should we store just the version instead of the file name?
+  const currentDXMTVersion = DXMT.getCurrentDXMTVersion()
+    .replace(/.*dxmt-/, '')
+    .replace(/-builtin.*/, '')
+
+  if (releasesInfo['dxmt'].tag === currentDXMTVersion) return
+
+  await DXMT.getLatest()
+
+  const availableWines = wineDownloaderInfoStore.get('wine-releases', [])
+  const installedWineStagingVersions = availableWines.filter(
+    (wine) => wine.type === 'Wine-Staging-macOS' && wine.isInstalled
+  )
+
+  installedWineStagingVersions.forEach((wine) => {
+    const wineWithDXMTFilePath = `${wine.installDir}-DXMT`
+
+    if (existsSync(wineWithDXMTFilePath))
+      DXMT.copyLatestDXMTFiles(wineWithDXMTFilePath)
+  })
 })


### PR DESCRIPTION
When I added the support for DXMT in one of the latest versions, since DXMT files were copied into copies of the wine file it was not being updated when new DXMT versions were released (only way to update DXMT was to reinstall the wine staging version).

This PR fixes that by using the new releasesInfo event and if the latest DXMT version is newer than the latest one installed locally it updates all DXMT wines with the new files.

I know we should actually use the `WINEDLLPATH_PREPEND` env variable for both DXVK-MacOS and DXMT to not have to copy files inside the wine file but until we implement that we can do this.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
