### PR TITLE
[FIX] Load wine versions on first run

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -30,6 +30,10 @@ import {
 } from './constants/paths'
 import { join } from 'path'
 import { spawnSync } from 'child_process'
+import {
+  updateWineVersionInfos,
+  wineDownloaderInfoStore
+} from './wine/manager/utils'
 
 function getSteamCompatFolder() {
   // Paths are from https://savelocation.net/steam-game-folder
@@ -186,6 +190,10 @@ abstract class GlobalConfig {
   public async getAlternativeWine(
     scanCustom = true
   ): Promise<WineInstallation[]> {
+    if (wineDownloaderInfoStore.get('wine-releases', []).length === 0) {
+      await updateWineVersionInfos(true)
+    }
+
     if (isMac) {
       const macOsWineSet = await this.getMacOsWineSet()
       return [...macOsWineSet]


### PR DESCRIPTION
I think this is an issue caused by the addition of the releases info refactor, but on a clean install of heroic, the wine manager is empty when you open it the first time and you have to click refresh to get the list populated.

This PR fixes that by getting all the info if the lists are totally empty so it only happens the first time.

How to reproduce the issue in main: start heroic with a new clean config folder > go to wine manager, it should be empty

with this PR it is populated

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
