### PR TITLE
[Fix] macOS app menu showing "heroic" in lowercase #5238

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -344,6 +344,9 @@ if (!gotTheLock) {
     if (isWindows) {
       app.setAppUserModelId('Heroic Games Launcher')
     }
+    if (isMac) {
+      app.setName('Heroic')
+    }
 
     runOnceWhenOnline(async () => {
       const isLoggedIn = LegendaryUser.isLoggedIn()


### PR DESCRIPTION
Fixes #5238

The menu bar title ("Heroic" in bold) was already correct becau
se Electron reads `CFBundleName` from `Info.plist`, which elect
ron-builder sets from `productName: Heroic` in `electron-builde
r.yml`.

However, the dropdown items ("About", "Hide", "Quit") are gener
ated by Electron using `app.getName()`, which returns the `name
` field from `package.json` — `"heroic"` (lowercase, as is conv
entional for npm packages).

## Fix

Added a single `app.setName()` call for macOS in `src/backend/m
ain.ts`, mirroring the existing Windows fix:

```ts
if (isWindows) {
  app.setAppUserModelId('Heroic Games Launcher')
}
if (isMac) {
  app.setName('Heroic')
}
```

This overrides `app.getName()` at runtime so Electron uses the
correctly capitalized name when generating the native macOS men
u items.
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
