### PR TITLE
Fix typo on TwoColTableInput component style

### DIFF
--- a/src/frontend/components/UI/TwoColTableInput/index.css
+++ b/src/frontend/components/UI/TwoColTableInput/index.css
@@ -33,7 +33,7 @@
   overflow: hidden;
   display: flex;
   align-items: center;
-  padding: 0 var(--space-xs-fixed) m;
+  padding: 0 var(--space-xs-fixed) 0;
 }
 
 .tableFieldWrapper td:last-child {


### PR DESCRIPTION
A typo in one of the TwoColTableInput component styles resulted in bad padding.

Before:
<img width="455" height="508" alt="before" src="https://github.com/user-attachments/assets/e4fe59e1-34ef-454a-a992-d46c33fd51fa" />

After:
<img width="455" height="508" alt="after" src="https://github.com/user-attachments/assets/cf85030c-a2f2-49bd-8530-62c3942f9dcd" />

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
