### PR TITLE
Fix: stop button on game page

### DIFF
--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -39,8 +39,7 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
     is.syncing ||
     is.launching ||
     is.installingWinetricksPackages ||
-    is.installingRedist ||
-    is.playing
+    is.installingRedist
 
   const disabledInstallButtons =
     is.playing ||


### PR DESCRIPTION
Closes _(I guess)_ https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5527

Does not disable play button when `is.playing`.

I've run:
- `pnpm run i18n`
- `pnpm prettier`
- `pnpm codecheck`
- `pnpm test`

The test was made on Linux using the `.appImage` build generated by `pnpm dist:linux`.

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
