### PR TITLE
Fix: Build stage 4 (Download all helper binaries)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prepare": "husky install",
     "prettier": "prettier --check .",
     "prettier-fix": "prettier --write .",
-    "download-helper-binaries": "esbuild --bundle --platform=node --target=node21 meta/downloadHelperBinaries.ts | node",
+    "download-helper-binaries": "esbuild --bundle --platform=node --target=node21 --external:undici meta/downloadHelperBinaries.ts | node",
     "lint-translations": "esbuild --bundle --platform=node --target=node21 meta/lintTranslations.ts | node"
   },
   "dependencies": {


### PR DESCRIPTION
The stage 4 of the build process (Download all helper binaries using pnpm download-helper-binaries) failed due to the issue with node 22+

Fix: mark undici as external in download-helper-binaries esbuild command
undici is not listed as a project dependency, causing Yarn PnP to block esbuild from resolving it. Since Node 22+ bundles undici natively, marking it as external resolves the build error.


Tested locally. 