### PR TITLE
[FIX] Use mirror for latest Wine-Crossover version

### DIFF
--- a/src/backend/wine/manager/downloader/constants.ts
+++ b/src/backend/wine/manager/downloader/constants.ts
@@ -16,7 +16,7 @@ export const WINELUTRIS_URL =
 
 /// Url to Wine Crossover github release page
 export const WINECROSSOVER_URL =
-  'https://api.github.com/repos/Gcenx/winecx/releases'
+  'https://api.github.com/repos/Heroic-Games-Launcher/wine-crossover/releases'
 
 /// Url to Wine Staging for macOS github release page
 export const WINESTAGINGMACOS_URL =


### PR DESCRIPTION
The wine crossover repo seems to be gone.

This PR adds a different repo with the latest version so it can still be used in heroic, it should be only used if no other option works, but it is known to help with some games specially for Intel macs that don't have as many options as apple silicon

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
