### PR TITLE
[FIX] Do not watch legendary file to refresh the lilbrary

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -22,7 +22,7 @@ import {
 import 'backend/updater'
 import { autoUpdater } from 'electron-updater'
 import { cpus } from 'os'
-import { existsSync, watch, readdirSync, readFileSync } from 'graceful-fs'
+import { existsSync, readdirSync, readFileSync } from 'graceful-fs'
 import 'source-map-support/register'
 
 import Backend from 'i18next-fs-backend'
@@ -132,7 +132,6 @@ import {
   wikiLink,
   wineprefixFAQ
 } from './constants/urls'
-import { legendaryInstalled } from './storeManagers/legendary/constants'
 import {
   isCLIFullscreen,
   isCLINoGui,
@@ -863,19 +862,6 @@ addListener('setSetting', (event, { appName, key, value }) => {
     GameConfig.get(appName).setSetting(key, value)
   }
 })
-
-// Watch the installed games file and trigger a refresh on the installed games if something changes
-if (existsSync(legendaryInstalled)) {
-  let watchTimeout: NodeJS.Timeout | undefined
-  watch(legendaryInstalled, () => {
-    logInfo('installed.json updated, refreshing library', LogPrefix.Legendary)
-    // `watch` might fire twice (while Legendary/we are still writing chunks of the file), which would in turn make LegendaryLibrary fail to
-    // decode the JSON data. So instead of immediately calling LegendaryLibrary.get().refreshInstalled(), call it only after no writes happen
-    // in a 500ms timespan
-    if (watchTimeout) clearTimeout(watchTimeout)
-    watchTimeout = setTimeout(LegendaryLibraryManager.refreshInstalled, 500)
-  })
-}
 
 addHandler('refreshLibrary', async (e, library?) => {
   if (library !== undefined && library !== 'all') {

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -20,7 +20,7 @@ import {
   getGameInfo as getLegLibraryGameInfo,
   changeGameInstallPath,
   installState,
-  refresh
+  refreshInstalled
 } from './library'
 import { LegendaryUser } from './user'
 import {
@@ -663,7 +663,7 @@ export async function install(
   }
   addShortcuts(appName)
 
-  refresh()
+  refreshInstalled()
 
   return { status: 'done' }
 }

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -19,7 +19,8 @@ import {
   listUpdateableGames,
   getGameInfo as getLegLibraryGameInfo,
   changeGameInstallPath,
-  installState
+  installState,
+  refresh
 } from './library'
 import { LegendaryUser } from './user'
 import {
@@ -661,6 +662,8 @@ export async function install(
     return { status: 'error', error: res.error }
   }
   addShortcuts(appName)
+
+  refresh()
 
   return { status: 'done' }
 }


### PR DESCRIPTION
We are always starting a watcher for changes in the legendary installed json file.

This has a few issues:
- it triggers a refresh of the installed games in a different way than the rest of the stores (it's done with an async watcher instead of sync right after the installation ends)
- we are always trying to add the watcher even if the file does not exist, showing an error in the logs (this added confusion to users that do not use Epic games)
- the code had a workaround for a known issue with the  `watch` function that it could be triggered twice while the file was being written, it was extra complexity
- the watcher was always added, even when not doing anything that would change this file like when running a game with no GUI, using resources for no reason

This PR removes that and uses a similar approach as the other stores: once the game is installed, we refresh the installed games in the backend and the frontend was already triggering a refresh.

I tried installing and uninstalling a game and it updates the frontend correctly.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
