### PR TITLE
[Fix] "Copy to clipboard" button in system info page

### DIFF
--- a/src/frontend/screens/Settings/sections/SystemInfo/index.tsx
+++ b/src/frontend/screens/Settings/sections/SystemInfo/index.tsx
@@ -127,7 +127,7 @@ export default function SystemInfo() {
           className="copyToClipboardButton button is-primary"
           variant="contained"
           startIcon={<ContentCopyIcon />}
-          onClick={window.api.systemInfo.copyToClipboard}
+          onClick={() => window.api.systemInfo.copyToClipboard()}
         >
           {t('settings.systemInformation.copyToClipboard', 'Copy to clipboard')}
         </Button>


### PR DESCRIPTION
The button did not work, as the `onClick` handler passed the `MouseEvent` onto the backend listener. Trying to copy the event (to pass it between the processes) did not work. I assume something changed in the MouseEvent structure between Electron versions, as the button of course worked in the past.

To test: Open Heroic without the patch, open "Settings" -> "System Information", click the "Copy to clipboard" button. Observe an error in the console/log, and the info not being copied. Open this PR's version, issue no longer occurs.

Closes #5526 

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
