### PR TITLE
Feat: add owned game filter on GOG Deals screen

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -291,6 +291,7 @@
             "genres": "Genres",
             "genresPlaceholder": "Any genre",
             "hideDlcs": "Hide DLCs",
+            "hideOwned": "Hide Owned",
             "lessFilters": "Less filters",
             "moreFilters": "More filters",
             "os": "Operating system",

--- a/src/backend/discounts/index.ts
+++ b/src/backend/discounts/index.ts
@@ -1,7 +1,8 @@
 import axios from 'axios'
 import { app } from 'electron'
 import { addHandler } from 'backend/ipc'
-import { logError, logInfo, LogPrefix } from 'backend/logger'
+import { logError, logInfo, LogPrefix, logWarning } from 'backend/logger'
+import { GOGUser } from 'backend/storeManagers/gog/user'
 import type {
   CatalogLocaleSettings,
   CatalogProduct
@@ -28,7 +29,11 @@ const isFallbackLocale = (locale: CatalogLocaleSettings) =>
   locale.currencyCode === FALLBACK_LOCALE.currencyCode &&
   locale.locale === FALLBACK_LOCALE.locale
 
-const buildUrl = (page: number, locale: CatalogLocaleSettings) => {
+const buildUrl = (
+  page: number,
+  locale: CatalogLocaleSettings,
+  hideOwned: boolean
+) => {
   const params = new URLSearchParams({
     limit: String(PAGE_LIMIT),
     order: 'desc:trending',
@@ -39,27 +44,50 @@ const buildUrl = (page: number, locale: CatalogLocaleSettings) => {
     locale: locale.locale,
     currencyCode: locale.currencyCode
   })
+
+  if (hideOwned) {
+    params.append('hideOwned', 'true')
+  }
+
   return `${CATALOG_URL}?${params.toString()}`
 }
 
-const fetchPage = async (page: number, locale: CatalogLocaleSettings) => {
-  const { data } = await axios.get<CatalogResponse>(buildUrl(page, locale), {
-    timeout: 15000,
-    headers: {
-      'User-Agent': `HeroicGamesLauncher/${app.getVersion()}`
+const fetchPage = async (
+  page: number,
+  locale: CatalogLocaleSettings,
+  hideOwned: boolean,
+  token: string | undefined
+) => {
+  const headers: Record<string, string> = {
+    'User-Agent': `HeroicGamesLauncher/${app.getVersion()}`
+  }
+
+  if (hideOwned && token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+
+  const { data } = await axios.get<CatalogResponse>(
+    buildUrl(page, locale, hideOwned),
+    {
+      timeout: 15000,
+      headers
     }
-  })
+  )
   return data
 }
 
-const fetchAllDiscounts = async (locale: CatalogLocaleSettings) => {
-  const first = await fetchPage(1, locale)
+const fetchAllDiscounts = async (
+  locale: CatalogLocaleSettings,
+  hideOwned: boolean,
+  token: string | undefined
+) => {
+  const first = await fetchPage(1, locale, hideOwned, token)
   const totalPages = Math.min(first.pages, MAX_PAGES)
   if (totalPages <= 1) return first.products
 
   const rest = await Promise.all(
     Array.from({ length: totalPages - 1 }, (_, i) =>
-      fetchPage(i + 2, locale)
+      fetchPage(i + 2, locale, hideOwned, token)
         .then((d) => d.products)
         .catch((err: unknown) => {
           logError(
@@ -83,20 +111,41 @@ const fetchAllDiscounts = async (locale: CatalogLocaleSettings) => {
   })
 }
 
-addHandler('getGogDiscounts', async (_event, locale) => {
-  try {
-    const products = await fetchAllDiscounts(locale)
-    if (products.length > 0 || isFallbackLocale(locale)) {
-      return products
-    }
+addHandler(
+  'getGogDiscounts',
+  async (_event, locale, hideOwned: boolean = false) => {
+    try {
+      let token: string | undefined = undefined
 
-    logInfo(
-      `No discounts for ${locale.countryCode}/${locale.currencyCode}, retrying with US/USD`,
-      LogPrefix.Backend
-    )
-    return await fetchAllDiscounts(FALLBACK_LOCALE)
-  } catch (err) {
-    logError(`Failed to fetch GOG discounts: ${String(err)}`, LogPrefix.Backend)
-    throw err
+      if (hideOwned) {
+        const credentials = await GOGUser.getCredentials()
+        if (credentials) {
+          token = credentials.access_token
+        } else {
+          hideOwned = false
+          logWarning(
+            'Failed to get user credentials: User maybe is not looged in',
+            LogPrefix.Backend
+          )
+        }
+      }
+
+      const products = await fetchAllDiscounts(locale, hideOwned, token)
+      if (products.length > 0 || isFallbackLocale(locale)) {
+        return products
+      }
+
+      logInfo(
+        `No discounts for ${locale.countryCode}/${locale.currencyCode}, retrying with US/USD`,
+        LogPrefix.Backend
+      )
+      return await fetchAllDiscounts(FALLBACK_LOCALE, hideOwned, token)
+    } catch (err) {
+      logError(
+        `Failed to fetch GOG discounts: ${String(err)}`,
+        LogPrefix.Backend
+      )
+      throw err
+    }
   }
-})
+)

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -323,7 +323,10 @@ interface AsyncIPCFunctions {
   getUploadedLogFiles: () => Promise<Record<string, UploadedLogData>>
   getCustomCSS: () => Promise<string>
   isIntelMac: () => boolean
-  getGogDiscounts: (locale: CatalogLocaleSettings) => Promise<CatalogProduct[]>
+  getGogDiscounts: (
+    locale: CatalogLocaleSettings,
+    hideOwned?: boolean
+  ) => Promise<CatalogProduct[]>
   'steamgriddb.hasApiKey': () => Promise<boolean>
   'steamgriddb.setApiKey': (key: string) => Promise<void>
   'steamgriddb.searchGame': (

--- a/src/frontend/screens/Discounts/components/DiscountFilters/index.css
+++ b/src/frontend/screens/Discounts/components/DiscountFilters/index.css
@@ -167,6 +167,20 @@
   color: var(--accent);
 }
 
+.discountFilters__hideOwned.MuiFormControlLabel-root {
+  margin: 0;
+  color: var(--text-default);
+  white-space: nowrap;
+}
+
+.discountFilters__hideOwned .MuiCheckbox-root {
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+}
+
+.discountFilters__hideOwned .MuiCheckbox-root.Mui-checked {
+  color: var(--accent);
+}
+
 .discountFilters__row--inputs {
   grid-template-columns:
     minmax(140px, 180px)

--- a/src/frontend/screens/Discounts/components/DiscountFilters/index.tsx
+++ b/src/frontend/screens/Discounts/components/DiscountFilters/index.tsx
@@ -280,7 +280,7 @@ const DiscountFilters = ({
           placeholder={t('search', 'Search for Games')}
         />
         <FormControlLabel
-          className="discountFilters__hideDlcs" // I can use the same class as hideDlcs
+          className="discountFilters__hideOwned"
           control={
             <Checkbox
               size="small"
@@ -291,7 +291,7 @@ const DiscountFilters = ({
           label={t('discounts.filters.hideOwned', 'Hide Owned')}
         />
         <FormControlLabel
-          className="discountFilters__hideOwned"
+          className="discountFilters__hideDlcs"
           control={
             <Checkbox
               size="small"

--- a/src/frontend/screens/Discounts/components/DiscountFilters/index.tsx
+++ b/src/frontend/screens/Discounts/components/DiscountFilters/index.tsx
@@ -53,6 +53,7 @@ interface Props {
   onHideDlcsChange: (value: boolean) => void
   hideOwned: boolean
   onHideOwnedChange: (value: boolean) => void
+  isGogLoggedIn: boolean
   pageSize: number
   onPageSizeChange: (value: number) => void
   onReset: () => void
@@ -180,6 +181,7 @@ const DiscountFilters = ({
   onHideDlcsChange,
   hideOwned,
   onHideOwnedChange,
+  isGogLoggedIn,
   pageSize,
   onPageSizeChange,
   onReset,
@@ -279,17 +281,19 @@ const DiscountFilters = ({
           onInputChanged={onSearchChange}
           placeholder={t('search', 'Search for Games')}
         />
-        <FormControlLabel
-          className="discountFilters__hideOwned"
-          control={
-            <Checkbox
-              size="small"
-              checked={hideOwned}
-              onChange={(e) => onHideOwnedChange(e.target.checked)}
-            />
-          }
-          label={t('discounts.filters.hideOwned', 'Hide Owned')}
-        />
+        {isGogLoggedIn && (
+          <FormControlLabel
+            className="discountFilters__hideOwned"
+            control={
+              <Checkbox
+                size="small"
+                checked={hideOwned}
+                onChange={(e) => onHideOwnedChange(e.target.checked)}
+              />
+            }
+            label={t('discounts.filters.hideOwned', 'Hide Owned')}
+          />
+        )}
         <FormControlLabel
           className="discountFilters__hideDlcs"
           control={

--- a/src/frontend/screens/Discounts/components/DiscountFilters/index.tsx
+++ b/src/frontend/screens/Discounts/components/DiscountFilters/index.tsx
@@ -51,6 +51,8 @@ interface Props {
   onSearchChange: (query: string) => void
   hideDlcs: boolean
   onHideDlcsChange: (value: boolean) => void
+  hideOwned: boolean
+  onHideOwnedChange: (value: boolean) => void
   pageSize: number
   onPageSizeChange: (value: number) => void
   onReset: () => void
@@ -176,6 +178,8 @@ const DiscountFilters = ({
   onSearchChange,
   hideDlcs,
   onHideDlcsChange,
+  hideOwned,
+  onHideOwnedChange,
   pageSize,
   onPageSizeChange,
   onReset,
@@ -276,7 +280,18 @@ const DiscountFilters = ({
           placeholder={t('search', 'Search for Games')}
         />
         <FormControlLabel
-          className="discountFilters__hideDlcs"
+          className="discountFilters__hideDlcs" // I can use the same class as hideDlcs
+          control={
+            <Checkbox
+              size="small"
+              checked={hideOwned}
+              onChange={(e) => onHideOwnedChange(e.target.checked)}
+            />
+          }
+          label={t('discounts.filters.hideOwned', 'Hide Owned')}
+        />
+        <FormControlLabel
+          className="discountFilters__hideOwned"
           control={
             <Checkbox
               size="small"

--- a/src/frontend/screens/Discounts/helpers.ts
+++ b/src/frontend/screens/Discounts/helpers.ts
@@ -243,6 +243,7 @@ interface StoredDiscountFilters {
   maxPegiAge?: PegiAge | null
   searchQuery?: string
   hideDlcs?: boolean
+  hideOwned?: boolean
   pageSize?: number
 }
 

--- a/src/frontend/screens/Discounts/index.tsx
+++ b/src/frontend/screens/Discounts/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { MenuItem, Select } from '@mui/material'
 
@@ -30,6 +30,7 @@ import {
   type PegiAge
 } from './helpers'
 import './index.css'
+import ContextProvider from 'frontend/state/ContextProvider'
 
 export default function Discounts() {
   const { t, i18n } = useTranslation()
@@ -40,6 +41,8 @@ export default function Discounts() {
     () => getLocaleSettings(i18n.language, regionOverride),
     [i18n.language, regionOverride]
   )
+  const { gog } = useContext(ContextProvider)
+  const isGogLoggedIn: boolean = !!gog?.username
 
   const handleRegionChange = (countryCode: string | null) => {
     setRegionOverride(countryCode)
@@ -565,6 +568,7 @@ export default function Discounts() {
             onHideDlcsChange={setHideDlcs}
             hideOwned={hideOwned}
             onHideOwnedChange={setHideOwned}
+            isGogLoggedIn={isGogLoggedIn}
             pageSize={pageSize}
             onPageSizeChange={setPageSize}
             onReset={handleReset}

--- a/src/frontend/screens/Discounts/index.tsx
+++ b/src/frontend/screens/Discounts/index.tsx
@@ -438,7 +438,8 @@ export default function Discounts() {
     ratingRange[1] !== RATING_SCALE_MAX ||
     maxPegiAge !== null ||
     searchQuery.trim() !== '' ||
-    hideDlcs || hideOwned ||
+    hideDlcs ||
+    hideOwned ||
     (priceRange !== null &&
       (priceRange[0] !== 0 || priceRange[1] !== priceMax)) ||
     (releaseYearRange !== null &&

--- a/src/frontend/screens/Discounts/index.tsx
+++ b/src/frontend/screens/Discounts/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { MenuItem, Select } from '@mui/material'
 
@@ -11,6 +11,7 @@ import type {
 import DiscountCard from './components/DiscountCard'
 import DiscountFilters from './components/DiscountFilters'
 import DiscountPagination from './components/DiscountPagination'
+import ContextProvider from 'frontend/state/ContextProvider'
 import {
   DEFAULT_PAGE_SIZE,
   getLocaleSettings,
@@ -33,6 +34,7 @@ import './index.css'
 
 export default function Discounts() {
   const { t, i18n } = useTranslation()
+  const { gog } = useContext(ContextProvider)
   const [regionOverride, setRegionOverride] = useState<string | null>(() =>
     getStoredRegionOverride()
   )
@@ -52,7 +54,13 @@ export default function Discounts() {
     setMaxPegiAge(null)
     setSearchQuery('')
     setHideDlcs(false)
+    setHideOwned(false)
   }
+
+  const ownedGogGameIds = useMemo(() => {
+    if (!gog?.library) return []
+    return gog.library.map((game) => game.app_name)
+  }, [gog])
 
   const [products, setProducts] = useState<CatalogProduct[]>([])
   const [loading, setLoading] = useState(true)
@@ -89,6 +97,7 @@ export default function Discounts() {
     storedFilters.searchQuery ?? ''
   )
   const [hideDlcs, setHideDlcs] = useState(storedFilters.hideDlcs ?? false)
+  const [hideOwned, setHideOwned] = useState(storedFilters.hideOwned ?? false)
   const [pageSize, setPageSize] = useState<number>(
     storedFilters.pageSize ?? DEFAULT_PAGE_SIZE
   )
@@ -112,6 +121,7 @@ export default function Discounts() {
       maxPegiAge,
       searchQuery,
       hideDlcs,
+      hideOwned,
       pageSize
     })
   }, [
@@ -125,6 +135,7 @@ export default function Discounts() {
     maxPegiAge,
     searchQuery,
     hideDlcs,
+    hideOwned,
     pageSize
   ])
 
@@ -260,6 +271,12 @@ export default function Discounts() {
 
       if (hideDlcs && p.productType === 'dlc') return false
 
+      if (hideOwned) {
+        if (ownedGogGameIds.includes(String(p.id))) {
+          return false
+        }
+      }
+
       const amount = parsePriceAmount(p.price.finalMoney?.amount)
       if (amount < minPrice || amount > maxPrice) return false
 
@@ -376,6 +393,8 @@ export default function Discounts() {
     selectedOS,
     searchQuery,
     hideDlcs,
+    hideOwned,
+    ownedGogGameIds,
     sortBy
   ])
 
@@ -395,6 +414,7 @@ export default function Discounts() {
     maxPegiAge,
     searchQuery,
     hideDlcs,
+    hideOwned,
     pageSize,
     products
   ])
@@ -418,7 +438,7 @@ export default function Discounts() {
     ratingRange[1] !== RATING_SCALE_MAX ||
     maxPegiAge !== null ||
     searchQuery.trim() !== '' ||
-    hideDlcs ||
+    hideDlcs || hideOwned ||
     (priceRange !== null &&
       (priceRange[0] !== 0 || priceRange[1] !== priceMax)) ||
     (releaseYearRange !== null &&
@@ -436,6 +456,7 @@ export default function Discounts() {
     setMaxPegiAge(null)
     setSearchQuery('')
     setHideDlcs(false)
+    setHideOwned(false)
   }
 
   const handlePageChange = (newPage: number) => {
@@ -553,6 +574,8 @@ export default function Discounts() {
             onSearchChange={setSearchQuery}
             hideDlcs={hideDlcs}
             onHideDlcsChange={setHideDlcs}
+            hideOwned={hideOwned}
+            onHideOwnedChange={setHideOwned}
             pageSize={pageSize}
             onPageSizeChange={setPageSize}
             onReset={handleReset}

--- a/src/frontend/screens/Discounts/index.tsx
+++ b/src/frontend/screens/Discounts/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { MenuItem, Select } from '@mui/material'
 
@@ -11,7 +11,6 @@ import type {
 import DiscountCard from './components/DiscountCard'
 import DiscountFilters from './components/DiscountFilters'
 import DiscountPagination from './components/DiscountPagination'
-import ContextProvider from 'frontend/state/ContextProvider'
 import {
   DEFAULT_PAGE_SIZE,
   getLocaleSettings,
@@ -34,7 +33,6 @@ import './index.css'
 
 export default function Discounts() {
   const { t, i18n } = useTranslation()
-  const { gog } = useContext(ContextProvider)
   const [regionOverride, setRegionOverride] = useState<string | null>(() =>
     getStoredRegionOverride()
   )
@@ -56,11 +54,6 @@ export default function Discounts() {
     setHideDlcs(false)
     setHideOwned(false)
   }
-
-  const ownedGogGameIds = useMemo(() => {
-    if (!gog?.library) return []
-    return gog.library.map((game) => game.app_name)
-  }, [gog])
 
   const [products, setProducts] = useState<CatalogProduct[]>([])
   const [loading, setLoading] = useState(true)
@@ -148,7 +141,10 @@ export default function Discounts() {
       setProducts([])
 
       try {
-        const result = await window.api.getGogDiscounts(localeSettings)
+        const result = await window.api.getGogDiscounts(
+          localeSettings,
+          hideOwned
+        )
         if (!cancelled) {
           setProducts(result)
           // Only clear data-bound ranges when this is a reload caused by a
@@ -179,7 +175,7 @@ export default function Discounts() {
     return () => {
       cancelled = true
     }
-  }, [localeSettings, t])
+  }, [localeSettings, hideOwned, t])
 
   const priceMax = useMemo(() => {
     const max = products.reduce((acc, p) => {
@@ -270,12 +266,6 @@ export default function Discounts() {
       if (search && !p.title.toLowerCase().includes(search)) return false
 
       if (hideDlcs && p.productType === 'dlc') return false
-
-      if (hideOwned) {
-        if (ownedGogGameIds.includes(String(p.id))) {
-          return false
-        }
-      }
 
       const amount = parsePriceAmount(p.price.finalMoney?.amount)
       if (amount < minPrice || amount > maxPrice) return false
@@ -393,8 +383,6 @@ export default function Discounts() {
     selectedOS,
     searchQuery,
     hideDlcs,
-    hideOwned,
-    ownedGogGameIds,
     sortBy
   ])
 


### PR DESCRIPTION
Closes #5518

Adds a new filter on **GOG Deals Page**, the filter stands for **Hide Owned**. When selected, it hides every game that the users already have on the GOG Library.

As I changed helper as well, I've run those command to be safe:
- `pnpm run i18n`
- `pnpm prettier --write FOR EVERY MODIFIED FILE`
- `pnpm codecheck`
- `pnpm test` _(even tho it runs only backend)_


Screenshots:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/bebd8ffb-dbcc-4691-924c-73ec0b1755af" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/e52c0816-668c-487e-a307-75a34b4f255b" />

obs:  no IA was used. Most projects ask about this, so I think it's good to have it here.

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
