### PR TITLE
[FIX] System info and game settings in logs for native sideloaded games

### DIFF
--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -1,11 +1,6 @@
 import { GameInfo, GameSettings, Runner } from 'common/types'
 import { GameConfig } from '../../game_config'
-import {
-  createGameLogWriter,
-  logInfo,
-  LogPrefix,
-  logWarning
-} from 'backend/logger'
+import { logInfo, LogPrefix, logWarning } from 'backend/logger'
 import { basename, dirname } from 'path'
 import { constants as FS_CONSTANTS } from 'graceful-fs'
 import i18next from 'i18next'
@@ -228,7 +223,6 @@ export async function launchGame(
         extraArgs.unshift(...wrappers, executable)
         executable = extraArgs.shift()!
       }
-      const logFileWriter = await createGameLogWriter(appName, 'sideload')
 
       await callRunner(
         extraArgs,
@@ -241,7 +235,7 @@ export async function launchGame(
         {
           env,
           wrappers,
-          logWriters: [logFileWriter],
+          logWriters: [logWriter],
           logMessagePrefix: LogPrefix.Backend
         }
       )


### PR DESCRIPTION
We have an issue with logs for native games sideloaded, for the launch command we are creating a new logger which overrides the logger, that creates a new files that replaces the log that was used in the previous part of the launch process that logs all the system info, game info, etc.

We end up with logs that are missing all the settings part and only include the game's output.

This fixes that by using the already available logWriter variable.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
