### PR TITLE
[Perf] Wine: parallel download and async checksum verification

### DIFF
--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -302,8 +302,8 @@ async function installVersion({
   })
 
   // Check if download checksum is correct
-  const downloadChecksum = await hashFile(tarFile)
   if (sourceChecksum) {
+    const downloadChecksum = await hashFile(tarFile)
     if (!sourceChecksum.includes(downloadChecksum)) {
       unlinkFile(tarFile)
       throw new Error('Checksum verification failed')

--- a/src/backend/wine/manager/downloader/main.ts
+++ b/src/backend/wine/manager/downloader/main.ts
@@ -1,9 +1,9 @@
 import { logWarning, LogPrefix, logError } from 'backend/logger'
-import * as crypto from 'crypto'
+import { createHash } from 'crypto'
 import {
+  createReadStream,
   existsSync,
   mkdirSync,
-  readFileSync,
   renameSync,
   rmSync,
   statSync
@@ -171,6 +171,16 @@ interface installProps {
   abortSignal?: AbortSignal
 }
 
+function hashFile(filePath: string, algorithm = 'sha512'): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash(algorithm)
+    const stream = createReadStream(filePath)
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('end', () => resolve(hash.digest('hex')))
+    stream.on('error', reject)
+  })
+}
+
 /**
  * Installs a given version to the given installation directory.
  *
@@ -292,11 +302,7 @@ async function installVersion({
   })
 
   // Check if download checksum is correct
-  const fileBuffer = readFileSync(tarFile)
-  const hashSum = crypto.createHash('sha512')
-  hashSum.update(fileBuffer)
-
-  const downloadChecksum = hashSum.digest('hex')
+  const downloadChecksum = await hashFile(tarFile)
   if (sourceChecksum) {
     if (!sourceChecksum.includes(downloadChecksum)) {
       unlinkFile(tarFile)

--- a/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
+++ b/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
@@ -1,7 +1,5 @@
-import { join } from 'path'
-import graceful_fs, { readFileSync } from 'graceful-fs'
 import { axiosClient } from 'backend/utils'
-import { getAssetDataFromDownload, downloadFile } from '../../util'
+import { getAssetDataFromDownload } from '../../util'
 import { test_data } from './test_data/github-api-heroic-test-data.json'
 import { describeSkipOnWindows } from 'backend/__tests__/skip'
 
@@ -9,7 +7,6 @@ jest.mock('backend/logger')
 
 const testUrl =
   'https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v2.3.9/Heroic-2.3.9.AppImage'
-const testTarFilePath = join(__dirname, 'test_data/TestArchive.tar.xz')
 
 afterEach(jest.restoreAllMocks)
 
@@ -66,77 +63,3 @@ describeSkipOnWindows('getAssetDataFromDownload', () => {
   })
 })
 
-describeSkipOnWindows('downloadFile', () => {
-  it('Success', async () => {
-    const expectedData = readFileSync(testTarFilePath)
-
-    jest.spyOn(axiosClient, 'get').mockResolvedValue({
-      status: 200,
-      data: expectedData
-    })
-    jest
-      .spyOn(graceful_fs, 'writeFile')
-      .mockImplementation(
-        (
-          path: any,
-          data: any,
-          callback: (err: NodeJS.ErrnoException | null) => void
-        ) => {
-          callback(null)
-        }
-      )
-
-    const tmpFileName = '/tmp/someFile'
-    await expect(downloadFile(testUrl, tmpFileName)).resolves.toBeUndefined()
-    expect(graceful_fs.writeFile).toBeCalledWith(
-      tmpFileName,
-      expectedData,
-      expect.anything()
-    )
-  })
-
-  it('Axios error', async () => {
-    expect.assertions(1)
-
-    jest.spyOn(axiosClient, 'get').mockRejectedValue({
-      toJSON: () => '{ "message": "Some error message" }'
-    })
-
-    await expect(downloadFile(testUrl, '')).rejects.toEqual(
-      Error(
-        `Failed to download ${testUrl}: { "message": "Some error message" }`
-      )
-    )
-  })
-
-  it('HTTP error', async () => {
-    expect.assertions(1)
-
-    jest.spyOn(axiosClient, 'get').mockResolvedValue({
-      status: 404,
-      data: {}
-    })
-    await expect(downloadFile(testUrl, '')).rejects.toEqual(
-      Error(`Failed to download ${testUrl}: HTTP error code 404`)
-    )
-  })
-
-  it('writeFile error', async () => {
-    const expectedData = readFileSync(
-      join(__dirname, 'test_data/TestArchive.tar.xz')
-    )
-
-    jest.spyOn(axiosClient, 'get').mockResolvedValue({
-      status: 200,
-      data: expectedData
-    })
-
-    jest.spyOn(graceful_fs, 'writeFile').mockImplementation((fn, data, cb) => {
-      cb({ stack: 'Mocked error stack' } as Error)
-    })
-
-    await expect(downloadFile(testUrl, '')).rejects.toEqual(
-      Error('Failed to save downloaded data to file: Mocked error stack')
-    )
-  })
-})

--- a/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
+++ b/src/backend/wine/runtimes/__tests__/runtimes/utils.test.ts
@@ -62,4 +62,3 @@ describeSkipOnWindows('getAssetDataFromDownload', () => {
     )
   })
 })
-

--- a/src/backend/wine/runtimes/runtimes.ts
+++ b/src/backend/wine/runtimes/runtimes.ts
@@ -9,8 +9,8 @@ import {
 import { join } from 'path'
 import { logError, logInfo, LogPrefix } from 'backend/logger'
 import { Runtime, RuntimeName } from 'common/types'
-import { downloadFile, extractTarFile } from './util'
-import { axiosClient } from 'backend/utils'
+import { extractTarFile } from './util'
+import { axiosClient, downloadFile } from 'backend/utils'
 import { runtimePath } from 'backend/constants/paths'
 
 async function _get(): Promise<Runtime[]> {
@@ -38,7 +38,7 @@ async function download(name: RuntimeName): Promise<boolean> {
 
     const tarFileName = runtime.url.split('/').pop()!
     const tarFilePath = join(runtimePath, tarFileName)
-    await downloadFile(runtime.url, tarFilePath)
+    await downloadFile({ url: runtime.url, dest: tarFilePath })
 
     const extractedFolderPath = join(runtimePath, name)
 

--- a/src/backend/wine/runtimes/util.ts
+++ b/src/backend/wine/runtimes/util.ts
@@ -1,5 +1,5 @@
 import { axiosClient, extractFiles } from 'backend/utils'
-import { existsSync, mkdirSync, writeFile } from 'graceful-fs'
+import { existsSync, mkdirSync } from 'graceful-fs'
 
 interface GithubAssetMetadata {
   url: string
@@ -51,27 +51,6 @@ async function getAssetDataFromDownload(
   return asset
 }
 
-async function downloadFile(url: string, filePath: string) {
-  const response = await axiosClient
-    .get(url, { responseType: 'arraybuffer' })
-    .catch((error) => {
-      throw new Error(`Failed to download ${url}: ${error.toJSON()}`)
-    })
-  if (response.status !== 200) {
-    throw new Error(
-      `Failed to download ${url}: HTTP error code ${response.status}`
-    )
-  }
-  return new Promise<void>((res, rej) => {
-    writeFile(filePath, response.data, (err) => {
-      if (err) {
-        rej(new Error(`Failed to save downloaded data to file: ${err.stack}`))
-      }
-      res()
-    })
-  })
-}
-
 async function extractTarFile(
   filePath: string,
   options?: { extractedPath?: string; strip?: number }
@@ -96,4 +75,4 @@ async function extractTarFile(
   })
 }
 
-export { getAssetDataFromDownload, downloadFile, extractTarFile }
+export { getAssetDataFromDownload, extractTarFile }


### PR DESCRIPTION
Two improvements to the Wine/runtime installation flow:

**Replace duplicated `downloadFile` implementation**

Wine packages were being downloaded entirely into memory before being written to disk. `runtimes.ts` had its own `downloadFile` that handled this, with no retry or abort support. It now uses the existing `downloadFile` from `backend/utils.ts`, which streams directly to disk, supports abort signals, and handles retries. This also results in a significant reduction in code.

**Async checksum verification**

Checksum verification after installation is now performed asynchronously, preventing the UI from freezing. Additionally, `hashFile` is now only called when there is an actual checksum to verify (GE-Proton, Wine-GE). For versions without a checksum (Wine-Staging-macOS and others), the file is skipped entirely.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
