### PR TITLE
feat: Enhance Protocol Behavior for External Callers

### DIFF
--- a/src/backend/__tests__/powershell.test.ts
+++ b/src/backend/__tests__/powershell.test.ts
@@ -1,0 +1,16 @@
+import { toPowerShellArgumentList } from '../launcher'
+
+describe('toPowerShellArgumentList', () => {
+  test('preserves Windows paths without doubling backslashes', () => {
+    expect(
+      toPowerShellArgumentList([
+        'install',
+        '--base-path',
+        'C:\\Games\\Amazon',
+        'amzn1.adg.product.6463784a-5716-481d-b006-e19c26e9214c'
+      ])
+    ).toBe(
+      '"`"install`"","`"--base-path`"","`"C:\\Games\\Amazon`"","`"amzn1.adg.product.6463784a-5716-481d-b006-e19c26e9214c`""'
+    )
+  })
+})

--- a/src/backend/__tests__/protocol.test.ts
+++ b/src/backend/__tests__/protocol.test.ts
@@ -124,7 +124,8 @@ describe('protocol.ts --no-gui behavior', () => {
     app_name: 'test-game',
     title: 'Test Game',
     runner: 'legendary' as const,
-    is_installed: false
+    is_installed: false,
+    install: {}
   }
 
   const mockGameSettings = {
@@ -238,7 +239,7 @@ describe('protocol.ts --no-gui behavior', () => {
       expect(dialog.showMessageBox).toHaveBeenCalledWith(
         mockMainWindow,
         expect.objectContaining({
-          title: 'Heroic Protocol Status'
+          message: expect.stringContaining('Runner: legendary')
         })
       )
     })

--- a/src/backend/__tests__/protocol.test.ts
+++ b/src/backend/__tests__/protocol.test.ts
@@ -19,6 +19,8 @@ import { app, dialog } from 'electron'
 import { gameManagerMap } from '../storeManagers'
 import { getMainWindow } from '../main_window'
 import { sendFrontendMessage } from '../ipc'
+import { addToQueue } from '../downloadmanager/downloadqueue'
+import { uninstallGameCallback } from '../utils/uninstaller'
 
 // Mock electron modules
 jest.mock('electron', () => ({
@@ -37,6 +39,28 @@ jest.mock('../main_window', () => ({
 
 jest.mock('../ipc', () => ({
   sendFrontendMessage: jest.fn()
+}))
+
+jest.mock('../downloadmanager/downloadqueue', () => ({
+  addToQueue: jest.fn()
+}))
+
+jest.mock('../config', () => ({
+  GlobalConfig: {
+    get: () => ({
+      getSettings: () => ({
+        defaultInstallPath: '/default/install/path'
+      })
+    })
+  }
+}))
+
+jest.mock('../utils/uninstaller', () => ({
+  uninstallGameCallback: jest.fn()
+}))
+
+jest.mock('../dialog/dialog', () => ({
+  notify: jest.fn()
 }))
 
 jest.mock('../storeManagers', () => ({
@@ -121,6 +145,79 @@ describe('protocol.ts --no-gui behavior', () => {
     ;(gameManagerMap.gog.getGameInfo as jest.Mock).mockReturnValue({})
     ;(gameManagerMap.nile.getGameInfo as jest.Mock).mockReturnValue({})
     ;(gameManagerMap.sideload.getGameInfo as jest.Mock).mockReturnValue({})
+  })
+
+  describe('extended actions', () => {
+    beforeEach(() => {
+      mockIsCLINoGui.mockReturnValue(false)
+      mockGameInfo.is_installed = true
+    })
+
+    test('should queue install when direct install parameters are provided', async () => {
+      mockGameInfo.is_installed = false
+
+      await handleProtocol([
+        'heroic://install/legendary/test-game?path=C%3A%5CGames&platform=Windows'
+      ])
+
+      expect(addToQueue).toHaveBeenCalledTimes(1)
+      expect(sendFrontendMessage).not.toHaveBeenCalledWith(
+        'installGame',
+        'test-game',
+        'legendary'
+      )
+    })
+
+    test('should queue install using default settings when install details are omitted', async () => {
+      mockGameInfo.is_installed = false
+
+      await handleProtocol(['heroic://install/legendary/test-game'])
+
+      expect(addToQueue).toHaveBeenCalledTimes(1)
+      expect(dialog.showMessageBox).not.toHaveBeenCalled()
+    })
+
+    test('should call uninstall callback for uninstall action', async () => {
+      await handleProtocol(['heroic://uninstall/legendary/test-game'])
+
+      expect(uninstallGameCallback).toHaveBeenCalledTimes(1)
+      expect(uninstallGameCallback).toHaveBeenCalledWith(
+        expect.anything(),
+        'test-game',
+        'legendary',
+        false,
+        false
+      )
+    })
+
+    test('should call runner repair for repair action', async () => {
+      ;(gameManagerMap.legendary as any).repair = jest.fn().mockResolvedValue({})
+
+      await handleProtocol(['heroic://repair/legendary/test-game'])
+
+      expect(gameManagerMap.legendary.repair).toHaveBeenCalledWith('test-game')
+    })
+
+    test('should route verify action to repair implementation', async () => {
+      ;(gameManagerMap.legendary as any).repair = jest.fn().mockResolvedValue({})
+
+      await handleProtocol(['heroic://verify/legendary/test-game'])
+
+      expect(gameManagerMap.legendary.repair).toHaveBeenCalledWith('test-game')
+    })
+
+    test('should show status information for status action', async () => {
+      ;(dialog.showMessageBox as jest.Mock).mockResolvedValue({ response: 0 })
+
+      await handleProtocol(['heroic://status/legendary/test-game'])
+
+      expect(dialog.showMessageBox).toHaveBeenCalledWith(
+        mockMainWindow,
+        expect.objectContaining({
+          title: 'Heroic Protocol Status'
+        })
+      )
+    })
   })
 
   describe('when game is not installed', () => {

--- a/src/backend/__tests__/protocol.test.ts
+++ b/src/backend/__tests__/protocol.test.ts
@@ -161,6 +161,14 @@ describe('protocol.ts --no-gui behavior', () => {
       ])
 
       expect(addToQueue).toHaveBeenCalledTimes(1)
+      expect(addToQueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            path: 'C:\\Games',
+            platformToInstall: 'Windows'
+          })
+        })
+      )
       expect(sendFrontendMessage).not.toHaveBeenCalledWith(
         'installGame',
         'test-game',
@@ -177,8 +185,20 @@ describe('protocol.ts --no-gui behavior', () => {
       expect(dialog.showMessageBox).not.toHaveBeenCalled()
     })
 
+    test('should not queue install when the game is already installed', async () => {
+      mockGameInfo.is_installed = true
+
+      await handleProtocol([
+        'heroic://install/legendary/test-game?path=C%3A%5CGames&platform=Windows'
+      ])
+
+      expect(addToQueue).not.toHaveBeenCalled()
+    })
+
     test('should call uninstall callback for uninstall action', async () => {
-      await handleProtocol(['heroic://uninstall/legendary/test-game'])
+      await handleProtocol([
+        'heroic://uninstall/legendary/test-game?path=C%3A%5COtherPath'
+      ])
 
       expect(uninstallGameCallback).toHaveBeenCalledTimes(1)
       expect(uninstallGameCallback).toHaveBeenCalledWith(
@@ -193,7 +213,9 @@ describe('protocol.ts --no-gui behavior', () => {
     test('should call runner repair for repair action', async () => {
       ;(gameManagerMap.legendary as any).repair = jest.fn().mockResolvedValue({})
 
-      await handleProtocol(['heroic://repair/legendary/test-game'])
+      await handleProtocol([
+        'heroic://repair/legendary/test-game?path=C%3A%5COtherPath'
+      ])
 
       expect(gameManagerMap.legendary.repair).toHaveBeenCalledWith('test-game')
     })
@@ -201,7 +223,9 @@ describe('protocol.ts --no-gui behavior', () => {
     test('should route verify action to repair implementation', async () => {
       ;(gameManagerMap.legendary as any).repair = jest.fn().mockResolvedValue({})
 
-      await handleProtocol(['heroic://verify/legendary/test-game'])
+      await handleProtocol([
+        'heroic://verify/legendary/test-game?path=C%3A%5COtherPath'
+      ])
 
       expect(gameManagerMap.legendary.repair).toHaveBeenCalledWith('test-game')
     })
@@ -280,6 +304,28 @@ describe('protocol.ts --no-gui behavior', () => {
         expect(app.quit).not.toHaveBeenCalled()
         expect(mockMainWindow.show).not.toHaveBeenCalled()
       })
+    })
+
+    test('should not uninstall a game that is not installed', async () => {
+      await handleProtocol(['heroic://uninstall/legendary/test-game'])
+
+      expect(uninstallGameCallback).not.toHaveBeenCalled()
+    })
+
+    test('should not repair a game that is not installed', async () => {
+      ;(gameManagerMap.legendary as any).repair = jest.fn().mockResolvedValue({})
+
+      await handleProtocol(['heroic://repair/legendary/test-game'])
+
+      expect(gameManagerMap.legendary.repair).not.toHaveBeenCalled()
+    })
+
+    test('should not verify a game that is not installed', async () => {
+      ;(gameManagerMap.legendary as any).repair = jest.fn().mockResolvedValue({})
+
+      await handleProtocol(['heroic://verify/legendary/test-game'])
+
+      expect(gameManagerMap.legendary.repair).not.toHaveBeenCalled()
     })
   })
 

--- a/src/backend/__tests__/protocol.test.ts
+++ b/src/backend/__tests__/protocol.test.ts
@@ -212,7 +212,9 @@ describe('protocol.ts --no-gui behavior', () => {
     })
 
     test('should call runner repair for repair action', async () => {
-      ;(gameManagerMap.legendary as any).repair = jest.fn().mockResolvedValue({})
+      ;(gameManagerMap.legendary as any).repair = jest
+        .fn()
+        .mockResolvedValue({})
 
       await handleProtocol([
         'heroic://repair/legendary/test-game?path=C%3A%5COtherPath'
@@ -222,7 +224,9 @@ describe('protocol.ts --no-gui behavior', () => {
     })
 
     test('should route verify action to repair implementation', async () => {
-      ;(gameManagerMap.legendary as any).repair = jest.fn().mockResolvedValue({})
+      ;(gameManagerMap.legendary as any).repair = jest
+        .fn()
+        .mockResolvedValue({})
 
       await handleProtocol([
         'heroic://verify/legendary/test-game?path=C%3A%5COtherPath'
@@ -314,7 +318,9 @@ describe('protocol.ts --no-gui behavior', () => {
     })
 
     test('should not repair a game that is not installed', async () => {
-      ;(gameManagerMap.legendary as any).repair = jest.fn().mockResolvedValue({})
+      ;(gameManagerMap.legendary as any).repair = jest
+        .fn()
+        .mockResolvedValue({})
 
       await handleProtocol(['heroic://repair/legendary/test-game'])
 
@@ -322,7 +328,9 @@ describe('protocol.ts --no-gui behavior', () => {
     })
 
     test('should not verify a game that is not installed', async () => {
-      ;(gameManagerMap.legendary as any).repair = jest.fn().mockResolvedValue({})
+      ;(gameManagerMap.legendary as any).repair = jest
+        .fn()
+        .mockResolvedValue({})
 
       await handleProtocol(['heroic://verify/legendary/test-game'])
 

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -1730,10 +1730,7 @@ async function callRunner(
       isWindows && !!(await searchForExecutableOnPath('powershell'))
 
   if (shouldUsePowerShell) {
-    const argsAsString = commandParts
-      .map((part) => part.replaceAll('\\', '\\\\'))
-      .map((part) => `"\`"${part}\`""`)
-      .join(',')
+    const argsAsString = toPowerShellArgumentList(commandParts)
     commandParts = [
       '-NoProfile',
       'Start-Process',
@@ -1877,6 +1874,10 @@ async function callRunner(
   commandsRunning[key] = promise
 
   return promise
+}
+
+function toPowerShellArgumentList(commandParts: string[]): string {
+  return commandParts.map((part) => `"\`"${part}\`""`).join(',')
 }
 
 /**
@@ -2094,6 +2095,7 @@ export {
   setupWrappers,
   runWineCommand,
   callRunner,
+  toPowerShellArgumentList,
   getWinePath,
   launchEventCallback,
   getKnownFixesEnvVariables

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -1,7 +1,14 @@
 import { dialog, app } from 'electron'
 import { logError, logInfo, LogPrefix } from './logger'
 import i18next from 'i18next'
-import { GameInfo, LaunchOption, Runner } from 'common/types'
+import {
+  DMQueueElement,
+  GameInfo,
+  InstallArgs,
+  InstallPlatform,
+  LaunchOption,
+  Runner
+} from 'common/types'
 import { getMainWindow } from './main_window'
 import { sendFrontendMessage } from './ipc'
 import { gameManagerMap } from './storeManagers'
@@ -10,8 +17,33 @@ import { z } from 'zod'
 import { windowIcon } from './constants/paths'
 import { Path } from './schemas'
 import { isCLINoGui } from './constants/environment'
+import { addToQueue } from './downloadmanager/downloadqueue'
+import { GlobalConfig } from './config'
+import { uninstallGameCallback } from './utils/uninstaller'
+import { notify } from './dialog/dialog'
 
 const RUNNERS = z.enum(['legendary', 'gog', 'nile', 'sideload'])
+const PROTOCOL_ACTIONS = z.enum([
+  'ping',
+  'launch',
+  'install',
+  'uninstall',
+  'repair',
+  'verify',
+  'status'
+])
+
+type ProtocolAction = z.infer<typeof PROTOCOL_ACTIONS>
+
+type ProtocolRequest = {
+  action: ProtocolAction
+  appName?: string
+  runner?: Runner
+  args: string[]
+  altExe?: Path
+  install: Partial<InstallArgs>
+  rawUrl: URL
+}
 
 export function handleProtocol(args: string[]) {
   const urlStr = args.find((arg) => arg.startsWith('heroic://'))
@@ -21,11 +53,106 @@ export function handleProtocol(args: string[]) {
 
   logInfo(['Received', url.href], LogPrefix.ProtocolHandler)
 
-  switch (url.hostname) {
+  const request = parseProtocolRequest(url)
+  if (!request) return
+
+  return dispatchProtocolRequest(request)
+}
+
+function parseProtocolRequest(url: URL): ProtocolRequest | undefined {
+  const actionParse = PROTOCOL_ACTIONS.safeParse(url.hostname)
+  if (!actionParse.success) {
+    logError(`Unsupported protocol action: ${url.hostname}`, LogPrefix.ProtocolHandler)
+    return
+  }
+
+  let appName: string | null | undefined
+  let runnerStr: string | null | undefined
+  let args: string[] = []
+  let altExe: Path | undefined
+  const install: Partial<InstallArgs> = {}
+
+  // Windows automatically adds a trailing / to shortcuts
+  if (url.pathname && url.pathname !== '/') {
+    const splitPath = url.pathname.split('/').filter(Boolean)
+    appName = splitPath.pop()
+    runnerStr = splitPath.pop()
+  }
+
+  if (!appName) {
+    appName = url.searchParams.get('appName')
+  }
+
+  if (!runnerStr) {
+    runnerStr = url.searchParams.get('runner')
+  }
+
+  args = url.searchParams.getAll('arg').map(decodeURIComponent)
+
+  const altExeParameter = url.searchParams.get('altExe')
+  if (altExeParameter) {
+    const altExeParse = Path.safeParse(decodeURIComponent(altExeParameter))
+    if (altExeParse.success) altExe = altExeParse.data
+  }
+
+  const pathParameter = url.searchParams.get('path')
+  if (pathParameter) {
+    const pathParse = Path.safeParse(decodeURIComponent(pathParameter))
+    if (pathParse.success) install.path = pathParse.data
+  }
+
+  const platformParameter = url.searchParams.get('platform')
+  if (platformParameter) {
+    install.platformToInstall = platformParameter as InstallPlatform
+  }
+
+  const installLanguage = url.searchParams.get('installLanguage')
+  if (installLanguage) install.installLanguage = installLanguage
+
+  const build = url.searchParams.get('build')
+  if (build) install.build = build
+
+  const branch = url.searchParams.get('branch')
+  if (branch) install.branch = branch
+
+  const installDlcs = url.searchParams.getAll('dlc').map(decodeURIComponent)
+  if (installDlcs.length) install.installDlcs = installDlcs
+
+  const sdlList = url.searchParams.getAll('sdl').map(decodeURIComponent)
+  if (sdlList.length) install.sdlList = sdlList
+
+  let runner: Runner | undefined
+  const runnerParse = RUNNERS.safeParse(runnerStr)
+  if (runnerParse.success) {
+    runner = runnerParse.data
+  }
+
+  return {
+    action: actionParse.data,
+    appName: appName || undefined,
+    runner,
+    args,
+    altExe,
+    install,
+    rawUrl: url
+  }
+}
+
+function dispatchProtocolRequest(request: ProtocolRequest) {
+  switch (request.action) {
     case 'ping':
-      return handlePing(url)
+      return handlePing(request.rawUrl)
     case 'launch':
-      return handleLaunch(url)
+      return handleLaunch(request)
+    case 'install':
+      return handleInstall(request)
+    case 'uninstall':
+      return handleUninstall(request)
+    case 'repair':
+    case 'verify':
+      return handleRepair(request)
+    case 'status':
+      return handleStatus(request)
     default:
       return
   }
@@ -35,44 +162,12 @@ function handlePing(url: URL) {
   logInfo(['Received ping! Args:', url.searchParams], LogPrefix.ProtocolHandler)
 }
 
-async function handleLaunch(url: URL) {
-  let appName
-  let runnerStr
-  let args: string[] = []
-  let altExe: Path | undefined = undefined
-
-  // Windows automatically adds a trailing / to shortcuts
-  if (url.pathname && url.pathname !== '/') {
-    // Old-style pathname URLs:
-    // - `heroic://launch/Quail`
-    // - `heroic://launch/legendary/Quail`
-    const splitPath = url.pathname.split('/').filter(Boolean)
-    appName = splitPath.pop()
-    runnerStr = splitPath.pop()
-  } else {
-    // New-style params URL:
-    // `heroic://launch?appName=Quail&runner=legendary&arg=foo&arg=bar`
-    appName = url.searchParams.get('appName')
-    runnerStr = url.searchParams.get('runner')
-    args = url.searchParams.getAll('arg').map(decodeURIComponent)
-
-    const altExeParameter = url.searchParams.get('altExe')
-    if (altExeParameter) {
-      const altExeParse = Path.safeParse(decodeURIComponent(altExeParameter))
-      if (altExeParse.success) altExe = altExeParse.data
-    }
-  }
-
+async function handleLaunch({ appName, runner, args, altExe }: ProtocolRequest) {
   if (!appName) {
     logError('No appName in protocol URL', LogPrefix.ProtocolHandler)
     return
   }
 
-  let runner: Runner | undefined
-  const runnerParse = RUNNERS.safeParse(runnerStr)
-  if (runnerParse.success) {
-    runner = runnerParse.data
-  }
   const gameInfo = findGame(appName, runner)
   if (!gameInfo) {
     return logError(
@@ -103,6 +198,116 @@ async function handleLaunch(url: URL) {
 
   logInfo(`"${title}" not installed.`, LogPrefix.ProtocolHandler)
 
+  return promptToInstall(appName, gameInfo.runner, title)
+}
+
+async function handleInstall(request: ProtocolRequest) {
+  const { appName, runner, install } = request
+  if (!appName) {
+    logError('No appName in protocol URL', LogPrefix.ProtocolHandler)
+    return
+  }
+
+  const gameInfo = findGame(appName, runner)
+  if (!gameInfo) {
+    return logError(
+      `Could not receive game data for ${appName}!`,
+      LogPrefix.ProtocolHandler
+    )
+  }
+
+  if (gameInfo.is_installed) {
+    logInfo(`"${gameInfo.title}" is already installed.`, LogPrefix.ProtocolHandler)
+    notify({
+      title: gameInfo.title,
+      body: i18next.t('notify.install.finished', 'Installation Finished')
+    })
+    return
+  }
+
+  const installArgs = buildInstallArgs(gameInfo, install)
+  if (!installArgs) {
+    return promptToInstall(appName, gameInfo.runner, gameInfo.title)
+  }
+
+  const queueElement: DMQueueElement = {
+    type: 'install',
+    params: {
+      appName,
+      gameInfo,
+      runner: gameInfo.runner,
+      ...installArgs
+    },
+    addToQueueTime: Date.now(),
+    startTime: 0,
+    endTime: 0
+  }
+
+  await addToQueue(queueElement)
+}
+
+async function handleUninstall(request: ProtocolRequest) {
+  const gameInfo = requireInstalledGame(request)
+  if (!gameInfo) return
+
+  await uninstallGameCallback(
+    {} as never,
+    gameInfo.app_name,
+    gameInfo.runner,
+    false,
+    false
+  )
+}
+
+async function handleRepair(request: ProtocolRequest) {
+  const gameInfo = requireInstalledGame(request)
+  if (!gameInfo) return
+
+  try {
+    await gameManagerMap[gameInfo.runner].repair(gameInfo.app_name)
+  } catch (error) {
+    logError(error, LogPrefix.ProtocolHandler)
+  }
+}
+
+async function handleStatus(request: ProtocolRequest) {
+  const { appName, runner } = request
+  if (!appName) {
+    logError('No appName in protocol URL', LogPrefix.ProtocolHandler)
+    return
+  }
+
+  const gameInfo = findGame(appName, runner)
+  if (!gameInfo) {
+    return logError(
+      `Could not receive game data for ${appName}!`,
+      LogPrefix.ProtocolHandler
+    )
+  }
+
+  const mainWindow = getMainWindow()
+  const message = [
+    `Runner: ${gameInfo.runner}`,
+    `App Name: ${gameInfo.app_name}`,
+    `Title: ${gameInfo.title}`,
+    `Installed: ${gameInfo.is_installed ? 'Yes' : 'No'}`,
+    `Install Path: ${gameInfo.install.install_path || 'N/A'}`
+  ].join('\n')
+
+  if (!mainWindow) {
+    logInfo(message, LogPrefix.ProtocolHandler)
+    return
+  }
+
+  await dialog.showMessageBox(mainWindow, {
+    buttons: [i18next.t('box.ok', 'OK')],
+    message,
+    title: i18next.t('box.protocol.status.title', 'Heroic Protocol Status'),
+    icon: windowIcon
+  })
+}
+
+async function promptToInstall(appName: string, runner: Runner, title: string) {
   const mainWindow = getMainWindow()
   if (!mainWindow) return
 
@@ -124,7 +329,7 @@ async function handleLaunch(url: URL) {
       )
       mainWindow.show()
     }
-    sendFrontendMessage('installGame', appName, gameInfo.runner)
+    sendFrontendMessage('installGame', appName, runner)
   } else if (response === 1) {
     logInfo('Not installing game', LogPrefix.ProtocolHandler)
     if (isCLINoGui) {
@@ -132,6 +337,69 @@ async function handleLaunch(url: URL) {
       app.quit()
     }
   }
+}
+
+function buildInstallArgs(
+  gameInfo: GameInfo,
+  install: Partial<InstallArgs>
+): InstallArgs | undefined {
+  const path = install.path || GlobalConfig.get().getSettings().defaultInstallPath
+  const platformToInstall =
+    install.platformToInstall ||
+    (gameInfo.install.platform as InstallPlatform | undefined) ||
+    getDefaultInstallPlatform(gameInfo.runner)
+
+  if (!path || !platformToInstall) {
+    return
+  }
+
+  return {
+    path,
+    platformToInstall,
+    installDlcs: install.installDlcs,
+    sdlList: install.sdlList,
+    installLanguage: install.installLanguage,
+    branch: install.branch,
+    build: install.build,
+    dependencies: install.dependencies
+  }
+}
+
+function getDefaultInstallPlatform(runner: Runner): InstallPlatform | undefined {
+  switch (runner) {
+    case 'legendary':
+      return 'Windows'
+    case 'gog':
+      return 'windows'
+    case 'nile':
+      return 'windows'
+    default:
+      return
+  }
+}
+
+function requireInstalledGame(request: ProtocolRequest): GameInfo | undefined {
+  const { appName, runner } = request
+  if (!appName) {
+    logError('No appName in protocol URL', LogPrefix.ProtocolHandler)
+    return
+  }
+
+  const gameInfo = findGame(appName, runner)
+  if (!gameInfo) {
+    logError(
+      `Could not receive game data for ${appName}!`,
+      LogPrefix.ProtocolHandler
+    )
+    return
+  }
+
+  if (!gameInfo.is_installed) {
+    logError(`"${gameInfo.title}" is not installed.`, LogPrefix.ProtocolHandler)
+    return
+  }
+
+  return gameInfo
 }
 
 function findGame(
@@ -144,7 +412,7 @@ function findGame(
   if (runner) return gameManagerMap[runner].getGameInfo(appName)
 
   // If no runner is specified, search for the game in all runners and return the first one found
-  for (const runner of RUNNERS.options) {
+  for (const runner of RUNNERS.options as Runner[]) {
     const maybeGameInfo = gameManagerMap[runner].getGameInfo(appName)
     if (maybeGameInfo.app_name) return maybeGameInfo
   }

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -62,7 +62,10 @@ export function handleProtocol(args: string[]) {
 function parseProtocolRequest(url: URL): ProtocolRequest | undefined {
   const actionParse = PROTOCOL_ACTIONS.safeParse(url.hostname)
   if (!actionParse.success) {
-    logError(`Unsupported protocol action: ${url.hostname}`, LogPrefix.ProtocolHandler)
+    logError(
+      `Unsupported protocol action: ${url.hostname}`,
+      LogPrefix.ProtocolHandler
+    )
     return
   }
 
@@ -162,7 +165,12 @@ function handlePing(url: URL) {
   logInfo(['Received ping! Args:', url.searchParams], LogPrefix.ProtocolHandler)
 }
 
-async function handleLaunch({ appName, runner, args, altExe }: ProtocolRequest) {
+async function handleLaunch({
+  appName,
+  runner,
+  args,
+  altExe
+}: ProtocolRequest) {
   if (!appName) {
     logError('No appName in protocol URL', LogPrefix.ProtocolHandler)
     return
@@ -217,7 +225,10 @@ async function handleInstall(request: ProtocolRequest) {
   }
 
   if (gameInfo.is_installed) {
-    logInfo(`"${gameInfo.title}" is already installed.`, LogPrefix.ProtocolHandler)
+    logInfo(
+      `"${gameInfo.title}" is already installed.`,
+      LogPrefix.ProtocolHandler
+    )
     notify({
       title: gameInfo.title,
       body: i18next.t('notify.install.finished', 'Installation Finished')
@@ -343,7 +354,8 @@ function buildInstallArgs(
   gameInfo: GameInfo,
   install: Partial<InstallArgs>
 ): InstallArgs | undefined {
-  const path = install.path || GlobalConfig.get().getSettings().defaultInstallPath
+  const path =
+    install.path || GlobalConfig.get().getSettings().defaultInstallPath
   const platformToInstall =
     install.platformToInstall ||
     gameInfo.install.platform ||
@@ -365,7 +377,9 @@ function buildInstallArgs(
   }
 }
 
-function getDefaultInstallPlatform(runner: Runner): InstallPlatform | undefined {
+function getDefaultInstallPlatform(
+  runner: Runner
+): InstallPlatform | undefined {
   switch (runner) {
     case 'legendary':
       return 'Windows'

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -346,7 +346,7 @@ function buildInstallArgs(
   const path = install.path || GlobalConfig.get().getSettings().defaultInstallPath
   const platformToInstall =
     install.platformToInstall ||
-    (gameInfo.install.platform as InstallPlatform | undefined) ||
+    gameInfo.install.platform ||
     getDefaultInstallPlatform(gameInfo.runner)
 
   if (!path || !platformToInstall) {

--- a/src/backend/schemas.ts
+++ b/src/backend/schemas.ts
@@ -1,9 +1,13 @@
 import { z } from 'zod'
 import path from 'path'
 
+function isValidPath(value: string) {
+  return path.posix.isAbsolute(value) || path.win32.isAbsolute(value)
+}
+
 const Path = z
   .string()
-  .refine((val) => path.parse(val).root, 'Path is not valid')
+  .refine((val) => isValidPath(val), 'Path is not valid')
   .brand('Path')
 type Path = z.infer<typeof Path>
 

--- a/src/backend/utils/filesystem/unix.ts
+++ b/src/backend/utils/filesystem/unix.ts
@@ -1,6 +1,6 @@
 import { genericSpawnWrapper } from '../os/processes'
 import { access } from 'fs/promises'
-import { join } from 'path'
+import { posix } from 'path'
 
 import type { Path } from 'backend/schemas'
 import type { DiskInfo } from './index'
@@ -26,7 +26,7 @@ async function getDiskInfo_unix(path: Path): Promise<DiskInfo> {
 async function findFirstExistingPath(path: Path): Promise<Path> {
   let maybeExistingPath = path
   while (!(await isWritable_unix(maybeExistingPath))) {
-    maybeExistingPath = join(maybeExistingPath, '..') as Path
+    maybeExistingPath = posix.dirname(maybeExistingPath) as Path
   }
   return maybeExistingPath
 }

--- a/src/backend/wine/manager/downloader/__tests__/utilities/rest.test.ts
+++ b/src/backend/wine/manager/downloader/__tests__/utilities/rest.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, writeFileSync } from 'graceful-fs'
 import { getFolderSize, unlinkFile } from '../../utilities'
 import { testSkipOnWindows } from 'backend/__tests__/skip'
+import { join } from 'path'
 
 jest.mock('backend/logger')
 
@@ -29,7 +30,16 @@ describe('Utilities - Rest', () => {
     expect(() => {
       unlinkFile(__dirname)
     }).toThrowError(
-      `Couldn't remove ${workDir}/src/backend/wine/manager/downloader/__tests__/utilities!`
+      `Couldn't remove ${join(
+        workDir,
+        'src',
+        'backend',
+        'wine',
+        'manager',
+        'downloader',
+        '__tests__',
+        'utilities'
+      )}!`
     )
   })
 


### PR DESCRIPTION
This simple functionality change allows the user to leverage the `heroic://` protocol to interact with the system in a lot more ways instead of the existing `heroic://launch/{runner}/{id}` - namely:

| Command   | Protocol Base | Description | Example |
|-----------|---------------|-------------|---------|
| Ping | `heroic://ping` | Just confirms that the `heroic://` protocol handler is registered and that Heroic can receive protocol URLs. | `heroic://ping?source=test&hello=world` |
| Launch | `heroic://launch/{runner}/{id}` | Launches an installed game. If the game is not installed, Heroic prompts to install it instead. Supports optional launch arguments and an alternate executable path. | `heroic://launch/legendary/Fortnite?arg=-dx12&arg=-windowed` |
| Install | `heroic://install/{runner}/{id}` | Installs a game. If the game is already installed, Heroic does not queue another install. Supports specifying the install path and other install-specific options. | `heroic://install/nile/amzn1.adg.product.6463784a-5716-481d-b006-e19c26e9214c?path=C%3A%5CGames%5CAmazon` |
| Uninstall | `heroic://uninstall/{runner}/{id}` | Uninstalls an installed game. If the game is not installed, the request is ignored. | `heroic://uninstall/legendary/Fortnite` |
| Repair | `heroic://repair/{runner}/{id}` | Repairs an installed game. If the game is not installed, the request is ignored. | `heroic://repair/legendary/Fortnite` |
| Verify | `heroic://verify/{runner}/{id}` | Verifies an installed game. Internally uses the same flow as repair. If the game is not installed, the request is ignored. | `heroic://verify/legendary/Fortnite` |
| Status | `heroic://status/{runner}/{id}` | Shows status information for a game. Can also return machine-readable output when requested with `format=json`. | `heroic://status/nile/amzn1.adg.product.6463784a-5716-481d-b006-e19c26e9214c?format=json` |

Main changes:
- fixes Windows path handling for protocol-triggered installs by avoiding backslash doubling in PowerShell argument serialization
- keeps `path` support scoped to install requests while leaving uninstall, repair, and verify based on installed game metadata
- adds stronger validation coverage for protocol actions such as install on already-installed games and uninstall/repair/verify on non-installed games
- adds backend regression tests for protocol behavior and PowerShell path formatting

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
