### PR TITLE
Fix: add auto focus to search bar

### DIFF
--- a/src/frontend/components/UI/SearchBar/index.tsx
+++ b/src/frontend/components/UI/SearchBar/index.tsx
@@ -69,6 +69,7 @@ export default function SearchBar({
         // and in src/helpers/gamepad.ts#isSearchInput
         id="search"
         className="searchBarInput"
+        autoFocus
       />
       {value.length > 0 && (
         <>


### PR DESCRIPTION
Closes _(maybe)_ https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4956

I think that it's an UX enhancement. Ever time that you open **Library**, **Deals** or **Wine Manager**, it will **focus** on **Search Box**, so the user can just type in.

I've run:
- `pnpm prettier`
- `pnpm codecheck`

The test was made on Linux using the `.appImage` build generated by `pnpm dist:linux` even tho I know that is not necessary.

https://github.com/user-attachments/assets/9d9eeaa1-783b-48fe-b730-9e5de6434b94



Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
