### PR TITLE
Bump system requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Heroic is built with Web Technologies:
 ## Supported Operating Systems
 
 - Linux:
-  - Ubuntu 20.04LTS or newer
-  - Fedora 33 or newer
+  - Ubuntu (latest 2 LTS versions)
+  - Fedora (latest 2 versions)
   - Arch Linux & derivatives (Manjaro, Garuda, EndeavourOS)
   - Heroic will still _work_ on most distros, but it is up to you to _get_ it to work
     Chances are though that someone on our [Discord](https://discord.gg/rHJ2uqdquK) can help you


### PR DESCRIPTION
The README mentioned supporting Ubuntu 20.04, which is very ancient at this point

Instead of manually having to update the dependencies, I now specified "latest 2 LTS versions". At the moment, this means 24.04 and 26.04 are supported. I believe this is a healthy range to support, especially with the Flatpak version mostly isolating Heroic from outdated distributions

Went ahead and made the same change for Fedora as well, Fedora 33 is equally ancient. Only supporting the last 2 versions means we only support Fedora versions for a year, but updating is also easier for the end user on Fedora, so I think the shortened timeframe is fine

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [X] Created / Updated documentation (If necessary)
