### PR TITLE
Feat: add help info on max workers under general settings

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -479,6 +479,9 @@
         },
         "general": "Sync with EGL if you have a working installation of the Epic Games Launcher elsewhere and want to import your games to avoid downloading them again.",
         "mangohud": "MangoHUD is an overlay that displays and monitors FPS, temperatures, CPU/GPU load and other system resources.",
+        "max_workers": {
+            "info": "Limits download speed. This sets the maximum number of parallel download chunks. High numbers can lead to high CPU usage."
+        },
         "msync": "Msync aims to reduce wineserver overhead in CPU-intensive games. Enabling may improve performance on supported Linux kernels.",
         "other": {
             "part4": "Use the ",

--- a/src/frontend/screens/Settings/components/MaxWorkers.tsx
+++ b/src/frontend/screens/Settings/components/MaxWorkers.tsx
@@ -30,13 +30,14 @@ const MaxWorkers = () => {
     <p>{helpContent}</p>
   )
 
-
   return (
-    <div style={{
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'flex-start',
-    }}>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start'
+      }}
+    >
       <SelectField
         htmlId="max_workers"
         label={t('setting.maxworkers')}
@@ -53,7 +54,7 @@ const MaxWorkers = () => {
           Max
         </MenuItem>
       </SelectField>
-      <InfoIcon text={helpContent}/>
+      <InfoIcon text={helpContent} />
     </div>
   )
 }

--- a/src/frontend/screens/Settings/components/MaxWorkers.tsx
+++ b/src/frontend/screens/Settings/components/MaxWorkers.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { SelectField } from 'frontend/components/UI'
 import useSetting from 'frontend/hooks/useSetting'
 import { MenuItem } from '@mui/material'
+import { hasHelp } from 'frontend/hooks/hasHelp'
+import InfoIcon from 'frontend/components/UI/InfoIcon'
 
 const MaxWorkers = () => {
   const { t } = useTranslation()
@@ -17,23 +19,42 @@ const MaxWorkers = () => {
     getMoreInfo()
   }, [maxWorkers])
 
+  const helpContent = t(
+    'help.max_workers.info',
+    'Limits download speed. This sets the maximum number of parallel download chunks. High numbers can lead to high CPU usage.'
+  )
+
+  hasHelp(
+    'maxWorkers',
+    t('setting.maxworkers', 'Maximum Number of Workers when downloading'),
+    <p>{helpContent}</p>
+  )
+
+
   return (
-    <SelectField
-      htmlId="max_workers"
-      label={t('setting.maxworkers')}
-      onChange={(event) => setMaxWorkers(Number(event.target.value))}
-      value={maxWorkers.toString()}
-      extraClass="smaller"
-    >
-      {Array.from(Array(maxCpus).keys()).map((n) => (
-        <MenuItem key={n + 1} value={n + 1}>
-          {n + 1}
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+    }}>
+      <SelectField
+        htmlId="max_workers"
+        label={t('setting.maxworkers')}
+        onChange={(event) => setMaxWorkers(Number(event.target.value))}
+        value={maxWorkers.toString()}
+        extraClass="smaller"
+      >
+        {Array.from(Array(maxCpus).keys()).map((n) => (
+          <MenuItem key={n + 1} value={n + 1}>
+            {n + 1}
+          </MenuItem>
+        ))}
+        <MenuItem key={0} value={0}>
+          Max
         </MenuItem>
-      ))}
-      <MenuItem key={0} value={0}>
-        Max
-      </MenuItem>
-    </SelectField>
+      </SelectField>
+      <InfoIcon text={helpContent}/>
+    </div>
   )
 }
 

--- a/src/frontend/screens/Settings/components/MaxWorkers.tsx
+++ b/src/frontend/screens/Settings/components/MaxWorkers.tsx
@@ -34,8 +34,9 @@ const MaxWorkers = () => {
     <div
       style={{
         display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start'
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'flex-end'
       }}
     >
       <SelectField

--- a/src/frontend/screens/Settings/components/MaxWorkers.tsx
+++ b/src/frontend/screens/Settings/components/MaxWorkers.tsx
@@ -21,7 +21,7 @@ const MaxWorkers = () => {
 
   const helpContent = t(
     'help.max_workers.info',
-    'Limits download speed. This sets the maximum number of parallel download chunks. High numbers can lead to high CPU usage.'
+    'Sets the maximum number of parallel download chunks. Lower numbers limit download speed. High numbers can lead to high CPU usage.'
   )
 
   hasHelp(


### PR DESCRIPTION
Related to this old issue: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/1819

Adds an help `InfoIcon` with the description: _Limits download speed. This sets the maximum number of parallel download chunks. High numbers can lead to high CPU usage._

to edit `translation.json` I did: `pnpm run i18n`
to fix lint I did: `pnpm prettier --write src/frontend/screens/Settings/components/MaxWorkers.tsx`

Preview:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/81ffbfc5-438e-4810-bd9b-f37ceb62b7e1" />

obs:  no IA was used. Most projects ask about this, so I think it's good to have it here.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
