### PR TITLE
[Perf] Avoid unnecessary network refresh after Legendary operations

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -907,21 +907,18 @@ if (existsSync(legendaryInstalled)) {
   })
 }
 
-addHandler('refreshLibrary', async (e, library?, localOnly?) => {
-  if (library !== undefined && library !== 'all') {
-    const manager = libraryManagerMap[library] as LibraryManager
-    if (localOnly && manager.refreshLocal) {
-      await manager.refreshLocal()
-    } else {
-      await manager.refresh()
-    }
-  } else {
-    const allRefreshPromises = []
-    for (const manager of Object.values(libraryManagerMap)) {
-      allRefreshPromises.push(manager.refresh())
-    }
-    await Promise.allSettled(allRefreshPromises)
+addHandler('refreshLibrary', async (e, library, localOnly) => {
+  async function doRefresh(manager: LibraryManager) {
+    if (localOnly && manager.refreshLocal) return manager.refreshLocal()
+    return manager.refresh()
   }
+
+  const managers =
+    library !== undefined && library !== 'all'
+      ? [libraryManagerMap[library]]
+      : Object.values(libraryManagerMap)
+
+  await Promise.allSettled(managers.map(doRefresh))
 })
 
 // get pid/tid on launch and inject

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -104,6 +104,7 @@ import {
   initStoreManagers,
   libraryManagerMap
 } from './storeManagers'
+import type { LibraryManager } from 'common/types/game_manager'
 import {
   setGameOverrides,
   getGameOverrides,
@@ -906,9 +907,14 @@ if (existsSync(legendaryInstalled)) {
   })
 }
 
-addHandler('refreshLibrary', async (e, library?) => {
+addHandler('refreshLibrary', async (e, library?, localOnly?) => {
   if (library !== undefined && library !== 'all') {
-    await libraryManagerMap[library].refresh()
+    const manager = libraryManagerMap[library] as LibraryManager
+    if (localOnly && manager.refreshLocal) {
+      await manager.refreshLocal()
+    } else {
+      await manager.refresh()
+    }
   } else {
     const allRefreshPromises = []
     for (const manager of Object.values(libraryManagerMap)) {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -907,7 +907,7 @@ if (existsSync(legendaryInstalled)) {
   })
 }
 
-addHandler('refreshLibrary', async (e, library, localOnly) => {
+addHandler('refreshLibrary', async (e, { library, localOnly } = {}) => {
   async function doRefresh(manager: LibraryManager) {
     if (localOnly && manager.refreshLocal) return manager.refreshLocal()
     return manager.refresh()

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -175,6 +175,22 @@ export default class LegendaryLibraryManager implements LibraryManager {
     return this.defaultExecResult
   }
 
+  async refreshLocal(): Promise<void> {
+    this.loadGamesInAccount()
+    this.refreshInstalled()
+    try {
+      await this.loadAll()
+    } catch (error) {
+      logError(error, LogPrefix.Legendary)
+    }
+    const arr = Array.from(library.values())
+    libraryStore.set('library', arr)
+    logInfo(
+      ['Game list updated locally, got', `${arr.length}`, 'games & DLCs'],
+      LogPrefix.Legendary
+    )
+  }
+
   getListOfGames() {
     return libraryStore.get('library', [])
   }

--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -158,16 +158,7 @@ export default class LegendaryLibraryManager implements LibraryManager {
     }
 
     await this.refreshLegendary()
-    this.loadGamesInAccount()
-    this.refreshInstalled()
-
-    try {
-      await this.loadAll()
-    } catch (error) {
-      logError(error, LogPrefix.Legendary)
-    }
-    const arr = Array.from(library.values())
-    libraryStore.set('library', arr)
+    const arr = await this.applyLocalData()
     logInfo(
       ['Game list updated, got', `${arr.length}`, 'games & DLCs'],
       LogPrefix.Legendary
@@ -175,7 +166,24 @@ export default class LegendaryLibraryManager implements LibraryManager {
     return this.defaultExecResult
   }
 
+  /**
+   * Refresh games in the user's library using only local data, without network calls.
+   */
   async refreshLocal(): Promise<void> {
+    logInfo('Refreshing library locally...', LogPrefix.Legendary)
+    const arr = await this.applyLocalData()
+    logInfo(
+      ['Game list updated locally, got', `${arr.length}`, 'games & DLCs'],
+      LogPrefix.Legendary
+    )
+  }
+
+  /**
+   * Load local game data into the library store.
+   *
+   * @returns Array of GameInfo objects.
+   */
+  private async applyLocalData(): Promise<GameInfo[]> {
     this.loadGamesInAccount()
     this.refreshInstalled()
     try {
@@ -185,10 +193,7 @@ export default class LegendaryLibraryManager implements LibraryManager {
     }
     const arr = Array.from(library.values())
     libraryStore.set('library', arr)
-    logInfo(
-      ['Game list updated locally, got', `${arr.length}`, 'games & DLCs'],
-      LogPrefix.Legendary
-    )
+    return arr
   }
 
   getListOfGames() {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -546,6 +546,7 @@ export type RefreshOptions = {
   fullRefresh?: boolean
   library?: Runner | 'all'
   runInBackground?: boolean
+  localOnly?: boolean
 }
 
 export interface WineVersionInfo extends VersionInfo {

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -78,6 +78,7 @@ export interface GameManager {
 export interface LibraryManager {
   init: () => Promise<void>
   refresh: () => Promise<ExecResult | null>
+  refreshLocal?: () => Promise<void>
   getGameInfo: (appName: string, forceReload?: boolean) => GameInfo | undefined
   getInstallInfo: (
     appName: string,

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -216,10 +216,10 @@ interface AsyncIPCFunctions {
   requestAppSettings: () => AppSettings
   requestGameSettings: (appName: string) => Promise<GameSettings>
   writeConfig: (args: { appName: string; config: Partial<AppSettings> }) => void
-  refreshLibrary: (
-    library?: Runner | 'all',
+  refreshLibrary: (options?: {
+    library?: Runner | 'all'
     localOnly?: boolean
-  ) => Promise<void>
+  }) => Promise<void>
   launch: (args: LaunchParams) => StatusPromise
   openDialog: (args: OpenDialogOptions) => Promise<string | false>
   install: (args: InstallParams) => Promise<void>

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -216,7 +216,7 @@ interface AsyncIPCFunctions {
   requestAppSettings: () => AppSettings
   requestGameSettings: (appName: string) => Promise<GameSettings>
   writeConfig: (args: { appName: string; config: Partial<AppSettings> }) => void
-  refreshLibrary: (library?: Runner | 'all') => Promise<void>
+  refreshLibrary: (library?: Runner | 'all', localOnly?: boolean) => Promise<void>
   launch: (args: LaunchParams) => StatusPromise
   openDialog: (args: OpenDialogOptions) => Promise<string | false>
   install: (args: InstallParams) => Promise<void>

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -216,7 +216,10 @@ interface AsyncIPCFunctions {
   requestAppSettings: () => AppSettings
   requestGameSettings: (appName: string) => Promise<GameSettings>
   writeConfig: (args: { appName: string; config: Partial<AppSettings> }) => void
-  refreshLibrary: (library?: Runner | 'all', localOnly?: boolean) => Promise<void>
+  refreshLibrary: (
+    library?: Runner | 'all',
+    localOnly?: boolean
+  ) => Promise<void>
   launch: (args: LaunchParams) => StatusPromise
   openDialog: (args: OpenDialogOptions) => Promise<string | false>
   install: (args: InstallParams) => Promise<void>

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -722,7 +722,7 @@ class GlobalState extends PureComponent<Props> {
     let gogLibrary = this.loadGOGLibrary(overrides)
     if (gog.username && (!gogLibrary.length || !gog.library.length)) {
       window.api.logInfo('No cache found, getting data from gog...')
-      await window.api.refreshLibrary('gog')
+      await window.api.refreshLibrary({ library: 'gog' })
       gogLibrary = this.loadGOGLibrary(overrides)
     }
 
@@ -731,7 +731,7 @@ class GlobalState extends PureComponent<Props> {
       zoomLibrary = this.loadZoomLibrary(overrides)
       if (zoom.username && (!zoomLibrary.length || !zoom.library.length)) {
         window.api.logInfo('No cache found, getting data from zoom...')
-        await window.api.refreshLibrary('zoom')
+        await window.api.refreshLibrary({ library: 'zoom' })
         zoomLibrary = this.loadZoomLibrary(overrides)
       }
     }
@@ -739,7 +739,7 @@ class GlobalState extends PureComponent<Props> {
     let amazonLibrary = nileLibraryStore.get('library', [])
     if (amazon.user_id && (!amazonLibrary.length || !amazon.library.length)) {
       window.api.logInfo('No cache found, getting data from nile...')
-      await window.api.refreshLibrary('nile')
+      await window.api.refreshLibrary({ library: 'nile' })
       amazonLibrary = this.loadAmazonLibrary(overrides)
     }
 
@@ -790,7 +790,7 @@ class GlobalState extends PureComponent<Props> {
     })
     window.api.logInfo(`Refreshing ${library} Library`)
     try {
-      await window.api.refreshLibrary(library, localOnly)
+      await window.api.refreshLibrary({ library, localOnly })
       return await this.refresh(library, checkForUpdates)
     } catch (error) {
       window.api.logError(`Library refresh failed: ${String(error)}`)

--- a/src/frontend/state/GlobalState.tsx
+++ b/src/frontend/state/GlobalState.tsx
@@ -779,7 +779,8 @@ class GlobalState extends PureComponent<Props> {
   refreshLibrary = async ({
     checkForUpdates,
     runInBackground = true,
-    library = undefined
+    library = undefined,
+    localOnly = false
   }: RefreshOptions): Promise<void> => {
     if (this.state.refreshing) return
 
@@ -789,7 +790,7 @@ class GlobalState extends PureComponent<Props> {
     })
     window.api.logInfo(`Refreshing ${library} Library`)
     try {
-      await window.api.refreshLibrary(library)
+      await window.api.refreshLibrary(library, localOnly)
       return await this.refresh(library, checkForUpdates)
     } catch (error) {
       window.api.logError(`Library refresh failed: ${String(error)}`)
@@ -858,7 +859,6 @@ class GlobalState extends PureComponent<Props> {
         const updatedGamesUpdates = gameUpdates.filter(
           (game) => game !== appName
         )
-        // This avoids calling legendary again before the previous process is killed when canceling
         this.refreshLibrary({
           checkForUpdates: true,
           runInBackground: true,
@@ -872,7 +872,11 @@ class GlobalState extends PureComponent<Props> {
         })
       }
 
-      this.refreshLibrary({ runInBackground: true, library: runner })
+      this.refreshLibrary({
+        runInBackground: true,
+        library: runner,
+        localOnly: runner === 'legendary'
+      })
 
       this.setState({ libraryStatus: newLibraryStatus })
     }


### PR DESCRIPTION
- Adds a `refreshLocal()` method to `LegendaryLibraryManager` that refreshes the library reading only local files, skipping the `legendary list` network call.
- Adds a `localOnly` option to `RefreshOptions`, `LibraryManager`, IPC types, and `GlobalState.refreshLibrary()`.
- After any Legendary operation completes or errors (install, uninstall, repair), the library refresh now uses `localOnly: true`. Game install state is always written to local files by Legendary before signaling completion, so the network call was redundant. Updates are excluded from this — they still trigger a full network refresh.

## Problem

After any Legendary operation finished, `refreshLibrary` triggered a full refresh which called `legendary list` against the Epic Games API. This was unnecessary: install state lives in `installed.json` and game metadata in `legendaryMetadata/*.json`, both written locally by Legendary before it signals completion. The network call only serves to sync the account's game catalogue, which doesn't change as a result of local operations.

## Solution

`refreshLocal()` calls `loadGamesInAccount()`, `refreshInstalled()`, and `loadAll()` — all purely local file reads — then saves the result to the library store. The `localOnly` flag is optional on `LibraryManager` so other store managers (GOG, Amazon) are unaffected. Game updates still go through the full network refresh since `checkForUpdates` requires up-to-date remote data.

---

## How to test
1. Build and run the app from this branch (yarn start / pnpm start).
2. Have an Epic (Legendary) account logged in with at least one installed game available.

Main scenario — Legendary uses local-only refresh
1. Install (or update) an Epic game.
2. When it finishes, watch the logs. You should see:
  - Refreshing library locally...
  - Game list updated locally, got X games & DLCs
3. Confirm there is no full legendary list/network recall after the install completes (no Game list updated, got ... line from the full refresh() path, and no extra network round-trip to Epic).
4. The newly installed game should still appear correctly in the library (installed state, size, etc.), since refreshInstalled + loadAll still run from local cache.

Regression checks
1. Other stores still do a full refresh: install/update a GOG, Amazon, or Zoom game and confirm the post-install refresh still goes through the normal refresh() path (localOnly is false for non-Legendary runners).
2. Manual full refresh still works: trigger a manual library refresh (refresh button) and confirm Legendary still performs the full network refresh and logs Game list updated, got X games & DLCs.
3. First-load cache population unaffected: with empty caches, GOG/Zoom/Nile still call refreshLibrary({ library }) and populate correctly (no localOnly).
4. Updating-game path: finish an update (not just install) of a Legendary game and confirm the game is removed from the updates list and the library reflects the new state.

What to look for
- Noticeably faster return-to-idle after installing a Legendary game (no redundant full library recall).
- No regressions in installed-state detection or DLC listing.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
