### PR TITLE
[FIX] Don't look for anticheat file if not present, don't check DXMT if not M chip

### DIFF
--- a/src/backend/anticheat/utils.ts
+++ b/src/backend/anticheat/utils.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { appFolder } from 'backend/constants/paths'
 import { isMac, isWindows } from 'backend/constants/environment'
 import { createHash } from 'node:crypto'
-import { createReadStream } from 'graceful-fs'
+import { createReadStream, existsSync } from 'graceful-fs'
 import { finished } from 'node:stream/promises'
 
 async function createMD5(filePath: string) {
@@ -24,20 +24,22 @@ async function downloadAntiCheatData(latestFileHash?: string) {
   if (process.env.CI === 'e2e') return
   if (isWindows) return
 
-  const localFileHash = await createMD5(anticheatDataPath)
+  if (existsSync(anticheatDataPath)) {
+    const localFileHash = await createMD5(anticheatDataPath)
 
-  if (latestFileHash && localFileHash === latestFileHash) {
+    if (latestFileHash && localFileHash === latestFileHash) {
+      logDebug(
+        'AreWeAnticheatYet data did not change. Skipping.',
+        LogPrefix.Backend
+      )
+      return
+    }
+
     logDebug(
-      'AreWeAnticheatYet data did not change. Skipping.',
+      'AreWeAnticheatYet data changed. Downloading latest file.',
       LogPrefix.Backend
     )
-    return
   }
-
-  logDebug(
-    'AreWeAnticheatYet data changed. Downloading latest file.',
-    LogPrefix.Backend
-  )
 
   runOnceWhenOnline(async () => {
     const url = isMac

--- a/src/backend/tools/dxmt.ts
+++ b/src/backend/tools/dxmt.ts
@@ -57,9 +57,12 @@ const DXMT = {
     }
   },
   getCurrentDXMTVersion: () => {
-    return readFileSync(join(toolsPath, 'dxmt', 'latest_dxmt'))
-      .toString()
-      .split('\n')[0]
+    const versionFilePath = join(toolsPath, 'dxmt', 'latest_dxmt')
+    if (existsSync(versionFilePath)) {
+      return readFileSync(versionFilePath).toString().split('\n')[0]
+    } else {
+      return ''
+    }
   },
   deleteWineCopy: async (versionInfo: WineVersionInfo) => {
     const dxmtVersionPath = `${versionInfo.installDir}-DXMT`
@@ -143,6 +146,8 @@ backendEvents.on('wineVersionUninstalled', async (versionInfo) => {
 
 // Update DXMT version in `*-DXMT` wines if new version available
 backendEvents.on('releasesInfoReady', async (releasesInfo) => {
+  if (!isMac || isIntelMac) return
+
   // TODO: should we store just the version instead of the file name?
   const currentDXMTVersion = DXMT.getCurrentDXMTVersion()
     .replace(/.*dxmt-/, '')


### PR DESCRIPTION
This PR fixes 2 issues introduced by some of my previous PRs:

- with the introduction of the releases info refactor, one of the changes was to compare the MD5 of the local anticheat json file with the one in github, if the file didn't exist (like in a new installation), this was failing.
- in this [PR updating DXMT](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5427), there were 2 issues: for new installations the `latest_dxmt` version file doesn't exist, throwing an error; the other issue was that we should ONLY check for DXMT updates for mac with apple silicon chips and skip it for all the other platforms

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
