### PR TITLE
[FIX] Use dpaste.com instead of 0x0.st to upload logs

### DIFF
--- a/src/backend/logger/uploader.ts
+++ b/src/backend/logger/uploader.ts
@@ -33,6 +33,7 @@ async function sendRequestToApi(
 
 const KiB = 1024
 const MiB = KiB * 1024
+const EXPIRY_DAYS = 2
 
 /**
  * Reads the first `size` bytes of a file
@@ -69,9 +70,9 @@ async function uploadLogFile(
 
   // const formData = new FormData()
   // formData.set('file', fileBlob, filename)
-  // formData.set('expires', '24')
+  // formData.set('expires', (EXPIRY_DAYS * 24).toString())
 
-  const formData = `content=${fileContents.toString()}&expiry_days=2`
+  const formData = `content=${fileContents.toString()}&expiry_days=${EXPIRY_DAYS}`
 
   const response = await sendRequestToApi(formData)
   if (!response) return false
@@ -149,8 +150,8 @@ async function getUploadedLogFiles(): Promise<Record<string, UploadedLogData>> {
   // Filter and delete expired logs
   for (const [key, value] of Object.entries(allStoredLogs)) {
     const timeDifferenceMs = Date.now() - value.uploadedAt
-    const timeDifferenceHours = timeDifferenceMs / 1000 / 60 / 60
-    if (timeDifferenceHours >= 24) {
+    const timeDifferenceDays = timeDifferenceMs / 1000 / 60 / 60 / 24
+    if (timeDifferenceDays >= EXPIRY_DAYS) {
       uploadedLogFileStore.delete(key)
     } else {
       validUploadedLogs[key] = value

--- a/src/backend/logger/uploader.ts
+++ b/src/backend/logger/uploader.ts
@@ -1,6 +1,5 @@
 import { app } from 'electron'
 import { open } from 'fs/promises'
-import path from 'path'
 import { z } from 'zod'
 
 import { TypeCheckedStoreBackend } from '../electron_store'
@@ -15,15 +14,19 @@ const uploadedLogFileStore = new TypeCheckedStoreBackend('uploadedLogs', {
   accessPropertiesByDotNotation: false
 })
 
-async function sendRequestToApi(formData: FormData, url = 'https://0x0.st') {
+async function sendRequestToApi(
+  formData: FormData | string,
+  url = 'https://dpaste.com/api/v2/'
+) {
   return fetch(url, {
     body: formData,
     method: 'post',
     headers: {
-      'User-Agent': `HeroicGamesLauncher/${app.getVersion()}`
+      'User-Agent': `HeroicGamesLauncher/${app.getVersion()}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
     }
   }).catch((err) => {
-    logError([`Failed to send data to 0x0.st:`, err], LogPrefix.LogUploader)
+    logError([`Failed to send data to dpaste.com:`, err], LogPrefix.LogUploader)
     return null
   })
 }
@@ -49,7 +52,7 @@ async function readPartOfFile(file: string, size: number) {
 }
 
 /**
- * Uploads the log file of a game / runner / Heroic to https://0x0.st
+ * Uploads the log file of a game / runner / Heroic to https://dpaste.com/api/v2/
  * @param name See {@link UploadedLogData.name}
  * @param getLogFileArgs Used to get the log file path. See {@link getLogFilePath}
  * @returns `false` if an error occurred, otherwise the URL to the uploaded file and {@link UploadedLogData}
@@ -59,19 +62,24 @@ async function uploadLogFile(
   getLogFileArgs: Parameters<typeof getLogFilePath>[0]
 ): Promise<false | [string, UploadedLogData]> {
   const fileLocation = getLogFilePath(getLogFileArgs)
-  const filename = path.basename(fileLocation)
-
   const fileContents = await readPartOfFile(fileLocation, 10 * MiB)
-  const fileBlob = new Blob([fileContents])
 
-  const formData = new FormData()
-  formData.set('file', fileBlob, filename)
-  formData.set('expires', '24')
+  // const filename = path.basename(fileLocation)
+  // const fileBlob = new Blob([fileContents])
+
+  // const formData = new FormData()
+  // formData.set('file', fileBlob, filename)
+  // formData.set('expires', '24')
+
+  const formData = `content=${fileContents.toString()}&expiry_days=2`
 
   const response = await sendRequestToApi(formData)
   if (!response) return false
 
-  const token = response.headers.get('X-Token')
+  // TODO: dpaste.com does not support deleting files, there's not token
+  // Setting 1 here so I don't have to remove all the code, in case 0x0.st
+  // starts working in the future. I'll hide the delete option.
+  const token = '1' // response.headers.get('X-Token')
   const responseText = (await response.text()).trim()
   const maybeUrl = z.string().url().safeParse(responseText)
   if (!response.ok || !token || !maybeUrl.success) {

--- a/src/frontend/screens/Settings/sections/LogSettings/components/UploadedLogFilesList/index.tsx
+++ b/src/frontend/screens/Settings/sections/LogSettings/components/UploadedLogFilesList/index.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Launch, Delete } from '@mui/icons-material'
+import { Launch } from '@mui/icons-material'
 
 import {
   Dialog,
@@ -43,6 +43,8 @@ const UploadedLogFileItem = memo(function UploadedLogFileItem(
     )
   }, [(Date.now() - uploadedAt) / 1000 / 60 > 60])
 
+  // TODO: Added here so we don't lose the translation for when we add this back
+  // t('setting.log.upload.delete', 'Request log file deletion')
   return (
     <tr>
       <td>{name}</td>
@@ -54,12 +56,12 @@ const UploadedLogFileItem = memo(function UploadedLogFileItem(
         >
           <Launch color="primary" />
         </SvgButton>
-        <SvgButton
+        {/* <SvgButton
           onClick={async () => window.api.deleteUploadedLogFile(url)}
           title={t('setting.log.upload.delete', 'Request log file deletion')}
         >
           <Delete color="error" />
-        </SvgButton>
+        </SvgButton> */}
       </td>
     </tr>
   )


### PR DESCRIPTION
0x0.st doesn't seem to work anymore

This PR replaces that service with dpaste.com, at least temporarily we can use 0x0.st again or we find an alternative that has the same features (dpaste.com does not have the option to delete files unless we create an account and have an API key, which makes no sense since the API key will be shared with the world)

I left the code for the 0x0.st integration and deleting logs commented out, removing it means a lot of changes and I rather keep this as simple as possible before a release and also maybe 0x0.st starts working again.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
