### PR TITLE
[FIX] Always pick staging asset instead of devel for Wine Staging on MacOS

### DIFF
--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -19,6 +19,19 @@ function getVersionName(type: string, tag_name: string): string {
   }
 }
 
+interface ReleasesData {
+  data: {
+    tag_name: string
+    published_at: string
+    html_url: string
+    assets: {
+      name: string
+      browser_download_url: string
+      size: number
+    }[]
+  }[]
+}
+
 /**
  * Helper to fetch releases from given url.
  *
@@ -37,7 +50,7 @@ async function fetchReleases({
   return new Promise((resolve, reject) => {
     axiosClient
       .get(url + '?per_page=' + count)
-      .then((data) => {
+      .then((data: ReleasesData) => {
         for (const release of data.data) {
           const release_data = {} as VersionInfo
           release_data.version = getVersionName(type, release.tag_name)
@@ -46,15 +59,26 @@ async function fetchReleases({
           release_data.disksize = 0
           release_data.release_notes_link = release.html_url
 
-          for (const asset of release.assets) {
-            if (asset.name.endsWith('sha512sum')) {
-              release_data.checksum = asset.browser_download_url
-            } else if (
-              asset.name.endsWith('tar.gz') ||
-              asset.name.endsWith('tar.xz')
-            ) {
-              release_data.download = asset.browser_download_url
-              release_data.downsize = asset.size
+          if (type === 'Wine-Staging-macOS') {
+            // Sometimes, the wine-devel package is first in the list, we want to download Wine-Staging always
+            const stagingAsset = release.assets.find((asset) =>
+              asset.name.includes('staging')
+            )
+            if (stagingAsset) {
+              release_data.download = stagingAsset.browser_download_url
+              release_data.downsize = stagingAsset.size
+            }
+          } else {
+            for (const asset of release.assets) {
+              if (asset.name.endsWith('sha512sum')) {
+                release_data.checksum = asset.browser_download_url
+              } else if (
+                asset.name.endsWith('tar.gz') ||
+                asset.name.endsWith('tar.xz')
+              ) {
+                release_data.download = asset.browser_download_url
+                release_data.downsize = asset.size
+              }
             }
           }
 


### PR DESCRIPTION
When we fetch the information of Wine releases, we always pick the first wine asset. In the Wine Staging repo, sometimes the `wine-devel` package is listed first instead of the `wine-staging` package, so we end up downloading the wrong package (like in version 11.6).

We want to always download Wine-Staging for consistency, as the Staging package has an extra battle.net patch that is not included in Wine-Devel (check the release notes https://github.com/Gcenx/macOS_Wine_builds/releases/tag/11.6), so if a user is already using Battle.net we don't break that if they change to a newer Wine version.

For users with this information already cached this won't change though, only new elements added to that versions cache will have this fix, but I think it's good enough, it's only one patch different for one specific app, anyone using Battle.net can be instructed to clear that file and get the new version if needed.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
