### PR TITLE
feat: support ubisoftconnect managed titles

### DIFF
--- a/src/backend/downloadmanager/downloadqueue.ts
+++ b/src/backend/downloadmanager/downloadqueue.ts
@@ -145,7 +145,7 @@ async function addToQueue(element: DMQueueElement) {
     const gameInfo = libraryManagerMap[element.params.runner].getGameInfo(
       element.params.appName
     )
-    if (!gameInfo?.isEAManaged) {
+    if (!gameInfo?.isEAManaged && !gameInfo?.isUbisoftManaged) {
       const installInfo = await libraryManagerMap[
         element.params.runner
       ].getInstallInfo(

--- a/src/backend/storeManagers/legendary/commands/launch.ts
+++ b/src/backend/storeManagers/legendary/commands/launch.ts
@@ -15,6 +15,7 @@ interface LaunchCommand {
   '--reset-defaults'?: true
   '--override-exe'?: Path
   '--origin'?: true
+  '--ubisoft'?: true
   '--json'?: true
   '--wine'?: Path
   '--wine-prefix'?: Path

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -589,15 +589,17 @@ export async function install(
 }> {
   const gameInfo = getGameInfo(appName)
   if (gameInfo.thirdPartyManagedApp) {
-    if (!gameInfo.isEAManaged) {
-      logError(
-        ['Third party app', gameInfo.thirdPartyManagedApp, 'not supported'],
-        LogPrefix.Legendary
-      )
-      return { status: 'error' }
+    if (gameInfo.isEAManaged) {
+      return installEA(gameInfo, platformToInstall)
+    } else if (gameInfo.isUbisoftManaged) {
+      return installUbisoft(gameInfo, platformToInstall)
     }
 
-    return installEA(gameInfo, platformToInstall)
+    logError(
+      ['Third party app', gameInfo.thirdPartyManagedApp, 'not supported'],
+      LogPrefix.Legendary
+    )
+    return { status: 'error' }
   }
   const { maxWorkers, downloadNoHttps } = GlobalConfig.get().getSettings()
   const info = await getInstallInfo(appName, platformToInstall)
@@ -695,6 +697,44 @@ async function installEA(
       'EAX_LAUNCH_CLIENT=0',
       'IGNORE_INSTALLED=1'
     ])
+
+    if (process.code !== null && process.code === 3) {
+      return { status: 'abort' }
+    }
+  }
+
+  await thirdParty.addInstalledGame(gameInfo.app_name, platformToInstall)
+
+  return { status: 'done' }
+}
+
+async function installUbisoft(
+  gameInfo: GameInfo,
+  platformToInstall: string
+): Promise<{
+  status: 'done' | 'error' | 'abort'
+  error?: string
+}> {
+  logInfo('Getting Ubisoft installer', LogPrefix.Legendary)
+  const installerPath = join(epicRedistPath, 'UbisoftConnectInstaller.exe')
+
+  if (!existsSync(epicRedistPath)) {
+    mkdirSync(epicRedistPath, { recursive: true })
+  }
+
+  if (!existsSync(installerPath)) {
+    try {
+      await downloadFile({
+        url: 'https://static3.cdn.ubi.com/orbit/launcher_installer/UbisoftConnectInstaller.exe',
+        dest: installerPath
+      })
+    } catch (e) {
+      return { status: 'error', error: `${e}` }
+    }
+  }
+
+  if (isWindows) {
+    const process = await spawnAsync(installerPath, ['/S'])
 
     if (process.code !== null && process.code === 3) {
       return { status: 'abort' }
@@ -983,6 +1023,7 @@ export async function launch(
   if (offlineMode) command['--offline'] = true
   if (isCLINoGui) command['--skip-version-check'] = true
   if (gameInfo.isEAManaged) command['--origin'] = true
+  if (gameInfo.isUbisoftManaged) command['--ubisoft'] = true
 
   sendGameStatusUpdate({ appName, runner: 'legendary', status: 'playing' })
 

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -544,7 +544,9 @@ function loadFile(app_name: string): boolean {
   const FolderName = customAttributes?.FolderName
   const canRunOffline = customAttributes?.CanRunOffline?.value === 'true'
   const thirdPartyManagedApp =
-    customAttributes?.ThirdPartyManagedApp?.value || undefined
+    customAttributes?.ThirdPartyManagedApp?.value ||
+    customAttributes?.ThirdPartyManagedProvider?.value ||
+    undefined
 
   if (dlcItemList) {
     dlcItemList.forEach((v: { releaseInfo: { appId: string }[] }) => {
@@ -642,6 +644,9 @@ function loadFile(app_name: string): boolean {
     isEAManaged:
       !!thirdPartyManagedApp &&
       ['origin', 'the ea app'].includes(thirdPartyManagedApp.toLowerCase()),
+    isUbisoftManaged:
+      !!thirdPartyManagedApp &&
+      'ubisoftconnect' == thirdPartyManagedApp.toLowerCase(),
     is_linux_native: false,
     runner: 'legendary',
     store_url: formatEpicStoreUrl(title)

--- a/src/backend/storeManagers/legendary/setup.ts
+++ b/src/backend/storeManagers/legendary/setup.ts
@@ -43,7 +43,8 @@ export const legendarySetup = async (appName: string, logWriter: LogWriter) => {
   if (
     gameInfo.install.platform &&
     winPlatforms.includes(gameInfo.install.platform) &&
-    !gameInfo.isEAManaged
+    !gameInfo.isEAManaged &&
+    !gameInfo.isUbisoftManaged
   ) {
     try {
       const info = await getInstallInfo(appName, gameInfo.install.platform)
@@ -85,6 +86,19 @@ export const legendarySetup = async (appName: string, logWriter: LogWriter) => {
       })
     } catch (e) {
       logError(`Failed to run EA App installer ${e}`, LogPrefix.Legendary)
+    }
+  } else if (gameInfo.isUbisoftManaged) {
+    const installerPath = join(epicRedistPath, 'UbisoftConnectInstaller.exe')
+    console.log('Installing', installerPath)
+    try {
+      await runWineCommand({
+        gameSettings,
+        commandParts: [installerPath, '/S'],
+        wait: true,
+        protonVerb: 'run'
+      })
+    } catch (e) {
+      logError(`Failed to run Ubisoft installer ${e}`, LogPrefix.Legendary)
     }
   }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -204,6 +204,7 @@ export interface GameInfo {
   canRunOffline: boolean
   thirdPartyManagedApp?: string
   isEAManaged?: boolean
+  isUbisoftManaged?: boolean
   is_mac_native?: boolean
   is_linux_native?: boolean
   browserUrl?: string

--- a/src/common/types/legendary.ts
+++ b/src/common/types/legendary.ts
@@ -106,6 +106,10 @@ type CustomAttributeType =
   | 'extraLaunchOption_001_Name'
   | 'ThirdPartyManagedApp'
   | 'AdditionalCommandLine'
+  | 'ThirdPartyManagedProvider'
+  | 'GameID'
+  | 'RegistryKey'
+  | 'RegistryPath'
 
 interface CustomAttributeValue {
   type: 'STRING'

--- a/src/frontend/hooks/hasStatus.ts
+++ b/src/frontend/hooks/hasStatus.ts
@@ -25,7 +25,8 @@ export function hasStatus(gameInfo: GameInfo, gameSize?: string) {
     thirdPartyManagedApp = undefined,
     is_installed,
     runner = 'sideload',
-    isEAManaged
+    isEAManaged,
+    isUbisoftManaged
   } = { ...newGameInfo }
 
   React.useEffect(() => {
@@ -65,7 +66,7 @@ export function hasStatus(gameInfo: GameInfo, gameSize?: string) {
         return setGameStatus({ status, folder, label, statusContext })
       }
 
-      if (thirdPartyManagedApp && !isEAManaged) {
+      if (thirdPartyManagedApp && !isEAManaged && !isUbisoftManaged) {
         const label = getStatusLabel({
           status: 'notSupportedGame',
           t,

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -163,7 +163,8 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const notSupportedGame =
     gameInfo.runner !== 'sideload' &&
     !!gameInfo.thirdPartyManagedApp &&
-    !gameInfo.isEAManaged
+    !gameInfo.isEAManaged &&
+    !gameInfo.isUbisoftManaged
   const isOffline = connectivity.status !== 'online'
   const notPlayableOffline = isOffline && !gameInfo.canRunOffline
 


### PR DESCRIPTION
This relies on a patch to legendary https://github.com/legendary-gl/legendary/pull/750 in order to enable `uplay://` launch protocol

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
