### PR TITLE
Feat: tray icon acts as toggle

### DIFF
--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -37,14 +37,11 @@ export const initTrayIcon = async (mainWindow: BrowserWindow) => {
   appIcon.on('click', () => {
     const { exitToTray } = GlobalConfig.get().getSettings()
 
-    if (!exitToTray) return
-
-    if (mainWindow.isVisible()) {
+    if (exitToTray && mainWindow.isVisible()) {
       mainWindow.hide()
-      return
+    } else {
+      mainWindow.show()
     }
-
-    mainWindow.show()
   })
 
   backendEvents.on('languageChanged', async () => {

--- a/src/backend/tray_icon/tray_icon.ts
+++ b/src/backend/tray_icon/tray_icon.ts
@@ -35,6 +35,15 @@ export const initTrayIcon = async (mainWindow: BrowserWindow) => {
 
   // event listeners
   appIcon.on('click', () => {
+    const { exitToTray } = GlobalConfig.get().getSettings()
+
+    if (!exitToTray) return
+
+    if (mainWindow.isVisible()) {
+      mainWindow.hide()
+      return
+    }
+
     mainWindow.show()
   })
 


### PR DESCRIPTION
Closes _(if it's done correctly)_ https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5533

Click on tray icon now acts like a toggle.
If the `Exit to System Tray` is enabled, when clicking on tray icon, it will show the window if the windows is hidden, otherwise it will show. Also, if `Exit to System Tray` is not enabled, then it does nothing  when clicking.

I've run:
- `pnpm prettier`
- `pnpm codecheck`
- `pnpm test`

I tested on Linux using the `.appImage` generated by `pnpm dist:linux`.

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
