### PR TITLE
[Console] Add ability to install games from console mode

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -233,7 +233,7 @@
             "all": "All",
             "sideload": "Other"
         },
-        "games": "Installed Games",
+        "games": "Installed games",
         "hints": {
             "change_store": "Change store",
             "launch": "Launch",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -233,7 +233,7 @@
             "all": "All",
             "sideload": "Other"
         },
-        "games": "Installed games",
+        "games": "Installed Games",
         "hints": {
             "change_store": "Change store",
             "launch": "Launch",

--- a/src/frontend/screens/ConsoleMode/InstallOverlay/index.scss
+++ b/src/frontend/screens/ConsoleMode/InstallOverlay/index.scss
@@ -2,28 +2,24 @@
 .consoleInstallOverlay {
   position: fixed;
   inset: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   gap: 16px;
-  background: color-mix(
-    in srgb,
-    var(--body-background, #101014) 70%,
-    transparent
-  );
   backdrop-filter: blur(10px);
   z-index: 10;
+  align-items: center;
   animation: overlayFade 220ms ease;
+  display: flex;
+  justify-content: center;
 }
 
 .consoleModal {
   background: color-mix(
     in srgb,
-    var(--body-background, #101014) 100%,
+    var(--body-background, #101014) 80%,
     transparent
   );
   z-index: 20;
+  gap: 16px;
+  flex-direction: column;
 }
 
 @keyframes overlayFade {
@@ -99,4 +95,8 @@
     opacity: 1;
     color: var(--cancel-button, #b94a3a);
   }
+}
+
+.consoleInstallButtons {
+  gap: 1rem;
 }

--- a/src/frontend/screens/ConsoleMode/InstallOverlay/index.scss
+++ b/src/frontend/screens/ConsoleMode/InstallOverlay/index.scss
@@ -14,12 +14,14 @@
 .consoleModal {
   background: color-mix(
     in srgb,
-    var(--body-background, #101014) 80%,
+    var(--body-background, #101014) 90%,
     transparent
   );
   z-index: 20;
   gap: 16px;
   flex-direction: column;
+  padding: var(--space-xl);
+  border-radius: var(--space-lg);
 }
 
 @keyframes overlayFade {
@@ -31,36 +33,21 @@
   }
 }
 
-.consoleLaunchSpinner {
-  position: relative;
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
-  border: 4px solid
-    color-mix(in srgb, var(--text-default, #eae8e5) 20%, transparent);
-  border-top-color: var(--accent, #0080ff);
-  animation: spin 900ms linear infinite;
-
-  &.idle {
-    border-top-color: var(--status-success, #2bbd60);
-    animation-duration: 2.4s;
-  }
-}
-
 @keyframes spin {
   to {
     transform: rotate(360deg);
   }
 }
 
-.consoleLaunchText {
+.consoleModalTitle {
   font-size: 1rem;
   color: var(--text-secondary, #b1b1b1);
   text-transform: uppercase;
   letter-spacing: 0.2em;
+  margin-bottom: var(--space-md);
 }
 
-.consoleLaunchGameTitle {
+.consoleModalGameTitle {
   font-size: clamp(1.6rem, 2.4vw, 2.4rem);
   font-weight: 700;
   color: var(--text-title, var(--text-default, #eae8e5));
@@ -69,34 +56,10 @@
   text-align: center;
 }
 
-.consoleLaunchHint {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 12px;
-  font-size: 0.85rem;
-  color: var(--text-secondary, #b1b1b1);
-  opacity: 0.75;
-  transition:
-    opacity 180ms ease,
-    color 180ms ease;
-
-  kbd {
-    font-family: var(--primary-font-family);
-    font-size: 0.8rem;
-    font-weight: 700;
-    padding: 3px 8px;
-    border-radius: 6px;
-    border: 1px solid color-mix(in srgb, currentColor 40%, transparent);
-    background: color-mix(in srgb, currentColor 10%, transparent);
-  }
-
-  &.active {
-    opacity: 1;
-    color: var(--cancel-button, #b94a3a);
-  }
-}
-
 .consoleInstallButtons {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
   gap: 1rem;
+  margin-top: var(--space-lg);
 }

--- a/src/frontend/screens/ConsoleMode/InstallOverlay/index.scss
+++ b/src/frontend/screens/ConsoleMode/InstallOverlay/index.scss
@@ -1,0 +1,102 @@
+// Install overlay
+.consoleInstallOverlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background: color-mix(
+    in srgb,
+    var(--body-background, #101014) 70%,
+    transparent
+  );
+  backdrop-filter: blur(10px);
+  z-index: 10;
+  animation: overlayFade 220ms ease;
+}
+
+.consoleModal {
+  background: color-mix(
+    in srgb,
+    var(--body-background, #101014) 100%,
+    transparent
+  );
+  z-index: 20;
+}
+
+@keyframes overlayFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.consoleLaunchSpinner {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 4px solid
+    color-mix(in srgb, var(--text-default, #eae8e5) 20%, transparent);
+  border-top-color: var(--accent, #0080ff);
+  animation: spin 900ms linear infinite;
+
+  &.idle {
+    border-top-color: var(--status-success, #2bbd60);
+    animation-duration: 2.4s;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.consoleLaunchText {
+  font-size: 1rem;
+  color: var(--text-secondary, #b1b1b1);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.consoleLaunchGameTitle {
+  font-size: clamp(1.6rem, 2.4vw, 2.4rem);
+  font-weight: 700;
+  color: var(--text-title, var(--text-default, #eae8e5));
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.5);
+  max-width: 80vw;
+  text-align: center;
+}
+
+.consoleLaunchHint {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #b1b1b1);
+  opacity: 0.75;
+  transition:
+    opacity 180ms ease,
+    color 180ms ease;
+
+  kbd {
+    font-family: var(--primary-font-family);
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 3px 8px;
+    border-radius: 6px;
+    border: 1px solid color-mix(in srgb, currentColor 40%, transparent);
+    background: color-mix(in srgb, currentColor 10%, transparent);
+  }
+
+  &.active {
+    opacity: 1;
+    color: var(--cancel-button, #b94a3a);
+  }
+}

--- a/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
+++ b/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
@@ -7,6 +7,8 @@ import { hasStatus } from 'frontend/hooks/hasStatus'
 
 import type { GameInfo } from 'common/types'
 import { useEffect } from 'react'
+import { install } from 'frontend/helpers'
+import { hasProgress } from 'frontend/hooks/hasProgress'
 
 export default function InstallOverlay({
   game,
@@ -17,6 +19,7 @@ export default function InstallOverlay({
 }) {
   const { t } = useTranslation()
   const { status, statusContext } = hasStatus(game)
+  const [progress] = hasProgress(game.app_name, game.runner)
 
   let label: string | null = null
 
@@ -34,19 +37,40 @@ export default function InstallOverlay({
     }
   }, [])
 
+  const installGame = () => {
+    try {
+      install({
+        gameInfo: game,
+        previousProgress: null,
+        progress: progress,
+        installPath: 'default',
+        isInstalling: false,
+        t,
+        showDialogModal: () => <div>Dialog Modal</div>
+      })
+
+      // we're now installing, close modal
+      onDismiss()
+    } catch {}
+  }
+
   return (
     <div className="consoleInstallOverlay" role="status" aria-live="polite">
       {/* set modal */}
       <div className="consoleModal">
         {/* list game info to install */}
-
-        {/* list runner to be used */}
-
-        {/* Confirm or Cancel buttons */}
         <div className="consoleLaunchText">
-          {label || t('console.launching', 'Launching')}
+          {label || t('status.installing', 'Installing')}
         </div>
         <div className="consoleLaunchGameTitle">{game.title}</div>
+        {/* list runner to be used */}
+
+        <div>{t('status.installing', 'Installing')}</div>
+        {/* Confirm or Cancel buttons */}
+        <div className="consoleInstallButtons">
+          <button onClick={onDismiss}>Cancel</button>
+          <button onClick={installGame}>Install</button>
+        </div>
       </div>
     </div>
   )

--- a/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
+++ b/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
@@ -47,7 +47,7 @@ export default function InstallOverlay({
         installPath: 'default',
         isInstalling: false,
         t,
-        showDialogModal: () => <div>Dialog Modal</div>
+        showDialogModal: () => {}
       })
 
       // we're now installing, close modal
@@ -57,26 +57,25 @@ export default function InstallOverlay({
 
   return (
     <div className="consoleInstallOverlay" role="status" aria-live="polite">
-      {/* set modal */}
       <div className="consoleModal">
-        {/* list game info to install */}
         <div className="consoleModalTitle">
           {label || t('status.installing', 'Installing')}
         </div>
         <div className="consoleModalGameTitle">{game.title}</div>
-        {/* list runner to be used */}
+
+        {/* list runner to be used, use InstallModal in the future */}
 
         {/* Confirm or Cancel buttons */}
         <div className="consoleInstallButtons">
           <button className="consoleChip" onClick={onDismiss}>
-            Cancel
+            {t('button.cancel', 'Cancel')}
           </button>
           <button
             ref={installButtonRef}
             className="consoleChip"
             onClick={installGame}
           >
-            Install
+            {t('generic.install', 'Install')}
           </button>
         </div>
       </div>

--- a/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
+++ b/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from 'react-i18next'
-import classNames from 'classnames'
 
 import './index.scss'
 
@@ -19,7 +18,7 @@ export default function InstallOverlay({
   const [progress] = hasProgress(game.app_name, game.runner)
   const installButtonRef = useRef<HTMLButtonElement | null>(null)
 
-  let label: string | null = null
+  const label: string | null = null
 
   const onOverlayKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
@@ -47,7 +46,7 @@ export default function InstallOverlay({
         installPath: 'default',
         isInstalling: false,
         t,
-        showDialogModal: () => {}
+        showDialogModal: () => null
       })
 
       // we're now installing, close modal

--- a/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
+++ b/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from 'react-i18next'
+import classNames from 'classnames'
+
+import './index.scss'
+
+import { hasStatus } from 'frontend/hooks/hasStatus'
+
+import type { GameInfo } from 'common/types'
+import { useEffect } from 'react'
+
+export default function InstallOverlay({
+  game,
+  onDismiss
+}: {
+  game: GameInfo
+  onDismiss: () => void
+}) {
+  const { t } = useTranslation()
+  const { status, statusContext } = hasStatus(game)
+
+  let label: string | null = null
+
+  const onOverlayKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onDismiss()
+      return
+    }
+  }
+
+  useEffect(() => {
+    window.addEventListener('keydown', onOverlayKeyDown)
+    return () => {
+      window.removeEventListener('keydown', onOverlayKeyDown)
+    }
+  }, [])
+
+  return (
+    <div className="consoleInstallOverlay" role="status" aria-live="polite">
+      {/* set modal */}
+      <div className="consoleModal">
+        {/* list game info to install */}
+
+        {/* list runner to be used */}
+
+        {/* Confirm or Cancel buttons */}
+        <div className="consoleLaunchText">
+          {label || t('console.launching', 'Launching')}
+        </div>
+        <div className="consoleLaunchGameTitle">{game.title}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
+++ b/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
@@ -3,10 +3,8 @@ import classNames from 'classnames'
 
 import './index.scss'
 
-import { hasStatus } from 'frontend/hooks/hasStatus'
-
 import type { GameInfo } from 'common/types'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { install } from 'frontend/helpers'
 import { hasProgress } from 'frontend/hooks/hasProgress'
 
@@ -18,8 +16,8 @@ export default function InstallOverlay({
   onDismiss: () => void
 }) {
   const { t } = useTranslation()
-  const { status, statusContext } = hasStatus(game)
   const [progress] = hasProgress(game.app_name, game.runner)
+  const installButtonRef = useRef<HTMLButtonElement | null>(null)
 
   let label: string | null = null
 
@@ -31,6 +29,9 @@ export default function InstallOverlay({
   }
 
   useEffect(() => {
+    // focus action button
+    installButtonRef?.current?.focus()
+
     window.addEventListener('keydown', onOverlayKeyDown)
     return () => {
       window.removeEventListener('keydown', onOverlayKeyDown)
@@ -59,17 +60,24 @@ export default function InstallOverlay({
       {/* set modal */}
       <div className="consoleModal">
         {/* list game info to install */}
-        <div className="consoleLaunchText">
+        <div className="consoleModalTitle">
           {label || t('status.installing', 'Installing')}
         </div>
-        <div className="consoleLaunchGameTitle">{game.title}</div>
+        <div className="consoleModalGameTitle">{game.title}</div>
         {/* list runner to be used */}
 
-        <div>{t('status.installing', 'Installing')}</div>
         {/* Confirm or Cancel buttons */}
         <div className="consoleInstallButtons">
-          <button onClick={onDismiss}>Cancel</button>
-          <button onClick={installGame}>Install</button>
+          <button className="consoleChip" onClick={onDismiss}>
+            Cancel
+          </button>
+          <button
+            ref={installButtonRef}
+            className="consoleChip"
+            onClick={installGame}
+          >
+            Install
+          </button>
         </div>
       </div>
     </div>

--- a/src/frontend/screens/ConsoleMode/components/BackHint/index.tsx
+++ b/src/frontend/screens/ConsoleMode/components/BackHint/index.tsx
@@ -1,18 +1,20 @@
 import classNames from 'classnames'
+import { useGamepadInfo } from '../../hooks'
+import { getBackButtonLabel } from '../../controller'
 
 export default function BackHint({
   prefix,
   suffix,
-  gamepadConnected,
-  backButtonLabel,
   active
 }: {
   prefix: string
   suffix: string
-  gamepadConnected: boolean
-  backButtonLabel: string
   active?: boolean
 }) {
+  const { connected: gamepadConnected, layout: controllerLayout } =
+    useGamepadInfo()
+  const backButtonLabel = getBackButtonLabel(controllerLayout)
+
   return (
     <div className={classNames('consoleLaunchHint', { active })}>
       {prefix} <kbd>{gamepadConnected ? backButtonLabel : 'Esc'}</kbd> {suffix}

--- a/src/frontend/screens/ConsoleMode/components/LaunchOverlay/index.scss
+++ b/src/frontend/screens/ConsoleMode/components/LaunchOverlay/index.scss
@@ -1,0 +1,93 @@
+// Launch overlay
+.consoleLaunchOverlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background: color-mix(
+    in srgb,
+    var(--body-background, #101014) 70%,
+    transparent
+  );
+  backdrop-filter: blur(10px);
+  z-index: 10;
+  animation: overlayFade 220ms ease;
+}
+
+@keyframes overlayFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.consoleLaunchSpinner {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 4px solid
+    color-mix(in srgb, var(--text-default, #eae8e5) 20%, transparent);
+  border-top-color: var(--accent, #0080ff);
+  animation: spin 900ms linear infinite;
+
+  &.idle {
+    border-top-color: var(--status-success, #2bbd60);
+    animation-duration: 2.4s;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.consoleLaunchText {
+  font-size: 1rem;
+  color: var(--text-secondary, #b1b1b1);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.consoleLaunchGameTitle {
+  font-size: clamp(1.6rem, 2.4vw, 2.4rem);
+  font-weight: 700;
+  color: var(--text-title, var(--text-default, #eae8e5));
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.5);
+  max-width: 80vw;
+  text-align: center;
+}
+
+.consoleLaunchHint {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #b1b1b1);
+  opacity: 0.75;
+  transition:
+    opacity 180ms ease,
+    color 180ms ease;
+
+  kbd {
+    font-family: var(--primary-font-family);
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 3px 8px;
+    border-radius: 6px;
+    border: 1px solid color-mix(in srgb, currentColor 40%, transparent);
+    background: color-mix(in srgb, currentColor 10%, transparent);
+  }
+
+  &.active {
+    opacity: 1;
+    color: var(--cancel-button, #b94a3a);
+  }
+}

--- a/src/frontend/screens/ConsoleMode/components/LaunchOverlay/index.tsx
+++ b/src/frontend/screens/ConsoleMode/components/LaunchOverlay/index.tsx
@@ -9,12 +9,8 @@ import BackHint from '../BackHint'
 
 import type { GameInfo, Runner } from 'common/types'
 import { useContext, useEffect } from 'react'
-import {
-  useCancelOnHold,
-  useGamepadButtonHold,
-  useGamepadInfo
-} from '../../hooks'
-import { BTN_BACK, getBackButtonLabel } from '../../controller'
+import { useCancelOnHold, useGamepadButtonHold } from '../../hooks'
+import { BTN_BACK } from '../../controller'
 import { launch, sendKill } from 'frontend/helpers'
 import ContextProvider from 'frontend/state/ContextProvider'
 
@@ -31,9 +27,6 @@ export default function LaunchOverlay({
   const { status, statusContext } = hasStatus(game)
   let label: string | null = null
 
-  const { connected: gamepadConnected, layout: controllerLayout } =
-    useGamepadInfo()
-  const backButtonLabel = getBackButtonLabel(controllerLayout)
   const { showDialogModal } = useContext(ContextProvider)
 
   // Hold-to-cancel for in-flight launches. Triggered by Escape (keyboard) or

--- a/src/frontend/screens/ConsoleMode/components/LaunchOverlay/index.tsx
+++ b/src/frontend/screens/ConsoleMode/components/LaunchOverlay/index.tsx
@@ -1,27 +1,94 @@
 import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
 
+import './index.scss'
+
 import { hasStatus } from 'frontend/hooks/hasStatus'
 
 import BackHint from '../BackHint'
 
-import type { GameInfo } from 'common/types'
+import type { GameInfo, Runner } from 'common/types'
+import { useContext, useEffect } from 'react'
+import {
+  useCancelOnHold,
+  useGamepadButtonHold,
+  useGamepadInfo
+} from '../../hooks'
+import { BTN_BACK, getBackButtonLabel } from '../../controller'
+import { launch, sendKill } from 'frontend/helpers'
+import ContextProvider from 'frontend/state/ContextProvider'
+
+const CANCEL_HOLD_MS = 3000
 
 export default function LaunchOverlay({
   game,
-  holdStart,
-  gamepadConnected,
-  backButtonLabel
+  onDismiss
 }: {
   game: GameInfo
-  holdStart: number | null
-  gamepadConnected: boolean
-  backButtonLabel: string
+  onDismiss: () => void
 }) {
   const { t } = useTranslation()
   const { status, statusContext } = hasStatus(game)
-
   let label: string | null = null
+
+  const { connected: gamepadConnected, layout: controllerLayout } =
+    useGamepadInfo()
+  const backButtonLabel = getBackButtonLabel(controllerLayout)
+  const { showDialogModal } = useContext(ContextProvider)
+
+  // Hold-to-cancel for in-flight launches. Triggered by Escape (keyboard) or
+  // the back button (gamepad); fires `sendKill` after CANCEL_HOLD_MS.
+  const { holdStart, startHold, stopHold } = useCancelOnHold({
+    active: !!game,
+    holdMs: CANCEL_HOLD_MS,
+    onCancel: () => {
+      if (game) void sendKill(game.app_name, game.runner)
+
+      // prevent UX from hanging in "Launching" mode
+      onDismiss()
+    }
+  })
+
+  const onOverlayKeyDown = (e: React.KeyboardEvent) => {}
+  const onOverlayKeyUp = (e: React.KeyboardEvent) => {}
+
+  // Escape quits when idle; hold it while launching to cancel.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      e.preventDefault()
+
+      if (!e.repeat) startHold()
+    }
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') stopHold()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
+    }
+  }, [startHold, stopHold])
+
+  useEffect(() => {
+    launch({
+      appName: game.app_name,
+      t,
+      runner: game.runner as Runner,
+      hasUpdate: false,
+      showDialogModal
+    }).finally(() => {
+      onDismiss()
+    })
+  }, [])
+
+  useGamepadButtonHold(
+    BTN_BACK,
+    (held) => (held ? startHold() : stopHold()),
+    !!game
+  )
+
   switch (status) {
     case 'syncing-saves':
       label = t('gamepage:status.syncingSaves', 'Syncing Saves')
@@ -45,7 +112,13 @@ export default function LaunchOverlay({
   }
 
   return (
-    <div className="consoleLaunchOverlay" role="status" aria-live="polite">
+    <div
+      onKeyDown={onOverlayKeyDown}
+      onKeyUp={onOverlayKeyUp}
+      className="consoleLaunchOverlay"
+      role="status"
+      aria-live="polite"
+    >
       <div
         className={classNames('consoleLaunchSpinner', {
           idle: status === 'playing'
@@ -58,8 +131,6 @@ export default function LaunchOverlay({
       <BackHint
         prefix={t('console.cancel.hintPrefix', 'Hold')}
         suffix={t('console.cancel.hintSuffix', 'for 3s to cancel')}
-        gamepadConnected={gamepadConnected}
-        backButtonLabel={backButtonLabel}
         active={holdStart != null}
       />
     </div>

--- a/src/frontend/screens/ConsoleMode/components/UpdateNotice/index.tsx
+++ b/src/frontend/screens/ConsoleMode/components/UpdateNotice/index.tsx
@@ -9,14 +9,10 @@ import type { GameInfo } from 'common/types'
 
 export default function UpdateNotice({
   game,
-  onDismiss,
-  gamepadConnected,
-  backButtonLabel
+  onDismiss
 }: {
   game: GameInfo
   onDismiss: () => void
-  gamepadConnected: boolean
-  backButtonLabel: string
 }) {
   const { t } = useTranslation()
 
@@ -38,7 +34,7 @@ export default function UpdateNotice({
     }
     window.addEventListener('keydown', onKeyDown, true)
     return () => window.removeEventListener('keydown', onKeyDown, true)
-  }, [onDismiss])
+  }, [])
 
   useGamepadButtonPress(BTN_BACK, onDismiss)
 
@@ -62,8 +58,6 @@ export default function UpdateNotice({
       <BackHint
         prefix={t('console.update.hintPrefix', 'Press')}
         suffix={t('console.update.hintSuffix', 'to go back')}
-        gamepadConnected={gamepadConnected}
-        backButtonLabel={backButtonLabel}
       />
     </div>
   )

--- a/src/frontend/screens/ConsoleMode/hooks.ts
+++ b/src/frontend/screens/ConsoleMode/hooks.ts
@@ -110,14 +110,14 @@ export function useColumnCount(
         setColumns(1)
         return
       }
+      const firstTop = cards[0].offsetTop
 
       let count = 1
       for (let i = 1; i < cards.length; i++) {
-        if (cards[i].offsetTop !== cards[i - 1].offsetTop) break
+        if (cards[i].offsetTop !== firstTop) break
         count++
       }
-
-      setColumns(count)
+      setColumns(Math.max(1, count))
     }
     compute()
     window.addEventListener('resize', compute)

--- a/src/frontend/screens/ConsoleMode/hooks.ts
+++ b/src/frontend/screens/ConsoleMode/hooks.ts
@@ -109,13 +109,24 @@ export function useColumnCount(
         setColumns(1)
         return
       }
-      const firstTop = cards[0].offsetTop
-      let count = 1
+
+      // go through all cards, make sure we're reaching the total maximum
+      // of columns depending on whether we're checking for installed
+      // or uninstalled games
+      let previousTop = cards[0].offsetTop
+      let maxCount = 1
+      let currCount = 0
       for (let i = 1; i < cards.length; i++) {
-        if (cards[i].offsetTop !== firstTop) break
-        count++
+        // we've hit a new line, check again for the next line
+        if (cards[i].offsetTop !== previousTop) {
+          previousTop = cards[i].offsetTop
+          maxCount = Math.max(maxCount, currCount)
+          currCount = 0
+        }
+
+        currCount++
       }
-      setColumns(Math.max(1, count))
+      setColumns(maxCount)
     }
     compute()
     window.addEventListener('resize', compute)

--- a/src/frontend/screens/ConsoleMode/hooks.ts
+++ b/src/frontend/screens/ConsoleMode/hooks.ts
@@ -105,28 +105,19 @@ export function useColumnCount(
       const cards = (cardRefs.current ?? []).filter(
         (el): el is HTMLElement => !!el
       )
+
       if (cards.length < 2) {
         setColumns(1)
         return
       }
 
-      // go through all cards, make sure we're reaching the total maximum
-      // of columns depending on whether we're checking for installed
-      // or uninstalled games
-      let previousTop = cards[0].offsetTop
-      let maxCount = 1
-      let currCount = 0
+      let count = 1
       for (let i = 1; i < cards.length; i++) {
-        // we've hit a new line, check again for the next line
-        if (cards[i].offsetTop !== previousTop) {
-          previousTop = cards[i].offsetTop
-          maxCount = Math.max(maxCount, currCount)
-          currCount = 0
-        }
-
-        currCount++
+        if (cards[i].offsetTop !== cards[i - 1].offsetTop) break
+        count++
       }
-      setColumns(maxCount)
+
+      setColumns(count)
     }
     compute()
     window.addEventListener('resize', compute)

--- a/src/frontend/screens/ConsoleMode/index.scss
+++ b/src/frontend/screens/ConsoleMode/index.scss
@@ -71,6 +71,7 @@
   display: flex;
   gap: 8px;
   flex: 1;
+  height: 100%;
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
@@ -117,12 +118,28 @@
     outline: none;
   }
 
+  &:hover.active,
+  &:focus-visible.active {
+    border: 1px solid
+      color-mix(in srgb, var(--text-title, #eae8e5) 90%, transparent);
+    background: color-mix(in srgb, var(--accent, #1a1a20) 60%, transparent);
+    outline: none;
+  }
+
   &.active {
     border: 1px solid
       color-mix(in srgb, var(--text-title, #eae8e5) 70%, transparent);
     background: color-mix(in srgb, var(--accent, #1a1a20) 30%, transparent);
     color: var(--text-title, #fff);
   }
+}
+
+.consoleDividerVertical {
+  height: 60%;
+  margin-left: 0.2rem;
+  margin-right: 0.2rem;
+  border: 1px solid
+    color-mix(in srgb, var(--text-title, #eae8e5) 30%, transparent);
 }
 
 .consoleQuitButton {
@@ -369,100 +386,6 @@
   to {
     opacity: 1;
     transform: translateY(0);
-  }
-}
-
-// Launch overlay
-.consoleLaunchOverlay {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
-  background: color-mix(
-    in srgb,
-    var(--body-background, #101014) 70%,
-    transparent
-  );
-  backdrop-filter: blur(10px);
-  z-index: 10;
-  animation: overlayFade 220ms ease;
-}
-
-@keyframes overlayFade {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.consoleLaunchSpinner {
-  position: relative;
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
-  border: 4px solid
-    color-mix(in srgb, var(--text-default, #eae8e5) 20%, transparent);
-  border-top-color: var(--accent, #0080ff);
-  animation: spin 900ms linear infinite;
-
-  &.idle {
-    border-top-color: var(--status-success, #2bbd60);
-    animation-duration: 2.4s;
-  }
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.consoleLaunchText {
-  font-size: 1rem;
-  color: var(--text-secondary, #b1b1b1);
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-}
-
-.consoleLaunchGameTitle {
-  font-size: clamp(1.6rem, 2.4vw, 2.4rem);
-  font-weight: 700;
-  color: var(--text-title, var(--text-default, #eae8e5));
-  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.5);
-  max-width: 80vw;
-  text-align: center;
-}
-
-.consoleLaunchHint {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 12px;
-  font-size: 0.85rem;
-  color: var(--text-secondary, #b1b1b1);
-  opacity: 0.75;
-  transition:
-    opacity 180ms ease,
-    color 180ms ease;
-
-  kbd {
-    font-family: var(--primary-font-family);
-    font-size: 0.8rem;
-    font-weight: 700;
-    padding: 3px 8px;
-    border-radius: 6px;
-    border: 1px solid color-mix(in srgb, currentColor 40%, transparent);
-    background: color-mix(in srgb, currentColor 10%, transparent);
-  }
-
-  &.active {
-    opacity: 1;
-    color: var(--cancel-button, #b94a3a);
   }
 }
 

--- a/src/frontend/screens/ConsoleMode/index.tsx
+++ b/src/frontend/screens/ConsoleMode/index.tsx
@@ -25,7 +25,7 @@ import UpdateNotice from './components/UpdateNotice'
 import { BTN_L1, BTN_R1, BTN_R2, getBackButtonLabel } from './controller'
 import { useColumnCount, useGamepadButtonPress, useGamepadInfo } from './hooks'
 
-import type { GameInfo, Runner } from 'common/types'
+import type { GameInfo, Runner, Status } from 'common/types'
 
 type StoreKey = Runner | 'all'
 
@@ -37,6 +37,7 @@ export default function ConsoleMode() {
     gog,
     amazon,
     zoom,
+    libraryStatus,
     sideloadedLibrary,
     refreshLibrary,
     refreshing,
@@ -164,17 +165,8 @@ export default function ConsoleMode() {
   const columns = useColumnCount(cardRefs, visibleGames.length)
 
   useEffect(() => {
-    // if index is in between installed and uninstalled,
-    // move to installed games
-    if (
-      focusedIndex >= installedGames.length &&
-      focusedIndex <
-        installedGames.length + columns - (installedGames.length % columns)
-    ) {
-      setFocusedIndex(installedGames.length - 1)
-    }
     // otherwise, always make sane focused index
-    else if (focusedIndex >= visibleGames.length || focusedIndex < 0) {
+    if (focusedIndex >= visibleGames.length || focusedIndex < 0) {
       setFocusedIndex(
         Math.max(0, Math.min(focusedIndex, visibleGames.length - 1))
       )
@@ -363,6 +355,18 @@ export default function ConsoleMode() {
               {visibleGames.map((game, i) => {
                 const isFocused = i === focusedIndex
                 const needsUpdate = gameUpdates.includes(game.app_name)
+                // badges we want to show status updates on
+                const badgeStates: Status[] = [
+                  'installing',
+                  'redist',
+                  'queued',
+                  'updating',
+                  'uninstalling'
+                ]
+
+                const gameStatus = libraryStatus.find(
+                  (st) => st.appName === game.app_name
+                )
 
                 return (
                   <button
@@ -398,6 +402,15 @@ export default function ConsoleMode() {
                         {t('console.card.needsUpdate', 'Needs update')}
                       </span>
                     )}
+                    {gameStatus?.status &&
+                      badgeStates.includes(gameStatus?.status) && (
+                        <span className="consoleCardBadge">
+                          {t(
+                            `gamepage:status.${gameStatus?.status}`,
+                            'Installing'
+                          )}
+                        </span>
+                      )}
                   </button>
                 )
               })}

--- a/src/frontend/screens/ConsoleMode/index.tsx
+++ b/src/frontend/screens/ConsoleMode/index.tsx
@@ -110,22 +110,34 @@ export default function ConsoleMode() {
     sideloadedLibrary
   ])
 
-  const visibleGames = useMemo(() => {
-    let list = installedGames
+  const installedGames = allGames.filter((game) => game.is_installed)
+  const uninstalledGames = allGames.filter((game) => !game.is_installed)
+
+  const filterAndSortGames = (games: GameInfo[]) => {
+    let filteredGames = games
+
     if (activeStore !== 'all') {
-      list = list.filter((g) => g.runner === activeStore)
+      filteredGames = filteredGames.filter((g) => g.runner === activeStore)
     }
-    return [...list].sort((a, b) => {
+
+    return filteredGames.sort((a, b) => {
       const cmp = a.title.localeCompare(b.title)
       return ascending ? cmp : -cmp
     })
-  }, [installedGames, activeStore, ascending])
+  }
+
+  const visibleGames = useMemo(() => {
+    let filteredInstalledGames = filterAndSortGames(installedGames)
+    let filteredUninstalledGames = filterAndSortGames(uninstalledGames)
+
+    return [...filteredInstalledGames, ...filteredUninstalledGames]
+  }, [allGames, activeStore, ascending])
 
   const storesWithGames = useMemo(() => {
     const set = new Set<Runner>()
-    for (const g of installedGames) set.add(g.runner)
+    for (const g of allGames) set.add(g.runner)
     return set
-  }, [installedGames])
+  }, [allGames])
 
   const storeFilters = useMemo<
     { key: StoreKey; label: string; enabled: boolean }[]
@@ -134,7 +146,7 @@ export default function ConsoleMode() {
       {
         key: 'all',
         label: t('console.filter.all', 'All'),
-        enabled: installedGames.length > 0
+        enabled: allGames.length > 0
       },
       {
         key: 'legendary',
@@ -150,7 +162,7 @@ export default function ConsoleMode() {
       },
       { key: 'zoom', label: 'ZOOM', enabled: storesWithGames.has('zoom') }
     ],
-    [t, storesWithGames, installedGames.length]
+    [t, storesWithGames, allGames.length]
   )
 
   const enabledStoreKeys = useMemo(
@@ -167,8 +179,11 @@ export default function ConsoleMode() {
   const columns = useColumnCount(cardRefs, visibleGames.length)
 
   useEffect(() => {
-    if (focusedIndex >= visibleGames.length) {
-      setFocusedIndex(Math.max(0, visibleGames.length - 1))
+    // always make sane focused index
+    if (focusedIndex >= visibleGames.length || focusedIndex < 0) {
+      setFocusedIndex(
+        Math.max(0, Math.min(focusedIndex, visibleGames.length - 1))
+      )
     }
   }, [visibleGames.length, focusedIndex])
 
@@ -225,6 +240,9 @@ export default function ConsoleMode() {
     onCancel: () => {
       if (launchingGame)
         void sendKill(launchingGame.app_name, launchingGame.runner)
+
+      // prevent UX from hanging in "Launching" mode
+      setLaunchingGame(null)
     }
   })
 
@@ -292,8 +310,8 @@ export default function ConsoleMode() {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
       e.preventDefault()
-      if (!launchingGame) quit()
-      else if (!e.repeat) startHold()
+
+      if (!e.repeat) startHold()
     }
     const onKeyUp = (e: KeyboardEvent) => {
       if (e.key === 'Escape') stopHold()

--- a/src/frontend/screens/ConsoleMode/index.tsx
+++ b/src/frontend/screens/ConsoleMode/index.tsx
@@ -62,7 +62,7 @@ export default function ConsoleMode() {
   const topBarRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    // window.api.setFullscreen(true)
+    window.api.setFullscreen(true)
     if (
       !refreshing &&
       epic.library.length === 0 &&
@@ -161,7 +161,7 @@ export default function ConsoleMode() {
   const columns = useColumnCount(cardRefs, visibleGames.length)
 
   useEffect(() => {
-    // otherwise, always make sane focused index
+    // always make sane focused index
     if (focusedIndex >= visibleGames.length || focusedIndex < 0) {
       setFocusedIndex(
         Math.max(0, Math.min(focusedIndex, visibleGames.length - 1))

--- a/src/frontend/screens/ConsoleMode/index.tsx
+++ b/src/frontend/screens/ConsoleMode/index.tsx
@@ -91,7 +91,7 @@ export default function ConsoleMode() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const installedGames = useMemo<GameInfo[]>(() => {
+  const allGames = useMemo<GameInfo[]>(() => {
     const all: GameInfo[] = [
       ...epic.library,
       ...gog.library,
@@ -99,9 +99,7 @@ export default function ConsoleMode() {
       ...zoom.library,
       ...sideloadedLibrary
     ]
-    return all.filter(
-      (g) => g?.is_installed && !g.install?.is_dlc && !g.thirdPartyManagedApp
-    )
+    return all.filter((g) => !g.install?.is_dlc && !g.thirdPartyManagedApp)
   }, [
     epic.library,
     gog.library,
@@ -179,8 +177,17 @@ export default function ConsoleMode() {
   const columns = useColumnCount(cardRefs, visibleGames.length)
 
   useEffect(() => {
-    // always make sane focused index
-    if (focusedIndex >= visibleGames.length || focusedIndex < 0) {
+    // if index is in between installed and uninstalled,
+    // move to installed games
+    if (
+      focusedIndex >= installedGames.length &&
+      focusedIndex <
+        installedGames.length + columns - (installedGames.length % columns)
+    ) {
+      setFocusedIndex(installedGames.length - 1)
+    }
+    // otherwise, always make sane focused index
+    else if (focusedIndex >= visibleGames.length || focusedIndex < 0) {
       setFocusedIndex(
         Math.max(0, Math.min(focusedIndex, visibleGames.length - 1))
       )
@@ -278,7 +285,13 @@ export default function ConsoleMode() {
     if (e.key === 'ArrowRight') {
       e.preventDefault()
       e.stopPropagation()
-      setFocusedIndex((i) => Math.min(i + 1, last))
+      // check if we're the last installed game, skip to next row
+      if (focusedIndex === installedGames.length - 1) {
+        const diff = columns - (installedGames.length % columns) + 1
+        setFocusedIndex((i) => Math.min(i + diff, last))
+      } else {
+        setFocusedIndex((i) => Math.min(i + 1, last))
+      }
     } else if (e.key === 'ArrowLeft') {
       e.preventDefault()
       e.stopPropagation()
@@ -419,43 +432,92 @@ export default function ConsoleMode() {
             aria-label={t('console.games', 'Installed games')}
             onKeyDown={onGridKeyDown}
           >
+            <h3>{t('console.games', 'Installed Games')}</h3>
             <div className="consoleGrid">
-              {visibleGames.map((game, i) => {
-                const isFocused = i === focusedIndex
-                const needsUpdate = gameUpdates.includes(game.app_name)
-                return (
-                  <button
-                    key={`${game.runner}-${game.app_name}`}
-                    ref={(el) => {
-                      cardRefs.current[i] = el
-                    }}
-                    className={classNames('consoleCard', {
-                      focused: isFocused
-                    })}
-                    tabIndex={isFocused ? 0 : -1}
-                    onClick={() => {
-                      if (isFocused) void launchGame(game)
-                      else setFocusedIndex(i)
-                    }}
-                    onMouseEnter={() => setFocusedIndex(i)}
-                    onFocus={() => setFocusedIndex(i)}
-                  >
-                    <CachedImage
-                      src={
-                        getImageFormatting(game.art_square, game.runner) ||
-                        fallBackImage
-                      }
-                      alt={game.title}
-                      className="consoleCardArt"
-                    />
-                    {needsUpdate && (
-                      <span className="consoleCardBadge">
-                        {t('console.card.needsUpdate', 'Needs update')}
-                      </span>
-                    )}
-                  </button>
-                )
-              })}
+              {visibleGames
+                .filter((game) => game.is_installed)
+                .map((game, i) => {
+                  const isFocused = i === focusedIndex
+                  const needsUpdate = gameUpdates.includes(game.app_name)
+                  return (
+                    <button
+                      key={`${game.runner}-${game.app_name}`}
+                      ref={(el) => {
+                        cardRefs.current[i] = el
+                      }}
+                      className={classNames('consoleCard', {
+                        focused: isFocused
+                      })}
+                      tabIndex={isFocused ? 0 : -1}
+                      onClick={() => {
+                        if (isFocused) void launchGame(game)
+                        else setFocusedIndex(i)
+                      }}
+                      onMouseEnter={() => setFocusedIndex(i)}
+                      onFocus={() => setFocusedIndex(i)}
+                    >
+                      <CachedImage
+                        src={
+                          getImageFormatting(game.art_square, game.runner) ||
+                          fallBackImage
+                        }
+                        alt={game.title}
+                        className="consoleCardArt"
+                      />
+                      {needsUpdate && (
+                        <span className="consoleCardBadge">
+                          {t('console.card.needsUpdate', 'Needs update')}
+                        </span>
+                      )}
+                    </button>
+                  )
+                })}
+            </div>
+
+            <h3>{t('title.allGames', 'All Games')}</h3>
+            <div className="consoleGrid">
+              {visibleGames
+                .filter((game) => !game.is_installed)
+                .map((game, i) => {
+                  // start at the next clean interval of columns to simplify math
+                  const offset = columns - (installedGames.length % columns)
+                  const cardIndex = installedGames.length + offset + i
+                  const isFocused = cardIndex === focusedIndex
+                  const needsUpdate = gameUpdates.includes(game.app_name)
+
+                  return (
+                    <button
+                      key={`${game.runner}-${game.app_name}`}
+                      ref={(el) => {
+                        cardRefs.current[cardIndex] = el
+                      }}
+                      className={classNames('consoleCard', {
+                        focused: isFocused
+                      })}
+                      tabIndex={isFocused ? 0 : -1}
+                      onClick={() => {
+                        if (isFocused) void installGame(game)
+                        else setFocusedIndex(cardIndex)
+                      }}
+                      onMouseEnter={() => setFocusedIndex(cardIndex)}
+                      onFocus={() => setFocusedIndex(cardIndex)}
+                    >
+                      <CachedImage
+                        src={
+                          getImageFormatting(game.art_square, game.runner) ||
+                          fallBackImage
+                        }
+                        alt={game.title}
+                        className="consoleCardArt"
+                      />
+                      {needsUpdate && (
+                        <span className="consoleCardBadge">
+                          {t('console.card.needsUpdate', 'Needs update')}
+                        </span>
+                      )}
+                    </button>
+                  )
+                })}
             </div>
           </div>
         )}

--- a/src/frontend/screens/ConsoleMode/index.tsx
+++ b/src/frontend/screens/ConsoleMode/index.tsx
@@ -56,7 +56,6 @@ export default function ConsoleMode() {
 
   const { connected: gamepadConnected, layout: controllerLayout } =
     useGamepadInfo()
-  const backButtonLabel = getBackButtonLabel(controllerLayout)
 
   const cardRefs = useRef<Array<HTMLButtonElement | null>>([])
   const gridRef = useRef<HTMLDivElement | null>(null)
@@ -95,9 +94,6 @@ export default function ConsoleMode() {
     zoom.library,
     sideloadedLibrary
   ])
-
-  const installedGames = allGames.filter((game) => game.is_installed)
-  const uninstalledGames = allGames.filter((game) => !game.is_installed)
 
   const visibleGames = useMemo(() => {
     // reset card refs to rebuild them
@@ -358,7 +354,6 @@ export default function ConsoleMode() {
                 // badges we want to show status updates on
                 const badgeStates: Status[] = [
                   'installing',
-                  'redist',
                   'queued',
                   'updating',
                   'uninstalling'

--- a/src/frontend/screens/ConsoleMode/index.tsx
+++ b/src/frontend/screens/ConsoleMode/index.tsx
@@ -22,7 +22,7 @@ import ControllerHints from './components/ControllerHints'
 import LaunchOverlay from './components/LaunchOverlay'
 import InstallOverlay from './InstallOverlay'
 import UpdateNotice from './components/UpdateNotice'
-import { BTN_L1, BTN_R1, BTN_R2, getBackButtonLabel } from './controller'
+import { BTN_L1, BTN_R1, BTN_R2 } from './controller'
 import { useColumnCount, useGamepadButtonPress, useGamepadInfo } from './hooks'
 
 import type { GameInfo, Runner, Status } from 'common/types'

--- a/src/frontend/screens/ConsoleMode/index.tsx
+++ b/src/frontend/screens/ConsoleMode/index.tsx
@@ -13,7 +13,6 @@ import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
 
 import ContextProvider from 'frontend/state/ContextProvider'
-import { launch, sendKill } from 'frontend/helpers'
 import { getImageFormatting } from '../Library/components/GameCard/constants'
 import { CachedImage } from 'frontend/components/UI'
 import fallBackImage from 'frontend/assets/heroic_card.jpg'
@@ -21,25 +20,12 @@ import HeroicIcon from 'frontend/assets/heroic-icon.svg?react'
 
 import ControllerHints from './components/ControllerHints'
 import LaunchOverlay from './components/LaunchOverlay'
+import InstallOverlay from './InstallOverlay'
 import UpdateNotice from './components/UpdateNotice'
-import {
-  BTN_BACK,
-  BTN_L1,
-  BTN_R1,
-  BTN_R2,
-  getBackButtonLabel
-} from './controller'
-import {
-  useCancelOnHold,
-  useColumnCount,
-  useGamepadButtonHold,
-  useGamepadButtonPress,
-  useGamepadInfo
-} from './hooks'
+import { BTN_L1, BTN_R1, BTN_R2, getBackButtonLabel } from './controller'
+import { useColumnCount, useGamepadButtonPress, useGamepadInfo } from './hooks'
 
 import type { GameInfo, Runner } from 'common/types'
-
-const CANCEL_HOLD_MS = 3000
 
 type StoreKey = Runner | 'all'
 
@@ -52,7 +38,6 @@ export default function ConsoleMode() {
     amazon,
     zoom,
     sideloadedLibrary,
-    showDialogModal,
     refreshLibrary,
     refreshing,
     gameUpdates
@@ -60,8 +45,10 @@ export default function ConsoleMode() {
 
   const [activeStore, setActiveStore] = useState<StoreKey>('all')
   const [ascending, setAscending] = useState(true)
+  const [filteringByInstalled, setFilteringByInstalled] = useState(false)
   const [focusedIndex, setFocusedIndex] = useState(0)
   const [launchingGame, setLaunchingGame] = useState<GameInfo | null>(null)
+  const [installingGame, setInstallingGame] = useState<GameInfo | null>(null)
   const [updateNoticeGame, setUpdateNoticeGame] = useState<GameInfo | null>(
     null
   )
@@ -75,7 +62,7 @@ export default function ConsoleMode() {
   const topBarRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    window.api.setFullscreen(true)
+    // window.api.setFullscreen(true)
     if (
       !refreshing &&
       epic.library.length === 0 &&
@@ -111,8 +98,15 @@ export default function ConsoleMode() {
   const installedGames = allGames.filter((game) => game.is_installed)
   const uninstalledGames = allGames.filter((game) => !game.is_installed)
 
-  const filterAndSortGames = (games: GameInfo[]) => {
-    let filteredGames = games
+  const visibleGames = useMemo(() => {
+    // reset card refs to rebuild them
+    cardRefs.current = []
+
+    let filteredGames = allGames
+
+    if (filteringByInstalled) {
+      filteredGames = filteredGames.filter((g) => g.is_installed)
+    }
 
     if (activeStore !== 'all') {
       filteredGames = filteredGames.filter((g) => g.runner === activeStore)
@@ -122,14 +116,7 @@ export default function ConsoleMode() {
       const cmp = a.title.localeCompare(b.title)
       return ascending ? cmp : -cmp
     })
-  }
-
-  const visibleGames = useMemo(() => {
-    let filteredInstalledGames = filterAndSortGames(installedGames)
-    let filteredUninstalledGames = filterAndSortGames(uninstalledGames)
-
-    return [...filteredInstalledGames, ...filteredUninstalledGames]
-  }, [allGames, activeStore, ascending])
+  }, [allGames, filteringByInstalled, activeStore, ascending])
 
   const storesWithGames = useMemo(() => {
     const set = new Set<Runner>()
@@ -216,43 +203,6 @@ export default function ConsoleMode() {
 
   const quit = useCallback(() => navigate('/'), [navigate])
 
-  const launchGame = useCallback(
-    async (game: GameInfo) => {
-      if (launchingGame || updateNoticeGame) return
-      if (gameUpdates.includes(game.app_name)) {
-        setUpdateNoticeGame(game)
-        return
-      }
-      setLaunchingGame(game)
-      try {
-        await launch({
-          appName: game.app_name,
-          t,
-          runner: game.runner as Runner,
-          hasUpdate: false,
-          showDialogModal
-        })
-      } finally {
-        setLaunchingGame(null)
-      }
-    },
-    [launchingGame, updateNoticeGame, gameUpdates, showDialogModal, t]
-  )
-
-  // Hold-to-cancel for in-flight launches. Triggered by Escape (keyboard) or
-  // the back button (gamepad); fires `sendKill` after CANCEL_HOLD_MS.
-  const { holdStart, startHold, stopHold } = useCancelOnHold({
-    active: !!launchingGame,
-    holdMs: CANCEL_HOLD_MS,
-    onCancel: () => {
-      if (launchingGame)
-        void sendKill(launchingGame.app_name, launchingGame.runner)
-
-      // prevent UX from hanging in "Launching" mode
-      setLaunchingGame(null)
-    }
-  })
-
   const onTopBarKeyDown = (e: React.KeyboardEvent) => {
     if (launchingGame || updateNoticeGame) return
     const root = topBarRef.current
@@ -282,16 +232,11 @@ export default function ConsoleMode() {
   const onGridKeyDown = (e: React.KeyboardEvent) => {
     if (visibleGames.length === 0 || launchingGame || updateNoticeGame) return
     const last = visibleGames.length - 1
+
     if (e.key === 'ArrowRight') {
       e.preventDefault()
       e.stopPropagation()
-      // check if we're the last installed game, skip to next row
-      if (focusedIndex === installedGames.length - 1) {
-        const diff = columns - (installedGames.length % columns) + 1
-        setFocusedIndex((i) => Math.min(i + diff, last))
-      } else {
-        setFocusedIndex((i) => Math.min(i + 1, last))
-      }
+      setFocusedIndex((i) => Math.min(i + 1, last))
     } else if (e.key === 'ArrowLeft') {
       e.preventDefault()
       e.stopPropagation()
@@ -311,31 +256,8 @@ export default function ConsoleMode() {
       } else {
         setFocusedIndex((i) => Math.max(i - columns, 0))
       }
-    } else if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      const g = visibleGames[focusedIndex]
-      if (g) void launchGame(g)
     }
   }
-
-  // Escape quits when idle; hold it while launching to cancel.
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return
-      e.preventDefault()
-
-      if (!e.repeat) startHold()
-    }
-    const onKeyUp = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') stopHold()
-    }
-    window.addEventListener('keydown', onKeyDown)
-    window.addEventListener('keyup', onKeyUp)
-    return () => {
-      window.removeEventListener('keydown', onKeyDown)
-      window.removeEventListener('keyup', onKeyUp)
-    }
-  }, [quit, launchingGame, startHold, stopHold])
 
   // Read by gamepad.ts to block the Guide/back buttons during launch.
   useEffect(() => {
@@ -350,11 +272,6 @@ export default function ConsoleMode() {
   useGamepadButtonPress(BTN_L1, () => cycleStore(-1), idle)
   useGamepadButtonPress(BTN_R1, () => cycleStore(1), idle)
   useGamepadButtonPress(BTN_R2, toggleSort, idle)
-  useGamepadButtonHold(
-    BTN_BACK,
-    (held) => (held ? startHold() : stopHold()),
-    !!launchingGame
-  )
 
   return (
     <div className={classNames('ConsoleMode', { launching: !!launchingGame })}>
@@ -365,6 +282,16 @@ export default function ConsoleMode() {
       >
         <HeroicIcon className="consoleLogo" />
         <div className="consoleFilters">
+          <button
+            key={'installedGames'}
+            className={classNames('consoleChip', {
+              active: filteringByInstalled
+            })}
+            onClick={() => setFilteringByInstalled(!filteringByInstalled)}
+          >
+            {t('status.installed', 'Installed')}
+          </button>
+          <div className="consoleDividerVertical" />
           {storeFilters
             .filter((f) => f.enabled)
             .map((f) => (
@@ -432,92 +359,48 @@ export default function ConsoleMode() {
             aria-label={t('console.games', 'Installed games')}
             onKeyDown={onGridKeyDown}
           >
-            <h3>{t('console.games', 'Installed Games')}</h3>
             <div className="consoleGrid">
-              {visibleGames
-                .filter((game) => game.is_installed)
-                .map((game, i) => {
-                  const isFocused = i === focusedIndex
-                  const needsUpdate = gameUpdates.includes(game.app_name)
-                  return (
-                    <button
-                      key={`${game.runner}-${game.app_name}`}
-                      ref={(el) => {
-                        cardRefs.current[i] = el
-                      }}
-                      className={classNames('consoleCard', {
-                        focused: isFocused
-                      })}
-                      tabIndex={isFocused ? 0 : -1}
-                      onClick={() => {
-                        if (isFocused) void launchGame(game)
-                        else setFocusedIndex(i)
-                      }}
-                      onMouseEnter={() => setFocusedIndex(i)}
-                      onFocus={() => setFocusedIndex(i)}
-                    >
-                      <CachedImage
-                        src={
-                          getImageFormatting(game.art_square, game.runner) ||
-                          fallBackImage
-                        }
-                        alt={game.title}
-                        className="consoleCardArt"
-                      />
-                      {needsUpdate && (
-                        <span className="consoleCardBadge">
-                          {t('console.card.needsUpdate', 'Needs update')}
-                        </span>
-                      )}
-                    </button>
-                  )
-                })}
-            </div>
+              {visibleGames.map((game, i) => {
+                const isFocused = i === focusedIndex
+                const needsUpdate = gameUpdates.includes(game.app_name)
 
-            <h3>{t('title.allGames', 'All Games')}</h3>
-            <div className="consoleGrid">
-              {visibleGames
-                .filter((game) => !game.is_installed)
-                .map((game, i) => {
-                  // start at the next clean interval of columns to simplify math
-                  const offset = columns - (installedGames.length % columns)
-                  const cardIndex = installedGames.length + offset + i
-                  const isFocused = cardIndex === focusedIndex
-                  const needsUpdate = gameUpdates.includes(game.app_name)
-
-                  return (
-                    <button
-                      key={`${game.runner}-${game.app_name}`}
-                      ref={(el) => {
-                        cardRefs.current[cardIndex] = el
-                      }}
-                      className={classNames('consoleCard', {
-                        focused: isFocused
-                      })}
-                      tabIndex={isFocused ? 0 : -1}
-                      onClick={() => {
-                        if (isFocused) void installGame(game)
-                        else setFocusedIndex(cardIndex)
-                      }}
-                      onMouseEnter={() => setFocusedIndex(cardIndex)}
-                      onFocus={() => setFocusedIndex(cardIndex)}
-                    >
-                      <CachedImage
-                        src={
-                          getImageFormatting(game.art_square, game.runner) ||
-                          fallBackImage
-                        }
-                        alt={game.title}
-                        className="consoleCardArt"
-                      />
-                      {needsUpdate && (
-                        <span className="consoleCardBadge">
-                          {t('console.card.needsUpdate', 'Needs update')}
-                        </span>
-                      )}
-                    </button>
-                  )
-                })}
+                return (
+                  <button
+                    key={`${game.runner}-${game.app_name}`}
+                    ref={(el) => {
+                      cardRefs.current[i] = el
+                    }}
+                    className={classNames('consoleCard', {
+                      focused: isFocused
+                    })}
+                    tabIndex={isFocused ? 0 : -1}
+                    onClick={() => {
+                      if (isFocused) {
+                        if (gameUpdates.includes(game.app_name)) {
+                          setUpdateNoticeGame(game)
+                        } else if (game.is_installed) setLaunchingGame(game)
+                        else setInstallingGame(game)
+                      } else setFocusedIndex(i)
+                    }}
+                    onMouseEnter={() => setFocusedIndex(i)}
+                    onFocus={() => setFocusedIndex(i)}
+                  >
+                    <CachedImage
+                      src={
+                        getImageFormatting(game.art_square, game.runner) ||
+                        fallBackImage
+                      }
+                      alt={game.title}
+                      className="consoleCardArt"
+                    />
+                    {needsUpdate && (
+                      <span className="consoleCardBadge">
+                        {t('console.card.needsUpdate', 'Needs update')}
+                      </span>
+                    )}
+                  </button>
+                )
+              })}
             </div>
           </div>
         )}
@@ -532,9 +415,14 @@ export default function ConsoleMode() {
       {launchingGame && (
         <LaunchOverlay
           game={launchingGame}
-          holdStart={holdStart}
-          gamepadConnected={gamepadConnected}
-          backButtonLabel={backButtonLabel}
+          onDismiss={() => setLaunchingGame(null)}
+        />
+      )}
+
+      {installingGame && (
+        <InstallOverlay
+          game={installingGame}
+          onDismiss={() => setInstallingGame(null)}
         />
       )}
 
@@ -542,8 +430,6 @@ export default function ConsoleMode() {
         <UpdateNotice
           game={updateNoticeGame}
           onDismiss={() => setUpdateNoticeGame(null)}
-          gamepadConnected={gamepadConnected}
-          backButtonLabel={backButtonLabel}
         />
       )}
     </div>


### PR DESCRIPTION
This PR adds some new things: 
- added ability to install games from within console mode, and sort by installed;
- shows small badge for installing games to have some indication of progress;

Also refactored some things. Extracted launching and installing functions to their own components.

Here's a video of it in action: 


https://github.com/user-attachments/assets/ef251026-d5c2-4ccf-8f57-d2f65ae96168


- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
