### PR TITLE
[UX] Add proton-cachyos to the wine manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Heroic would not be possible without the work done in many other projects:
 - Nile: https://github.com/imLinguin/nile
 - Comet: https://github.com/imLinguin/comet
 - GE-Proton: https://github.com/GloriousEggroll/proton-ge-custom
+- Proton-cachyos: https://github.com/CachyOS/proton-cachyos
 - umu-launcher: https://github.com/Open-Wine-Components/umu-launcher
 - DXVK: https://github.com/doitsujin/dxvk
 - VKD3D: https://github.com/HansKristian-Work/vkd3d-proton
@@ -332,6 +333,6 @@ Heroic would not be possible without the work done in many other projects:
 - DXVK-MacOS: https://github.com/Gcenx/DXVK-macOS
 - DXMT: https://github.com/3Shain/dxmt
 - Heroic-Epic integration exe: https://github.com/Etaash-mathamsetty/heroic-epic-integration
-- vulkan helper: https://github.com/imLinguin/vulkan-helper-rs
+- vulkan helper: https://github.com/imLinguin/vulkan-helper-rs1
 
 So be sure to follow and support those projects too!

--- a/README.md
+++ b/README.md
@@ -333,6 +333,6 @@ Heroic would not be possible without the work done in many other projects:
 - DXVK-MacOS: https://github.com/Gcenx/DXVK-macOS
 - DXMT: https://github.com/3Shain/dxmt
 - Heroic-Epic integration exe: https://github.com/Etaash-mathamsetty/heroic-epic-integration
-- vulkan helper: https://github.com/imLinguin/vulkan-helper-rs1
+- vulkan helper: https://github.com/imLinguin/vulkan-helper-rs
 
 So be sure to follow and support those projects too!

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Heroic would not be possible without the work done in many other projects:
 - Nile: https://github.com/imLinguin/nile
 - Comet: https://github.com/imLinguin/comet
 - GE-Proton: https://github.com/GloriousEggroll/proton-ge-custom
+- Proton-cachyos: https://github.com/CachyOS/proton-cachyos
 - umu-launcher: https://github.com/Open-Wine-Components/umu-launcher
 - DXVK: https://github.com/doitsujin/dxvk
 - VKD3D: https://github.com/HansKristian-Work/vkd3d-proton

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1023,6 +1023,7 @@
         "size": "Size"
     },
     "wineExplanation": {
+        "proton-cachyos": "Proton-cachyos is a Proton variant maintaned by the CachyOS team. It includes extra tools like DXVK-Sarek and D7VK.",
         "proton-ge": "GE-Proton is a Proton variant created by Glorious Eggroll. It is meant to be used along with the umu launcher (default in Heroic).",
         "wine-ge": "Wine-GE-Proton is a Wine variant created by Glorious Eggroll. It has been deprecated in favor of GE-Proton with the umu launcher."
     },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1199,7 +1199,7 @@
     },
     "wineExplanation": {
         "gpt": "Game Porting Toolkit is developed by Apple and it is recommended for Apple Silicon Macs with the M1+ chips and works best for newer games that use DX12.",
-        "proton-cachyos": "Proton-cachyos is a Proton variant maintaned by the CachyOS team. It includes extra tools like DXVK-Sarek and D7VK.",
+        "proton-cachyos": "Proton-CachyOS is a Proton variant maintaned by the CachyOS team. It includes extra tools like DXVK-Sarek and D7VK.",
         "proton-ge": "GE-Proton is a Proton variant created by Glorious Eggroll. It is meant to be used along with the umu launcher (default in Heroic).",
         "wine-crossover": "Wine-Crossover is based on the Crossover OpenSource Wine project and is recommended for Intel Macs and for DX11 or older games.",
         "wine-ge": "Wine-GE-Proton is a Wine variant created by Glorious Eggroll. It has been deprecated in favor of GE-Proton with the umu launcher.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1199,6 +1199,7 @@
     },
     "wineExplanation": {
         "gpt": "Game Porting Toolkit is developed by Apple and it is recommended for Apple Silicon Macs with the M1+ chips and works best for newer games that use DX12.",
+        "proton-cachyos": "Proton-cachyos is a Proton variant maintaned by the CachyOS team. It includes extra tools like DXVK-Sarek and D7VK.",
         "proton-ge": "GE-Proton is a Proton variant created by Glorious Eggroll. It is meant to be used along with the umu launcher (default in Heroic).",
         "wine-crossover": "Wine-Crossover is based on the Crossover OpenSource Wine project and is recommended for Intel Macs and for DX11 or older games.",
         "wine-ge": "Wine-GE-Proton is a Wine variant created by Glorious Eggroll. It has been deprecated in favor of GE-Proton with the umu launcher.",

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -815,7 +815,7 @@ function getDxvkUrl(): string {
   }
   if (any_gpu_supports_version([1, 1, 0])) {
     logInfo(
-      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to DXVK 1.10.3',
+      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to DXVK 1.10.3 for Wine, or use DXVK-Sarek with proton-cachyos',
       LogPrefix.ToolInstaller
     )
     return 'https://api.github.com/repos/doitsujin/dxvk/releases/tags/v1.10.3'
@@ -851,7 +851,7 @@ function getVkd3dUrl(): string {
   }
   if (any_gpu_supports_version([1, 1, 0])) {
     logInfo(
-      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to VKD3D 2.6',
+      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to VKD3D 2.6 for Wine, or use DXVK-Sarek with proton-cachyos',
       LogPrefix.ToolInstaller
     )
     return 'https://api.github.com/repos/Heroic-Games-Launcher/vkd3d-proton/releases/tags/v2.6'

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -818,7 +818,7 @@ function getDxvkUrl(): string {
   }
   if (any_gpu_supports_version([1, 1, 0])) {
     logInfo(
-      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to DXVK 1.10.3',
+      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to DXVK 1.10.3 for Wine, or use DXVK-Sarek with proton-cachyos',
       LogPrefix.ToolInstaller
     )
     return 'https://api.github.com/repos/doitsujin/dxvk/releases/tags/v1.10.3'
@@ -854,7 +854,7 @@ function getVkd3dUrl(): string {
   }
   if (any_gpu_supports_version([1, 1, 0])) {
     logInfo(
-      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to VKD3D 2.6',
+      'The GPU(s) in this system only support Vulkan 1.1/1.2, falling back to VKD3D 2.6 for Wine, or use DXVK-Sarek with proton-cachyos',
       LogPrefix.ToolInstaller
     )
     return 'https://api.github.com/repos/Heroic-Games-Launcher/vkd3d-proton/releases/tags/v2.6'

--- a/src/backend/wine/manager/downloader/constants.ts
+++ b/src/backend/wine/manager/downloader/constants.ts
@@ -25,3 +25,7 @@ export const WINESTAGINGMACOS_URL =
 /// Url to Game Porting Toolkit from Gcenx github release page
 export const GPTK_URL =
   'https://api.github.com/repos/Gcenx/game-porting-toolkit/releases'
+
+/// Url to proton-cachyos from the CachyOS team github release page
+export const PROTON_CACHYOS_URL =
+  'https://api.github.com/repos/CachyOS/proton-cachyos/releases'

--- a/src/backend/wine/manager/downloader/constants.ts
+++ b/src/backend/wine/manager/downloader/constants.ts
@@ -26,6 +26,6 @@ export const WINESTAGINGMACOS_URL =
 export const GPTK_URL =
   'https://api.github.com/repos/Gcenx/game-porting-toolkit/releases'
 
-/// Url to proton-cachyos from the CachyOS team github release page
+/// Url to Proton-CachyOS from the CachyOS team github release page
 export const PROTON_CACHYOS_URL =
   'https://api.github.com/repos/CachyOS/proton-cachyos/releases'

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -16,7 +16,8 @@ import {
   WINELUTRIS_URL,
   WINECROSSOVER_URL,
   WINESTAGINGMACOS_URL,
-  GPTK_URL
+  GPTK_URL,
+  PROTON_CACHYOS_URL
 } from './constants'
 import { VersionInfo, Repositorys, WineVersionInfo } from 'common/types'
 import {
@@ -140,6 +141,20 @@ async function getAvailableVersions({
         await fetchReleases({
           url: GPTK_URL,
           type: 'Game-Porting-Toolkit',
+          count: count
+        })
+          .then((fetchedReleases: VersionInfo[]) => {
+            releases.push(...fetchedReleases)
+          })
+          .catch((error: Error) => {
+            logError(error, LogPrefix.WineDownloader)
+          })
+        break
+      }
+      case Repositorys.PROTONCACHYOS: {
+        await fetchReleases({
+          url: PROTON_CACHYOS_URL,
+          type: 'Proton-Cachyos',
           count: count
         })
           .then((fetchedReleases: VersionInfo[]) => {

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -154,7 +154,7 @@ async function getAvailableVersions({
       case Repositorys.PROTONCACHYOS: {
         await fetchReleases({
           url: PROTON_CACHYOS_URL,
-          type: 'Proton-Cachyos',
+          type: 'Proton-CachyOS',
           count: count
         })
           .then((fetchedReleases: VersionInfo[]) => {

--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -19,6 +19,19 @@ function getVersionName(type: string, tag_name: string): string {
   }
 }
 
+interface ReleasesData {
+  data: {
+    tag_name: string
+    published_at: string
+    html_url: string
+    assets: {
+      name: string
+      browser_download_url: string
+      size: number
+    }[]
+  }[]
+}
+
 /**
  * Helper to fetch releases from given url.
  *
@@ -37,7 +50,7 @@ async function fetchReleases({
   return new Promise((resolve, reject) => {
     axiosClient
       .get(url + '?per_page=' + count)
-      .then((data) => {
+      .then((data: ReleasesData) => {
         for (const release of data.data) {
           const release_data = {} as VersionInfo
           release_data.version = getVersionName(type, release.tag_name)
@@ -46,15 +59,31 @@ async function fetchReleases({
           release_data.disksize = 0
           release_data.release_notes_link = release.html_url
 
-          for (const asset of release.assets) {
-            if (asset.name.endsWith('sha512sum')) {
-              release_data.checksum = asset.browser_download_url
-            } else if (
-              asset.name.endsWith('tar.gz') ||
-              asset.name.endsWith('tar.xz')
-            ) {
-              release_data.download = asset.browser_download_url
-              release_data.downsize = asset.size
+          // for proton-cachyos we want to always get the main x86 asset,
+          // the other logic sometimes gets the V3, V4 or arm asset incorrectly
+          if (type === 'Proton-Cachyos') {
+            const shaAsset = release.assets.find((asset) =>
+              asset.browser_download_url.endsWith('x86_64.sha512sum')
+            )
+            if (shaAsset) release_data.checksum = shaAsset.browser_download_url
+            const tarAsset = release.assets.find((asset) =>
+              asset.browser_download_url.endsWith('x86_64.tar.xz')
+            )
+            if (tarAsset) {
+              release_data.download = tarAsset.browser_download_url
+              release_data.downsize = tarAsset.size
+            }
+          } else {
+            for (const asset of release.assets) {
+              if (asset.name.endsWith('sha512sum')) {
+                release_data.checksum = asset.browser_download_url
+              } else if (
+                asset.name.endsWith('tar.gz') ||
+                asset.name.endsWith('tar.xz')
+              ) {
+                release_data.download = asset.browser_download_url
+                release_data.downsize = asset.size
+              }
             }
           }
 

--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -68,7 +68,7 @@ async function fetchReleases({
               release_data.download = stagingAsset.browser_download_url
               release_data.downsize = stagingAsset.size
             }
-          } else if (type === 'Proton-Cachyos') {
+          } else if (type === 'Proton-CachyOS') {
             const shaAsset = release.assets.find((asset) =>
               asset.browser_download_url.endsWith('x86_64.sha512sum')
             )

--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -68,6 +68,18 @@ async function fetchReleases({
               release_data.download = stagingAsset.browser_download_url
               release_data.downsize = stagingAsset.size
             }
+          } else if (type === 'Proton-Cachyos') {
+            const shaAsset = release.assets.find((asset) =>
+              asset.browser_download_url.endsWith('x86_64.sha512sum')
+            )
+            if (shaAsset) release_data.checksum = shaAsset.browser_download_url
+            const tarAsset = release.assets.find((asset) =>
+              asset.browser_download_url.endsWith('x86_64.tar.xz')
+            )
+            if (tarAsset) {
+              release_data.download = tarAsset.browser_download_url
+              release_data.downsize = tarAsset.size
+            }
           } else {
             for (const asset of release.assets) {
               if (asset.name.endsWith('sha512sum')) {

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -42,6 +42,9 @@ function getLatestLocalVersions(): Record<string, string | undefined> {
         ?.date,
       latestGEProton: localWines.find(
         (wine) => wine.version === 'GE-Proton-latest'
+      )?.date,
+      latestProtonCachyos: localWines.find(
+        (wine) => wine.version === 'Proton-Cachyos-latest'
       )?.date
     }
   }
@@ -104,6 +107,14 @@ export function updateWineListsIfOutdated(releasesData: ReleasesInfo) {
       )
     )
       repositoriesToFetch.push(Repositorys.WINEGE)
+
+    if (
+      localVersionIsOlder(
+        latestLocalVersions.latestProtonCachyos,
+        releasesData['proton-cachyos']
+      )
+    )
+      repositoriesToFetch.push(Repositorys.PROTONCACHYOS)
   }
 
   if (isMac) {
@@ -155,7 +166,7 @@ async function updateWineVersionInfos(
             Repositorys.WINESTAGINGMACOS,
             Repositorys.GPTK
           ]
-        : [Repositorys.WINEGE, Repositorys.PROTONGE]
+        : [Repositorys.WINEGE, Repositorys.PROTONGE, Repositorys.PROTONCACHYOS]
     }
 
     await getAvailableVersions({

--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -44,7 +44,7 @@ function getLatestLocalVersions(): Record<string, string | undefined> {
         (wine) => wine.version === 'GE-Proton-latest'
       )?.date,
       latestProtonCachyos: localWines.find(
-        (wine) => wine.version === 'Proton-Cachyos-latest'
+        (wine) => wine.version === 'Proton-CachyOS-latest'
       )?.date
     }
   }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -744,6 +744,7 @@ export type Type =
   | 'Wine-Crossover'
   | 'Wine-Staging-macOS'
   | 'Game-Porting-Toolkit'
+  | 'Proton-Cachyos'
 
 /**
  * Interface contains information about a version
@@ -775,7 +776,8 @@ export enum Repositorys {
   WINELUTRIS,
   WINECROSSOVER,
   WINESTAGINGMACOS,
-  GPTK
+  GPTK,
+  PROTONCACHYOS
 }
 
 export type WineManagerStatus =
@@ -848,6 +850,7 @@ export type ReleasesInfo = Record<
   | 'ge-proton'
   | 'wine-ge'
   | 'game-porting-toolkit'
+  | 'proton-cachyos'
   | 'wine-staging'
   | 'wine-crossover'
   | 'dxvk'

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -759,7 +759,7 @@ export type Type =
   | 'Wine-Crossover'
   | 'Wine-Staging-macOS'
   | 'Game-Porting-Toolkit'
-  | 'Proton-Cachyos'
+  | 'Proton-CachyOS'
 
 /**
  * Interface contains information about a version

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -759,6 +759,7 @@ export type Type =
   | 'Wine-Crossover'
   | 'Wine-Staging-macOS'
   | 'Game-Porting-Toolkit'
+  | 'Proton-Cachyos'
 
 /**
  * Interface contains information about a version
@@ -790,7 +791,8 @@ export enum Repositorys {
   WINELUTRIS,
   WINECROSSOVER,
   WINESTAGINGMACOS,
-  GPTK
+  GPTK,
+  PROTONCACHYOS
 }
 
 export type WineManagerStatus =
@@ -873,6 +875,7 @@ export type ReleasesInfo = Record<
   | 'ge-proton'
   | 'wine-ge'
   | 'game-porting-toolkit'
+  | 'proton-cachyos'
   | 'wine-staging'
   | 'wine-crossover'
   | 'dxvk'

--- a/src/frontend/helpers/electronStores.ts
+++ b/src/frontend/helpers/electronStores.ts
@@ -9,7 +9,7 @@ import {
 } from 'common/types/electron_store'
 import { GameInfo } from 'common/types'
 
-export class TypeCheckedStoreFrontend<
+class TypeCheckedStoreFrontend<
   Name extends ValidStoreName
 > implements TypeCheckedStore<Name> {
   private storeName: ValidStoreName

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -6,10 +6,7 @@ import { UpdateComponent } from 'frontend/components/UI'
 import React, { lazy, useContext, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Tab, Tabs } from '@mui/material'
-import {
-  TypeCheckedStoreFrontend,
-  wineDownloaderInfoStore
-} from 'frontend/helpers/electronStores'
+import { wineDownloaderInfoStore } from 'frontend/helpers/electronStores'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faCheck,
@@ -24,10 +21,6 @@ import useGlobalState from 'frontend/state/GlobalStateV2'
 const WineItem = lazy(
   async () => import('frontend/screens/WineManager/components/WineItem')
 )
-
-const configStore = new TypeCheckedStoreFrontend('wineManagerConfigStore', {
-  cwd: 'store'
-})
 
 export default function WineManager(): JSX.Element | null {
   const { t } = useTranslation()
@@ -87,15 +80,14 @@ export default function WineManager(): JSX.Element | null {
     getDefaultRepository()
   )
 
-  const [wineManagerSettings, setWineManagerSettings] = useState<
-    WineManagerUISettings[]
-  >([
+  const wineManagerSettings: WineManagerUISettings[] = [
     protonge,
+    { type: 'Proton-Cachyos', value: 'protoncachyos', enabled: isLinux },
     { type: 'Wine-GE', value: 'winege', enabled: isLinux },
     gamePortingToolkit,
     wineCrossover,
     wineStagingMacOS
-  ])
+  ]
 
   const getWineVersions = (repo: Type) => {
     let versions = wineDownloaderInfoStore.get('wine-releases', [])
@@ -119,15 +111,6 @@ export default function WineManager(): JSX.Element | null {
     setRepository(repo)
     setWineVersions(getWineVersions(repo.type))
   }
-
-  useEffect(() => {
-    const oldWineManagerSettings = configStore.get_nodefault(
-      'wine-manager-settings'
-    )
-    if (oldWineManagerSettings) {
-      setWineManagerSettings(oldWineManagerSettings)
-    }
-  }, [])
 
   useEffect(() => {
     const removeListener = window.api.handleWineVersionsUpdated(() => {
@@ -160,10 +143,20 @@ export default function WineManager(): JSX.Element | null {
             )}
           </div>
         )
+      case 'Proton-Cachyos':
+        return (
+          <div className="infoBox">
+            <FontAwesomeIcon icon={faCheck} color={'green'} />
+            {t(
+              'wineExplanation.proton-cachyos',
+              'Proton-cachyos is a Proton variant maintaned by the CachyOS team. It includes extra tools like DXVK-Sarek and D7VK.'
+            )}
+          </div>
+        )
       default:
         return <></>
     }
-  }, [repository])
+  }, [repository, t])
 
   return (
     <>

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -50,6 +50,7 @@ export default function WineManager(): JSX.Element | null {
     if (isLinux) {
       return [
         { type: 'GE-Proton', value: 'protonge' },
+        { type: 'Proton-Cachyos', value: 'proton-cachyos' },
         { type: 'Wine-GE', value: 'winege' }
       ]
     }
@@ -159,6 +160,16 @@ export default function WineManager(): JSX.Element | null {
             {t(
               'wineExplanation.wine-staging-macos',
               'Wine-Staging-macOS is based on the mainline Wine project and is recommended for Intel Macs and for DX11 or older games, especially when paired with the DXMT tool.'
+            )}
+          </div>
+        )
+      case 'Proton-Cachyos':
+        return (
+          <div className="infoBox">
+            <FontAwesomeIcon icon={faCheck} color={'green'} />
+            {t(
+              'wineExplanation.proton-cachyos',
+              'Proton-cachyos is a Proton variant maintaned by the CachyOS team. It includes extra tools like DXVK-Sarek and D7VK.'
             )}
           </div>
         )

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -50,7 +50,7 @@ export default function WineManager(): JSX.Element | null {
     if (isLinux) {
       return [
         { type: 'GE-Proton', value: 'protonge' },
-        { type: 'Proton-Cachyos', value: 'proton-cachyos' },
+        { type: 'Proton-CachyOS', value: 'proton-cachyos' },
         { type: 'Wine-GE', value: 'winege' }
       ]
     }
@@ -163,13 +163,13 @@ export default function WineManager(): JSX.Element | null {
             )}
           </div>
         )
-      case 'Proton-Cachyos':
+      case 'Proton-CachyOS':
         return (
           <div className="infoBox">
             <FontAwesomeIcon icon={faCheck} color={'green'} />
             {t(
               'wineExplanation.proton-cachyos',
-              'Proton-cachyos is a Proton variant maintaned by the CachyOS team. It includes extra tools like DXVK-Sarek and D7VK.'
+              'Proton-CachyOS is a Proton variant maintaned by the CachyOS team. It includes extra tools like DXVK-Sarek and D7VK.'
             )}
           </div>
         )


### PR DESCRIPTION
This PR adds proton-cachyos as an option to download in the Wine Manager, this replaces https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5424

The benefits of proton-cachyos are:
- it updates more often
- it includes DXVK alternatives [through env variables](https://github.com/CachyOS/proton-cachyos?tab=readme-ov-file#proton-cachyos-config-options) (dxvk-sarek, d7vk, dxvk-low-latency)
- it has more users in general since it's the default in cachyos, so issues are identified faster

I updated the releases-info repo to also check cachyos https://github.com/Heroic-Games-Launcher/releases-info/blob/main/release-data.json#L34

I'll add some extra notes in the diff

I think we can later add some feature for users to enable the DXVK alternatives from the UI without the need of env variables, but I think that would be out of the scope of this PR, we can instruct users to use the env variable.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
