### PR TITLE
[Perf] GOG. Use native du/PowerShell for install size calculation

### DIFF
--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -439,7 +439,10 @@ export default class GOGGameManager implements GameManager {
       return { status: 'error' }
     }
 
-    const sizeOnDisk = await getPathDiskSize(join(path, gameInfo.folder_name))
+    const sizeOnDisk = await getPathDiskSize(
+      join(path, gameInfo.folder_name),
+      installInfo.manifest.download_size
+    )
     const install_path = join(path, gameInfo.folder_name)
 
     const installedData: InstalledInfo = {
@@ -1200,6 +1203,7 @@ export default class GOGGameManager implements GameManager {
     )
     const gameObject = installedArray[gameIndex]
 
+    let downloadSizeHint: number | undefined
     if (gameData.install.platform !== 'linux') {
       const installInfo = await libraryManagerMap['gog'].getInstallInfo(
         appName,
@@ -1221,6 +1225,7 @@ export default class GOGGameManager implements GameManager {
       gameObject.branch = updateOverwrites?.branch
       gameObject.language = overwrittenLanguage
       gameObject.versionEtag = etag
+      downloadSizeHint = installInfo.manifest.download_size
     } else {
       const installerInfo =
         await libraryManagerMap['gog'].getLinuxInstallerInfo(appName)
@@ -1232,7 +1237,10 @@ export default class GOGGameManager implements GameManager {
     if (updateOverwrites?.dlcs) {
       gameObject.installedDLCs = updateOverwrites?.dlcs
     }
-    const sizeOnDisk = await getPathDiskSize(join(gameObject.install_path))
+    const sizeOnDisk = await getPathDiskSize(
+      join(gameObject.install_path),
+      downloadSizeHint
+    )
     gameObject.install_size = getFileSize(sizeOnDisk)
     installedGamesStore.set('installed', installedArray)
     libraryManagerMap['gog'].refreshInstalled()

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1312,7 +1312,7 @@ const POWERSHELL_SIZE_THRESHOLD = 5 * 1024 * 1024 * 1024 // 5 GB
 
 async function getPathDiskSize(
   dirPath: string,
-  hintBytes?: number
+  hintBytes?: number // compressed download size; used on Windows to decide whether to spawn PowerShell
 ): Promise<number> {
   if (!isWindows) {
     try {

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1306,22 +1306,85 @@ function removeFolder(path: string, folderName: string) {
   return
 }
 
-async function getPathDiskSize(path: string): Promise<number> {
-  const statData = await lstat(path)
-  let size = 0
-  if (statData.isSymbolicLink()) {
-    return 0
+// Games above this compressed download size likely have enough files to make
+// PowerShell's startup cost worthwhile over the sequential JS walk on Windows.
+const POWERSHELL_SIZE_THRESHOLD = 5 * 1024 * 1024 * 1024 // 5 GB
+
+async function getPathDiskSize(
+  dirPath: string,
+  hintBytes?: number
+): Promise<number> {
+  if (!isWindows) {
+    try {
+      // du -sb on Linux gives bytes directly; du -sk on macOS gives 1K-blocks
+      const args = isMac ? ['-sk', dirPath] : ['-sb', dirPath]
+      const { code, stdout } = await spawnAsync('du', args)
+      if (code === 0) {
+        const raw = parseInt(stdout.split('\t')[0], 10)
+        logInfo(
+          [`Disk size for ${dirPath} calculated via du`],
+          LogPrefix.Backend
+        )
+        return isMac ? raw * 1024 : raw
+      }
+    } catch {
+      logWarning(
+        [`du failed for ${dirPath}, falling back to JS recursive walk`],
+        LogPrefix.Backend
+      )
+    }
+  } else if (
+    hintBytes !== undefined &&
+    hintBytes >= POWERSHELL_SIZE_THRESHOLD
+  ) {
+    try {
+      // PowerShell is always available on Windows 10+; output is a plain number.
+      // Only used for large games where the JS walk would be prohibitively slow.
+      const escapedPath = dirPath.replace(/'/g, "''")
+      const psCommand = `(Get-ChildItem -Recurse -File -LiteralPath '${escapedPath}' | Measure-Object -Property Length -Sum).Sum`
+      const { code, stdout } = await spawnAsync('powershell', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        psCommand
+      ])
+      if (code === 0) {
+        const bytes = parseInt(stdout.trim(), 10)
+        if (!isNaN(bytes)) {
+          logInfo(
+            [`Disk size for ${dirPath} calculated via PowerShell`],
+            LogPrefix.Backend
+          )
+          return bytes
+        }
+      }
+    } catch {
+      logWarning(
+        [
+          `PowerShell size query failed for ${dirPath}, falling back to JS recursive walk`
+        ],
+        LogPrefix.Backend
+      )
+    }
   }
+  logInfo(
+    [`Disk size for ${dirPath} calculated via JS recursive walk`],
+    LogPrefix.Backend
+  )
+  return getPathDiskSizeJS(dirPath)
+}
+
+async function getPathDiskSizeJS(path: string): Promise<number> {
+  const statData = await lstat(path)
+  if (statData.isSymbolicLink()) return 0
   if (statData.isDirectory()) {
     const contents = await readdir(path)
-
+    let size = 0
     for (const item of contents) {
-      const itemPath = join(path, item)
-      size += await getPathDiskSize(itemPath)
+      size += await getPathDiskSizeJS(join(path, item))
     }
     return size
   }
-
   return statData.size
 }
 


### PR DESCRIPTION
Replaces the pure-JS recursive file walk used to calculate installed game size with native OS tools where available. Only GOG games, installed.

Why

The previous implementation walked every file in the game directory using Node's fs APIs. For large games with thousands of files this is noticeably slow, blocking the library refresh.

How

    Linux: runs du -sb — reports bytes directly and is orders of magnitude faster than a JS walk.
    macOS: runs du -sk and converts 1K-blocks to bytes.
    Windows (large games only, ≥ 5 GB compressed download size): runs PowerShell Get-ChildItem | Measure-Object -Sum — only triggered for large games where the startup cost of PowerShell is worth it.
    Fallback: if the native command fails or the conditions above aren't met, falls back to the original JS recursive walk (now getPathDiskSizeJS).

The download_size from the GOG manifest is passed as a hint to decide whether to invoke PowerShell on Windows.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
