### PR TITLE
fix: clear GOG presence when disabling the setting

### DIFF
--- a/src/backend/storeManagers/gog/presence.ts
+++ b/src/backend/storeManagers/gog/presence.ts
@@ -4,6 +4,7 @@ import { axiosClient } from 'backend/utils'
 import { GOGUser } from './user'
 import { isOnline } from 'backend/online_monitor'
 import { GlobalConfig } from 'backend/config'
+import { backendEvents } from 'backend/backend_events'
 
 interface PresencePayload {
   application_type: string
@@ -63,13 +64,13 @@ async function setPresence() {
   }
 }
 
-async function deletePresence() {
+async function deletePresence(force = false) {
   try {
     const { disablePlaytimeSync, disableGOGPresence } =
       GlobalConfig.get().getSettings()
     if (
       disablePlaytimeSync ||
-      disableGOGPresence ||
+      (!force && disableGOGPresence) ||
       !GOGUser.isLoggedIn() ||
       !isOnline()
     )
@@ -90,6 +91,18 @@ async function deletePresence() {
     logError(['Failed to delete gog presence', e], LogPrefix.Gog)
   }
 }
+
+
+// React immediately when the user toggles GOG presence on/off in settings
+backendEvents.on('settingChanged', ({ key, newValue }) => {
+  if (key === 'disableGOGPresence') {
+    if (newValue) {
+      deletePresence(true)
+    } else {
+      setPresence()
+    }
+  }
+})
 
 export default {
   setCurrentGame,

--- a/src/backend/storeManagers/gog/presence.ts
+++ b/src/backend/storeManagers/gog/presence.ts
@@ -92,7 +92,6 @@ async function deletePresence(force = false) {
   }
 }
 
-
 // React immediately when the user toggles GOG presence on/off in settings
 backendEvents.on('settingChanged', ({ key, newValue }) => {
   if (key === 'disableGOGPresence') {

--- a/src/backend/storeManagers/gog/presence.ts
+++ b/src/backend/storeManagers/gog/presence.ts
@@ -97,9 +97,9 @@ async function deletePresence(force = false) {
 backendEvents.on('settingChanged', ({ key, newValue }) => {
   if (key === 'disableGOGPresence') {
     if (newValue) {
-      deletePresence(true)
+      void deletePresence(true)
     } else {
-      setPresence()
+      void setPresence()
     }
   }
 })


### PR DESCRIPTION
## Problem
When `Disable GOG Presence updates` is enabled and the app is closed, the user still shows as **Online** on gog.com. The presence is never cleared.

## Root Cause
`deletePresence()` in `src/backend/storeManagers/gog/presence.ts` has a `disableGOGPresence` guard that causes it to return early when the setting is enabled — exactly when presence needs to be deleted.

## Fix
Removed the `disableGOGPresence` check from `deletePresence()`. The `disablePlaytimeSync`, `isLoggedIn()`, and `isOnline()` guards remain as valid reasons to skip the API call.

Closes #5443