### PR TITLE
[UX] Show a message to the user suggesting disabling verbose logs

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -99,6 +99,7 @@
     },
     "cloud_save_unsupported": "Unsupported",
     "disabled": "Disabled",
+    "disableLogsHint": "Looks like the game is working. You might want to disable verbose logs for better performance. Click the ^ icon and use the \"Play Now\" button without logs",
     "enabled": "Enabled",
     "game": {
         "achievements": "Achievements",

--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -7,6 +7,7 @@ import {
   CloudQueue,
   Download,
   Error,
+  Info,
   Pause,
   PlayArrow,
   Stop,
@@ -15,6 +16,7 @@ import {
 import classNames from 'classnames'
 import { GameInfo } from 'common/types'
 import useSetting from 'frontend/hooks/useSetting'
+import { timestampStore } from 'frontend/helpers/electronStores'
 
 interface Props {
   gameInfo: GameInfo
@@ -34,6 +36,7 @@ const MainButton = ({
   const { t } = useTranslation('gamepage')
   const { is } = useContext(GameContext)
   const [verboseLogs, setVerboseLogs] = useSetting('verboseLogs', true)
+  const playedTime = timestampStore.get_nodefault(gameInfo.app_name)
 
   function getPlayLabel(): React.ReactNode {
     if (is.syncing) {
@@ -183,81 +186,96 @@ const MainButton = ({
     )
   }
 
+  // Show hint to disable logs if the game is installed and was player for more than 5 minutes
+  const showDisableLogsHint =
+    is_installed && verboseLogs && playedTime && playedTime.totalPlayed > 60 * 5
+
   return (
-    <div className="playButtons">
-      {is_installed && !is.queued && !is.uninstalling && (
-        <>
-          <button
-            disabled={
-              is.reparing ||
-              is.moving ||
-              is.updating ||
-              is.uninstalling ||
-              is.syncing ||
-              is.launching ||
-              is.installingWinetricksPackages ||
-              is.installingRedist
-            }
-            autoFocus={true}
-            onClick={async () => handlePlay(gameInfo)}
-            className={classNames(
-              'button',
-              {
-                'is-secondary': !is_installed && !is.queued,
-                'is-success':
-                  is.syncing ||
-                  (!is.updating &&
-                    !is.playing &&
-                    is_installed &&
-                    !is.notAvailable),
-                'is-tertiary':
-                  is.playing ||
-                  (!is_installed && is.queued) ||
-                  (is_installed && is.notAvailable),
-                'is-disabled': is.updating
-              },
-              'mainBtn'
-            )}
-          >
-            {getPlayLabel()}
-          </button>
-          {altPlayAction()}
-        </>
+    <>
+      {showDisableLogsHint && (
+        <span className="disableLogsHint">
+          <Info />
+          {t(
+            'disableLogsHint',
+            'Looks like the game is working. You might want to disable verbose logs for better performance. Click the ^ icon and use the "Play Now" button without logs'
+          )}
+        </span>
       )}
-      {(!is_installed || is.queued) && (
-        <>
-          <button
-            onClick={async () => handleInstall(is_installed)}
-            disabled={
-              is.playing ||
-              is.updating ||
-              is.reparing ||
-              is.moving ||
-              is.uninstalling ||
-              is.notSupportedGame ||
-              is.notInstallable
-            }
-            autoFocus={true}
-            className={classNames(
-              'button',
-              {
-                'is-primary': is_installed,
-                'is-tertiary':
-                  is.notAvailable ||
-                  is.installing ||
-                  is.queued ||
-                  is.notInstallable,
-                'is-secondary': !is_installed && !is.queued
-              },
-              'mainBtn'
-            )}
-          >
-            {getButtonLabel()}
-          </button>
-          {altInstallAction()}
-        </>
-      )}
-    </div>
+      <div className="playButtons">
+        {is_installed && !is.queued && !is.uninstalling && (
+          <>
+            <button
+              disabled={
+                is.reparing ||
+                is.moving ||
+                is.updating ||
+                is.uninstalling ||
+                is.syncing ||
+                is.launching ||
+                is.installingWinetricksPackages ||
+                is.installingRedist
+              }
+              autoFocus={true}
+              onClick={async () => handlePlay(gameInfo)}
+              className={classNames(
+                'button',
+                {
+                  'is-secondary': !is_installed && !is.queued,
+                  'is-success':
+                    is.syncing ||
+                    (!is.updating &&
+                      !is.playing &&
+                      is_installed &&
+                      !is.notAvailable),
+                  'is-tertiary':
+                    is.playing ||
+                    (!is_installed && is.queued) ||
+                    (is_installed && is.notAvailable),
+                  'is-disabled': is.updating
+                },
+                'mainBtn'
+              )}
+            >
+              {getPlayLabel()}
+            </button>
+            {altPlayAction()}
+          </>
+        )}
+        {(!is_installed || is.queued) && (
+          <>
+            <button
+              onClick={async () => handleInstall(is_installed)}
+              disabled={
+                is.playing ||
+                is.updating ||
+                is.reparing ||
+                is.moving ||
+                is.uninstalling ||
+                is.notSupportedGame ||
+                is.notInstallable
+              }
+              autoFocus={true}
+              className={classNames(
+                'button',
+                {
+                  'is-primary': is_installed,
+                  'is-tertiary':
+                    is.notAvailable ||
+                    is.installing ||
+                    is.queued ||
+                    is.notInstallable,
+                  'is-secondary': !is_installed && !is.queued
+                },
+                'mainBtn'
+              )}
+            >
+              {getButtonLabel()}
+            </button>
+            {altInstallAction()}
+          </>
+        )}
+      </div>
+    </>
   )
 }
 

--- a/src/frontend/screens/Game/GamePage/index.css
+++ b/src/frontend/screens/Game/GamePage/index.css
@@ -262,11 +262,24 @@
       .buttons {
         display: flex;
         flex-direction: row;
+        flex-wrap: wrap;
         justify-content: flex-start;
         align-items: center;
         margin-top: 15px;
-        max-width: 250px;
         border-radius: 8px;
+
+        .disableLogsHint {
+          flex-basis: 100%;
+          flex-shrink: 0;
+          background: var(--status-warning);
+          color: black;
+          padding: 0.5rem 1rem;
+          & svg {
+            margin-inline-end: 0.2rem;
+            height: 1rem;
+            width: 1rem;
+          }
+        }
 
         .buttonWithIcon > svg {
           display: flex;


### PR DESCRIPTION
This might be a solution for https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5134

Currently, we have logs enabled by default to make support and troubleshooting easier, but when a game is already working correctly there's no real need to keep the verbose logs enabled and for some games with too much output this can really hurt performance.

This PR adds a message next to the play button suggesting the user to disable logs if they are enabled and the total played time is more than 5 minutes (I imagine that if there's a 5 minutes play time it means the game runs, which I think it's good enough).

This way, users can see the message and turn off the verbose logs and also learn about this and the possible impact.

<img width="1487" height="905" alt="Captura de pantalla 2026-04-02 a la(s) 12 55 56 a  m" src="https://github.com/user-attachments/assets/29ad1245-1b8f-4797-9b03-521a6573ed83" />
(the screenshot shows the message for a game with more than 1 minute, but I changed to 5 after taking the screenshot)

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
