### PR TITLE
[Fix] pause download button game on the game page #5668

### DIFF
--- a/src/frontend/screens/Game/GameContext.tsx
+++ b/src/frontend/screens/Game/GameContext.tsx
@@ -32,7 +32,8 @@ const initialContext: GameContextType = {
     uninstalling: false,
     updating: false,
     win: false,
-    notPlayableOffline: false
+    notPlayableOffline: false,
+    downloadPaused: false
   },
   status: undefined,
   wikiInfo: null

--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -17,8 +17,6 @@ import {
 import classNames from 'classnames'
 import { DownloadManagerState, GameInfo } from 'common/types'
 import useSetting from 'frontend/hooks/useSetting'
-import { hasProgress } from 'frontend/hooks/hasProgress'
-import { handleStopInstallation } from 'frontend/helpers/library'
 
 interface Props {
   gameInfo: GameInfo
@@ -33,7 +31,6 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
   const { is } = useContext(GameContext)
   const { showDialogModal } = useContext(ContextProvider)
   const [verboseLogs, setVerboseLogs] = useSetting('verboseLogs', true)
-  const [progress] = hasProgress(gameInfo.app_name, gameInfo.runner)
 
   // Keep track of the Download Manager state so the button can react to the
   // real download status. When a download is paused the backend reports the
@@ -85,16 +82,17 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
   }
 
   const handleCancelDownload = () => {
-    const path =
-      gameInfo.install.install_path || gameInfo.folder_name || 'default'
-    handleStopInstallation(
-      gameInfo.app_name,
-      path,
-      t,
-      progress,
-      gameInfo.runner,
-      showDialogModal
-    )
+    showDialogModal({
+      title: t('gamepage:box.stopInstall.title'),
+      message: t('gamepage:box.stopInstall.message'),
+      buttons: [
+        { text: t('gamepage:box.stopInstall.keepInstalling') },
+        {
+          text: t('button.cancel'),
+          onClick: () => window.api.cancelDownload(false)
+        }
+      ]
+    })
   }
   const disabledPlayButtons =
     is.reparing ||
@@ -258,7 +256,7 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
           </button>
           <button
             onClick={handleCancelDownload}
-            className={'button mainBtn outline'}
+            className={'button mainBtn is-secondary'}
           >
             <span className="buttonWithIcon">
               <Stop data-icon="stop" />

--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -1,7 +1,8 @@
-import React, { useContext } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { openInstallGameModal } from 'frontend/state/InstallGameModal'
 import GameContext from '../../GameContext'
+import ContextProvider from 'frontend/state/ContextProvider'
 import {
   ArrowBackIosNew,
   Cancel,
@@ -14,8 +15,10 @@ import {
   Warning
 } from '@mui/icons-material'
 import classNames from 'classnames'
-import { GameInfo } from 'common/types'
+import { DownloadManagerState, GameInfo } from 'common/types'
 import useSetting from 'frontend/hooks/useSetting'
+import { hasProgress } from 'frontend/hooks/hasProgress'
+import { handleStopInstallation } from 'frontend/helpers/library'
 
 interface Props {
   gameInfo: GameInfo
@@ -28,9 +31,71 @@ interface Props {
 const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
   const { t } = useTranslation('gamepage')
   const { is } = useContext(GameContext)
+  const { showDialogModal } = useContext(ContextProvider)
   const [verboseLogs, setVerboseLogs] = useSetting('verboseLogs', true)
+  const [progress] = hasProgress(gameInfo.app_name, gameInfo.runner)
+
+  // Keep track of the Download Manager state so the button can react to the
+  // real download status. When a download is paused the backend reports the
+  // game status as "done", so `is.installing`/`is.updating` are no longer
+  // reliable on their own to know if there's an ongoing (paused) download.
+  const [dmState, setDmState] = useState<DownloadManagerState>('idle')
+  const [currentDownloadAppName, setCurrentDownloadAppName] = useState<string>()
+
+  useEffect(() => {
+    window.api
+      .getDMQueueInformation()
+      .then(({ elements, state }) => {
+        setCurrentDownloadAppName(elements[0]?.params.appName)
+        setDmState(state)
+      })
+      .catch((error) => {
+        console.error('Failed to get DM queue information:', error)
+      })
+
+    const removeHandleDMQueueInformation = window.api.handleDMQueueInformation(
+      (e, elements, state) => {
+        setCurrentDownloadAppName(elements[0]?.params.appName)
+        setDmState(state)
+      }
+    )
+
+    return () => {
+      removeHandleDMQueueInformation()
+    }
+  }, [])
 
   const is_installed = gameInfo.is_installed
+
+  // This game is the one currently being processed by the Download Manager
+  const isCurrentDownload = currentDownloadAppName === gameInfo.app_name
+  const isDownloadPaused = dmState === 'paused'
+
+  // Show the pause/cancel controls while the game is actively downloading or
+  // while its download is the current (paused) one in the queue.
+  const showDownloadControls =
+    is.installing || is.updating || (isCurrentDownload && isDownloadPaused)
+
+  const handlePauseResume = () => {
+    if (isDownloadPaused) {
+      window.api.resumeCurrentDownload()
+    } else {
+      window.api.pauseCurrentDownload()
+    }
+  }
+
+  const handleCancelDownload = () => {
+    const path =
+      gameInfo.install.install_path || gameInfo.folder_name || 'default'
+    handleStopInstallation(
+      gameInfo.app_name,
+      path,
+      t,
+      progress,
+      gameInfo.runner,
+      showDialogModal
+    )
+  }
   const disabledPlayButtons =
     is.reparing ||
     is.moving ||
@@ -168,6 +233,41 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
   const handleAltLaunch = async () => {
     setVerboseLogs(!verboseLogs)
     await handlePlay(gameInfo)
+  }
+
+  if (showDownloadControls) {
+    return (
+      <div className="buttonsWrapper">
+        <span className="installButtons">
+          <button
+            onClick={handlePauseResume}
+            autoFocus={true}
+            className={classNames('button', 'is-tertiary', 'mainBtn')}
+          >
+            {isDownloadPaused ? (
+              <span className="buttonWithIcon">
+                <PlayArrow data-icon="play" />
+                {t('queue.label.resume', 'Resume download')}
+              </span>
+            ) : (
+              <span className="buttonWithIcon">
+                <Pause />
+                {t('queue.label.pause', 'Pause download')}
+              </span>
+            )}
+          </button>
+          <button
+            onClick={handleCancelDownload}
+            className={'button mainBtn outline'}
+          >
+            <span className="buttonWithIcon">
+              <Stop data-icon="stop" />
+              {t('button.cancel')}
+            </span>
+          </button>
+        </span>
+      </div>
+    )
   }
 
   return (

--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { openInstallGameModal } from 'frontend/state/InstallGameModal'
 import GameContext from '../../GameContext'
@@ -15,7 +15,7 @@ import {
   Warning
 } from '@mui/icons-material'
 import classNames from 'classnames'
-import { DownloadManagerState, GameInfo } from 'common/types'
+import { GameInfo } from 'common/types'
 import useSetting from 'frontend/hooks/useSetting'
 
 interface Props {
@@ -32,49 +32,12 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
   const { showDialogModal } = useContext(ContextProvider)
   const [verboseLogs, setVerboseLogs] = useSetting('verboseLogs', true)
 
-  // Keep track of the Download Manager state so the button can react to the
-  // real download status. When a download is paused the backend reports the
-  // game status as "done", so `is.installing`/`is.updating` are no longer
-  // reliable on their own to know if there's an ongoing (paused) download.
-  const [dmState, setDmState] = useState<DownloadManagerState>('idle')
-  const [currentDownloadAppName, setCurrentDownloadAppName] = useState<string>()
-
-  useEffect(() => {
-    window.api
-      .getDMQueueInformation()
-      .then(({ elements, state }) => {
-        setCurrentDownloadAppName(elements[0]?.params.appName)
-        setDmState(state)
-      })
-      .catch((error) => {
-        console.error('Failed to get DM queue information:', error)
-      })
-
-    const removeHandleDMQueueInformation = window.api.handleDMQueueInformation(
-      (e, elements, state) => {
-        setCurrentDownloadAppName(elements[0]?.params.appName)
-        setDmState(state)
-      }
-    )
-
-    return () => {
-      removeHandleDMQueueInformation()
-    }
-  }, [])
-
   const is_installed = gameInfo.is_installed
 
-  // This game is the one currently being processed by the Download Manager
-  const isCurrentDownload = currentDownloadAppName === gameInfo.app_name
-  const isDownloadPaused = dmState === 'paused'
-
-  // Show the pause/cancel controls while the game is actively downloading or
-  // while its download is the current (paused) one in the queue.
-  const showDownloadControls =
-    is.installing || is.updating || (isCurrentDownload && isDownloadPaused)
+  const showDownloadControls = is.installing || is.updating || is.downloadPaused
 
   const handlePauseResume = () => {
-    if (isDownloadPaused) {
+    if (is.downloadPaused) {
       window.api.resumeCurrentDownload()
     } else {
       window.api.pauseCurrentDownload()
@@ -242,7 +205,7 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
             autoFocus={true}
             className={classNames('button', 'is-tertiary', 'mainBtn')}
           >
-            {isDownloadPaused ? (
+            {is.downloadPaused ? (
               <span className="buttonWithIcon">
                 <PlayArrow data-icon="play" />
                 {t('queue.label.resume', 'Resume download')}

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -26,6 +26,7 @@ import { CachedImage, UpdateComponent, TabPanel } from 'frontend/components/UI'
 import UninstallModal from 'frontend/components/UI/UninstallModal'
 
 import {
+  DownloadManagerState,
   ExtraInfo,
   GameInfo,
   GameSettings,
@@ -136,6 +137,32 @@ export default React.memo(function GamePage(): JSX.Element | null {
     message: unknown
   }>({ error: false, message: '' })
   const [playClicked, setPlayClicked] = useState(false)
+
+  const [dmState, setDmState] = useState<DownloadManagerState>('idle')
+  const [currentDMAppName, setCurrentDMAppName] = useState<string>()
+
+  useEffect(() => {
+    window.api
+      .getDMQueueInformation()
+      .then(({ elements, state }) => {
+        setCurrentDMAppName(elements[0]?.params.appName)
+        setDmState(state)
+      })
+      .catch((error) => {
+        console.error('Failed to get DM queue information:', error)
+      })
+
+    const removeHandleDMQueueInformation = window.api.handleDMQueueInformation(
+      (e, elements, state) => {
+        setCurrentDMAppName(elements[0]?.params.appName)
+        setDmState(state)
+      }
+    )
+
+    return () => {
+      removeHandleDMQueueInformation()
+    }
+  }, [])
 
   const anticheatInfo = hasAnticheatInfo(gameInfo)
 
@@ -362,7 +389,10 @@ export default React.memo(function GamePage(): JSX.Element | null {
         uninstalling: isUninstalling,
         updating: isUpdating,
         win: isWin,
-        notPlayableOffline: notPlayableOffline
+        notPlayableOffline: notPlayableOffline,
+        // When a download is paused the backend reports game status as "done",
+        // so is.installing/is.updating become false. This flag covers that gap.
+        downloadPaused: dmState === 'paused' && currentDMAppName === appName
       },
       statusContext,
       status,

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -288,6 +288,7 @@ export interface GameContextType {
     updating: boolean
     win: boolean
     notPlayableOffline: boolean
+    downloadPaused: boolean
   }
   statusContext?: string
   status: Status | undefined


### PR DESCRIPTION
Fixes #5668
This fix adds the `is.downloadPaused` state to the context window so that the `mainbutton` detects this and can adjust the current pause/cancel buttons that aren't working.

I had to add those pause and cancel buttons.

This is one possible fix; there are other ways to do it.


---

## How to test

▎ Frontend-only change. Adds Pause / Resume / Cancel download controls to the game page's main button and fixes the controls disappearing when a download is paused.

Setup
1. Clean/current build, logged in to a store (Epic/GOG/Amazon).
2. Have a game available to install (ideally a large-ish one so you have time to interact while it downloads).

Main flow — install
1. Start installing a game and open its game page.
2. Confirm the main button now shows Pause download + Cancel while it's downloading.
3. Click Pause download:
  - The download pauses.
  - The button changes to Resume download and the controls stay visible (this is the bug being fixed — previously they disappeared because the backend reports done when paused).
4. Click Resume download:
  - The download continues and the button goes back to Pause download.
5. Click Cancel:
  - A confirmation dialog appears.
  - Keep installing → dialog closes, download keeps going.
  - Cancel → the download is stopped/cancelled.

Update flow
6. Repeat the Pause / Resume / Cancel checks for a game that is updating (not just first install).

Scoping check
7. While a download is active/paused, open a different game's page → it should show its normal buttons (Play/Install), not the download controls. (The controls are tied to the game actually in the DM queue, via downloadPaused: dmState === 'paused' && currentDMAppName === appName.)

Regression
8. Confirm normal flows still work on a clean install: Login, Install, Play, Uninstall, Move games.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
