### PR TITLE
[FIX] Do not reinstall GPTK if WineCrossover or WineStaging or Crossover are installed

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -182,6 +182,10 @@ async function initializeWindow(): Promise<BrowserWindow> {
   setTimeout(async () => {
     // Will download Wine/GPTK if none was found
     const availableWine = await GlobalConfig.get().getAlternativeWine()
+    const installedWines = wineDownloaderInfoStore
+      .get('wine-releases', [])
+      .filter((wineInfo) => wineInfo.isInstalled)
+
     let shouldDownloadWine = !availableWine.length
 
     if (isMac && !isIntelMac) {
@@ -189,7 +193,7 @@ async function initializeWindow(): Promise<BrowserWindow> {
         (wine) => wine.type === 'toolkit'
       )
 
-      if (!toolkitDownloaded) {
+      if (!toolkitDownloaded && installedWines.length === 0) {
         shouldDownloadWine = true
       }
     }
@@ -1408,3 +1412,4 @@ import './wiki_game_info/ipc_handler'
 import './recent_games/ipc_handler'
 import './tools/ipc_handler'
 import './progress_bar'
+import { wineDownloaderInfoStore } from './wine/manager/utils'

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -155,6 +155,7 @@ import {
 import { supportedLanguages } from 'common/languages'
 import MigrationSystem from './migration'
 import { getAchievements as getAchievementsGOG } from './storeManagers/gog/games'
+import { wineDownloaderInfoStore } from './wine/manager/utils'
 
 app.commandLine?.appendSwitch('ozone-platform-hint', 'auto')
 if (isLinux) app.commandLine?.appendSwitch('--gtk-version', '3')
@@ -1419,4 +1420,3 @@ import './wiki_game_info/ipc_handler'
 import './recent_games/ipc_handler'
 import './tools/ipc_handler'
 import './progress_bar'
-import { wineDownloaderInfoStore } from './wine/manager/utils'

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -192,8 +192,15 @@ async function initializeWindow(): Promise<BrowserWindow> {
       const toolkitDownloaded = availableWine.some(
         (wine) => wine.type === 'toolkit'
       )
+      const crossoverDownloaded = availableWine.some(
+        (wine) => wine.type === 'crossover'
+      )
 
-      if (!toolkitDownloaded && installedWines.length === 0) {
+      if (
+        !toolkitDownloaded &&
+        !crossoverDownloaded &&
+        installedWines.length === 0
+      ) {
         shouldDownloadWine = true
       }
     }


### PR DESCRIPTION
This PR closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5428

We were always installing GPTK-Latest if no version of GPTK was found on the system, even when the user explicitly uninstalled it and made Wine-Staging the default or when Crossover is available (which has better compatibility than GPTK).

This respect that by checking not only if gptk is found but also if there's any other installed wine through the Wine Manager and if Crossover is installed.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
