### PR TITLE
Added a check for Steam installed as flatpak.

### DIFF
--- a/src/backend/constants/environment.ts
+++ b/src/backend/constants/environment.ts
@@ -31,10 +31,8 @@ const isSteamDeckDesktopMode =
   env.SESSION_MANAGER?.includes('unix/steamdeck') &&
   env.HOME === '/home/deck' &&
   env.DESKTOP_SESSION?.includes('steamos')
-export const isSteamFlatpak = spawnSync('flatpak', [
-    'info',
-    'com.valvesoftware.Steam'
-  ]).status === 0 // check if steam is installed as flatpak
+export const isSteamFlatpak =
+  spawnSync('flatpak', ['info', 'com.valvesoftware.Steam']).status === 0 // check if steam is installed as flatpak
 export const isSteamDeck = isSteamDeckGameMode || isSteamDeckDesktopMode
 export const isCLIFullscreen = process.argv.includes('--fullscreen')
 export const isCLINoGui = process.argv.includes('--no-gui')

--- a/src/backend/constants/environment.ts
+++ b/src/backend/constants/environment.ts
@@ -1,6 +1,7 @@
 import { env } from 'process'
 import { cpus } from 'os'
 import { readFileSync } from 'graceful-fs'
+import { spawnSync } from 'child_process'
 
 interface Manifest {
   'runtime-version': string
@@ -30,6 +31,10 @@ const isSteamDeckDesktopMode =
   env.SESSION_MANAGER?.includes('unix/steamdeck') &&
   env.HOME === '/home/deck' &&
   env.DESKTOP_SESSION?.includes('steamos')
+export const isSteamFlatpak = spawnSync('flatpak', [
+    'info',
+    'com.valvesoftware.Steam'
+  ]).status === 0 // check if steam is installed as flatpak
 export const isSteamDeck = isSteamDeckGameMode || isSteamDeckDesktopMode
 export const isCLIFullscreen = process.argv.includes('--fullscreen')
 export const isCLINoGui = process.argv.includes('--no-gui')

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -24,7 +24,12 @@ import { notify, showDialogBoxModalAuto } from '../../dialog/dialog'
 import { GlobalConfig } from '../../config'
 import { getWikiGameInfo } from 'backend/wiki_game_info/wiki_game_info'
 import { tsStore } from 'backend/constants/key_value_stores'
-import { isAppImage, isFlatpak, isWindows, isSteamFlatpak } from 'backend/constants/environment'
+import {
+  isAppImage,
+  isFlatpak,
+  isWindows,
+  isSteamFlatpak
+} from 'backend/constants/environment'
 
 const getSteamUserdataDir = async () => {
   const { defaultSteamPath } = GlobalConfig.get().getSettings()
@@ -266,6 +271,7 @@ async function addNonSteamGame(props: {
     newEntry.Exe = `"${app.getPath('exe')}"`
     newEntry.StartDir = `"${process.cwd()}"`
 
+    // use xdg-open if Steam installed as flatpak
     if (isFlatpak && isSteamFlatpak) {
       newEntry.Exe = `"xdg-open"`
     } else if (isFlatpak) {
@@ -275,7 +281,7 @@ async function addNonSteamGame(props: {
     } else if (isWindows && process.env.PORTABLE_EXECUTABLE_FILE) {
       newEntry.Exe = `"${process.env.PORTABLE_EXECUTABLE_FILE}"`
       newEntry.StartDir = `"${process.env.PORTABLE_EXECUTABLE_DIR}"`
-    } // use xdg-open if Steam installed as flatpak
+    }
 
     newEntry.appid = generateShortcutId(newEntry.Exe, newEntry.AppName)
 
@@ -298,21 +304,23 @@ async function addNonSteamGame(props: {
       steamID: steamID
     })
 
+    // no args when using xdg-open..
     const args = []
     if (!isSteamFlatpak) {
       args.push('--no-gui')
       if (!isWindows) {
         args.push('--no-sandbox')
       }
-    } // no args when using xdg-open..
+    }
 
     const { runner, app_name } = props.gameInfo
 
+    // no run option for flatpak when using xdg-open
     args.push(`"heroic://launch?appName=${app_name}&runner=${runner}"`)
     newEntry.LaunchOptions = args.join(' ')
     if (isFlatpak && !isSteamFlatpak) {
       newEntry.LaunchOptions = `run com.heroicgameslauncher.hgl ${newEntry.LaunchOptions}`
-    } // fefomod - no run option for flatpak when using xdg-open..
+    }
     newEntry.IsHidden = false
     newEntry.AllowDesktopConfig = true
     newEntry.AllowOverlay = true

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -24,7 +24,7 @@ import { notify, showDialogBoxModalAuto } from '../../dialog/dialog'
 import { GlobalConfig } from '../../config'
 import { getWikiGameInfo } from 'backend/wiki_game_info/wiki_game_info'
 import { tsStore } from 'backend/constants/key_value_stores'
-import { isAppImage, isFlatpak, isWindows } from 'backend/constants/environment'
+import { isAppImage, isFlatpak, isWindows, isSteamFlatpak } from 'backend/constants/environment'
 
 const getSteamUserdataDir = async () => {
   const { defaultSteamPath } = GlobalConfig.get().getSettings()
@@ -266,14 +266,16 @@ async function addNonSteamGame(props: {
     newEntry.Exe = `"${app.getPath('exe')}"`
     newEntry.StartDir = `"${process.cwd()}"`
 
-    if (isFlatpak) {
+    if (isFlatpak && isSteamFlatpak) {
+      newEntry.Exe = `"xdg-open"`
+    } else if (isFlatpak) {
       newEntry.Exe = `"flatpak"`
     } else if (!isWindows && isAppImage) {
       newEntry.Exe = `"${process.env.APPIMAGE}"`
     } else if (isWindows && process.env.PORTABLE_EXECUTABLE_FILE) {
       newEntry.Exe = `"${process.env.PORTABLE_EXECUTABLE_FILE}"`
       newEntry.StartDir = `"${process.env.PORTABLE_EXECUTABLE_DIR}"`
-    }
+    } // use xdg-open if Steam installed as flatpak
 
     newEntry.appid = generateShortcutId(newEntry.Exe, newEntry.AppName)
 
@@ -297,18 +299,20 @@ async function addNonSteamGame(props: {
     })
 
     const args = []
-    args.push('--no-gui')
-    if (!isWindows) {
-      args.push('--no-sandbox')
-    }
+    if (!isSteamFlatpak) {
+      args.push('--no-gui')
+      if (!isWindows) {
+        args.push('--no-sandbox')
+      }
+    } // no args when using xdg-open..
 
     const { runner, app_name } = props.gameInfo
 
     args.push(`"heroic://launch?appName=${app_name}&runner=${runner}"`)
     newEntry.LaunchOptions = args.join(' ')
-    if (isFlatpak) {
+    if (isFlatpak && !isSteamFlatpak) {
       newEntry.LaunchOptions = `run com.heroicgameslauncher.hgl ${newEntry.LaunchOptions}`
-    }
+    } // fefomod - no run option for flatpak when using xdg-open..
     newEntry.IsHidden = false
     newEntry.AllowDesktopConfig = true
     newEntry.AllowOverlay = true


### PR DESCRIPTION
Adding to Steam removes the arguments and uses "xdg-open" instead of "flatpak" in the .exe path when both Heroic and Steam are flatpaks.

<img width="839" height="596" alt="Schermata_20260416_002934" src="https://github.com/user-attachments/assets/b4a9b888-edc4-4359-ba01-fcfdba4380cd" />


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
