### PR TITLE
tech: update nile to 1.2.0

### DIFF
--- a/meta/downloadHelperBinaries.ts
+++ b/meta/downloadHelperBinaries.ts
@@ -17,7 +17,7 @@ type DownloadedBinary =
 const RELEASE_TAGS = {
   legendary: '0.20.43',
   gogdl: 'v1.2.1',
-  nile: 'v1.1.2',
+  nile: 'v1.2.0',
   comet: 'v0.2.0',
   'epic-integration': 'v0.4'
 } as const satisfies Record<DownloadedBinary, string>

--- a/src/backend/storeManagers/nile/constants.ts
+++ b/src/backend/storeManagers/nile/constants.ts
@@ -4,4 +4,4 @@ import { join } from 'path'
 export const nileConfigPath = join(appFolder, 'nile_config', 'nile')
 export const nileInstalled = join(nileConfigPath, 'installed.json')
 export const nileLibrary = join(nileConfigPath, 'library.json')
-export const nileUserData = join(nileConfigPath, 'user.json')
+export const nileUserData = join(nileConfigPath, 'current_user.json')

--- a/src/backend/storeManagers/nile/user.ts
+++ b/src/backend/storeManagers/nile/user.ts
@@ -108,19 +108,17 @@ export class NileUser {
       return
     }
 
-    const user: { extensions: { customer_info: NileUserData } } = JSON.parse(
-      readFileSync(nileUserData, 'utf-8')
-    )
+    const user: NileUserData = JSON.parse(readFileSync(nileUserData, 'utf-8'))
     if (!Object.keys(user).length) {
       logInfo('user.json is empty', LogPrefix.Nile)
       configStore.delete('userData')
       return
     }
 
-    configStore.set('userData', user.extensions.customer_info)
+    configStore.set('userData', user)
     logInfo('Saved user data to config file', LogPrefix.Nile)
 
-    return user.extensions.customer_info
+    return user
   }
 
   public static isLoggedIn() {

--- a/src/common/types/nile.ts
+++ b/src/common/types/nile.ts
@@ -102,11 +102,8 @@ export interface FuelSchema {
 }
 
 export interface NileUserData {
-  account_pool: string
   user_id: string
-  home_region: string
   name: string
-  given_name: string
 }
 
 export interface NileLoginData {


### PR DESCRIPTION
Important note is that the login credentials migrated to this version are incompatible with old ones - requiring users to login again if they decide to rollback

Release notes https://github.com/imLinguin/nile/releases/tag/v1.2.0

## Breaking change
This release includes a breaking change that will make auth data incompatible with previous versions of nile. Authorization tokens will be stored in obfuscated file instead of raw json. 

## What's Changed
* [Feat] Add arm64 support in https://github.com/imLinguin/nile/pull/59
* minor additions to allow for better intergration in https://github.com/imLinguin/nile/pull/58
* feat: introduce an encrypted store type in https://github.com/imLinguin/nile/commit/b89bd1fbd717f1b359fa7f993df69927f3018a5f

**Full Changelog**: https://github.com/imLinguin/nile/compare/v1.1.2...v1.2.0

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
