### PR TITLE
[Fix] "Add Game" dialog resetting the Wineprefix if SteamGridDB API is used

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -33,28 +33,27 @@ import Folder from '@mui/icons-material/Folder'
 type Props = {
   availablePlatforms: AvailablePlatforms
   winePrefix: string
-  crossoverBottle: string
   wineVersion: WineInstallation | undefined
-  setWinePrefix: React.Dispatch<React.SetStateAction<string>>
   children: React.ReactNode
   platformToInstall: InstallPlatform
   backdropClick: () => void
   appName?: string
+  title: string
+  setTitle: (title: string) => void
 }
 
 export default function SideloadDialog({
   availablePlatforms,
   backdropClick,
   winePrefix,
-  crossoverBottle,
   wineVersion,
   platformToInstall,
-  setWinePrefix,
   children,
-  appName
+  appName,
+  title,
+  setTitle
 }: Props) {
   const { t, i18n } = useTranslation('gamepage')
-  const [title, setTitle] = useState<string>(t('sideload.field.title', 'Title'))
   const [selectedExe, setSelectedExe] = useState('')
   const [gameUrl, setGameUrl] = useState('')
   const [customUserAgent, setCustomUserAgent] = useState('')
@@ -130,15 +129,6 @@ export default function SideloadDialog({
     }
   }, [])
 
-  // Suggest default Wine prefix if we're adding a new app
-  useEffect(() => {
-    if (editMode) return
-    window.api.requestAppSettings().then(({ defaultWinePrefixDir }) => {
-      const suggestedWinePrefix = `${defaultWinePrefixDir}/${title}`
-      setWinePrefix(suggestedWinePrefix)
-    })
-  }, [title, editMode])
-
   async function searchImage() {
     if (hasSgdbKey) {
       setSgdbTarget('square')
@@ -205,20 +195,6 @@ export default function SideloadDialog({
       customUserAgent,
       launchFullScreen
     })
-    const gameSettings = await getGameSettings(app_name, 'sideload')
-    if (!gameSettings) {
-      return
-    }
-    if (!editMode)
-      window.api.writeConfig({
-        appName: app_name,
-        config: {
-          ...gameSettings,
-          winePrefix,
-          wineVersion,
-          wineCrossoverBottle: crossoverBottle
-        }
-      })
 
     await refreshLibrary({
       library: 'sideload',

--- a/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/WineSelector/index.tsx
@@ -4,7 +4,7 @@ import {
   TextInputField,
   PathSelectionBox
 } from 'frontend/components/UI'
-import React from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { WineInstallation } from 'common/types'
 import { Trans, useTranslation } from 'react-i18next'
 import { removeSpecialcharacters } from 'frontend/helpers'
@@ -12,12 +12,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faWarning } from '@fortawesome/free-solid-svg-icons'
 import { WineVersionListItem } from 'frontend/screens/Settings/components/WineVersionSelector'
 import { MenuItem } from '@mui/material'
+import { useAwaited } from 'frontend/hooks/useAwaited'
 
 type Props = {
-  setWineVersion: React.Dispatch<
-    React.SetStateAction<WineInstallation | undefined>
-  >
-  setWinePrefix: React.Dispatch<React.SetStateAction<string>>
+  setWineVersion: (newVersion: WineInstallation) => void
+  setWinePrefix: (newPrefix: string) => void
   setCrossoverBottle: React.Dispatch<React.SetStateAction<string>>
   winePrefix: string
   crossoverBottle: string
@@ -42,42 +41,43 @@ export default function WineSelector({
 }: Props) {
   const { t, i18n } = useTranslation('gamepage')
 
-  const [detailsOpen, setDetailsOpen] = React.useState(!!initiallyOpen)
-  const [useDefaultSettings, setUseDefaultSettings] = React.useState(false)
-  const [description, setDescription] = React.useState('')
+  const [detailsOpen, setDetailsOpen] = useState(!!initiallyOpen)
+  const [useSharedPrefix, setUseSharedPrefix] = useState(false)
 
-  React.useEffect(() => {
-    const getAppSettings = async () => {
-      const {
-        defaultWinePrefixDir,
-        wineVersion,
-        winePrefix: defaultPrefix,
-        wineCrossoverBottle: defaultBottle
-      } = await window.api.requestAppSettings()
+  const globalConfig = useAwaited(() => window.api.requestAppSettings())
 
-      if (!wineVersion || !defaultPrefix || !defaultBottle) return
-      setDescription(
-        `${wineVersion.name.replace('Proton - ', '')}\n${defaultPrefix}`
-      )
+  const sharedToggleDescription = useMemo(() => {
+    if (!globalConfig) return ''
+    return `${globalConfig.wineVersion.name}\n${globalConfig.defaultWinePrefix}`
+  }, [globalConfig])
 
-      if (!useDefaultSettings && wineVersion.type === 'crossover') {
-        return setCrossoverBottle(defaultBottle)
-      }
+  useEffect(() => {
+    if (!globalConfig) return
 
-      if (useDefaultSettings) {
-        setWinePrefix(defaultPrefix)
-        setWineVersion(wineVersion)
-        setCrossoverBottle(defaultBottle)
-      } else {
-        const dirName =
-          removeSpecialcharacters(title) || removeSpecialcharacters(appName)
-        const suggestedWinePrefix = `${defaultWinePrefixDir}/${dirName}`
-        setWinePrefix(suggestedWinePrefix)
-        setWineVersion(wineVersion || undefined)
-      }
+    if (useSharedPrefix) {
+      setWinePrefix(globalConfig.winePrefix)
+      setWineVersion(globalConfig.wineVersion)
+      setCrossoverBottle(globalConfig.wineCrossoverBottle)
+    } else {
+      const suggestedPrefix = `${globalConfig.defaultWinePrefixDir}/${removeSpecialcharacters(title ?? appName)}`
+      setWinePrefix(suggestedPrefix)
     }
-    getAppSettings()
-  }, [useDefaultSettings])
+  }, [
+    globalConfig,
+    useSharedPrefix,
+    setWinePrefix,
+    setWineVersion,
+    setCrossoverBottle,
+    title,
+    appName
+  ])
+
+  useEffect(() => {
+    if (wineVersion) return
+
+    const firstAvailableVersion = wineVersionList.at(0)
+    if (firstAvailableVersion) setWineVersion(firstAvailableVersion)
+  }, [wineVersion, wineVersionList, setWineVersion])
 
   const showPrefix = wineVersion?.type !== 'crossover'
   const showBottle = wineVersion?.type === 'crossover'
@@ -95,11 +95,11 @@ export default function WineSelector({
               'setting.use-shared-wine-config',
               'Use shared Wine prefix'
             )}
-            value={useDefaultSettings}
-            handleChange={() => setUseDefaultSettings(!useDefaultSettings)}
-            description={description}
+            value={useSharedPrefix}
+            handleChange={() => setUseSharedPrefix(!useSharedPrefix)}
+            description={sharedToggleDescription}
           />
-          {useDefaultSettings && (
+          {useSharedPrefix && (
             <div className="infoBox">
               <FontAwesomeIcon icon={faWarning} />
               <Trans
@@ -123,7 +123,7 @@ export default function WineSelector({
               label={t('install.wineprefix', 'WinePrefix')}
               htmlId="setinstallpath"
               noDeleteButton
-              disabled={useDefaultSettings}
+              disabled={useSharedPrefix}
             />
           )}
           {showBottle && (
@@ -132,7 +132,7 @@ export default function WineSelector({
               htmlId="crossoverBottle"
               value={crossoverBottle}
               onChange={(newValue) => setCrossoverBottle(newValue)}
-              disabled={useDefaultSettings}
+              disabled={useSharedPrefix}
             />
           )}
 
@@ -140,12 +140,12 @@ export default function WineSelector({
             label={`${t('install.wineversion')}:`}
             htmlId="wineVersion"
             value={wineVersion?.name || ''}
-            disabled={useDefaultSettings || wineVersionList.length === 0}
+            disabled={useSharedPrefix || wineVersionList.length === 0}
             onChange={(e) =>
               setWineVersion(
                 wineVersionList.find(
                   (version) => version.name === e.target.value
-                )
+                )!
               )
             }
           >

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -50,6 +50,9 @@ function InstallModal({ appName, runner, gameInfo = null }: Props) {
   const [wineVersion, setWineVersion] = useState<WineInstallation>()
   const [wineVersionList, setWineVersionList] = useState<WineInstallation[]>([])
   const [crossoverBottle, setCrossoverBottle] = useState('')
+  const [sideloadTitle, setSideloadTitle] = useState(
+    t('sideload.field.title', 'Title')
+  )
 
   const isLinuxNative = Boolean(gameInfo?.is_linux_native)
   const isMacNative = Boolean(gameInfo?.is_mac_native)
@@ -251,14 +254,14 @@ function InstallModal({ appName, runner, gameInfo = null }: Props) {
           </DownloadDialog>
         ) : (
           <SideloadDialog
-            setWinePrefix={setWinePrefix}
+            title={sideloadTitle}
+            setTitle={setSideloadTitle}
             winePrefix={winePrefix}
             wineVersion={wineVersion}
             availablePlatforms={availablePlatforms}
             backdropClick={closeModal}
             platformToInstall={platformToInstall}
             appName={appName}
-            crossoverBottle={crossoverBottle}
           >
             {platformSelection()}
             {hasWine ? (
@@ -271,6 +274,7 @@ function InstallModal({ appName, runner, gameInfo = null }: Props) {
                 setWineVersion={setWineVersion}
                 crossoverBottle={crossoverBottle}
                 setCrossoverBottle={setCrossoverBottle}
+                title={sideloadTitle}
               />
             ) : null}
           </SideloadDialog>


### PR DESCRIPTION
When adding a game, after finishing the title input, Heroic will search for the game on SteamGridDB. This causes the WineSelector to re-render, resetting the prefix path to the default, without SideloadDialog setting it to the title-based path (WineSelector and SideloadDialog both had code for recommending the prefix folder). The result is: After the user finishes searching for cover art, the game title will still be set, but the prefix will be reset

This PR resolves the issue by removing the prefix path suggestion of SideloadDialog, only relying on WineSelector for it. In turn, the game title is now passed along from the former to the latter (using the parent InstallModal component).  
Both components were also cleaned up a bit (they were both doing redundant things). SideloadDialog is still doing some redundant config changes when running an EXE, but that was out of the scope of this PR.

To test:
Click "Add Game" in the library. Expand "Show Wine settings", note that the prefix is correctly using `<default prefix folder>/Title`. Select the title input and type anything; again observe the prefix input changing accordingly. Now de-select the title input box; the SteamGridDB search will open. Select an entry (or just close it), and again expand "Show Wine settings".
On `main`: Observe the prefix folder now saying `<default prefix folder>/sideload`
On this PR: Observe the prefix folder still saying `<default prefix folder>/<title>`

> [!TIP]
> To fix existing games with this issue, open the game settings, then set the "WinePrefix folder" to a game-specific folder (the default should've been `~/Games/Heroic/Prefixes/<game title>`).  
> Note that this may make save files and other configuration data unavailable. They will be somewhere in `~/Games/Heroic/Prefixes/sideload/`. If you need help finding them, please ask on our Discord server.

Closes #5593

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
