### PR TITLE
[UX] Support multiple profiles

### DIFF
--- a/src/backend/anticheat/utils.ts
+++ b/src/backend/anticheat/utils.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { appFolder } from 'backend/constants/paths'
 import { isMac, isWindows } from 'backend/constants/environment'
 import { createHash } from 'node:crypto'
-import { createReadStream } from 'graceful-fs'
+import { createReadStream, existsSync } from 'graceful-fs'
 import { finished } from 'node:stream/promises'
 
 async function createMD5(filePath: string) {
@@ -24,20 +24,22 @@ async function downloadAntiCheatData(latestFileHash?: string) {
   if (process.env.CI === 'e2e') return
   if (isWindows) return
 
-  const localFileHash = await createMD5(anticheatDataPath)
+  if (existsSync(anticheatDataPath)) {
+    const localFileHash = await createMD5(anticheatDataPath)
 
-  if (latestFileHash && localFileHash === latestFileHash) {
+    if (latestFileHash && localFileHash === latestFileHash) {
+      logDebug(
+        'AreWeAnticheatYet data did not change. Skipping.',
+        LogPrefix.Backend
+      )
+      return
+    }
+
     logDebug(
-      'AreWeAnticheatYet data did not change. Skipping.',
+      'AreWeAnticheatYet data changed. Downloading latest file.',
       LogPrefix.Backend
     )
-    return
   }
-
-  logDebug(
-    'AreWeAnticheatYet data changed. Downloading latest file.',
-    LogPrefix.Backend
-  )
 
   runOnceWhenOnline(async () => {
     const url = isMac

--- a/src/backend/cache.ts
+++ b/src/backend/cache.ts
@@ -1,4 +1,5 @@
 import Store from 'electron-store'
+import { cacheStoresPath } from './constants/key_value_stores'
 
 export default class CacheStore<ValueType, KeyType extends string = string> {
   private readonly store: Store
@@ -20,7 +21,7 @@ export default class CacheStore<ValueType, KeyType extends string = string> {
     options?: { invalidateCheck?: (data: ValueType) => boolean }
   ) {
     this.store = new Store({
-      cwd: 'store_cache',
+      cwd: cacheStoresPath,
       name: filename,
       clearInvalidConfig: true
     })

--- a/src/backend/constants/key_value_stores.ts
+++ b/src/backend/constants/key_value_stores.ts
@@ -1,10 +1,36 @@
+import { env } from 'process'
 import { TypeCheckedStoreBackend } from '../electron_store'
+import { join } from 'path'
+
+export const storesPath = env.HEROIC_PROFILE
+  ? join(env.HEROIC_PROFILE, 'stores')
+  : 'stores'
+
+export const cacheStoresPath = env.HEROIC_PROFILE
+  ? join(env.HEROIC_PROFILE, 'store_cache')
+  : 'store_cache'
+
+export const gogStorePath = env.HEROIC_PROFILE
+  ? join(env.HEROIC_PROFILE, 'gog_store')
+  : 'gog_store'
+
+export const nileStorePath = env.HEROIC_PROFILE
+  ? join(env.HEROIC_PROFILE, 'nile_store')
+  : 'nile_store'
+
+export const sideloadAppsStorePath = env.HEROIC_PROFILE
+  ? join(env.HEROIC_PROFILE, 'sideload_apps')
+  : 'sideload_apps'
+
+export const zoomStorePath = env.HEROIC_PROFILE
+  ? join(env.HEROIC_PROFILE, 'zoom_store')
+  : 'zoom_store'
 
 export const configStore = new TypeCheckedStoreBackend('configStore', {
-  cwd: 'store'
+  cwd: storesPath
 })
 
 export const tsStore = new TypeCheckedStoreBackend('timestampStore', {
-  cwd: 'store',
+  cwd: storesPath,
   name: 'timestamp'
 })

--- a/src/backend/constants/paths.ts
+++ b/src/backend/constants/paths.ts
@@ -21,13 +21,22 @@ if (process.env.CI === 'e2e') {
 export const flatpakHome = env.XDG_DATA_HOME?.replace('/data', '') || homedir()
 export const userHome = isSnap ? env.SNAP_REAL_HOME! : homedir()
 
+// general `heroic` folder for shared elements like anticheat data or downloaded tools
 export const appFolder = join(configFolder, 'heroic')
-export const userDataPath = app.getPath('userData')
+// profile-specific subfolder for isolated data like configurations, installed games, etc
+export const profileFolder = env.HEROIC_PROFILE
+  ? join(configFolder, 'heroic', env.HEROIC_PROFILE)
+  : appFolder
+// this is used by gog to store it's user_auth.json file
+export const userDataPath = env.HEROIC_PROFILE
+  ? join(app.getPath('userData'), env.HEROIC_PROFILE)
+  : app.getPath('userData')
+
 export const toolsPath = join(appFolder, 'tools')
 export const runtimePath = join(toolsPath, 'runtimes')
 export const defaultUmuPath = join(runtimePath, 'umu', 'umu_run.py')
-export const configPath = join(appFolder, 'config.json')
-export const gamesConfigPath = join(appFolder, 'GamesConfig')
+export const configPath = join(profileFolder, 'config.json')
+export const gamesConfigPath = join(profileFolder, 'GamesConfig')
 export const heroicIconFolder = join(appFolder, 'icons')
 export const heroicInstallPath = join(userHome, 'Games', 'Heroic')
 const defaultWinePrefixDir = join(userHome, 'Games', 'Heroic', 'Prefixes')

--- a/src/backend/downloadmanager/downloadqueue.ts
+++ b/src/backend/downloadmanager/downloadqueue.ts
@@ -12,9 +12,10 @@ import { createRedistDMQueueElement } from 'backend/storeManagers/gog/redist'
 import { existsSync } from 'fs'
 import { gogRedistPath } from 'backend/storeManagers/gog/constants'
 import { onConnectivityChange } from 'backend/online_monitor'
+import { storesPath } from 'backend/constants/key_value_stores'
 
 const downloadManager = new TypeCheckedStoreBackend('downloadManager', {
-  cwd: 'store',
+  cwd: storesPath,
   name: 'download-manager'
 })
 

--- a/src/backend/logger/uploader.ts
+++ b/src/backend/logger/uploader.ts
@@ -8,9 +8,10 @@ import { getLogFilePath, logError, logInfo, LogPrefix } from '../logger'
 import { sendFrontendMessage } from '../ipc'
 
 import type { UploadedLogData } from 'common/types'
+import { storesPath } from 'backend/constants/key_value_stores'
 
 const uploadedLogFileStore = new TypeCheckedStoreBackend('uploadedLogs', {
-  cwd: 'store',
+  cwd: storesPath,
   name: 'uploadedLogs',
   accessPropertiesByDotNotation: false
 })

--- a/src/backend/migration/index.ts
+++ b/src/backend/migration/index.ts
@@ -1,3 +1,4 @@
+import { storesPath } from 'backend/constants/key_value_stores'
 import { TypeCheckedStoreBackend } from '../electron_store'
 import { logError, logInfo } from '../logger'
 
@@ -15,7 +16,7 @@ export default class MigrationSystem {
 
   constructor() {
     this.migrationsStore = new TypeCheckedStoreBackend('migrationsStore', {
-      cwd: 'store',
+      cwd: storesPath,
       name: 'migrations'
     })
   }

--- a/src/backend/storeManagers/gog/constants.ts
+++ b/src/backend/storeManagers/gog/constants.ts
@@ -1,7 +1,11 @@
-import { appFolder, toolsPath, userDataPath } from 'backend/constants/paths'
+import { profileFolder, toolsPath, userDataPath } from 'backend/constants/paths'
 import { join } from 'path'
 
-export const gogdlConfigPath = join(appFolder, 'gogdlConfig', 'heroic_gogdl')
+export const gogdlConfigPath = join(
+  profileFolder,
+  'gogdlConfig',
+  'heroic_gogdl'
+)
 export const gogSupportPath = join(gogdlConfigPath, 'gog-support')
 export const gogRedistPath = join(toolsPath, 'redist', 'gog')
 export const gogdlAuthConfig = join(userDataPath, 'gog_store', 'auth.json')

--- a/src/backend/storeManagers/gog/electronStores.ts
+++ b/src/backend/storeManagers/gog/electronStores.ts
@@ -6,17 +6,18 @@ import {
   GamesDBData,
   GogInstallInfo
 } from 'common/types/gog'
+import { gogStorePath } from 'backend/constants/key_value_stores'
 
 const installedGamesStore = new TypeCheckedStoreBackend(
   'gogInstalledGamesStore',
   {
-    cwd: 'gog_store',
+    cwd: gogStorePath,
     name: 'installed'
   }
 )
 
 const configStore = new TypeCheckedStoreBackend('gogConfigStore', {
-  cwd: 'gog_store'
+  cwd: gogStorePath
 })
 
 const apiInfoCache = new CacheStore<GamesDBData>('gog_api_info')
@@ -26,7 +27,7 @@ const achievementStore = new CacheStore<GOGAchievement[]>(
   null
 )
 const syncStore = new TypeCheckedStoreBackend('gogSyncStore', {
-  cwd: 'gog_store',
+  cwd: gogStorePath,
   name: 'saveTimestamps',
   clearInvalidConfig: true
 })
@@ -34,7 +35,7 @@ const syncStore = new TypeCheckedStoreBackend('gogSyncStore', {
 const installInfoStore = new CacheStore<GogInstallInfo>('gog_install_info')
 
 const privateBranchesStore = new TypeCheckedStoreBackend('gogPrivateBranches', {
-  cwd: 'gog_store',
+  cwd: gogStorePath,
   name: 'privateBranches',
   clearInvalidConfig: true
 })

--- a/src/backend/storeManagers/legendary/constants.ts
+++ b/src/backend/storeManagers/legendary/constants.ts
@@ -1,11 +1,11 @@
 import { isSnap } from 'backend/constants/environment'
-import { appFolder, toolsPath } from 'backend/constants/paths'
+import { profileFolder, toolsPath } from 'backend/constants/paths'
 import { join } from 'path'
 import { env } from 'process'
 
 export const legendaryConfigPath = isSnap
   ? join(env.XDG_CONFIG_HOME!, 'legendary')
-  : join(appFolder, 'legendaryConfig', 'legendary')
+  : join(profileFolder, 'legendaryConfig', 'legendary')
 export const legendaryUserInfo = join(legendaryConfigPath, 'user.json')
 export const legendaryInstalled = join(legendaryConfigPath, 'installed.json')
 export const thirdPartyInstalled = join(

--- a/src/backend/storeManagers/legendary/user.ts
+++ b/src/backend/storeManagers/legendary/user.ts
@@ -10,6 +10,7 @@ import { LegendaryCommand } from './commands'
 import { NonEmptyString } from './commands/base'
 import { configStore } from 'backend/constants/key_value_stores'
 import { legendaryUserInfo } from './constants'
+import { env } from 'process'
 
 export class LegendaryUser {
   public static async login(
@@ -65,7 +66,10 @@ export class LegendaryUser {
       return
     }
 
-    const ses = session.fromPartition('persist:epicstore')
+    let partition = 'persist:epicstore'
+    if (env.HEROIC_PROFILE) partition = `persist:${env.HEROIC_PROFILE}-epictore`
+
+    const ses = session.fromPartition(partition)
     await ses.clearStorageData()
     await ses.clearCache()
     await ses.clearAuthCache()

--- a/src/backend/storeManagers/nile/constants.ts
+++ b/src/backend/storeManagers/nile/constants.ts
@@ -1,7 +1,7 @@
-import { appFolder } from 'backend/constants/paths'
+import { profileFolder } from 'backend/constants/paths'
 import { join } from 'path'
 
-export const nileConfigPath = join(appFolder, 'nile_config', 'nile')
+export const nileConfigPath = join(profileFolder, 'nile_config', 'nile')
 export const nileInstalled = join(nileConfigPath, 'installed.json')
 export const nileLibrary = join(nileConfigPath, 'library.json')
 export const nileUserData = join(nileConfigPath, 'user.json')

--- a/src/backend/storeManagers/nile/electronStores.ts
+++ b/src/backend/storeManagers/nile/electronStores.ts
@@ -1,4 +1,5 @@
 import CacheStore from 'backend/cache'
+import { nileStorePath } from 'backend/constants/key_value_stores'
 import { TypeCheckedStoreBackend } from 'backend/electron_store'
 import { GameInfo } from 'common/types'
 import { NileInstallInfo } from 'common/types/nile'
@@ -10,5 +11,5 @@ export const libraryStore = new CacheStore<GameInfo[], 'library'>(
 )
 
 export const configStore = new TypeCheckedStoreBackend('nileConfigStore', {
-  cwd: 'nile_store'
+  cwd: nileStorePath
 })

--- a/src/backend/storeManagers/sideload/electronStores.ts
+++ b/src/backend/storeManagers/sideload/electronStores.ts
@@ -1,7 +1,8 @@
+import { sideloadAppsStorePath } from 'backend/constants/key_value_stores'
 import { TypeCheckedStoreBackend } from '../../electron_store'
 
 export const libraryStore = new TypeCheckedStoreBackend('sideloadedStore', {
-  cwd: 'sideload_apps',
+  cwd: sideloadAppsStorePath,
   name: 'library',
   clearInvalidConfig: true
 })

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -57,13 +57,17 @@ const openNewBrowserGameWindow = async ({
 }: BrowserGameOptions): Promise<boolean> => {
   const hostname = new URL(browserUrl).hostname
 
+  let partition = `persist:${hostname}`
+  if (window.heroicProfile !== 'default')
+    partition = `persist:${window.heroicProfile}-${hostname}`
+
   return new Promise((res) => {
     const browserGame = new BrowserWindow({
       icon: windowIcon,
       fullscreen: launchFullScreen ?? false,
       autoHideMenuBar: true,
       webPreferences: {
-        partition: `persist:${hostname}`
+        partition: partition
       }
     })
 

--- a/src/backend/storeManagers/zoom/electronStores.ts
+++ b/src/backend/storeManagers/zoom/electronStores.ts
@@ -2,17 +2,18 @@ import { TypeCheckedStoreBackend } from '../../electron_store'
 import CacheStore from '../../cache'
 import { GameInfo } from 'common/types'
 import { ZoomInstallInfo } from 'common/types/zoom'
+import { zoomStorePath } from 'backend/constants/key_value_stores'
 
 const installedGamesStore = new TypeCheckedStoreBackend(
   'zoomInstalledGamesStore',
   {
-    cwd: 'zoom_store',
+    cwd: zoomStorePath,
     name: 'installed'
   }
 )
 
 const configStore = new TypeCheckedStoreBackend('zoomConfigStore', {
-  cwd: 'zoom_store'
+  cwd: zoomStorePath
 })
 
 const libraryStore = new CacheStore<GameInfo[], 'games'>('zoom_library', null)

--- a/src/backend/tools/dxmt.ts
+++ b/src/backend/tools/dxmt.ts
@@ -57,9 +57,12 @@ const DXMT = {
     }
   },
   getCurrentDXMTVersion: () => {
-    return readFileSync(join(toolsPath, 'dxmt', 'latest_dxmt'))
-      .toString()
-      .split('\n')[0]
+    const versionFilePath = join(toolsPath, 'dxmt', 'latest_dxmt')
+    if (existsSync(versionFilePath)) {
+      return readFileSync(versionFilePath).toString().split('\n')[0]
+    } else {
+      return ''
+    }
   },
   deleteWineCopy: async (versionInfo: WineVersionInfo) => {
     const dxmtVersionPath = `${versionInfo.installDir}-DXMT`
@@ -143,6 +146,8 @@ backendEvents.on('wineVersionUninstalled', async (versionInfo) => {
 
 // Update DXMT version in `*-DXMT` wines if new version available
 backendEvents.on('releasesInfoReady', async (releasesInfo) => {
+  if (!isMac) return
+
   // TODO: should we store just the version instead of the file name?
   const currentDXMTVersion = DXMT.getCurrentDXMTVersion()
     .replace(/.*dxmt-/, '')

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -24,11 +24,12 @@ import { isLinux, isMac, isWindows } from 'backend/constants/environment'
 import { GlobalConfig } from '../../config'
 import { join } from 'path'
 import { backendEvents } from 'backend/backend_events'
+import { storesPath } from 'backend/constants/key_value_stores'
 
 export const wineDownloaderInfoStore = new TypeCheckedStoreBackend(
   'wineDownloaderInfoStore',
   {
-    cwd: 'store',
+    cwd: storesPath,
     name: 'wine-downloader-info'
   }
 )

--- a/src/frontend/components/UI/ChangelogModal/index.tsx
+++ b/src/frontend/components/UI/ChangelogModal/index.tsx
@@ -10,8 +10,9 @@ type Props = {
   dimissVersionCheck?: boolean
 }
 
-const storage = window.localStorage
-const lastChangelog = storage.getItem('last_changelog')?.replaceAll('"', '')
+const lastChangelog = window.storage
+  .getItem('last_changelog')
+  ?.replaceAll('"', '')
 
 export function ChangelogModal({ onClose, dimissVersionCheck }: Props) {
   const [currentChangelog, setCurrentChangelog] = useState<Release | null>(null)

--- a/src/frontend/components/UI/ExternalLinkDialog/index.tsx
+++ b/src/frontend/components/UI/ExternalLinkDialog/index.tsx
@@ -25,7 +25,7 @@ export default function ExternalLinkDialog() {
   }
 
   function onHideDialogChange() {
-    localStorage.setItem(
+    window.storage.setItem(
       SHOW_EXTERNAL_LINK_DIALOG_STORAGE_KEY,
       showDialog ? 'false' : 'true'
     )

--- a/src/frontend/components/UI/LanguageSelector/index.tsx
+++ b/src/frontend/components/UI/LanguageSelector/index.tsx
@@ -5,8 +5,6 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import { SelectField } from '..'
 import { MenuItem } from '@mui/material'
 
-const storage: Storage = window.localStorage
-
 export enum FlagPosition {
   NONE = 'none',
   PREPEND = 'prepend',
@@ -120,7 +118,7 @@ export default function LanguageSelector({
 
   const handleChangeLanguage = (newLanguage: string) => {
     window.api.changeLanguage(newLanguage)
-    storage.setItem('language', newLanguage)
+    window.storage.setItem('language', newLanguage)
     configStore.set('language', newLanguage)
     i18n.changeLanguage(newLanguage)
     setLanguage(newLanguage)

--- a/src/frontend/components/UI/Sidebar/components/HeroicVersion/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/HeroicVersion/index.tsx
@@ -16,8 +16,7 @@ type Release = {
   body?: string
 }
 
-const storage = window.localStorage
-const lastVersion = storage.getItem('last_version')?.replaceAll('"', '')
+const lastVersion = window.storage.getItem('last_version')?.replaceAll('"', '')
 
 export default React.memo(function HeroicVersion() {
   const { t } = useTranslation()
@@ -36,7 +35,7 @@ export default React.memo(function HeroicVersion() {
         window.api.logInfo('Updated to a new version, cleaaning up the cache.')
         window.api.clearCache(false, true)
       }
-      storage.setItem('last_version', JSON.stringify(version))
+      window.storage.setItem('last_version', JSON.stringify(version))
       setHeroicVersion(version)
     })
   }, [])

--- a/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
+++ b/src/frontend/components/UI/Sidebar/components/SidebarLinks/index.tsx
@@ -48,7 +48,7 @@ export default function SidebarLinks() {
     epic.username || gog.username || amazon.user_id || zoom.username
 
   async function handleRefresh() {
-    localStorage.setItem('scrollPosition', '0')
+    window.storage.setItem('scrollPosition', '0')
 
     const shouldRefresh =
       (epic.username && !epic.library.length) ||
@@ -62,7 +62,7 @@ export default function SidebarLinks() {
   }
 
   function handleExternalLink(linkCallback: () => void) {
-    const showDialogSetting = localStorage.getItem(
+    const showDialogSetting = window.storage.getItem(
       SHOW_EXTERNAL_LINK_DIALOG_STORAGE_KEY
     )
     const showExternalLinkDialog = showDialogSetting

--- a/src/frontend/components/UI/Sidebar/index.tsx
+++ b/src/frontend/components/UI/Sidebar/index.tsx
@@ -11,7 +11,7 @@ import HeroicIcon from 'frontend/assets/heroic-icon.svg?react'
 import { useNavigate } from 'react-router-dom'
 import { WebviewTag } from 'electron'
 
-let sidebarSize = localStorage.getItem('sidebar-width') || 240
+let sidebarSize = window.storage.getItem('sidebar-width') || 240
 const minWidth = 60
 const maxWidth = 400
 const collapsedWidth = 120
@@ -86,7 +86,7 @@ export default React.memo(function Sidebar() {
       document.body.removeEventListener('mouseup', finishDrag)
       document.body.removeEventListener('mouseleave', finishDrag)
       dragging = false
-      localStorage.setItem('sidebar-width', sidebarSize.toString())
+      window.storage.setItem('sidebar-width', sidebarSize.toString())
 
       // Re-enable pointer events on webview element
       const webviewEl = document.querySelector<WebviewTag>('webview')

--- a/src/frontend/components/UI/UninstallModal/index.tsx
+++ b/src/frontend/components/UI/UninstallModal/index.tsx
@@ -86,7 +86,6 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
     checkIfIsNative()
   }, [])
 
-  const storage: Storage = window.localStorage
   const uninstallGame = async () => {
     onClose()
 
@@ -99,7 +98,7 @@ const UninstallModal: React.FC<UninstallModalProps> = function ({
     if (runner === 'sideload' && location.pathname.match(/gamepage/)) {
       navigate('/#library')
     }
-    storage.removeItem(appName)
+    window.storage.removeItem(appName)
   }
 
   const showWineCheckbox = !isNative && !isDlc

--- a/src/frontend/helpers/electronStores.ts
+++ b/src/frontend/helpers/electronStores.ts
@@ -9,6 +9,31 @@ import {
 } from 'common/types/electron_store'
 import { GameInfo } from 'common/types'
 
+const profilePrefix =
+  window.heroicProfile === 'default' ? '' : `${window.heroicProfile}/`
+
+const storesPath = window.heroicProfile ? `${profilePrefix}stores` : 'stores'
+
+const cacheStoresPath = window.heroicProfile
+  ? `${profilePrefix}store_cache`
+  : 'store_cache'
+
+const gogStorePath = window.heroicProfile
+  ? `${profilePrefix}gog_store`
+  : 'gog_store'
+
+const nileStorePath = window.heroicProfile
+  ? `${profilePrefix}nile_store`
+  : 'nile_store'
+
+const sideloadAppsStorePath = window.heroicProfile
+  ? `${profilePrefix}sideload_apps`
+  : 'sideload_apps'
+
+const zoomStorePath = window.heroicProfile
+  ? `${profilePrefix}zoom_store`
+  : 'zoom_store'
+
 export class TypeCheckedStoreFrontend<
   Name extends ValidStoreName
 > implements TypeCheckedStore<Name> {
@@ -70,7 +95,7 @@ class CacheStore<ValueType, KeyType extends string = string> {
   constructor(filename: string, max_value_lifespan: number | null = 60 * 6) {
     this.storeName = filename
     window.api.storeNew(filename, {
-      cwd: 'store_cache',
+      cwd: cacheStoresPath,
       name: filename,
       clearInvalidConfig: true
     })
@@ -110,7 +135,7 @@ class CacheStore<ValueType, KeyType extends string = string> {
 }
 
 const configStore = new TypeCheckedStoreFrontend('configStore', {
-  cwd: 'store'
+  cwd: storesPath
 })
 
 const libraryStore = new CacheStore<GameInfo[], 'library'>(
@@ -121,7 +146,7 @@ const libraryStore = new CacheStore<GameInfo[], 'library'>(
 const wineDownloaderInfoStore = new TypeCheckedStoreFrontend(
   'wineDownloaderInfoStore',
   {
-    cwd: 'store',
+    cwd: storesPath,
     name: 'wine-downloader-info'
   }
 )
@@ -130,12 +155,12 @@ const gogLibraryStore = new CacheStore<GameInfo[], 'games'>('gog_library', null)
 const gogInstalledGamesStore = new TypeCheckedStoreFrontend(
   'gogInstalledGamesStore',
   {
-    cwd: 'gog_store',
+    cwd: gogStorePath,
     name: 'installed'
   }
 )
 const gogConfigStore = new TypeCheckedStoreFrontend('gogConfigStore', {
-  cwd: 'gog_store'
+  cwd: gogStorePath
 })
 
 const zoomLibraryStore = new CacheStore<GameInfo[], 'games'>(
@@ -145,12 +170,12 @@ const zoomLibraryStore = new CacheStore<GameInfo[], 'games'>(
 const zoomInstalledGamesStore = new TypeCheckedStoreFrontend(
   'zoomInstalledGamesStore',
   {
-    cwd: 'zoom_store',
+    cwd: zoomStorePath,
     name: 'installed'
   }
 )
 const zoomConfigStore = new TypeCheckedStoreFrontend('zoomConfigStore', {
-  cwd: 'zoom_store'
+  cwd: zoomStorePath
 })
 
 const nileLibraryStore = new CacheStore<GameInfo[], 'library'>(
@@ -158,21 +183,21 @@ const nileLibraryStore = new CacheStore<GameInfo[], 'library'>(
   null
 )
 const nileConfigStore = new TypeCheckedStoreFrontend('nileConfigStore', {
-  cwd: 'nile_store'
+  cwd: nileStorePath
 })
 
 const timestampStore = new TypeCheckedStoreFrontend('timestampStore', {
-  cwd: 'store',
+  cwd: storesPath,
   name: 'timestamp'
 })
 
 const sideloadLibrary = new TypeCheckedStoreFrontend('sideloadedStore', {
-  cwd: 'sideload_apps',
+  cwd: sideloadAppsStorePath,
   name: 'library'
 })
 
 const downloadManagerStore = new TypeCheckedStoreFrontend('downloadManager', {
-  cwd: 'store',
+  cwd: storesPath,
   name: 'download-manager'
 })
 

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -12,8 +12,6 @@ import { TFunction } from 'i18next'
 import { getGameInfo } from './index'
 import { DialogModalOptions } from 'frontend/types'
 
-const storage: Storage = window.localStorage
-
 type InstallArgs = {
   gameInfo: GameInfo
   installPath: string
@@ -107,7 +105,7 @@ async function install({
 
   // If the user changed the previous folder, the percentage should start from zero again.
   if (previousProgress && previousProgress.folder !== installPath) {
-    storage.removeItem(appName)
+    window.storage.removeItem(appName)
   }
 
   return window.api.install({
@@ -140,7 +138,7 @@ function handleStopInstallation(
       {
         text: t('box.yes'),
         onClick: () => {
-          storage.setItem(
+          window.storage.setItem(
             appName,
             JSON.stringify({ ...progress, folder: path })
           )
@@ -151,7 +149,7 @@ function handleStopInstallation(
         text: t('box.no'),
         onClick: () => {
           window.api.cancelDownload(true)
-          storage.removeItem(appName)
+          window.storage.removeItem(appName)
         }
       }
     ]

--- a/src/frontend/helpers/profile_local_storage.ts
+++ b/src/frontend/helpers/profile_local_storage.ts
@@ -1,0 +1,20 @@
+// Wrapper around the window's localStorage to prefix the profile name to all keys
+export class ProfileLocalStorage {
+  private profileSuffix
+
+  public constructor(profile: string) {
+    this.profileSuffix = profile === 'default' ? '' : `${profile}-`
+  }
+
+  public removeItem(key: string) {
+    return window.localStorage.removeItem(`${this.profileSuffix}${key}`)
+  }
+
+  public getItem(key: string) {
+    return window.localStorage.getItem(`${this.profileSuffix}${key}`)
+  }
+
+  public setItem(key: string, value: string) {
+    window.localStorage.setItem(`${this.profileSuffix}${key}`, value)
+  }
+}

--- a/src/frontend/hooks/constants.ts
+++ b/src/frontend/hooks/constants.ts
@@ -48,8 +48,7 @@ export function getStatusLabel({
   return statusMap[status] || t('gamepage:status.notinstalled')
 }
 
-const storage = window.localStorage
-const nonAvailbleGames = storage.getItem('nonAvailableGames') || '[]'
+const nonAvailbleGames = window.storage.getItem('nonAvailableGames') || '[]'
 const nonAvailbleGamesArray = JSON.parse(nonAvailbleGames)
 
 export async function handleNonAvailableGames(appName: string, runner: Runner) {
@@ -61,7 +60,7 @@ export async function handleNonAvailableGames(appName: string, runner: Runner) {
   if (!gameAvailable) {
     if (!nonAvailbleGamesArray.includes(appName)) {
       nonAvailbleGamesArray.push(appName)
-      storage.setItem(
+      window.storage.setItem(
         'nonAvailableGames',
         JSON.stringify(nonAvailbleGamesArray)
       )
@@ -69,7 +68,7 @@ export async function handleNonAvailableGames(appName: string, runner: Runner) {
   } else {
     if (nonAvailbleGamesArray.includes(appName)) {
       nonAvailbleGamesArray.splice(nonAvailbleGamesArray.indexOf(appName), 1)
-      storage.setItem(
+      window.storage.setItem(
         'nonAvailableGames',
         JSON.stringify(nonAvailbleGamesArray)
       )

--- a/src/frontend/hooks/hasProgress.ts
+++ b/src/frontend/hooks/hasProgress.ts
@@ -2,12 +2,10 @@ import { useCallback, useEffect, useState } from 'react'
 import { InstallProgress, Runner } from 'common/types'
 import { useInstallProgress } from 'frontend/state/InstallProgress'
 
-const storage: Storage = window.localStorage
-
 export const hasProgress = (appName: string, runner: Runner) => {
   const [previousProgress] = useState<InstallProgress>(
     JSON.parse(
-      storage.getItem(`${appName}_${runner}_progress`) || '{}'
+      window.storage.getItem(`${appName}_${runner}_progress`) || '{}'
     ) as InstallProgress
   )
 

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -13,6 +13,7 @@ import { configStore } from './helpers/electronStores'
 import { initOnlineMonitor } from './helpers/onlineMonitor'
 import { defaultThemes } from './components/UI/ThemeSelector'
 import Loading from './screens/Loading'
+import { ProfileLocalStorage } from './helpers/profile_local_storage'
 
 initOnlineMonitor()
 
@@ -30,11 +31,13 @@ const Backend = new HttpApi(null, {
 initGamepad()
 initShortcuts()
 
-const storage: Storage = window.localStorage
-storage.removeItem('nonAvailableGames')
+window.storage = new ProfileLocalStorage(window.heroicProfile)
+window.storage.removeItem('nonAvailableGames')
 
 const languageCode: string =
-  configStore.get_nodefault('language') ?? storage.getItem('language') ?? 'en'
+  configStore.get_nodefault('language') ??
+  window.storage.getItem('language') ??
+  'en'
 configStore.set('language', languageCode)
 document.querySelector('html')?.setAttribute('lang', languageCode)
 

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -169,8 +169,6 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
   const backRoute = location.state?.fromDM ? '/download-manager' : '/library'
 
-  const storage: Storage = window.localStorage
-
   const [currentTab, setCurrentTab] = useState<
     'info' | 'achievements' | 'extra' | 'requirements'
   >('info')
@@ -603,7 +601,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
   async function handleInstall(is_installed: boolean) {
     if (isQueued) {
-      storage.removeItem(appName)
+      window.storage.removeItem(appName)
       return window.api.removeFromDMQueue(appName)
     }
 

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -63,8 +63,6 @@ interface Card {
   dataTour?: string
 }
 
-const storage: Storage = window.localStorage
-
 const GameCard = ({
   hasUpdate,
   buttonClick,
@@ -551,7 +549,7 @@ const GameCard = ({
     }
 
     if (isQueued) {
-      storage.removeItem(appName)
+      window.storage.removeItem(appName)
       return window.api.removeFromDMQueue(appName)
     }
 

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -73,8 +73,6 @@ type DiskSpaceInfo = {
   spaceLeftAfter: string
 }
 
-const storage: Storage = window.localStorage
-
 function getUniqueKey(sdl: SelectiveDownload) {
   if (sdl.tags) {
     return sdl.tags.join(',')
@@ -104,7 +102,7 @@ export default function DownloadDialog({
   crossoverBottle
 }: Props) {
   const previousProgress = JSON.parse(
-    storage.getItem(appName) || '{}'
+    window.storage.getItem(appName) || '{}'
   ) as InstallProgress
   const { libraryStatus, platform, showDialogModal } =
     useContext(ContextProvider)

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -38,8 +38,6 @@ import LibraryTour from './components/LibraryTour'
 import AlphabetFilter from './components/AlphabetFilter'
 import { openInstallGameModal } from 'frontend/state/InstallGameModal'
 
-const storage = window.localStorage
-
 type SearchableGame = {
   original: GameInfo
   title: string
@@ -73,21 +71,24 @@ export default React.memo(function Library(): JSX.Element {
     <p>{t('help.content.library', 'Shows all owned games.')}</p>
   )
 
-  const [layout, setLayout] = useState(storage.getItem('layout') || 'grid')
+  const [layout, setLayout] = useState(
+    window.storage.getItem('layout') || 'grid'
+  )
   const handleLayout = (layout: string) => {
-    storage.setItem('layout', layout)
+    window.storage.setItem('layout', layout)
     setLayout(layout)
   }
 
   let initialStoresfilters
-  const storesFiltersString = storage.getItem('storesFilters')
+  const storesFiltersString = window.storage.getItem('storesFilters')
   if (storesFiltersString) {
     // If we have something stored, use that
     initialStoresfilters = JSON.parse(storesFiltersString) as StoresFilters
   } else {
     // Else, use the old `category` filter
     // TODO: we can remove this eventually after a few releases and just use the code of the if
-    const storedCategory = (storage.getItem('category') as Category) || 'all'
+    const storedCategory =
+      (window.storage.getItem('category') as Category) || 'all'
     initialStoresfilters = {
       legendary: epicCategories.includes(storedCategory),
       gog: gogCategories.includes(storedCategory),
@@ -101,12 +102,12 @@ export default React.memo(function Library(): JSX.Element {
     useState<StoresFilters>(initialStoresfilters)
 
   const setStoresFilters = (newFilters: StoresFilters) => {
-    storage.setItem('storesFilters', JSON.stringify(newFilters))
+    window.storage.setItem('storesFilters', JSON.stringify(newFilters))
     setStoresFilters_(newFilters)
   }
 
   let initialPlatformsfilters
-  const plaformsFiltersString = storage.getItem('platformsFilters')
+  const plaformsFiltersString = window.storage.getItem('platformsFilters')
   if (plaformsFiltersString) {
     // If we have something stored, use that
     initialPlatformsfilters = JSON.parse(
@@ -115,7 +116,7 @@ export default React.memo(function Library(): JSX.Element {
   } else {
     // Else, use the old `category` filter
     // TODO: we can remove this eventually after a few releases and just use the code of the if
-    const storedCategory = storage.getItem('filterPlatform') || 'all'
+    const storedCategory = window.storage.getItem('filterPlatform') || 'all'
     initialPlatformsfilters = {
       win: ['all', 'win'].includes(storedCategory),
       linux: ['all', 'linux'].includes(storedCategory),
@@ -129,76 +130,81 @@ export default React.memo(function Library(): JSX.Element {
   )
 
   const setPlatformsFilters = (newFilters: PlatformsFilters) => {
-    storage.setItem('platformsFilters', JSON.stringify(newFilters))
+    window.storage.setItem('platformsFilters', JSON.stringify(newFilters))
     setPlatformsFilters_(newFilters)
   }
 
   const [filterText, setFilterText] = useState('')
 
   const [showHidden, setShowHidden] = useState(
-    JSON.parse(storage.getItem('show_hidden') || 'false')
+    JSON.parse(window.storage.getItem('show_hidden') || 'false')
   )
   const handleShowHidden = (value: boolean) => {
-    storage.setItem('show_hidden', JSON.stringify(value))
+    window.storage.setItem('show_hidden', JSON.stringify(value))
     setShowHidden(value)
   }
 
   const [showFavouritesLibrary, setShowFavourites] = useState(
-    JSON.parse(storage.getItem('show_favorites') || 'false')
+    JSON.parse(window.storage.getItem('show_favorites') || 'false')
   )
   const handleShowFavourites = (value: boolean) => {
-    storage.setItem('show_favorites', JSON.stringify(value))
+    window.storage.setItem('show_favorites', JSON.stringify(value))
     setShowFavourites(value)
   }
 
   const [showInstalledOnly, setShowInstalledOnly] = useState(
-    JSON.parse(storage.getItem('show_installed_only') || 'false')
+    JSON.parse(window.storage.getItem('show_installed_only') || 'false')
   )
   const handleShowInstalledOnly = (value: boolean) => {
-    storage.setItem('show_installed_only', JSON.stringify(value))
+    window.storage.setItem('show_installed_only', JSON.stringify(value))
     setShowInstalledOnly(value)
   }
 
   const [showNonAvailable, setShowNonAvailable] = useState(
-    JSON.parse(storage.getItem('show_non_available') || 'true')
+    JSON.parse(window.storage.getItem('show_non_available') || 'true')
   )
   const handleShowNonAvailable = (value: boolean) => {
-    storage.setItem('show_non_available', JSON.stringify(value))
+    window.storage.setItem('show_non_available', JSON.stringify(value))
     setShowNonAvailable(value)
   }
 
   const [showSupportOfflineOnly, setSupportOfflineOnly] = useState(
-    JSON.parse(storage.getItem('show_support_offline_only') || 'false')
+    JSON.parse(window.storage.getItem('show_support_offline_only') || 'false')
   )
   const handleShowSupportOfflineOnly = (value: boolean) => {
-    storage.setItem('show_support_offline_only', JSON.stringify(value))
+    window.storage.setItem('show_support_offline_only', JSON.stringify(value))
     setSupportOfflineOnly(value)
   }
 
   const [showThirdPartyManagedOnly, setShowThirdPartyManagedOnly] = useState(
-    JSON.parse(storage.getItem('show_third_party_managed_only') || 'false')
+    JSON.parse(
+      window.storage.getItem('show_third_party_managed_only') || 'false'
+    )
   )
   const handleShowThirdPartyOnly = (value: boolean) => {
-    storage.setItem('show_third_party_managed_only', JSON.stringify(value))
+    window.storage.setItem(
+      'show_third_party_managed_only',
+      JSON.stringify(value)
+    )
     setShowThirdPartyManagedOnly(value)
   }
 
   const [showUpdatesOnly, setShowUpdatesOnly] = useState(
-    JSON.parse(storage.getItem('show_updates_only') || 'false')
+    JSON.parse(window.storage.getItem('show_updates_only') || 'false')
   )
   const handleShowUpdatesOnly = (value: boolean) => {
-    storage.setItem('show_updates_only', JSON.stringify(value))
+    window.storage.setItem('show_updates_only', JSON.stringify(value))
     setShowUpdatesOnly(value)
   }
 
   const [showCategories, setShowCategories] = useState(false)
 
   const [showAlphabetFilter, setShowAlphabetFilter] = useState(
-    JSON.parse(storage.getItem('showAlphabetFilter') || 'true')
+    JSON.parse(window.storage.getItem('showAlphabetFilter') || 'true')
   )
   const handleToggleAlphabetFilter = () => {
     const newValue = !showAlphabetFilter
-    storage.setItem('showAlphabetFilter', JSON.stringify(newValue))
+    window.storage.setItem('showAlphabetFilter', JSON.stringify(newValue))
     setShowAlphabetFilter(newValue)
   }
   const [alphabetFilterLetter, setAlphabetFilterLetter] = useState<
@@ -206,18 +212,18 @@ export default React.memo(function Library(): JSX.Element {
   >(null)
 
   const [sortDescending, setSortDescending] = useState(
-    JSON.parse(storage?.getItem('sortDescending') || 'false')
+    JSON.parse(window.storage?.getItem('sortDescending') || 'false')
   )
   function handleSortDescending(value: boolean) {
-    storage.setItem('sortDescending', JSON.stringify(value))
+    window.storage.setItem('sortDescending', JSON.stringify(value))
     setSortDescending(value)
   }
 
   const [sortInstalled, setSortInstalled] = useState(
-    JSON.parse(storage?.getItem('sortInstalled') || 'true')
+    JSON.parse(window.storage?.getItem('sortInstalled') || 'true')
   )
   function handleSortInstalled(value: boolean) {
-    storage.setItem('sortInstalled', JSON.stringify(value))
+    window.storage.setItem('sortInstalled', JSON.stringify(value))
     setSortInstalled(value)
   }
 
@@ -225,10 +231,12 @@ export default React.memo(function Library(): JSX.Element {
 
   //Remember scroll position
   useLayoutEffect(() => {
-    const scrollPosition = parseInt(storage?.getItem('scrollPosition') || '0')
+    const scrollPosition = parseInt(
+      window.storage?.getItem('scrollPosition') || '0'
+    )
 
     const storeScrollPosition = () => {
-      storage?.setItem(
+      window.storage?.setItem(
         'scrollPosition',
         document.body.scrollTop.toString() || '0'
       )
@@ -496,7 +504,8 @@ export default React.memo(function Library(): JSX.Element {
       }
 
       if (!showNonAvailable) {
-        const nonAvailbleGames = storage.getItem('nonAvailableGames') || '[]'
+        const nonAvailbleGames =
+          window.storage.getItem('nonAvailableGames') || '[]'
         const nonAvailbleGamesArray = JSON.parse(nonAvailbleGames)
         library = library.filter(
           (game) => !nonAvailbleGamesArray.includes(game.app_name)
@@ -508,7 +517,8 @@ export default React.memo(function Library(): JSX.Element {
       }
 
       if (!showNonAvailable) {
-        const nonAvailbleGames = storage.getItem('nonAvailableGames') || '[]'
+        const nonAvailbleGames =
+          window.storage.getItem('nonAvailableGames') || '[]'
         const nonAvailbleGamesArray = JSON.parse(nonAvailbleGames)
         library = library.filter(
           (game) => !nonAvailbleGamesArray.includes(game.app_name)

--- a/src/frontend/screens/Settings/components/AnalyticsDialog.tsx
+++ b/src/frontend/screens/Settings/components/AnalyticsDialog.tsx
@@ -10,10 +10,10 @@ export default function AnalyticsDialog() {
   const { t } = useTranslation()
 
   React.useEffect(() => {
-    if (!localStorage.getItem(STORAGE_KEY)) {
+    if (!window.storage.getItem(STORAGE_KEY)) {
       if (window.isE2ETesting) {
         // Skip showing the dialog in E2E tests
-        localStorage.setItem(STORAGE_KEY, 'true')
+        window.storage.setItem(STORAGE_KEY, 'true')
         return
       }
 
@@ -68,7 +68,7 @@ export default function AnalyticsDialog() {
           {
             text: t('analyticsModal.enable', 'Enable'),
             onClick: () => {
-              localStorage.setItem(STORAGE_KEY, 'true')
+              window.storage.setItem(STORAGE_KEY, 'true')
               window.api.setSetting({
                 appName: 'default',
                 key: 'analyticsOptIn',
@@ -80,7 +80,7 @@ export default function AnalyticsDialog() {
           {
             text: t('analyticsModal.disable', 'Disable'),
             onClick: () => {
-              localStorage.setItem(STORAGE_KEY, 'true')
+              window.storage.setItem(STORAGE_KEY, 'true')
               window.api.setSetting({
                 appName: 'default',
                 key: 'analyticsOptIn',

--- a/src/frontend/screens/Settings/components/ClearCache.tsx
+++ b/src/frontend/screens/Settings/components/ClearCache.tsx
@@ -9,8 +9,7 @@ const ClearCache = () => {
   const { t } = useTranslation()
 
   async function clearHeroicCache() {
-    const storage: Storage = window.localStorage
-    storage.removeItem('updates')
+    window.storage.removeItem('updates')
     window.api.clearCache(true)
     return refreshLibrary({ runInBackground: true })
   }

--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -105,7 +105,8 @@ export default function GamesSettings() {
     ? `${gameInfo.app_name}-setting_tab`
     : 'default'
   const latestTabIndex =
-    localStorage.getItem(localStorageKey) || getStartingTab(platform, gameInfo)
+    window.storage.getItem(localStorageKey) ||
+    getStartingTab(platform, gameInfo)
   const [value, setValue] = useState(latestTabIndex)
 
   const handleChange = (
@@ -114,7 +115,7 @@ export default function GamesSettings() {
   ) => {
     setValue(newValue)
     // Store the latest used tab index for the current game
-    localStorage.setItem(localStorageKey, newValue.toString())
+    window.storage.setItem(localStorageKey, newValue.toString())
   }
 
   useEffect(() => {

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -226,7 +226,7 @@ export default function WebView() {
           // - imLinguin - 01/07/24
           url.port = ''
           webview.loadURL(url.toString())
-          if (!localStorage.getItem('adtraction-warning')) {
+          if (!window.storage.getItem('adtraction-warning')) {
             setShowAdtractionWarning(true)
           }
         }
@@ -366,6 +366,10 @@ export default function WebView() {
     return <></>
   }
 
+  let partition = `persist:${startUrl === epicLoginUrl ? 'epicstore' : store}`
+  if (window.heroicProfile !== 'default')
+    partition = `persist:${window.heroicProfile}-${startUrl === epicLoginUrl ? 'epicstore' : store}`
+
   return (
     <div className="WebView">
       {webviewRef.current && (
@@ -380,7 +384,7 @@ export default function WebView() {
         key={store}
         ref={webviewRef}
         className="WebView__webview"
-        partition={`persist:${startUrl === epicLoginUrl ? 'epicstore' : store}`}
+        partition={partition}
         src={startUrl}
         allowpopups={trueAsStr}
         preload={webviewPreloadPath}
@@ -397,14 +401,14 @@ export default function WebView() {
           onClose={() => {
             setShowAdtractionWarning(false)
             if (dontShowAdtractionWarning)
-              localStorage.setItem('adtraction-warning', 'true')
+              window.storage.setItem('adtraction-warning', 'true')
           }}
         >
           <DialogHeader
             onClose={() => {
               setShowAdtractionWarning(false)
               if (dontShowAdtractionWarning)
-                localStorage.setItem('adtraction-warning', 'true')
+                window.storage.setItem('adtraction-warning', 'true')
             }}
           >
             {t('adtraction-locked.title', 'Adtraction is blocked')}

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -20,13 +20,14 @@ import { WineVersionInfo, Type, WineManagerUISettings } from 'common/types'
 import { hasHelp } from 'frontend/hooks/hasHelp'
 import classNames from 'classnames'
 import useGlobalState from 'frontend/state/GlobalStateV2'
+import { storesPath } from 'backend/constants/key_value_stores'
 
 const WineItem = lazy(
   async () => import('frontend/screens/WineManager/components/WineItem')
 )
 
 const configStore = new TypeCheckedStoreFrontend('wineManagerConfigStore', {
-  cwd: 'store'
+  cwd: storesPath
 })
 
 export default function WineManager(): JSX.Element | null {

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -41,7 +41,6 @@ import {
 import { IpcRendererEvent } from 'electron'
 import { NileRegisterData } from 'common/types/nile'
 
-const storage: Storage = window.localStorage
 const globalSettings = configStore.get_nodefault('settings')
 
 const RTL_LANGUAGES = ['fa', 'ar']
@@ -117,9 +116,11 @@ interface StateProps {
 
 // function to load the new key or fallback to the old one
 const loadCurrentCategories = () => {
-  const currentCategories = storage.getItem('current_custom_categories') || null
+  const currentCategories =
+    window.storage.getItem('current_custom_categories') || null
   if (!currentCategories) {
-    const currentCategory = storage.getItem('current_custom_category') || null
+    const currentCategory =
+      window.storage.getItem('current_custom_category') || null
     if (!currentCategory) {
       return []
     } else {
@@ -199,7 +200,7 @@ class GlobalState extends PureComponent<Props> {
     hiddenGames: configStore.get('games.hidden', []),
     currentCustomCategories: loadCurrentCategories(),
     sidebarCollapsed: JSON.parse(
-      storage.getItem('sidebar_collapsed') || 'false'
+      window.storage.getItem('sidebar_collapsed') || 'false'
     ),
     favouriteGames: configStore.get('games.favourites', []),
     customCategories: configStore.get('games.customCategories', {}),
@@ -231,7 +232,9 @@ class GlobalState extends PureComponent<Props> {
     dialogModalOptions: { showDialog: false },
     externalLinkDialogOptions: { showDialog: false },
     hideChangelogsOnStartup: globalSettings?.hideChangelogsOnStartup || false,
-    lastChangelogShown: JSON.parse(storage.getItem('last_changelog') || 'null'),
+    lastChangelogShown: JSON.parse(
+      window.storage.getItem('last_changelog') || 'null'
+    ),
     helpItems: {},
     experimentalFeatures: {
       enableHelp: false,
@@ -247,7 +250,7 @@ class GlobalState extends PureComponent<Props> {
   }
 
   setCurrentCustomCategories = (newCustomCategories: string[]) => {
-    storage.setItem(
+    window.storage.setItem(
       'current_custom_categories',
       JSON.stringify(newCustomCategories)
     )
@@ -502,7 +505,7 @@ class GlobalState extends PureComponent<Props> {
   }
 
   handleSuccessfulLogin = (runner: Runner) => {
-    storage.setItem('category', 'all')
+    window.storage.setItem('category', 'all')
     this.refreshLibrary({
       runInBackground: false,
       library: runner
@@ -811,7 +814,7 @@ class GlobalState extends PureComponent<Props> {
           library: runner
         })
 
-        storage.setItem('updates', JSON.stringify(updatedGamesUpdates))
+        window.storage.setItem('updates', JSON.stringify(updatedGamesUpdates))
         return this.setState({
           gameUpdates: updatedGamesUpdates,
           libraryStatus: newLibraryStatus
@@ -938,7 +941,9 @@ class GlobalState extends PureComponent<Props> {
     }
 
     if (!gameUpdates.length) {
-      const storedGameUpdates = JSON.parse(storage.getItem('updates') || '[]')
+      const storedGameUpdates = JSON.parse(
+        window.storage.getItem('updates') || '[]'
+      )
       this.setState({ gameUpdates: storedGameUpdates })
     }
 
@@ -993,10 +998,16 @@ class GlobalState extends PureComponent<Props> {
     const isRTL = RTL_LANGUAGES.includes(language)
     document.body.classList.toggle('isRTL', isRTL)
 
-    storage.setItem('updates', JSON.stringify(gameUpdates))
-    storage.setItem('sidebar_collapsed', JSON.stringify(sidebarCollapsed))
-    storage.setItem('hide_changelogs', JSON.stringify(hideChangelogsOnStartup))
-    storage.setItem('last_changelog', JSON.stringify(lastChangelogShown))
+    window.storage.setItem('updates', JSON.stringify(gameUpdates))
+    window.storage.setItem(
+      'sidebar_collapsed',
+      JSON.stringify(sidebarCollapsed)
+    )
+    window.storage.setItem(
+      'hide_changelogs',
+      JSON.stringify(hideChangelogsOnStartup)
+    )
+    window.storage.setItem('last_changelog', JSON.stringify(lastChangelogShown))
 
     const allowedPendingOps: Status[] = [
       'installing',

--- a/src/frontend/state/TourContext.tsx
+++ b/src/frontend/state/TourContext.tsx
@@ -40,13 +40,13 @@ type TourProviderProps = {
 export const TourProvider: React.FC<TourProviderProps> = ({ children }) => {
   const [tourState, setTourState] = useState<TourState>(() => {
     // Try to load tour state from localStorage
-    const savedState = localStorage.getItem('heroic-tour-state') || undefined
+    const savedState = window.storage.getItem('heroic-tour-state') || undefined
     return savedState ? (JSON.parse(savedState) as TourState) : defaultState
   })
 
   // Save state to localStorage whenever it changes
   React.useEffect(() => {
-    localStorage.setItem('heroic-tour-state', JSON.stringify(tourState))
+    window.storage.setItem('heroic-tour-state', JSON.stringify(tourState))
   }, [tourState])
 
   const startTour = (tourId: string) => {

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -17,6 +17,7 @@ import {
   InstallInfo
 } from 'common/types'
 import { NileLoginData, NileRegisterData } from 'common/types/nile'
+import { ProfileLocalStorage } from './helpers/profile_local_storage'
 
 export type Category =
   | 'all'
@@ -180,6 +181,8 @@ declare global {
     platform: NodeJS.Platform
     setCustomCSS: (cssString: string) => void
     isE2ETesting: boolean
+    heroicProfile: string
+    storage: ProfileLocalStorage
   }
 
   interface WindowEventMap {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,7 @@
 import { contextBridge } from 'electron'
 import api from './api'
 import { flatpakRuntimeVersion, isFlatpak, isSteamDeck, isSteamDeckGameMode } from 'backend/constants/environment'
+import { env } from 'process'
 
 contextBridge.exposeInMainWorld('api', api)
 contextBridge.exposeInMainWorld('isSteamDeckGameMode', isSteamDeckGameMode)
@@ -10,6 +11,7 @@ contextBridge.exposeInMainWorld('isSteamDeck', isSteamDeck)
 contextBridge.exposeInMainWorld('platform', process.platform)
 contextBridge.exposeInMainWorld('isE2ETesting', process.env.CI === 'e2e')
 contextBridge.exposeInMainWorld('flatpakRuntimeVersion', flatpakRuntimeVersion)
+contextBridge.exposeInMainWorld('heroicProfile', env.HEROIC_PROFILE || 'default')
 
 if (navigator.userAgent.includes('Windows')) {
   Object.defineProperty(navigator, 'platform', {


### PR DESCRIPTION
This PR adds a new feature to be able to open heroic with different profiles. This is NOT for opening multiple accounts simultaneously, it's also not for opening 2 instances of Heroic at the same time with different profiles.

## How to use it

When running heroic, we can define the `HEROIC_PROFILE` env variable to define a profile name to use internally by heroic and isolate configuration files and other files like cache stores, etc.

Passing no env variable is the "default" profile (files are stored at the root of the ~/.config/heroic folder, like it is now without this feature).

Passing the environment variable adds new folder under ~/.config/heroic with the profile name defined to create all files for that profile inside that folder.

<img width="200" height="772" alt="image" src="https://github.com/user-attachments/assets/3be1c043-915d-45bb-98ee-50a82db46f41" />

## Main changes

In the backend, the stores and other configuration files are configured to use the subfolder both in the frontend and the backend.

In the frontend:

Since we use the window's localStorage, I added a wrapper class that prefixes the profile name for all keys

<img width="348" height="355" alt="image" src="https://github.com/user-attachments/assets/db4620a2-ceaa-4dd5-bbab-545a4b8e1f07" />

Also, the webview partitions are prefixed for each profile to avoid sharing the login when opening the stores.

Finally, the configuration for the stores also uses the subfolders.

## some comments

I'm opening this PR mainly to get feedback of the approach and help with some tests. Currently the profile is only configured through the command line with the environment variable. I was thinking about keeping it like this for now and eventually we can implement an option to switch profiles in the frontend maybe? but I don't know how that would work yet.

The builds are failing (not sure why it can't import env but it can in other files), I didn't want to spend too much time checking that if this approach is not good.

I'll add more notes in the diff. The changes are not that many different changes but a few un many places

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
