### PR TITLE
[FIX] GOG Links from Deals screen

### DIFF
--- a/src/frontend/screens/Discounts/helpers.ts
+++ b/src/frontend/screens/Discounts/helpers.ts
@@ -166,12 +166,15 @@ export const getLocaleSettings = (
   return { countryCode, currencyCode, locale: 'en-US' }
 }
 
+// GOG's affiliate program requires links to use the af.gog.com domain with
+// the path of the original www.gog.com URL preserved, plus the ?as=<id>
+// affiliate parameter. Links pointing at www.gog.com directly are not
+// tracked by GOG even if ?as= is present.
 export const withAffiliate = (storeLink: string): string => {
   try {
     const url = new URL(storeLink)
-    if (!url.searchParams.has('as')) {
-      url.searchParams.set('as', GOG_AFFILIATE_ID)
-    }
+    url.hostname = 'af.gog.com'
+    url.searchParams.set('as', GOG_AFFILIATE_ID)
     return url.toString()
   } catch {
     return storeLink


### PR DESCRIPTION
Small fix to the links from the Deals screen since they were not being counted as affiliate.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
