### PR TITLE
[Fix] Update status not updating when game starts processing

### DIFF
--- a/src/backend/downloadmanager/downloadqueue.ts
+++ b/src/backend/downloadmanager/downloadqueue.ts
@@ -124,13 +124,6 @@ async function addToQueue(element: DMQueueElement) {
     return
   }
 
-  sendGameStatusUpdate({
-    appName: element.params.appName,
-    runner: element.params.runner,
-    folder: element.params.path,
-    status: 'queued'
-  })
-
   const elements = downloadManager.get('queue', [])
 
   const elementIndex = elements.findIndex(
@@ -138,6 +131,20 @@ async function addToQueue(element: DMQueueElement) {
       el.params.appName === element.params.appName &&
       el.params.runner === element.params.runner
   )
+
+  const isCurrentlyProcessing =
+    isRunning() &&
+    currentElement?.params.appName === element.params.appName &&
+    currentElement?.params.runner === element.params.runner
+
+  if (!isCurrentlyProcessing) {
+    sendGameStatusUpdate({
+      appName: element.params.appName,
+      runner: element.params.runner,
+      folder: element.params.path,
+      status: 'queued'
+    })
+  }
 
   if (elementIndex >= 0) {
     elements[elementIndex] = element

--- a/src/frontend/hooks/constants.ts
+++ b/src/frontend/hooks/constants.ts
@@ -24,10 +24,12 @@ export function getStatusLabel({
     playing: t('gamepage:status.playing', 'Playing'),
     queued: `${t('gamepage:status.queued', 'Queued')}`,
     uninstalling: t('gamepage:status.uninstalling', 'Uninstalling'),
-    updating: `${t('gamepage:status.updating')} ${Math.ceil(percent || 0)}%`,
-    installing: `${t('gamepage:status.downloading', 'Downloading')} ${Math.ceil(
-      percent || 0
-    )}%`,
+    updating: percent
+      ? `${t('gamepage:status.updating')} ${Math.ceil(percent)}%`
+      : t('gamepage:status.updating'),
+    installing: percent
+      ? `${t('gamepage:status.downloading', 'Downloading')} ${Math.ceil(percent)}%`
+      : t('gamepage:status.downloading', 'Downloading'),
     extracting: t('gamepage:status.extracting', 'Extracting'),
     'syncing-saves': t('gamepage:status.syncingSaves', 'Syncing Saves'),
     moving: t('gamepage:gamecard.moving', 'Moving'),


### PR DESCRIPTION
This PR fixes two visual issues on the game card while a game is being installed or updated.

What changed

1. Hide the percentage while the update/install is being prepared

During the preparation phase (before any real download progress is reported), percent is 0/undefined, so the card showed Updating 0% / Downloading 0%. Now, when there is no progress yet, it shows just Updating / Downloading, and the percentage only appears once the actual download starts.

- File: src/frontend/hooks/constants.ts (getStatusLabel)

2. Don't override the status of a game that is already being processed with Queued

addToQueue always sent a queued status update, even when the game being added was the one currently downloading/updating. This made the card incorrectly flip to Queued while it was actually in progress. Now the queued status is only sent if the element is not the one currently being processed.

- File: src/backend/downloadmanager/downloadqueue.ts (addToQueue)

---

How to test

Build and run Heroic from this branch. Have at least one installed game with an update available (or any game to install).

Case 1 — Percentage hidden during preparation
1. Start updating (or installing) a game.
2. Watch the game card during the initial preparation phase (before data starts downloading).
  -  Expected: shows only Updating / Downloading, without 0%.
  -  Before: showed Updating 0% / Downloading 0%.
3. Once real progress begins (percent > 0), the card shows Updating 45% / Downloading 45% as usual.

Case 2 — Queued no longer overrides an in-progress game
1. Start updating/downloading a game and leave it actively in progress.
2. While it's processing, trigger an action that re-adds that same game to the queue (e.g. launch its update again).
  -  Expected: the card keeps Updating / Downloading. It does not flip to Queued.
  -  Before: the card incorrectly changed to Queued while still downloading.

Regressions to verify (existing behavior still works)
- Adding a different game to the queue while another is processing → the new one does show Queued.
- Adding a game to the queue when nothing is processing → shows Queued.
- An in-progress download/update keeps showing its percentage normally as it advances.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
