### PR TITLE
[Fix] Remove redundant legendary list call on startup  #5641

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -56,10 +56,6 @@ const fallBackImage = 'fallback'
 const allGames: Set<string> = new Set()
 let installedGames: Map<string, InstalledJsonMetadata> = new Map()
 const library: Map<string, GameInfo> = new Map()
-// Timestamp (ms) of the last successful `legendary list` run; used to skip
-// redundant calls in listUpdateableGames when refresh just ran.
-const LIST_TTL_MS = 30 * 1000
-let lastLegendaryListTimestamp = 0
 
 export default class LegendaryLibraryManager implements LibraryManager {
   async init() {
@@ -110,8 +106,6 @@ export default class LegendaryLibraryManager implements LibraryManager {
 
     if (res.error) {
       logError(['Failed to refresh library:', res.error], LogPrefix.Legendary)
-    } else {
-      lastLegendaryListTimestamp = Date.now()
     }
     this.refreshInstalled()
     return res
@@ -274,52 +268,13 @@ export default class LegendaryLibraryManager implements LibraryManager {
    * @returns App names of updateable games.
    */
   async listUpdateableGames(): Promise<string[]> {
-    const isLoggedIn = LegendaryUser.isLoggedIn()
-
-    if (!isLoggedIn || !isOnline()) {
-      return []
-    }
-    const epicOffline = await isEpicServiceOffline()
-    if (epicOffline) {
-      logWarning(
-        'Epic servers are offline, cannot check for game updates',
-        LogPrefix.Backend
-      )
+    if (!LegendaryUser.isLoggedIn() || !isOnline()) {
       return []
     }
 
-    const listAge = Date.now() - lastLegendaryListTimestamp
-    if (listAge < LIST_TTL_MS) {
-      logDebug(
-        `Skipping 'legendary list' for update check (ran ${Math.round(listAge / 1000)}s ago)`,
-        LogPrefix.Legendary
-      )
-    } else {
-      const res = await this.runRunnerCommand(
-        { subcommand: 'list', '--third-party': true },
-        {
-          abortId: 'legendary-check-updates',
-          logMessagePrefix: 'Checking for game updates'
-        }
-      )
-
-      if (res.abort) {
-        return []
-      }
-
-      if (res.error) {
-        logError(
-          ['Failed to check for game updates:', res.error],
-          LogPrefix.Legendary
-        )
-        return []
-      }
-
-      lastLegendaryListTimestamp = Date.now()
-    }
-
-    // Once we ran `legendary list`, `assets.json` will be updated with the newest
-    // game versions, and `installed.json` has our currently installed ones
+    // `refresh()` already ran `legendary list` and wrote assets.json with the
+    // newest game versions; installed.json has our currently installed ones.
+    // No network call needed here — just compare the two local files.
     const installedJsonFile = join(legendaryConfigPath, 'installed.json')
     let installedJson: Record<string, InstalledJsonMetadata> = {}
     try {

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -56,6 +56,10 @@ const fallBackImage = 'fallback'
 const allGames: Set<string> = new Set()
 let installedGames: Map<string, InstalledJsonMetadata> = new Map()
 const library: Map<string, GameInfo> = new Map()
+// Timestamp (ms) of the last successful `legendary list` run; used to skip
+// redundant calls in listUpdateableGames when refresh just ran.
+const LIST_TTL_MS = 60 * 1000
+let lastLegendaryListTimestamp = 0
 
 export default class LegendaryLibraryManager implements LibraryManager {
   async init() {
@@ -106,6 +110,8 @@ export default class LegendaryLibraryManager implements LibraryManager {
 
     if (res.error) {
       logError(['Failed to refresh library:', res.error], LogPrefix.Legendary)
+    } else {
+      lastLegendaryListTimestamp = Date.now()
     }
     this.refreshInstalled()
     return res
@@ -282,24 +288,34 @@ export default class LegendaryLibraryManager implements LibraryManager {
       return []
     }
 
-    const res = await this.runRunnerCommand(
-      { subcommand: 'list', '--third-party': true },
-      {
-        abortId: 'legendary-check-updates',
-        logMessagePrefix: 'Checking for game updates'
-      }
-    )
-
-    if (res.abort) {
-      return []
-    }
-
-    if (res.error) {
-      logError(
-        ['Failed to check for game updates:', res.error],
+    const listAge = Date.now() - lastLegendaryListTimestamp
+    if (listAge < LIST_TTL_MS) {
+      logDebug(
+        `Skipping 'legendary list' for update check (ran ${Math.round(listAge / 1000)}s ago)`,
         LogPrefix.Legendary
       )
-      return []
+    } else {
+      const res = await this.runRunnerCommand(
+        { subcommand: 'list', '--third-party': true },
+        {
+          abortId: 'legendary-check-updates',
+          logMessagePrefix: 'Checking for game updates'
+        }
+      )
+
+      if (res.abort) {
+        return []
+      }
+
+      if (res.error) {
+        logError(
+          ['Failed to check for game updates:', res.error],
+          LogPrefix.Legendary
+        )
+        return []
+      }
+
+      lastLegendaryListTimestamp = Date.now()
     }
 
     // Once we ran `legendary list`, `assets.json` will be updated with the newest

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -58,7 +58,7 @@ let installedGames: Map<string, InstalledJsonMetadata> = new Map()
 const library: Map<string, GameInfo> = new Map()
 // Timestamp (ms) of the last successful `legendary list` run; used to skip
 // redundant calls in listUpdateableGames when refresh just ran.
-const LIST_TTL_MS = 60 * 1000
+const LIST_TTL_MS = 30 * 1000
 let lastLegendaryListTimestamp = 0
 
 export default class LegendaryLibraryManager implements LibraryManager {


### PR DESCRIPTION
Fixes #5641
LegendaryLibraryManager.refresh() already calls refreshLegendary(), which runs legendary list --third-party and writes the up-to-date assets.json. However, listUpdateableGames() was running that exact same legendary list --third-party command again (plus its own login/online/Epic-offline guards) right before comparing versions.

Since listUpdateableGames() runs as part of the startup library refresh, this meant legendary list was being executed twice on startup — a redundant network round-trip that slowed things down for no benefit.

This PR removes the redundant command and its guards from listUpdateableGames(). The method now just reads the local installed.json and assets.json (already refreshed by refresh()) and compares versions to find updateable games.

- Removed: the second legendary list --third-party call, plus the duplicate isLoggedIn / isOnline / isEpicServiceOffline / abort / error handling.
- Kept: a lightweight isLoggedIn() && isOnline() early-return guard, and the local-file version comparison.

Net result: one fewer legendary list invocation per startup, faster library refresh, identical update-detection behavior.

---
How to test

1. Have at least one installed Epic/Legendary game that currently has an update available (or just one installed game to confirm no false positives).
2. Clear the cache so the refresh path runs fully from scratch:
  - Close Heroic.
  - Remove the legendary cache files so they get regenerated: delete (or back up) assets.json and installed.json's sibling cache under the legendary config dir, e.g. ~/.config/legendary/ (or use Heroic's Settings → Advanced → Clear Cache).
3. Start Heroic with logs enabled and watch the legendary log during startup.
4. In the logs, confirm:
  - Refreshing library... / Refreshing Epic Games... appears and legendary list runs once (no longer a second "Checking for game updates" list call).
  - Game list updated, got N games & DLCs shows the correct game count.
  - Updateable games are still detected — look for Update is available for <appName>: <current> != <latest> and the final updateable-games log line.
5. Confirm the library loads correctly and games show their update badge where applicable — i.e. the startup state updates the same as before, just without the duplicate network call.
6. 
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
