### PR TITLE
[UI] fix: prevent play with logs popup from closing when moving mouse to it

### DIFF
--- a/src/frontend/screens/Game/GamePage/index.css
+++ b/src/frontend/screens/Game/GamePage/index.css
@@ -300,10 +300,30 @@
               white-space: nowrap;
             }
 
+            /* extend the hover hit-area to bridge the gap between the arrow
+               button and the popup above it, so moving the cursor upward
+               doesn't dismiss the popup before reaching it */
+            &::before {
+              display: none;
+              content: '';
+              position: absolute;
+              left: 0;
+              right: 0;
+              bottom: 100%;
+              height: 6%;
+              /* transparent area that still receives pointer events,
+                 sized to exactly match the 6% gap from bottom: 106% */
+              background: transparent;
+            }
+
             &:focus,
             &:hover,
             &:focus-within {
               a {
+                display: block;
+              }
+
+              &::before {
                 display: block;
               }
             }


### PR DESCRIPTION
When hovering over the small arrow next to the play button, the play with logs button appears. However, there is a small gap between the arrow and the play with logs button. Therefore, when moving the mouse slow enough towards it, it closes.

Fix the bug by adding a transparent css object that appears when the arrow is hovered over and fills the gap between the arrow and the play with logs button.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/eb359f10-7f95-442e-8f54-84fd0ac8e825"></td>
    <td><video src="https://github.com/user-attachments/assets/2defb60d-d3a5-467e-989a-aab7841ea7d6"></td>
  </tr>
</table>

Warning: AI was used to help me write this PR. I decided to keep the AI-generated comments because it isn't obvious why the css object is needed, but feel free to ask for removal.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [X] Created / Updated Tests (If necessary)
- [X] Created / Updated documentation (If necessary)
