### PR TITLE
[DRAFT] Deduplicate games

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "dist:win": "electron-vite build && electron-builder --win",
     "dist:flatpak": "pnpm dist:linux appimage && pnpm flatpak:prepare && pnpm flatpak:build",
     "lint": "eslint --cache .",
-    "lint-fix": "eslint --fix --ext .tsx,ts ./src",
+    "lint-fix": "eslint --fix --quiet --ext .tsx,ts ./src",
     "flatpak:build": "cd flatpak-build && flatpak-builder build com.heroicgameslauncher.hgl.yml --install --force-clean --user",
     "flatpak:prepare": "node ./flatpak/prepareFlatpak.js",
     "flatpak:prepare-release": "node ./flatpak/prepareFlatpak.js release",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -795,6 +795,7 @@
             "cometSupport": "Comet support",
             "enableHelp": "Help component",
             "enableNewDesign": "New design",
+            "hideDuplicateGames": "Hide duplicate games",
             "zoomPlatform": "Zoom Platform support (only Linux)"
         },
         "frameless-window": {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -103,7 +103,7 @@ import {
   getBranchPassword,
   setBranchPassword,
   getGOGPlaytime,
-  syncQueuedPlaytimeGOG
+  syncQueuedPlaytimeGOG, getAchievements as getAchievementsGOG 
 } from 'backend/storeManagers/gog/games'
 import { playtimeSyncQueue } from './storeManagers/gog/electronStores'
 import * as LegendaryLibraryManager from 'backend/storeManagers/legendary/library'
@@ -157,7 +157,6 @@ import {
 } from './constants/paths'
 import { supportedLanguages } from 'common/languages'
 import MigrationSystem from './migration'
-import { getAchievements as getAchievementsGOG } from './storeManagers/gog/games'
 
 if (isLinux) app.commandLine?.appendSwitch('--gtk-version', '3')
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -103,7 +103,8 @@ import {
   getBranchPassword,
   setBranchPassword,
   getGOGPlaytime,
-  syncQueuedPlaytimeGOG, getAchievements as getAchievementsGOG 
+  syncQueuedPlaytimeGOG,
+  getAchievements as getAchievementsGOG
 } from 'backend/storeManagers/gog/games'
 import { playtimeSyncQueue } from './storeManagers/gog/electronStores'
 import * as LegendaryLibraryManager from 'backend/storeManagers/legendary/library'

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -85,6 +85,14 @@ export type ExperimentalFeatures = {
   cometSupport: boolean
   umuSupport?: boolean
   zoomPlatform?: boolean
+  hideDuplicateGames: boolean
+}
+
+export interface GameGroup {
+  title: string
+  games: GameInfo[]
+  // Representative game for display (first installed, or first in list)
+  representative: GameInfo
 }
 
 export interface AppSettings extends GameSettings {

--- a/src/frontend/components/UI/StoreLogos/index.css
+++ b/src/frontend/components/UI/StoreLogos/index.css
@@ -1,0 +1,45 @@
+.store-logos-container {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--space-3xs);
+  flex-wrap: nowrap;
+}
+
+.store-logos-container .store-logo-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.store-logos-container .store-logo-button {
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
+.store-logos-container .store-logo-button.selected > svg {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+}
+
+.store-logos-container .store-logo-button:focus-visible > svg {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+}
+
+.store-logos-container .store-logo-badge > svg {
+  width: 46px;
+  height: 46px;
+  padding: var(--space-2xs);
+  border-radius: 10px;
+  background-color: var(--body-background);
+  fill: var(--text-default);
+  box-sizing: border-box;
+}
+
+.store-logos-container .store-logo-badge > svg.gogIcon {
+  padding: 0px var(--space-3xs) var(--space-3xs);
+}

--- a/src/frontend/components/UI/StoreLogos/index.tsx
+++ b/src/frontend/components/UI/StoreLogos/index.tsx
@@ -5,22 +5,31 @@ import SideLoad from 'frontend/assets/heroic-icon.svg?react'
 import AmazonLogo from 'frontend/assets/amazon-logo.svg?react'
 import ZoomLogo from 'frontend/assets/zoom-logo.svg?react'
 
-type Props = { runner: Runner; className?: string }
+type Props = { runner?: Runner; runners?: Runner[]; className?: string }
 
 export default function StoreLogos({
   runner,
+  runners,
   className = 'store-icon'
 }: Props) {
-  switch (runner) {
-    case 'legendary':
-      return <EpicLogo className={className} />
-    case 'gog':
-      return <GOGLogo className={className} />
-    case 'nile':
-      return <AmazonLogo className={className} />
-    case 'zoom':
-      return <ZoomLogo className={className} />
-    default:
-      return <SideLoad className={className} />
-  }
+  const runnersToShow = runners || (runner ? [runner] : [])
+
+  return (
+    <div className="store-logos-container">
+      {runnersToShow.map((r, index) => {
+        switch (r) {
+          case 'legendary':
+            return <EpicLogo key={index} className={className} />
+          case 'gog':
+            return <GOGLogo key={index} className={className} />
+          case 'nile':
+            return <AmazonLogo key={index} className={className} />
+          case 'zoom':
+            return <ZoomLogo key={index} className={className} />
+          default:
+            return <SideLoad key={index} className={className} />
+        }
+      })}
+    </div>
+  )
 }

--- a/src/frontend/components/UI/StoreLogos/index.tsx
+++ b/src/frontend/components/UI/StoreLogos/index.tsx
@@ -25,9 +25,7 @@ export default function StoreLogos({
   selectedRunner,
   onGameClick
 }: Props) {
-  const runnersToShow = Array.from(
-    new Set(runners || (runner ? [runner] : []))
-  )
+  const runnersToShow = Array.from(new Set(runners || (runner ? [runner] : [])))
 
   const selectableGames =
     onGameClick && games && games.length > 1 ? games : undefined

--- a/src/frontend/components/UI/StoreLogos/index.tsx
+++ b/src/frontend/components/UI/StoreLogos/index.tsx
@@ -1,35 +1,80 @@
-import { Runner } from 'common/types'
+import './index.css'
+
+import { GameInfo, Runner } from 'common/types'
+import { getStoreName } from 'frontend/helpers'
 import EpicLogo from 'frontend/assets/epic-logo.svg?react'
 import GOGLogo from 'frontend/assets/gog-logo.svg?react'
 import SideLoad from 'frontend/assets/heroic-icon.svg?react'
 import AmazonLogo from 'frontend/assets/amazon-logo.svg?react'
 import ZoomLogo from 'frontend/assets/zoom-logo.svg?react'
 
-type Props = { runner?: Runner; runners?: Runner[]; className?: string }
+type Props = {
+  runner?: Runner
+  runners?: Runner[]
+  games?: GameInfo[]
+  className?: string
+  selectedRunner?: Runner
+  onGameClick?: (game: GameInfo) => void
+}
 
 export default function StoreLogos({
   runner,
   runners,
-  className = 'store-icon'
+  games,
+  className = 'store-icon',
+  selectedRunner,
+  onGameClick
 }: Props) {
-  const runnersToShow = runners || (runner ? [runner] : [])
+  const runnersToShow = Array.from(
+    new Set(runners || (runner ? [runner] : []))
+  )
+
+  const selectableGames =
+    onGameClick && games && games.length > 1 ? games : undefined
+
+  const renderLogo = (store: Runner) => {
+    switch (store) {
+      case 'legendary':
+        return <EpicLogo />
+      case 'gog':
+        return <GOGLogo />
+      case 'nile':
+        return <AmazonLogo />
+      case 'zoom':
+        return <ZoomLogo />
+      default:
+        return <SideLoad />
+    }
+  }
 
   return (
-    <div className="store-logos-container">
-      {runnersToShow.map((r, index) => {
-        switch (r) {
-          case 'legendary':
-            return <EpicLogo key={index} className={className} />
-          case 'gog':
-            return <GOGLogo key={index} className={className} />
-          case 'nile':
-            return <AmazonLogo key={index} className={className} />
-          case 'zoom':
-            return <ZoomLogo key={index} className={className} />
-          default:
-            return <SideLoad key={index} className={className} />
-        }
-      })}
+    <div className={`store-logos-container ${className}`.trim()}>
+      {selectableGames
+        ? selectableGames.map((game, index) => {
+            const isSelected = selectedRunner === game.runner
+
+            return (
+              <button
+                key={`${game.runner}-${game.app_name}-${index}`}
+                type="button"
+                className={`store-logo-badge store-logo-button ${isSelected ? 'selected' : ''}`.trim()}
+                title={getStoreName(game.runner, 'Other')}
+                onClick={() => onGameClick?.(game)}
+                aria-pressed={isSelected}
+              >
+                {renderLogo(game.runner)}
+              </button>
+            )
+          })
+        : runnersToShow.map((store, index) => (
+            <span
+              key={`${store}-${index}`}
+              className="store-logo-badge"
+              title={getStoreName(store, 'Other')}
+            >
+              {renderLogo(store)}
+            </span>
+          ))}
     </div>
   )
 }

--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -31,6 +31,7 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
   const [verboseLogs, setVerboseLogs] = useSetting('verboseLogs', true)
 
   const actualGameInfo = 'games' in gameInfo ? gameInfo.representative : gameInfo
+
   const is_installed = actualGameInfo.is_installed
   const disabledPlayButtons =
     is.reparing ||
@@ -219,7 +220,7 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
               }
               handleInstall(is_installed)
             }}
-            disabled={disabledInstallButtons}
+            disabled={disabledInstallButtons || is.installing || is.importing}
             autoFocus={true}
             className={classNames(
               'button',

--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -14,11 +14,11 @@ import {
   Warning
 } from '@mui/icons-material'
 import classNames from 'classnames'
-import { GameInfo } from 'common/types'
+import { GameInfo, GameGroup } from 'common/types'
 import useSetting from 'frontend/hooks/useSetting'
 
 interface Props {
-  gameInfo: GameInfo
+  gameInfo: GameInfo | GameGroup
   handlePlay: (gameInfo: GameInfo) => Promise<void>
   handleInstall: (
     is_installed: boolean
@@ -30,7 +30,8 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
   const { is } = useContext(GameContext)
   const [verboseLogs, setVerboseLogs] = useSetting('verboseLogs', true)
 
-  const is_installed = gameInfo.is_installed
+  const actualGameInfo = 'games' in gameInfo ? gameInfo.representative : gameInfo
+  const is_installed = actualGameInfo.is_installed
   const disabledPlayButtons =
     is.reparing ||
     is.moving ||
@@ -168,7 +169,7 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
 
   const handleAltLaunch = async () => {
     setVerboseLogs(!verboseLogs)
-    await handlePlay(gameInfo)
+    await handlePlay(actualGameInfo)
   }
 
   return (
@@ -178,7 +179,7 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
           <button
             disabled={disabledPlayButtons}
             autoFocus={true}
-            onClick={async () => handlePlay(gameInfo)}
+            onClick={async () => handlePlay(actualGameInfo)}
             className={classNames(
               'button',
               {
@@ -209,9 +210,9 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
             onClick={async () => {
               if (!is_installed && !is.queued) {
                 openInstallGameModal({
-                  appName: gameInfo.app_name,
-                  runner: gameInfo.runner,
-                  gameInfo,
+                  appName: actualGameInfo.app_name,
+                  runner: actualGameInfo.runner,
+                  gameInfo: actualGameInfo,
                   action: 'install'
                 })
                 return
@@ -241,9 +242,9 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
             className={'button mainBtn outline'}
             onClick={() =>
               openInstallGameModal({
-                appName: gameInfo.app_name,
-                runner: gameInfo.runner,
-                gameInfo,
+                appName: actualGameInfo.app_name,
+                runner: actualGameInfo.runner,
+                gameInfo: actualGameInfo,
                 action: 'import'
               })
             }

--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -30,7 +30,8 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
   const { is } = useContext(GameContext)
   const [verboseLogs, setVerboseLogs] = useSetting('verboseLogs', true)
 
-  const actualGameInfo = 'games' in gameInfo ? gameInfo.representative : gameInfo
+  const actualGameInfo =
+    'games' in gameInfo ? gameInfo.representative : gameInfo
 
   const is_installed = actualGameInfo.is_installed
   const disabledPlayButtons =

--- a/src/frontend/screens/Game/GamePage/index.css
+++ b/src/frontend/screens/Game/GamePage/index.css
@@ -165,6 +165,11 @@
         position: absolute;
         left: 0.5rem;
         top: 0.5rem;
+        display: inline-flex;
+        width: fit-content;
+        height: fit-content;
+        padding: 0;
+        background: transparent;
       }
 
       .gamePicture {
@@ -313,6 +318,54 @@
         .installButtons {
           gap: var(--space-xs);
           flex-wrap: wrap;
+
+          .installSplitGroup {
+            display: inline-flex;
+            align-items: stretch;
+          }
+
+          .installPrimaryButton {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+          }
+
+          .installSplitArrowButton {
+            min-width: 46px;
+            padding-inline: var(--space-xs);
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+            margin-inline-start: 1px;
+
+            svg {
+              margin-inline-end: 0;
+            }
+          }
+
+          .installDropdown {
+            .dropdown {
+              min-width: 280px;
+              padding: var(--space-xs);
+              gap: var(--space-3xs);
+            }
+
+            .installStoreButton {
+              width: 100%;
+              margin: 0;
+              align-self: stretch;
+              justify-content: flex-start;
+              white-space: normal;
+              text-align: left;
+              min-width: 0;
+              padding-block: 12px;
+              padding-inline: var(--space-sm);
+            }
+
+            .installStoreButton .buttonWithIcon {
+              width: 100%;
+              gap: var(--space-2xs);
+              justify-content: flex-start;
+            }
+          }
         }
 
         & .mainBtn {

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -28,6 +28,7 @@ import UninstallModal from 'frontend/components/UI/UninstallModal'
 import {
   ExtraInfo,
   GameInfo,
+  GameGroup,
   GameSettings,
   Runner,
   WikiInfo,
@@ -79,7 +80,7 @@ import { LaunchOptionSelector } from 'frontend/screens/Settings/components'
 export default React.memo(function GamePage(): JSX.Element | null {
   const { appName, runner } = useParams() as { appName: string; runner: Runner }
   const location = useLocation() as {
-    state: { fromDM: boolean; gameInfo: GameInfo }
+    state: { fromDM: boolean; gameInfo: GameInfo | GameGroup }
   }
   const { t, i18n } = useTranslation('gamepage')
   const { t: t2 } = useTranslation()
@@ -105,7 +106,8 @@ export default React.memo(function GamePage(): JSX.Element | null {
     </p>
   )
 
-  const [gameInfo, setGameInfo] = useState(locationGameInfo)
+  const [gameInfo, setGameInfo] = useState<GameInfo>('games' in locationGameInfo ? locationGameInfo.representative : locationGameInfo)
+  const [gameGroup, setGameGroup] = useState<GameGroup | null>('games' in locationGameInfo ? locationGameInfo : null)
   const [gameSettings, setGameSettings] = useState<GameSettings | null>(null)
 
   const { status, folder, statusContext } = hasStatus(gameInfo)
@@ -439,7 +441,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
                         store={runner}
                       />
                       <div className="store-icon">
-                        <StoreLogos runner={runner} />
+                        <StoreLogos runner={gameGroup ? undefined : runner} runners={gameGroup ? gameGroup.games.map(g => g.runner) : undefined} />
                       </div>
 
                       <h1 style={{ opacity: art_logo ? 0 : 1 }}>{title}</h1>

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -19,7 +19,13 @@ import {
   sendKill,
   updateGame
 } from 'frontend/helpers'
-import { Link, NavLink, useLocation, useNavigate, useParams } from 'react-router-dom'
+import {
+  Link,
+  NavLink,
+  useLocation,
+  useNavigate,
+  useParams
+} from 'react-router-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { CachedImage, UpdateComponent, TabPanel } from 'frontend/components/UI'
@@ -108,7 +114,9 @@ export default React.memo(function GamePage(): JSX.Element | null {
   )
 
   const [gameInfo, setGameInfo] = useState<GameInfo>(
-    'games' in locationGameInfo ? locationGameInfo.representative : locationGameInfo
+    'games' in locationGameInfo
+      ? locationGameInfo.representative
+      : locationGameInfo
   )
   const [gameGroup, setGameGroup] = useState<GameGroup | null>(
     'games' in locationGameInfo ? locationGameInfo : null

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -19,7 +19,7 @@ import {
   sendKill,
   updateGame
 } from 'frontend/helpers'
-import { Link, NavLink, useLocation, useParams } from 'react-router-dom'
+import { Link, NavLink, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { CachedImage, UpdateComponent, TabPanel } from 'frontend/components/UI'
@@ -86,6 +86,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const { t: t2 } = useTranslation()
 
   const { gameInfo: locationGameInfo } = location.state
+  const navigate = useNavigate()
 
   const [showUninstallModal, setShowUninstallModal] = useState(false)
   const [wikiInfo, setWikiInfo] = useState<WikiInfo | null>(null)
@@ -106,8 +107,12 @@ export default React.memo(function GamePage(): JSX.Element | null {
     </p>
   )
 
-  const [gameInfo, setGameInfo] = useState<GameInfo>('games' in locationGameInfo ? locationGameInfo.representative : locationGameInfo)
-  const [gameGroup, setGameGroup] = useState<GameGroup | null>('games' in locationGameInfo ? locationGameInfo : null)
+  const [gameInfo, setGameInfo] = useState<GameInfo>(
+    'games' in locationGameInfo ? locationGameInfo.representative : locationGameInfo
+  )
+  const [gameGroup, setGameGroup] = useState<GameGroup | null>(
+    'games' in locationGameInfo ? locationGameInfo : null
+  )
   const [gameSettings, setGameSettings] = useState<GameSettings | null>(null)
 
   const { status, folder, statusContext } = hasStatus(gameInfo)
@@ -179,6 +184,22 @@ export default React.memo(function GamePage(): JSX.Element | null {
 
   const previousIsPlaying = useRef<boolean>(isPlaying)
   useEffect(() => {
+    if ('games' in locationGameInfo) {
+      const selectedGame =
+        locationGameInfo.games.find(
+          (game) => game.app_name === appName && game.runner === runner
+        ) || locationGameInfo.representative
+
+      setGameGroup(locationGameInfo)
+      setGameInfo(selectedGame)
+      return
+    }
+
+    setGameGroup(null)
+    setGameInfo(locationGameInfo)
+  }, [appName, runner, locationGameInfo])
+
+  useEffect(() => {
     const updateAchievements = async () => {
       if (!isPlaying && previousIsPlaying.current)
         window.api.clearAchievementCache(appName)
@@ -196,6 +217,31 @@ export default React.memo(function GamePage(): JSX.Element | null {
         if (newInfo) {
           setGameInfo(newInfo)
         }
+        if (gameGroup) {
+          const updatedGames = await Promise.all(
+            gameGroup.games.map(async (g) => {
+              if (g.app_name === appName && g.runner === runner && newInfo) {
+                return newInfo
+              }
+              const info = await getGameInfo(g.app_name, g.runner)
+              return info || g
+            })
+          )
+
+          const updatedRepresentative =
+            updatedGames.find(
+              (g) =>
+                g.app_name === gameGroup.representative.app_name &&
+                g.runner === gameGroup.representative.runner
+            ) || updatedGames[0]
+
+          setGameGroup({
+            ...gameGroup,
+            games: updatedGames,
+            representative: updatedRepresentative
+          })
+        }
+
         setExtraInfo(await window.api.getExtraInfo(appName, runner))
       }
     }
@@ -441,7 +487,22 @@ export default React.memo(function GamePage(): JSX.Element | null {
                         store={runner}
                       />
                       <div className="store-icon">
-                        <StoreLogos runner={gameGroup ? undefined : runner} runners={gameGroup ? gameGroup.games.map(g => g.runner) : undefined} />
+                        <StoreLogos
+                          runner={gameGroup ? undefined : runner}
+                          games={gameGroup?.games}
+                          selectedRunner={runner}
+                          onGameClick={(selectedGame) =>
+                            navigate(
+                              `/gamepage/${selectedGame.runner}/${selectedGame.app_name}`,
+                              {
+                                state: {
+                                  ...location.state,
+                                  gameInfo: gameGroup ?? locationGameInfo
+                                }
+                              }
+                            )
+                          }
+                        />
                       </div>
 
                       <h1 style={{ opacity: art_logo ? 0 : 1 }}>{title}</h1>

--- a/src/frontend/screens/Library/components/GameCard/index.css
+++ b/src/frontend/screens/Library/components/GameCard/index.css
@@ -169,12 +169,10 @@
   right: 5px;
   top: 4px;
   z-index: 2;
-  padding: var(--space-3xs);
-  width: 35px;
-  height: 35px;
-  place-content: center;
-  background: var(--background-darker);
-  fill: var(--text-default);
+  padding: 0;
+  width: fit-content;
+  height: fit-content;
+  background: transparent;
 }
 
 .gameCard:hover,

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faRepeat, faBan } from '@fortawesome/free-solid-svg-icons'
 
 import DownIcon from 'frontend/assets/down-icon.svg?react'
-import { FavouriteGame, GameInfo, HiddenGame, Runner } from 'common/types'
+import { FavouriteGame, GameInfo, GameGroup, HiddenGame, Runner } from 'common/types'
 import { Link, useNavigate } from 'react-router-dom'
 import PlayIcon from 'frontend/assets/play-icon.svg?react'
 import SettingsIcon from 'frontend/assets/settings_icon_alt.svg?react'
@@ -58,7 +58,7 @@ interface Card {
   hasUpdate: boolean
   isRecent: boolean
   justPlayed: boolean
-  gameInfo: GameInfo
+  gameInfo: GameInfo | GameGroup
   forceCard?: boolean
   dataTour?: string
 }
@@ -80,7 +80,8 @@ const GameCard = ({
     // render an empty div until the card enters the viewport
     // check GameList for the other side of this detection
     const callback = (e: CustomEvent<{ appNames: string[] }>) => {
-      if (e.detail.appNames.includes(gameInfoFromProps.app_name)) {
+      const appName = 'games' in gameInfoFromProps ? gameInfoFromProps.representative.app_name : gameInfoFromProps.app_name
+      if (e.detail.appNames.includes(appName)) {
         setVisible(true)
       }
     }
@@ -92,7 +93,7 @@ const GameCard = ({
     }
   }, [])
 
-  const [gameInfo, setGameInfo] = useState<GameInfo>(gameInfoFromProps)
+  const [gameInfo, setGameInfo] = useState<GameInfo>('games' in gameInfoFromProps ? gameInfoFromProps.representative : gameInfoFromProps)
   const [showUninstallModal, setShowUninstallModal] = useState(false)
   const [isLaunching, setIsLaunching] = useState(false)
 
@@ -117,6 +118,7 @@ const GameCard = ({
 
   const { layout } = useContext(LibraryContext)
 
+  const actualGameInfo = 'games' in gameInfoFromProps ? gameInfoFromProps.representative : gameInfoFromProps
   const {
     title,
     art_cover,
@@ -126,7 +128,7 @@ const GameCard = ({
     runner,
     is_installed: isInstalled,
     install: gameInstallInfo
-  } = { ...gameInfoFromProps }
+  } = { ...actualGameInfo }
 
   const isInstallable =
     gameInfo.installable === undefined || gameInfo.installable // If it's undefined we assume it's installable
@@ -450,12 +452,12 @@ const GameCard = ({
           )}
           <Link
             to={`/gamepage/${runner}/${appName}`}
-            state={{ gameInfo }}
+            state={{ gameInfo: gameInfoFromProps }}
             style={
               { '--installing-effect': installingGrayscale } as CSSProperties
             }
           >
-            <StoreLogos runner={runner} />
+            <StoreLogos runner={'games' in gameInfoFromProps ? undefined : runner} runners={'games' in gameInfoFromProps ? gameInfoFromProps.games.map(g => g.runner) : undefined} />
             {justPlayed ? (
               <CachedImage
                 src={art_cover || fallBackImage}

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -6,7 +6,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faRepeat, faBan } from '@fortawesome/free-solid-svg-icons'
 
 import DownIcon from 'frontend/assets/down-icon.svg?react'
-import { FavouriteGame, GameInfo, GameGroup, HiddenGame, Runner } from 'common/types'
+import {
+  FavouriteGame,
+  GameInfo,
+  GameGroup,
+  HiddenGame,
+  Runner
+} from 'common/types'
 import { Link, useNavigate } from 'react-router-dom'
 import PlayIcon from 'frontend/assets/play-icon.svg?react'
 import SettingsIcon from 'frontend/assets/settings_icon_alt.svg?react'
@@ -80,7 +86,10 @@ const GameCard = ({
     // render an empty div until the card enters the viewport
     // check GameList for the other side of this detection
     const callback = (e: CustomEvent<{ appNames: string[] }>) => {
-      const appName = 'games' in gameInfoFromProps ? gameInfoFromProps.representative.app_name : gameInfoFromProps.app_name
+      const appName =
+        'games' in gameInfoFromProps
+          ? gameInfoFromProps.representative.app_name
+          : gameInfoFromProps.app_name
       if (e.detail.appNames.includes(appName)) {
         setVisible(true)
       }
@@ -93,7 +102,11 @@ const GameCard = ({
     }
   }, [])
 
-  const [gameInfo, setGameInfo] = useState<GameInfo>('games' in gameInfoFromProps ? gameInfoFromProps.representative : gameInfoFromProps)
+  const [gameInfo, setGameInfo] = useState<GameInfo>(
+    'games' in gameInfoFromProps
+      ? gameInfoFromProps.representative
+      : gameInfoFromProps
+  )
   const [showUninstallModal, setShowUninstallModal] = useState(false)
   const [isLaunching, setIsLaunching] = useState(false)
 
@@ -118,7 +131,10 @@ const GameCard = ({
 
   const { layout } = useContext(LibraryContext)
 
-  const actualGameInfo = 'games' in gameInfoFromProps ? gameInfoFromProps.representative : gameInfoFromProps
+  const actualGameInfo =
+    'games' in gameInfoFromProps
+      ? gameInfoFromProps.representative
+      : gameInfoFromProps
   const {
     title,
     art_cover,
@@ -457,7 +473,14 @@ const GameCard = ({
               { '--installing-effect': installingGrayscale } as CSSProperties
             }
           >
-            <StoreLogos runner={'games' in gameInfoFromProps ? undefined : runner} runners={'games' in gameInfoFromProps ? gameInfoFromProps.games.map(g => g.runner) : undefined} />
+            <StoreLogos
+              runner={'games' in gameInfoFromProps ? undefined : runner}
+              runners={
+                'games' in gameInfoFromProps
+                  ? gameInfoFromProps.games.map((g) => g.runner)
+                  : undefined
+              }
+            />
             {justPlayed ? (
               <CachedImage
                 src={art_cover || fallBackImage}
@@ -505,7 +528,9 @@ const GameCard = ({
               {'games' in gameInfoFromProps
                 ? Array.from(
                     new Set(
-                      gameInfoFromProps.games.map((g) => getStoreName(g.runner, t2('Other')))
+                      gameInfoFromProps.games.map((g) =>
+                        getStoreName(g.runner, t2('Other'))
+                      )
                     )
                   ).join(', ')
                 : getStoreName(runner, t2('Other'))}

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -502,7 +502,13 @@ const GameCard = ({
                 installed: isInstalled
               })}
             >
-              {getStoreName(runner, t2('Other'))}
+              {'games' in gameInfoFromProps
+                ? Array.from(
+                    new Set(
+                      gameInfoFromProps.games.map((g) => getStoreName(g.runner, t2('Other')))
+                    )
+                  ).join(', ')
+                : getStoreName(runner, t2('Other'))}
             </span>
           </Link>
           <>

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -161,7 +161,7 @@ const GamesList = ({
               }}
               forceCard={layout === 'grid'}
               isRecent={isRecent}
-              gameInfo={gameInfo}
+              gameInfo={item}
               justPlayed={isJustPlayed}
               dataTour={index === 0 ? 'library-game-card' : undefined}
             />

--- a/src/frontend/screens/Library/components/GamesList/index.tsx
+++ b/src/frontend/screens/Library/components/GamesList/index.tsx
@@ -1,12 +1,12 @@
 import React, { useContext, useEffect, useRef } from 'react'
-import { GameInfo, Runner } from 'common/types'
+import { GameInfo, GameGroup, Runner } from 'common/types'
 import cx from 'classnames'
 import GameCard from '../GameCard'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
-  library: GameInfo[]
+  library: (GameInfo | GameGroup)[]
   layout?: string
   isFirstLane?: boolean
   handleGameCardClick: (
@@ -134,7 +134,8 @@ const GamesList = ({
         </div>
       )}
       {!!library.length &&
-        library.map((gameInfo, index) => {
+        library.map((item, index) => {
+          const gameInfo = 'games' in item ? item.representative : item
           const { app_name, is_installed, runner } = gameInfo
           const isJustPlayed = (isFavourite || isRecent) && index === 0
           let is_dlc = false

--- a/src/frontend/screens/Library/components/LibraryHeader/index.tsx
+++ b/src/frontend/screens/Library/components/LibraryHeader/index.tsx
@@ -1,13 +1,13 @@
 import React, { useContext, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionIcons from 'frontend/components/UI/ActionIcons'
-import { GameInfo } from 'common/types'
+import { GameInfo, GameGroup } from 'common/types'
 import LibraryContext from '../../LibraryContext'
 import './index.css'
 import AddGameButton from '../AddGameButton'
 
 type Props = {
-  list: GameInfo[]
+  list: (GameInfo | GameGroup)[]
 }
 
 export default React.memo(function LibraryHeader({ list }: Props) {
@@ -19,9 +19,13 @@ export default React.memo(function LibraryHeader({ list }: Props) {
       return 0
     }
     // is_dlc is only applicable when the game is from legendary, but checking anyway doesn't cause errors and enable accurate counting in the 'ALL' game tab
-    const dlcCount = list.filter(
-      (lib) => lib.runner !== 'sideload' && lib.install.is_dlc
-    ).length
+    const dlcCount = list.filter((lib) => {
+      if ('runner' in lib) {
+        return lib.runner !== 'sideload' && lib.install.is_dlc
+      } else {
+        return false // GameGroup doesn't have DLCs since they're filtered out
+      }
+    }).length
 
     const total = list.length - dlcCount
     return total > 0 ? `${total}` : 0

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -46,6 +46,29 @@ type SearchableGame = {
   normalizedTitle: string
 }
 
+function getDedupeKey(game: GameInfo): string {
+  let title = game.title.toLowerCase()
+
+  // 1. Remove common store-specific tags and noise
+  title = title.replace(/(\(.*\)|\[.*\]|™|®)/g, '')
+
+  // 2. Normalize punctuation and spacing
+  title = title.replace(/[:\-_]/g, ' ')
+  title = title.replace(/[^a-z0-9 ]/g, '')
+  title = title.trim().replace(/\s+/g, ' ')
+
+  // 3. Handle specific version suffixes (Optional)
+  // const versionTags = ['enhanced edition', 'directors cut', 'goty', 'gold edition']
+  // versionTags.forEach(tag => {
+  //   title = title.replace(tag, '').trim(); 
+  // })
+
+  // 4. DLC handling
+  const dlcPrefix = game.install.is_dlc ? 'dlc_' : 'game_'
+
+  return `${dlcPrefix}${title}`
+}
+
 export default React.memo(function Library(): JSX.Element {
   const { t } = useTranslation()
 
@@ -73,34 +96,6 @@ export default React.memo(function Library(): JSX.Element {
     t('help.title.library', 'Library'),
     <p>{t('help.content.library', 'Shows all owned games.')}</p>
   )
-
-  function getDedupeKey(game: GameInfo): string {
-    let title = game.title.toLowerCase()
-
-    // 1. Remove common store-specific tags and noise
-    // Handles things like "(Legacy)", "[EGS]", "TM", "(R)"
-    title = title.replace(/(\(.*\)|\[.*\]|™|®)/g, '')
-
-    // 2. Normalize punctuation and spacing
-    // Converts "Game: Subtitle" and "Game - Subtitle" to "game subtitle"
-    title = title.replace(/[:\-_]/g, ' ')
-    title = title.replace(/[^a-z0-9 ]/g, '')
-    title = title.trim().replace(/\s+/g, ' ')
-
-    // 3. Handle specific version suffixes (Optional)
-    // If you want "Game X" and "Game X: Enhanced Edition" to be duplicates,
-    // you would strip these. Otherwise, leave them to keep versions distinct.
-    const versionTags = ['enhanced edition', 'directors cut', 'goty', 'gold edition']
-    versionTags.forEach(tag => {
-      // title = title.replace(tag, '').trim(); 
-    })
-
-    // 4. DLC handling
-    // Ensure a DLC is never deduped with a base game
-    const dlcPrefix = game.install.is_dlc ? 'dlc_' : 'game_'
-
-    return `${dlcPrefix}${title}`
-  }
 
   const [layout, setLayout] = useState(storage.getItem('layout') || 'grid')
   const handleLayout = (layout: string) => {
@@ -644,11 +639,12 @@ export default React.memo(function Library(): JSX.Element {
           groups.set(key, [])
         }
         groups.get(key)!.push(game)
+        console.log(key, groups.get(key));
       })
 
       // Convert groups to GameGroup objects
       const groupedLibrary: GameGroup[] = []
-      groups.forEach((games, key) => {
+      groups.forEach((games) => {
         if (games.length > 1) {
           // Find representative game (prefer installed, then first)
           const representative = games.find(g => g.is_installed) || games[0]

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -17,7 +17,7 @@ import Fuse from 'fuse.js'
 import ContextProvider from 'frontend/state/ContextProvider'
 
 import GamesList from './components/GamesList'
-import { FavouriteGame, GameInfo, HiddenGame, Runner } from 'common/types'
+import { FavouriteGame, GameInfo, GameGroup, HiddenGame, Runner } from 'common/types'
 import ErrorComponent from 'frontend/components/UI/ErrorComponent'
 import LibraryHeader from './components/LibraryHeader'
 import {
@@ -64,7 +64,8 @@ export default React.memo(function Library(): JSX.Element {
     currentCustomCategories,
     customCategories,
     hiddenGames,
-    gameUpdates
+    gameUpdates,
+    experimentalFeatures
   } = useContext(ContextProvider)
 
   hasHelp(
@@ -72,6 +73,34 @@ export default React.memo(function Library(): JSX.Element {
     t('help.title.library', 'Library'),
     <p>{t('help.content.library', 'Shows all owned games.')}</p>
   )
+
+  function getDedupeKey(game: GameInfo): string {
+    let title = game.title.toLowerCase()
+
+    // 1. Remove common store-specific tags and noise
+    // Handles things like "(Legacy)", "[EGS]", "TM", "(R)"
+    title = title.replace(/(\(.*\)|\[.*\]|™|®)/g, '')
+
+    // 2. Normalize punctuation and spacing
+    // Converts "Game: Subtitle" and "Game - Subtitle" to "game subtitle"
+    title = title.replace(/[:\-_]/g, ' ')
+    title = title.replace(/[^a-z0-9 ]/g, '')
+    title = title.trim().replace(/\s+/g, ' ')
+
+    // 3. Handle specific version suffixes (Optional)
+    // If you want "Game X" and "Game X: Enhanced Edition" to be duplicates,
+    // you would strip these. Otherwise, leave them to keep versions distinct.
+    const versionTags = ['enhanced edition', 'directors cut', 'goty', 'gold edition']
+    versionTags.forEach(tag => {
+      // title = title.replace(tag, '').trim(); 
+    })
+
+    // 4. DLC handling
+    // Ensure a DLC is never deduped with a base game
+    const dlcPrefix = game.install.is_dlc ? 'dlc_' : 'game_'
+
+    return `${dlcPrefix}${title}`
+  }
 
   const [layout, setLayout] = useState(storage.getItem('layout') || 'grid')
   const handleLayout = (layout: string) => {
@@ -585,7 +614,7 @@ export default React.memo(function Library(): JSX.Element {
 
   // select library
   const libraryToShow = useMemo(() => {
-    let library = [...gamesForAlphabetFilter]
+    let library: (GameInfo | GameGroup)[] = [...gamesForAlphabetFilter]
 
     // Alphabetical filter
     if (alphabetFilterLetter) {
@@ -605,21 +634,73 @@ export default React.memo(function Library(): JSX.Element {
       })
     }
 
+    // Group duplicate games if feature is enabled
+    if (experimentalFeatures?.hideDuplicateGames) {
+      const groups = new Map<string, GameInfo[]>()
+      library.forEach(game => {
+        if ('games' in game) return // Skip if already grouped
+        const key = getDedupeKey(game)
+        if (!groups.has(key)) {
+          groups.set(key, [])
+        }
+        groups.get(key)!.push(game)
+      })
+
+      // Convert groups to GameGroup objects
+      const groupedLibrary: GameGroup[] = []
+      groups.forEach((games, key) => {
+        if (games.length > 1) {
+          // Find representative game (prefer installed, then first)
+          const representative = games.find(g => g.is_installed) || games[0]
+          groupedLibrary.push({
+            title: representative.title,
+            games,
+            representative
+          })
+        } else {
+          // Single game, still wrap in group for consistency
+          groupedLibrary.push({
+            title: games[0].title,
+            games,
+            representative: games[0]
+          })
+        }
+      })
+
+      library = groupedLibrary
+    }
+
     // sort
     library = library.sort((a, b) => {
-      const gameA = a.title.toUpperCase().replace('THE ', '')
-      const gameB = b.title.toUpperCase().replace('THE ', '')
+      const titleA = 'title' in a ? a.title : (a as GameGroup).representative.title
+      const titleB = 'title' in b ? b.title : (b as GameGroup).representative.title
+      const gameA = titleA.toUpperCase().replace('THE ', '')
+      const gameB = titleB.toUpperCase().replace('THE ', '')
       return sortDescending
         ? -gameA.localeCompare(gameB)
         : gameA.localeCompare(gameB)
     })
-    const installed = library.filter((game) => game?.is_installed)
-    const notInstalled = library.filter(
-      (game) => !game?.is_installed && !installing.includes(game?.app_name)
-    )
-    const installingGames = library.filter(
-      (g) => !g.is_installed && installing.includes(g.app_name)
-    )
+    const installed = library.filter((item) => {
+      if ('is_installed' in item) {
+        return item.is_installed
+      } else {
+        return (item).games.some(g => g.is_installed)
+      }
+    })
+    const notInstalled = library.filter((item) => {
+      if ('is_installed' in item) {
+        return !item.is_installed && !installing.includes(item.app_name)
+      } else {
+        return !(item).games.some(g => g.is_installed) && !(item).games.some(g => installing.includes(g.app_name))
+      }
+    })
+    const installingGames = library.filter((item) => {
+      if ('is_installed' in item) {
+        return !item.is_installed && installing.includes(item.app_name)
+      } else {
+        return !(item).games.some(g => g.is_installed) && (item).games.some(g => installing.includes(g.app_name))
+      }
+    })
 
     library = sortInstalled
       ? [...installed, ...installingGames, ...notInstalled]
@@ -631,7 +712,8 @@ export default React.memo(function Library(): JSX.Element {
     alphabetFilterLetter,
     sortDescending,
     sortInstalled,
-    installing
+    installing,
+    experimentalFeatures
   ])
 
   // we need this to do proper `position: sticky` of the Add Game area

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -17,7 +17,13 @@ import Fuse from 'fuse.js'
 import ContextProvider from 'frontend/state/ContextProvider'
 
 import GamesList from './components/GamesList'
-import { FavouriteGame, GameInfo, GameGroup, HiddenGame, Runner } from 'common/types'
+import {
+  FavouriteGame,
+  GameInfo,
+  GameGroup,
+  HiddenGame,
+  Runner
+} from 'common/types'
 import ErrorComponent from 'frontend/components/UI/ErrorComponent'
 import LibraryHeader from './components/LibraryHeader'
 import {
@@ -60,7 +66,7 @@ function getDedupeKey(game: GameInfo): string {
   // 3. Handle specific version suffixes (Optional)
   // const versionTags = ['enhanced edition', 'directors cut', 'goty', 'gold edition']
   // versionTags.forEach(tag => {
-  //   title = title.replace(tag, '').trim(); 
+  //   title = title.replace(tag, '').trim();
   // })
 
   // 4. DLC handling
@@ -632,14 +638,14 @@ export default React.memo(function Library(): JSX.Element {
     // Group duplicate games if feature is enabled
     if (experimentalFeatures?.hideDuplicateGames) {
       const groups = new Map<string, GameInfo[]>()
-      library.forEach(game => {
+      library.forEach((game) => {
         if ('games' in game) return // Skip if already grouped
         const key = getDedupeKey(game)
         if (!groups.has(key)) {
           groups.set(key, [])
         }
         groups.get(key)!.push(game)
-        console.log(key, groups.get(key));
+        console.log(key, groups.get(key))
       })
 
       // Convert groups to GameGroup objects
@@ -647,7 +653,7 @@ export default React.memo(function Library(): JSX.Element {
       groups.forEach((games) => {
         if (games.length > 1) {
           // Find representative game (prefer installed, then first)
-          const representative = games.find(g => g.is_installed) || games[0]
+          const representative = games.find((g) => g.is_installed) || games[0]
           groupedLibrary.push({
             title: representative.title,
             games,
@@ -668,8 +674,10 @@ export default React.memo(function Library(): JSX.Element {
 
     // sort
     library = library.sort((a, b) => {
-      const titleA = 'title' in a ? a.title : (a as GameGroup).representative.title
-      const titleB = 'title' in b ? b.title : (b as GameGroup).representative.title
+      const titleA =
+        'title' in a ? a.title : (a as GameGroup).representative.title
+      const titleB =
+        'title' in b ? b.title : (b as GameGroup).representative.title
       const gameA = titleA.toUpperCase().replace('THE ', '')
       const gameB = titleB.toUpperCase().replace('THE ', '')
       return sortDescending
@@ -680,21 +688,27 @@ export default React.memo(function Library(): JSX.Element {
       if ('is_installed' in item) {
         return item.is_installed
       } else {
-        return (item).games.some(g => g.is_installed)
+        return item.games.some((g) => g.is_installed)
       }
     })
     const notInstalled = library.filter((item) => {
       if ('is_installed' in item) {
         return !item.is_installed && !installing.includes(item.app_name)
       } else {
-        return !(item).games.some(g => g.is_installed) && !(item).games.some(g => installing.includes(g.app_name))
+        return (
+          !item.games.some((g) => g.is_installed) &&
+          !item.games.some((g) => installing.includes(g.app_name))
+        )
       }
     })
     const installingGames = library.filter((item) => {
       if ('is_installed' in item) {
         return !item.is_installed && installing.includes(item.app_name)
       } else {
-        return !(item).games.some(g => g.is_installed) && (item).games.some(g => installing.includes(g.app_name))
+        return (
+          !item.games.some((g) => g.is_installed) &&
+          item.games.some((g) => installing.includes(g.app_name))
+        )
       }
     })
 

--- a/src/frontend/screens/Settings/components/ExperimentalFeatures.tsx
+++ b/src/frontend/screens/Settings/components/ExperimentalFeatures.tsx
@@ -9,7 +9,8 @@ const ExperimentalFeatures = () => {
   const FEATURES: (keyof IExperimentalFeatures)[] = [
     'enableHelp',
     'cometSupport',
-    'zoomPlatform'
+    'zoomPlatform',
+    'hideDuplicateGames'
   ]
 
   const { t } = useTranslation()
@@ -18,7 +19,8 @@ const ExperimentalFeatures = () => {
     {
       enableHelp: false,
       cometSupport: true,
-      zoomPlatform: false
+      zoomPlatform: false,
+      hideDuplicateGames: false
     }
   )
   const { handleExperimentalFeatures } = useContext(ContextProvider)

--- a/src/frontend/state/ContextProvider.tsx
+++ b/src/frontend/state/ContextProvider.tsx
@@ -101,7 +101,8 @@ const initialContext: ContextType = {
   experimentalFeatures: {
     enableHelp: false,
     cometSupport: true,
-    zoomPlatform: false
+    zoomPlatform: false,
+    hideDuplicateGames: false
   },
   handleExperimentalFeatures: () => null,
   disableDialogBackdropClose: false,

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -237,6 +237,7 @@ class GlobalState extends PureComponent<Props> {
       enableHelp: false,
       cometSupport: true,
       zoomPlatform: false,
+      hideDuplicateGames: false,
       ...(globalSettings?.experimentalFeatures || {})
     },
     disableDialogBackdropClose: configStore.get(


### PR DESCRIPTION
Relates to: #3010 #4703

This feature cleans/normalizes titles to ignore inconsistent casing, special characters, store-specific tags, and maintain differences between base games, sequels, and DLCs.

Dup[licate games are grouped together in the GameList, with multiple store logos. On the GamePage it allows users to toggle between different store versions of the game.

https://github.com/user-attachments/assets/eb4f3647-94a7-4159-9349-11ee4855e3e5

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
