### PR TITLE
Fix #4699: Read no more than the last 1 MB of log files to be shown

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -717,6 +717,7 @@
                 "nile": "Amazon / Nile log",
                 "zoom": "Zoom log"
             },
+            "error": "Internal error reading log file",
             "instructions": "Join our Discord and look for the \"#-support\" section. Read the pinned \"Read Me First | Frequently Asked Questions\" thread and follow the instructions to share these logs and any relevant information about your problem.",
             "instructions_title": "How to report a problem?",
             "join-heroic-discord": "Join our Discord",

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -644,6 +644,7 @@
         "log": {
             "copy-to-clipboard": "Kopiera loggen till urklipp/klippbord",
             "current-log": "Aktuell logg",
+            "error": "Internt fel vid läsning av loggfil",
             "instructions": "Gå med i vår Discord och leta efter kanalen \"#-support\". Läs den fästa \"Read Me First | Frequently Asked Questions\" tråden och följ instruktionerna för att dela dessa loggar och all relevant information om ditt problem.",
             "instructions_title": "Hur rapporterar jag problem?",
             "last-log": "Senaste logg",

--- a/src/backend/logger/ipc_handler.ts
+++ b/src/backend/logger/ipc_handler.ts
@@ -1,5 +1,5 @@
 import { addListener, addHandler } from 'backend/ipc'
-import { existsSync, readFileSync } from 'graceful-fs'
+import { existsSync } from 'graceful-fs'
 
 import { showItemInFolder } from '../utils'
 
@@ -10,13 +10,15 @@ import {
   deleteUploadedLogFile,
   getUploadedLogFiles
 } from './uploader'
+import { readLastBytes } from 'backend/utils/filesystem/read_last_bytes'
 
 addListener('logInfo', (e, message) => logInfo(message, LogPrefix.Frontend))
 addListener('logError', (e, message) => logError(message, LogPrefix.Frontend))
 
-addHandler('getLogContent', (event, appNameOrRunner) => {
+addHandler('getLogContent', async (event, appNameOrRunner) => {
   const logPath = getLogFilePath(appNameOrRunner)
-  return existsSync(logPath) ? readFileSync(logPath, 'utf-8') : ''
+  const MAX_LOG_BYTES = 1024 * 1024  // 1 MB
+  return existsSync(logPath) ? await readLastBytes(logPath, MAX_LOG_BYTES) : ''
 })
 
 addListener('showLogFileInFolder', (e, args) =>

--- a/src/backend/logger/ipc_handler.ts
+++ b/src/backend/logger/ipc_handler.ts
@@ -17,7 +17,7 @@ addListener('logError', (e, message) => logError(message, LogPrefix.Frontend))
 
 addHandler('getLogContent', async (event, appNameOrRunner) => {
   const logPath = getLogFilePath(appNameOrRunner)
-  const MAX_LOG_BYTES = 1024 * 1024  // 1 MB
+  const MAX_LOG_BYTES = 1024 * 1024 // 1 MB
   return existsSync(logPath) ? await readLastBytes(logPath, MAX_LOG_BYTES) : ''
 })
 

--- a/src/backend/logger/ipc_handler.ts
+++ b/src/backend/logger/ipc_handler.ts
@@ -11,6 +11,7 @@ import {
   getUploadedLogFiles
 } from './uploader'
 import { readLastBytes } from 'backend/utils/filesystem/read_last_bytes'
+import { decodeUTF8 } from 'backend/utils/strings'
 
 addListener('logInfo', (e, message) => logInfo(message, LogPrefix.Frontend))
 addListener('logError', (e, message) => logError(message, LogPrefix.Frontend))
@@ -18,7 +19,11 @@ addListener('logError', (e, message) => logError(message, LogPrefix.Frontend))
 addHandler('getLogContent', async (event, appNameOrRunner) => {
   const logPath = getLogFilePath(appNameOrRunner)
   const MAX_LOG_BYTES = 1024 * 1024 // 1 MB
-  return existsSync(logPath) ? await readLastBytes(logPath, MAX_LOG_BYTES) : ''
+  if (existsSync(logPath)) {
+    const buffer = await readLastBytes(logPath, MAX_LOG_BYTES)
+    return decodeUTF8(buffer)
+  }
+  return ''
 })
 
 addListener('showLogFileInFolder', (e, args) =>

--- a/src/backend/utils/__tests__/strings.test.ts
+++ b/src/backend/utils/__tests__/strings.test.ts
@@ -1,0 +1,29 @@
+import { decodeUTF8 } from '../strings'
+
+jest.mock('backend/logger', () => ({
+  logError: jest.fn()
+}))
+
+describe('decodeUTF8', () => {
+  it('decodes a simple string', () => {
+    const buffer = Buffer.from('Hello World')
+    expect(decodeUTF8(buffer)).toBe('Hello World')
+  })
+
+  it('skips leading continuation bytes', () => {
+    // '🚀' is 4 bytes: 0xF0 0x9F 0x9A 0x80
+    // Test broken rocket + 'a'
+    const buffer = Buffer.from([0x9f, 0x9a, 0x80, 0x61])
+    expect(decodeUTF8(buffer)).toBe('a')
+  })
+
+  it('does not skip if first byte is not a continuation byte', () => {
+    const buffer = Buffer.from([0x61, 0x80, 0x80])
+    expect(decodeUTF8(buffer)).toBe(buffer.toString('utf-8'))
+  })
+
+  it('translates empty buffer to empty string', () => {
+    const buffer = Buffer.alloc(0)
+    expect(decodeUTF8(buffer)).toBe('')
+  })
+})

--- a/src/backend/utils/filesystem/__tests__/read_last_bytes.test.ts
+++ b/src/backend/utils/filesystem/__tests__/read_last_bytes.test.ts
@@ -56,9 +56,8 @@ describe('readLastBytes', () => {
     expect(result).toBe('🚀abc')
   })
 
-  it('handles non-existent files gracefully', async () => {
-    const result = await readLastBytes('non_existent_file.log', 100)
-    expect(result).toBe('')
+  it('throws error for non-existent files', async () => {
+    await expect(readLastBytes('non_existent_file.log', 100)).rejects.toThrow()
     expect(logError).toHaveBeenCalled()
   })
 })

--- a/src/backend/utils/filesystem/__tests__/read_last_bytes.test.ts
+++ b/src/backend/utils/filesystem/__tests__/read_last_bytes.test.ts
@@ -15,7 +15,7 @@ describe('readLastBytes', () => {
     if (fs.existsSync(testFile)) {
       try {
         fs.unlinkSync(testFile)
-      } catch (e) {
+      } catch {
         // Ignore if file was already removed
       }
     }

--- a/src/backend/utils/filesystem/__tests__/read_last_bytes.test.ts
+++ b/src/backend/utils/filesystem/__tests__/read_last_bytes.test.ts
@@ -42,7 +42,11 @@ describe('readLastBytes', () => {
     // '🚀' is 4 bytes: 0xF0 0x9F 0x9A 0x80
     const emoji = '🚀'
     const abc = 'abc'
-    const content = Buffer.concat([Buffer.from(abc), Buffer.from(emoji), Buffer.from(abc)])
+    const content = Buffer.concat([
+      Buffer.from(abc),
+      Buffer.from(emoji),
+      Buffer.from(abc)
+    ])
     fs.writeFileSync(testFile, content)
 
     let result = await readLastBytes(testFile, 6)

--- a/src/backend/utils/filesystem/__tests__/read_last_bytes.test.ts
+++ b/src/backend/utils/filesystem/__tests__/read_last_bytes.test.ts
@@ -26,34 +26,16 @@ describe('readLastBytes', () => {
     const content = 'Hello World'
     fs.writeFileSync(testFile, content)
 
-    const result = await readLastBytes(testFile, 100)
-    expect(result).toBe(content)
+    const buffer = await readLastBytes(testFile, 100)
+    expect(buffer.toString()).toBe(content)
   })
 
   it('reads only the last n bytes if the file is larger than n', async () => {
     const content = '0123456789'
     fs.writeFileSync(testFile, content)
 
-    const result = await readLastBytes(testFile, 5)
-    expect(result).toBe('56789')
-  })
-
-  it('skips UTF-8 continuation bytes at the start', async () => {
-    // '🚀' is 4 bytes: 0xF0 0x9F 0x9A 0x80
-    const emoji = '🚀'
-    const abc = 'abc'
-    const content = Buffer.concat([
-      Buffer.from(abc),
-      Buffer.from(emoji),
-      Buffer.from(abc)
-    ])
-    fs.writeFileSync(testFile, content)
-
-    let result = await readLastBytes(testFile, 6)
-    expect(result).toBe('abc')
-
-    result = await readLastBytes(testFile, 7)
-    expect(result).toBe('🚀abc')
+    const buffer = await readLastBytes(testFile, 5)
+    expect(buffer.toString()).toBe('56789')
   })
 
   it('throws error for non-existent files', async () => {

--- a/src/backend/utils/filesystem/__tests__/read_last_bytes.test.ts
+++ b/src/backend/utils/filesystem/__tests__/read_last_bytes.test.ts
@@ -1,0 +1,60 @@
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { readLastBytes } from '../read_last_bytes'
+import { logError } from 'backend/logger'
+
+jest.mock('backend/logger', () => ({
+  logError: jest.fn()
+}))
+
+describe('readLastBytes', () => {
+  const testFile = path.join(os.tmpdir(), `heroic_test_log_${Date.now()}.log`)
+
+  afterEach(() => {
+    if (fs.existsSync(testFile)) {
+      try {
+        fs.unlinkSync(testFile)
+      } catch (e) {
+        // Ignore if file was already removed
+      }
+    }
+    jest.clearAllMocks()
+  })
+
+  it('reads the whole file if it is smaller than n', async () => {
+    const content = 'Hello World'
+    fs.writeFileSync(testFile, content)
+
+    const result = await readLastBytes(testFile, 100)
+    expect(result).toBe(content)
+  })
+
+  it('reads only the last n bytes if the file is larger than n', async () => {
+    const content = '0123456789'
+    fs.writeFileSync(testFile, content)
+
+    const result = await readLastBytes(testFile, 5)
+    expect(result).toBe('56789')
+  })
+
+  it('skips UTF-8 continuation bytes at the start', async () => {
+    // '🚀' is 4 bytes: 0xF0 0x9F 0x9A 0x80
+    const emoji = '🚀'
+    const abc = 'abc'
+    const content = Buffer.concat([Buffer.from(abc), Buffer.from(emoji), Buffer.from(abc)])
+    fs.writeFileSync(testFile, content)
+
+    let result = await readLastBytes(testFile, 6)
+    expect(result).toBe('abc')
+
+    result = await readLastBytes(testFile, 7)
+    expect(result).toBe('🚀abc')
+  })
+
+  it('handles non-existent files gracefully', async () => {
+    const result = await readLastBytes('non_existent_file.log', 100)
+    expect(result).toBe('')
+    expect(logError).toHaveBeenCalled()
+  })
+})

--- a/src/backend/utils/filesystem/read_last_bytes.ts
+++ b/src/backend/utils/filesystem/read_last_bytes.ts
@@ -2,21 +2,20 @@ import { promises as fsp } from 'graceful-fs'
 import { logError } from 'backend/logger'
 
 /**
- * Reads the last `n` bytes of a file, treats them as UTF-8 and returns a string promise for it.
+ * Reads the last `n` bytes of a file as a Buffer.
  * If the file is smaller than `n` bytes, the whole file is read.
  */
-export async function readLastBytes(path: string, n: number): Promise<string> {
+export async function readLastBytes(path: string, n: number): Promise<Buffer> {
   let fileHandle: fsp.FileHandle | undefined
-  let buffer = undefined
-  let position = 0
   try {
     fileHandle = await fsp.open(path, 'r')
     const { size: fileSize } = await fileHandle.stat()
     const bytesToRead = Math.min(fileSize, n)
-    position = fileSize - bytesToRead
+    const position = fileSize - bytesToRead
 
-    buffer = Buffer.alloc(bytesToRead)
+    const buffer = Buffer.alloc(bytesToRead)
     await fileHandle.read(buffer, 0, bytesToRead, position)
+    return buffer
   } catch (error) {
     logError(`Error reading last bytes of ${path}: ${error}`)
     throw error
@@ -24,24 +23,5 @@ export async function readLastBytes(path: string, n: number): Promise<string> {
     if (fileHandle !== undefined) {
       await fileHandle.close()
     }
-  }
-
-  // If not at the start of the file, ensure we start at a valid UTF-8 boundary.
-  try {
-    let skip = 0
-    if (position > 0) {
-      while (
-        skip < 4 &&
-        skip < buffer.length &&
-        (buffer[skip] & 0xc0) === 0x80
-      ) {
-        skip++
-      }
-    }
-    return buffer.subarray(skip).toString('utf-8')
-  } catch (error) {
-    // toString is pretty permissive, but let's have this path as a fallback
-    logError(`Error decoding ${path} as UTF-8: ${error}`)
-    throw error
   }
 }

--- a/src/backend/utils/filesystem/read_last_bytes.ts
+++ b/src/backend/utils/filesystem/read_last_bytes.ts
@@ -7,16 +7,27 @@ import { logError } from 'backend/logger'
  */
 export async function readLastBytes(path: string, n: number): Promise<string> {
   let fileHandle: fsp.FileHandle | undefined
+  let buffer = undefined
+  let position = 0
   try {
     fileHandle = await fsp.open(path, 'r')
     const { size: fileSize } = await fileHandle.stat()
     const bytesToRead = Math.min(fileSize, n)
-    const position = fileSize - bytesToRead
+    position = fileSize - bytesToRead
 
-    const buffer = Buffer.alloc(bytesToRead)
+    buffer = Buffer.alloc(bytesToRead)
     await fileHandle.read(buffer, 0, bytesToRead, position)
+  } catch (error) {
+    logError(`Error reading last bytes of ${path}: ${error}`)
+    throw error
+  } finally {
+    if (fileHandle !== undefined) {
+      await fileHandle.close()
+    }
+  }
 
-    // If not at the start of the file, ensure we start at a valid UTF-8 boundary.
+  // If not at the start of the file, ensure we start at a valid UTF-8 boundary.
+  try {
     let skip = 0
     if (position > 0) {
       while (
@@ -29,11 +40,8 @@ export async function readLastBytes(path: string, n: number): Promise<string> {
     }
     return buffer.subarray(skip).toString('utf-8')
   } catch (error) {
-    logError(`Error reading last bytes of ${path}: ${error}`)
+    // toString is pretty permissive, but let's have this path as a fallback
+    logError(`Error decoding ${path} as UTF-8: ${error}`)
     throw error
-  } finally {
-    if (fileHandle !== undefined) {
-      await fileHandle.close()
-    }
   }
 }

--- a/src/backend/utils/filesystem/read_last_bytes.ts
+++ b/src/backend/utils/filesystem/read_last_bytes.ts
@@ -26,9 +26,11 @@ export async function readLastBytes(path: string, n: number): Promise<string> {
     // If not at the start of the file, ensure we start at a valid UTF-8 boundary.
     let skip = 0
     if (position > 0) {
-      while (skip < 4 &&
-             skip < buffer.length &&
-             (buffer[skip] & 0xc0) === 0x80) {
+      while (
+        skip < 4 &&
+        skip < buffer.length &&
+        (buffer[skip] & 0xc0) === 0x80
+      ) {
         skip++
       }
     }

--- a/src/backend/utils/filesystem/read_last_bytes.ts
+++ b/src/backend/utils/filesystem/read_last_bytes.ts
@@ -30,7 +30,7 @@ export async function readLastBytes(path: string, n: number): Promise<string> {
     return buffer.subarray(skip).toString('utf-8')
   } catch (error) {
     logError(`Error reading last bytes of ${path}: ${error}`)
-    return ''
+    throw error
   } finally {
     if (fileHandle !== undefined) {
       await fileHandle.close()

--- a/src/backend/utils/filesystem/read_last_bytes.ts
+++ b/src/backend/utils/filesystem/read_last_bytes.ts
@@ -1,27 +1,20 @@
-import { open, stat, read, close } from 'graceful-fs'
-import { promisify } from 'util'
+import { promises as fsp } from 'graceful-fs'
 import { logError } from 'backend/logger'
-
-const openAsync = promisify(open)
-const statAsync = promisify(stat)
-const readAsync = promisify(read)
-const closeAsync = promisify(close)
 
 /**
  * Reads the last `n` bytes of a file, treats them as UTF-8 and returns a string promise for it.
  * If the file is smaller than `n` bytes, the whole file is read.
  */
 export async function readLastBytes(path: string, n: number): Promise<string> {
-  let fd: number | undefined
+  let fileHandle: fsp.FileHandle | undefined
   try {
-    const stats = await statAsync(path)
-    const fileSize = stats.size
+    fileHandle = await fsp.open(path, 'r')
+    const { size: fileSize } = await fileHandle.stat()
     const bytesToRead = Math.min(fileSize, n)
     const position = fileSize - bytesToRead
 
-    fd = await openAsync(path, 'r')
     const buffer = Buffer.alloc(bytesToRead)
-    await readAsync(fd, buffer, 0, bytesToRead, position)
+    await fileHandle.read(buffer, 0, bytesToRead, position)
 
     // If not at the start of the file, ensure we start at a valid UTF-8 boundary.
     let skip = 0
@@ -39,8 +32,8 @@ export async function readLastBytes(path: string, n: number): Promise<string> {
     logError(`Error reading last bytes of ${path}: ${error}`)
     return ''
   } finally {
-    if (fd !== undefined) {
-      await closeAsync(fd)
+    if (fileHandle !== undefined) {
+      await fileHandle.close()
     }
   }
 }

--- a/src/backend/utils/filesystem/read_last_bytes.ts
+++ b/src/backend/utils/filesystem/read_last_bytes.ts
@@ -1,0 +1,44 @@
+import { open, stat, read, close } from 'graceful-fs'
+import { promisify } from 'util'
+import { logError } from 'backend/logger'
+
+const openAsync = promisify(open)
+const statAsync = promisify(stat)
+const readAsync = promisify(read)
+const closeAsync = promisify(close)
+
+/**
+ * Reads the last `n` bytes of a file, treats them as UTF-8 and returns a string promise for it.
+ * If the file is smaller than `n` bytes, the whole file is read.
+ */
+export async function readLastBytes(path: string, n: number): Promise<string> {
+  let fd: number | undefined
+  try {
+    const stats = await statAsync(path)
+    const fileSize = stats.size
+    const bytesToRead = Math.min(fileSize, n)
+    const position = fileSize - bytesToRead
+
+    fd = await openAsync(path, 'r')
+    const buffer = Buffer.alloc(bytesToRead)
+    await readAsync(fd, buffer, 0, bytesToRead, position)
+
+    // If not at the start of the file, ensure we start at a valid UTF-8 boundary.
+    let skip = 0
+    if (position > 0) {
+      while (skip < 4 &&
+             skip < buffer.length &&
+             (buffer[skip] & 0xc0) === 0x80) {
+        skip++
+      }
+    }
+    return buffer.subarray(skip).toString('utf-8')
+  } catch (error) {
+    logError(`Error reading last bytes of ${path}: ${error}`)
+    return ''
+  } finally {
+    if (fd !== undefined) {
+      await closeAsync(fd)
+    }
+  }
+}

--- a/src/backend/utils/strings.ts
+++ b/src/backend/utils/strings.ts
@@ -1,0 +1,20 @@
+import { logError } from 'backend/logger'
+
+/**
+ * Decodes a buffer to a UTF-8 string.
+ * Any leading continuation bytes are skipped to get a clean string start.
+ *
+ * @param buffer The buffer to decode
+ */
+export function decodeUTF8(buffer: Buffer): string {
+  try {
+    let skip = 0
+    while (skip < 4 && skip < buffer.length && (buffer[skip] & 0xc0) === 0x80) {
+      skip++
+    }
+    return buffer.subarray(skip).toString('utf-8')
+  } catch (error) {
+    logError(`Error decoding buffer as UTF-8: ${error}`)
+    throw error
+  }
+}

--- a/src/backend/utils/strings.ts
+++ b/src/backend/utils/strings.ts
@@ -9,6 +9,7 @@ import { logError } from 'backend/logger'
 export function decodeUTF8(buffer: Buffer): string {
   try {
     let skip = 0
+    // If bit 7 is set and bit 6 is cleared, this is a continuation byte.
     while (skip < 4 && skip < buffer.length && (buffer[skip] & 0xc0) === 0x80) {
       skip++
     }

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -237,7 +237,7 @@ interface AsyncIPCFunctions {
   getCustomThemes: () => Promise<string[]>
   getThemeCSS: (theme: string) => Promise<string>
   isNative: (args: { appName: string; runner: Runner }) => boolean
-  getLogContent: (args: GetLogFileArgs) => string
+  getLogContent: (args: GetLogFileArgs) => Promise<string>
   installWineVersion: (release: WineVersionInfo) => Promise<void>
   refreshWineVersionInfo: (fetch?: boolean) => Promise<void>
   removeWineVersion: (release: WineVersionInfo) => Promise<void>

--- a/src/frontend/screens/Settings/sections/LogSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/LogSettings/index.tsx
@@ -107,17 +107,27 @@ export default function LogSettings() {
   const getLogContent = () => {
     if (isFetching.current) return
     isFetching.current = true
-    void window.api.getLogContent(showLogOf).then((content: string) => {
-      isFetching.current = false
-      if (!content) {
-        setLogFileContent(t('setting.log.no-file', 'No log file found.'))
+    void window.api
+      .getLogContent(showLogOf)
+      .then((content: string) => {
+        if (!content) {
+          setLogFileContent(t('setting.log.no-file', 'No log file found'))
+          setLogFileExist(false)
+          return
+        }
+        setLogFileContent(content)
+        setLogFileExist(true)
+      })
+      .catch(() => {
+        setLogFileContent(
+          t('setting.log.error', 'Internal error reading log file')
+        )
         setLogFileExist(false)
-        return setRefreshing(false)
-      }
-      setLogFileContent(content)
-      setLogFileExist(true)
-      setRefreshing(false)
-    })
+      })
+      .finally(() => {
+        isFetching.current = false
+        setRefreshing(false)
+      })
   }
 
   useEffect(() => {

--- a/src/frontend/screens/Settings/sections/LogSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/LogSettings/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react'
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -102,8 +102,13 @@ export default function LogSettings() {
     zoom.library
   ])
 
+  const isFetching = useRef<boolean>(false)
+
   const getLogContent = () => {
+    if (isFetching.current) return
+    isFetching.current = true
     void window.api.getLogContent(showLogOf).then((content: string) => {
+      isFetching.current = false
       if (!content) {
         setLogFileContent(t('setting.log.no-file', 'No log file found.'))
         setLogFileExist(false)


### PR DESCRIPTION
Fix #4699 by only reading the last 1 MB of log files.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary) (no affected docs that I know of)
