### PR TITLE
[Chore] Check if Arm or x86 on plausible analytics

### DIFF
--- a/src/backend/utils/plausible.ts
+++ b/src/backend/utils/plausible.ts
@@ -6,11 +6,12 @@ import {
   isSteamDeckGameMode,
   isSteamDeck
 } from 'backend/constants/environment'
-import { logInfo, LogPrefix } from 'backend/logger'
+import { logInfo, logWarning, LogPrefix } from 'backend/logger'
 import { GOGUser } from 'backend/storeManagers/gog/user'
 import { LegendaryUser } from 'backend/storeManagers/legendary/user'
 import { NileUser } from 'backend/storeManagers/nile/user'
 import { libraryStore } from 'backend/storeManagers/sideload/electronStores'
+import { getOsInfo } from 'backend/utils/systeminfo/osInfo'
 import { app } from 'electron'
 import https from 'https'
 
@@ -70,7 +71,7 @@ function Plausible() {
   }
 }
 
-export function startPlausible() {
+export async function startPlausible() {
   if (process.env.CI === 'e2e') {
     logInfo('Skipping Plausible Analytics in E2E tests', LogPrefix.Backend)
     return
@@ -89,6 +90,19 @@ export function startPlausible() {
     .filter(([, v]) => v)
     .map(([k]) => k)
 
+  let distro = 'unknown'
+  let distroVersion = 'unknown'
+  try {
+    const osInfo = await getOsInfo()
+    if (osInfo.name) distro = osInfo.name
+    if (osInfo.version) distroVersion = osInfo.version
+  } catch (error) {
+    logWarning(
+      `Failed to read OS info for analytics: ${error}`,
+      LogPrefix.Backend
+    )
+  }
+
   const props = {
     version: appVersion,
     gog: providersObject.gog || false,
@@ -97,6 +111,9 @@ export function startPlausible() {
     sideloaded: providersObject.sideloaded || false,
     providers: loggedInProviders.join(', '),
     OS: process.platform,
+    arch: process.arch,
+    distro,
+    distroVersion,
     isFlatpak: isFlatpak,
     isAppImage: isAppImage,
     isSnap: isSnap,

--- a/src/frontend/screens/Settings/components/AnalyticsDialog.tsx
+++ b/src/frontend/screens/Settings/components/AnalyticsDialog.tsx
@@ -30,7 +30,7 @@ export default function AnalyticsDialog() {
               <li>
                 {t(
                   'analyticsModal.info.pt2',
-                  'Heroic uses the open-source Plausible Analytics platform to gather basic data: App Version, OS, Stores Connected and Country.'
+                  'Heroic uses the open-source Plausible Analytics platform to gather basic data: App Version, OS, System Architecture, Linux Distribution, Stores Connected and Country.'
                 )}
               </li>
               <li>


### PR DESCRIPTION
## Summary
- Include `process.arch` in the Plausible `App Loaded` event so we can see the split between x64 and arm64 users.
- Include the Linux distribution name and version (via the existing `getOsInfo()` helper that reads `/etc/os-release`) for Linux, plus the WMI-derived name on Windows.
- Update the analytics opt-in dialog wording to disclose the new fields.

## Test plan
- [x] `pnpm codecheck` passes
- [x] Launch the app with analytics opted in and confirm the `Shared Data` log line shows the new `arch`, `distro`, and `distroVersion` fields
- [x] Confirm the events reach the Plausible dashboard with the new custom properties