### PR TITLE
Feat: add wishlist only filter on GOG Deals screen

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -299,7 +299,8 @@
             "price": "Price",
             "rating": "Rating",
             "releaseYear": "Release year",
-            "sort": "Sort by"
+            "sort": "Sort by",
+            "wishlistOnly": "Wishlist Only"
         },
         "loading": "Loading discounted games...",
         "noMatches": "No games match the current filters.",

--- a/src/backend/discounts/index.ts
+++ b/src/backend/discounts/index.ts
@@ -32,7 +32,8 @@ const isFallbackLocale = (locale: CatalogLocaleSettings) =>
 const buildUrl = (
   page: number,
   locale: CatalogLocaleSettings,
-  hideOwned: boolean
+  hideOwned: boolean,
+  wishlistOnly: boolean
 ) => {
   const params = new URLSearchParams({
     limit: String(PAGE_LIMIT),
@@ -49,6 +50,10 @@ const buildUrl = (
     params.append('hideOwned', 'true')
   }
 
+  if (wishlistOnly) {
+    params.append('wishlist', 'eq:true')
+  }
+
   return `${CATALOG_URL}?${params.toString()}`
 }
 
@@ -56,18 +61,19 @@ const fetchPage = async (
   page: number,
   locale: CatalogLocaleSettings,
   hideOwned: boolean,
+  wishlistOnly: boolean,
   token: string | undefined
 ) => {
   const headers: Record<string, string> = {
     'User-Agent': `HeroicGamesLauncher/${app.getVersion()}`
   }
 
-  if (hideOwned && token) {
+  if ((hideOwned && token) || (wishlistOnly && token)) {
     headers['Authorization'] = `Bearer ${token}`
   }
 
   const { data } = await axios.get<CatalogResponse>(
-    buildUrl(page, locale, hideOwned),
+    buildUrl(page, locale, hideOwned, wishlistOnly),
     {
       timeout: 15000,
       headers
@@ -79,15 +85,16 @@ const fetchPage = async (
 const fetchAllDiscounts = async (
   locale: CatalogLocaleSettings,
   hideOwned: boolean,
+  wishlistOnly: boolean,
   token: string | undefined
 ) => {
-  const first = await fetchPage(1, locale, hideOwned, token)
+  const first = await fetchPage(1, locale, hideOwned, wishlistOnly, token)
   const totalPages = Math.min(first.pages, MAX_PAGES)
   if (totalPages <= 1) return first.products
 
   const rest = await Promise.all(
     Array.from({ length: totalPages - 1 }, (_, i) =>
-      fetchPage(i + 2, locale, hideOwned, token)
+      fetchPage(i + 2, locale, hideOwned, wishlistOnly, token)
         .then((d) => d.products)
         .catch((err: unknown) => {
           logError(
@@ -113,16 +120,22 @@ const fetchAllDiscounts = async (
 
 addHandler(
   'getGogDiscounts',
-  async (_event, locale, hideOwned: boolean = false) => {
+  async (
+    _event,
+    locale,
+    hideOwned: boolean = false,
+    wishlistOnly: boolean = false
+  ) => {
     try {
       let token: string | undefined = undefined
 
-      if (hideOwned) {
+      if (hideOwned || wishlistOnly) {
         const credentials = await GOGUser.getCredentials()
         if (credentials) {
           token = credentials.access_token
         } else {
           hideOwned = false
+          wishlistOnly = false
           logWarning(
             'Failed to get user credentials: User maybe is not looged in',
             LogPrefix.Backend
@@ -130,7 +143,12 @@ addHandler(
         }
       }
 
-      const products = await fetchAllDiscounts(locale, hideOwned, token)
+      const products = await fetchAllDiscounts(
+        locale,
+        hideOwned,
+        wishlistOnly,
+        token
+      )
       if (products.length > 0 || isFallbackLocale(locale)) {
         return products
       }
@@ -139,7 +157,12 @@ addHandler(
         `No discounts for ${locale.countryCode}/${locale.currencyCode}, retrying with US/USD`,
         LogPrefix.Backend
       )
-      return await fetchAllDiscounts(FALLBACK_LOCALE, hideOwned, token)
+      return await fetchAllDiscounts(
+        FALLBACK_LOCALE,
+        hideOwned,
+        wishlistOnly,
+        token
+      )
     } catch (err) {
       logError(
         `Failed to fetch GOG discounts: ${String(err)}`,

--- a/src/backend/discounts/index.ts
+++ b/src/backend/discounts/index.ts
@@ -120,12 +120,7 @@ const fetchAllDiscounts = async (
 
 addHandler(
   'getGogDiscounts',
-  async (
-    _event,
-    locale,
-    hideOwned: boolean = false,
-    wishlistOnly: boolean = false
-  ) => {
+  async (_event, locale, hideOwned = false, wishlistOnly = false) => {
     try {
       let token: string | undefined = undefined
 

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -325,7 +325,8 @@ interface AsyncIPCFunctions {
   isIntelMac: () => boolean
   getGogDiscounts: (
     locale: CatalogLocaleSettings,
-    hideOwned?: boolean
+    hideOwned?: boolean,
+    wishlistOnly?: boolean
   ) => Promise<CatalogProduct[]>
   'steamgriddb.hasApiKey': () => Promise<boolean>
   'steamgriddb.setApiKey': (key: string) => Promise<void>

--- a/src/frontend/screens/Discounts/components/DiscountFilters/index.css
+++ b/src/frontend/screens/Discounts/components/DiscountFilters/index.css
@@ -181,6 +181,20 @@
   color: var(--accent);
 }
 
+.discountFilters__wishlistOnly.MuiFormControlLabel-root {
+  margin: 0;
+  color: var(--text-default);
+  white-space: nowrap;
+}
+
+.discountFilters__wishlistOnly .MuiCheckbox-root {
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+}
+
+.discountFilters__wishlistOnly .MuiCheckbox-root.Mui-checked {
+  color: var(--accent);
+}
+
 .discountFilters__row--inputs {
   grid-template-columns:
     minmax(140px, 180px)

--- a/src/frontend/screens/Discounts/components/DiscountFilters/index.tsx
+++ b/src/frontend/screens/Discounts/components/DiscountFilters/index.tsx
@@ -53,6 +53,8 @@ interface Props {
   onHideDlcsChange: (value: boolean) => void
   hideOwned: boolean
   onHideOwnedChange: (value: boolean) => void
+  wishlistOnly: boolean
+  onWishlistOnlyChange: (value: boolean) => void
   isGogLoggedIn: boolean
   pageSize: number
   onPageSizeChange: (value: number) => void
@@ -181,6 +183,8 @@ const DiscountFilters = ({
   onHideDlcsChange,
   hideOwned,
   onHideOwnedChange,
+  wishlistOnly,
+  onWishlistOnlyChange,
   isGogLoggedIn,
   pageSize,
   onPageSizeChange,
@@ -282,17 +286,30 @@ const DiscountFilters = ({
           placeholder={t('search', 'Search for Games')}
         />
         {isGogLoggedIn && (
-          <FormControlLabel
-            className="discountFilters__hideOwned"
-            control={
-              <Checkbox
-                size="small"
-                checked={hideOwned}
-                onChange={(e) => onHideOwnedChange(e.target.checked)}
-              />
-            }
-            label={t('discounts.filters.hideOwned', 'Hide Owned')}
-          />
+          <>
+            <FormControlLabel
+              className="discountFilters__wishlistOnly"
+              control={
+                <Checkbox
+                  size="small"
+                  checked={wishlistOnly}
+                  onChange={(e) => onWishlistOnlyChange(e.target.checked)}
+                />
+              }
+              label={t('discounts.filters.wishlistOnly', 'Wishlist Only')}
+            />
+            <FormControlLabel
+              className="discountFilters__hideOwned"
+              control={
+                <Checkbox
+                  size="small"
+                  checked={hideOwned}
+                  onChange={(e) => onHideOwnedChange(e.target.checked)}
+                />
+              }
+              label={t('discounts.filters.hideOwned', 'Hide Owned')}
+            />
+          </>
         )}
         <FormControlLabel
           className="discountFilters__hideDlcs"

--- a/src/frontend/screens/Discounts/helpers.ts
+++ b/src/frontend/screens/Discounts/helpers.ts
@@ -244,6 +244,7 @@ interface StoredDiscountFilters {
   searchQuery?: string
   hideDlcs?: boolean
   hideOwned?: boolean
+  wishlistOnly?: boolean
   pageSize?: number
 }
 

--- a/src/frontend/screens/Discounts/index.tsx
+++ b/src/frontend/screens/Discounts/index.tsx
@@ -56,6 +56,7 @@ export default function Discounts() {
     setSearchQuery('')
     setHideDlcs(false)
     setHideOwned(false)
+    setWishlistOnly(false)
   }
 
   const [products, setProducts] = useState<CatalogProduct[]>([])
@@ -94,6 +95,9 @@ export default function Discounts() {
   )
   const [hideDlcs, setHideDlcs] = useState(storedFilters.hideDlcs ?? false)
   const [hideOwned, setHideOwned] = useState(storedFilters.hideOwned ?? false)
+  const [wishlistOnly, setWishlistOnly] = useState(
+    storedFilters.wishlistOnly ?? false
+  )
   const [pageSize, setPageSize] = useState<number>(
     storedFilters.pageSize ?? DEFAULT_PAGE_SIZE
   )
@@ -118,6 +122,7 @@ export default function Discounts() {
       searchQuery,
       hideDlcs,
       hideOwned,
+      wishlistOnly,
       pageSize
     })
   }, [
@@ -132,6 +137,7 @@ export default function Discounts() {
     searchQuery,
     hideDlcs,
     hideOwned,
+    wishlistOnly,
     pageSize
   ])
 
@@ -146,7 +152,8 @@ export default function Discounts() {
       try {
         const result = await window.api.getGogDiscounts(
           localeSettings,
-          hideOwned
+          hideOwned,
+          wishlistOnly
         )
         if (!cancelled) {
           setProducts(result)
@@ -178,7 +185,7 @@ export default function Discounts() {
     return () => {
       cancelled = true
     }
-  }, [localeSettings, hideOwned, t])
+  }, [localeSettings, hideOwned, wishlistOnly, t])
 
   const priceMax = useMemo(() => {
     const max = products.reduce((acc, p) => {
@@ -406,6 +413,7 @@ export default function Discounts() {
     searchQuery,
     hideDlcs,
     hideOwned,
+    wishlistOnly,
     pageSize,
     products
   ])
@@ -431,6 +439,7 @@ export default function Discounts() {
     searchQuery.trim() !== '' ||
     hideDlcs ||
     hideOwned ||
+    wishlistOnly ||
     (priceRange !== null &&
       (priceRange[0] !== 0 || priceRange[1] !== priceMax)) ||
     (releaseYearRange !== null &&
@@ -449,6 +458,7 @@ export default function Discounts() {
     setSearchQuery('')
     setHideDlcs(false)
     setHideOwned(false)
+    setWishlistOnly(false)
   }
 
   const handlePageChange = (newPage: number) => {
@@ -568,6 +578,8 @@ export default function Discounts() {
             onHideDlcsChange={setHideDlcs}
             hideOwned={hideOwned}
             onHideOwnedChange={setHideOwned}
+            wishlistOnly={wishlistOnly}
+            onWishlistOnlyChange={setWishlistOnly}
             isGogLoggedIn={isGogLoggedIn}
             pageSize={pageSize}
             onPageSizeChange={setPageSize}


### PR DESCRIPTION
related to this issue: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5525

Adds a new filter on **GOG Deals Page**, the filter stands for **Wishlist Only**. When selected, it shows only the deals of wishlisted games.

_Don't mind the commit name, please. It's working..._

I've run:
- `pnpm run i18n`
- `pnpm prettier --write FOR EVERY MODIFIED FILE`
- `pnpm codecheck`
- `pnpm test`

The test was made on Linux using the `.appImage` build generated by `pnpm dist:linux`.

Screenshots:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/02b0ab35-4269-4c29-a081-4903f09790da" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/79a818dd-dae0-4fb9-8f0f-761d21c1ec24" />

Here's my wishlist from GOG:
<img width="1126" height="453" alt="image" src="https://github.com/user-attachments/assets/b91cd74e-bac3-4bd3-b015-90456a9c6710" />


Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
