### PR TITLE
[Fix] possible fix to Heroic does not stay minimized #5611

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -173,8 +173,8 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   })
 
   const mainWindow = getMainWindow()
-  if (minimizeOnLaunch && !noTrayIcon) {
-    mainWindow?.hide()
+  if (minimizeOnLaunch && !noTrayIcon && mainWindow?.isVisible()) {
+    mainWindow.hide()
   }
 
   // Prevent display from sleep
@@ -264,9 +264,10 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     await gogPresence.setPresence()
   }
   // Stop display sleep blocker
-  if (powerDisplayId !== null) {
+  if (powerDisplayId !== null && powerDisplayId !== undefined) {
     logInfo('Stopping Display Power Saver Blocker', LogPrefix.Backend)
     powerSaveBlocker.stop(powerDisplayId)
+    powerDisplayId = null
   }
 
   // Update playtime and last played date


### PR DESCRIPTION
## What

Fixes the "minimize on launch" feature not maintaining the hidden state on
subsequent game launches without reopening Heroic.

Fixes #5611

## Root cause

`launchEventCallback` called `mainWindow.hide()` unconditionally whenever
`minimizeOnLaunch && !noTrayIcon`, with no check for whether the window was
already hidden.

After the first game exits, the window stays hidden (there is no `show()` call
in the exit path). On the second launch — e.g. from the tray icon's
"Recent Games" context menu, without explicitly reopening Heroic — `hide()` was
called on an already-hidden window ( this causes the
window to briefly flash with a frozen/blank background before the game starts and leaves the window state inconsistent for subsequent launches.).


`protocol.ts` already guards against this with an `isVisible()` check
(lines 128-134); `launchEventCallback` was missing the same guard.

## Changes

**`src/backend/launcher.ts`**

- Added `mainWindow?.isVisible()` guard before calling `hide()`, consistent
  with the pattern already used in `protocol.ts`. This prevents calling `hide()`
  on an already-hidden window, which caused the blank-window flash and
  inconsistent state on Linux.

- Fixed `powerDisplayId` never being reset to `null` after
  `powerSaveBlocker.stop()`. Because of this, starting from the **third** game
  launch the guard `if (!powerDisplayId)` evaluated to `false` (non-zero integer
  is truthy), silently skipping the display-sleep blocker for all subsequent
  sessions.

---

## How to test

Setup

1. Build/run Heroic from this branch (fix/minimize-on-launch).
2. Open Settings → General and make sure:
  - "Minimize Heroic after launching a game" is enabled.
  - "Enable Tray Icon" is enabled (i.e. noTrayIcon is off).

Test 1 — Minimize on launch (only hides when visible)

1. With the main window visible, launch any game.
  - Heroic should minimize/hide to the tray as soon as the game launches.
2. Bring Heroic back from the tray, then manually hide it (or launch a game from a state where the window is already hidden) and launch another game.
  - No errors/odd window behaviour from calling hide() on an already-hidden window; the window stays consistent.
3. (Optional) Disable Minimize on launch and confirm the window does not hide when launching a game.

Test 2 — Display sleep blocker re-arms on subsequent launches

This is the main fix: before, the "prevent display sleep" blocker was only armed for the first game of the session.

1. Launch a game and check the logs — you should see:
Preventing display from sleep
2. Close the game and check the logs — you should see:
Stopping Display Power Saver Blocker
3. Launch a second game (without restarting Heroic) and check the logs again:
  -  Before the fix: Preventing display from sleep did not appear again → display could sleep mid-game.
  -  After the fix: Preventing display from sleep appears again for the 2nd (and every subsequent) game.
4. Repeat with a 3rd game to confirm it keeps re-arming each session.

Regression check

- Launch/close several games in a row and verify there are no errors related to powerSaveBlocker.stop() (no stop(undefined)/stop(null) calls).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
