### PR TITLE
Move "Disable umu" into the "Legacy" section

### DIFF
--- a/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/GamesSettings/index.tsx
@@ -227,7 +227,6 @@ export default function GamesSettings() {
           </>
         )}
         <VerboseLogs />
-        <DisableUMU />
         <AlternativeExe />
         <LaunchOptionSelector />
         <LauncherArgs />
@@ -259,6 +258,7 @@ export default function GamesSettings() {
             )}
           </span>
           <EnableDXVKFpsLimit />
+          <DisableUMU />
         </TabPanel>
       )}
 


### PR DESCRIPTION
Supporting non-containerized Proton is a pain, especially in Flatpak (where we have to manually compile all kinds of dependencies). Umu has been enabled by default for a while now. Let's discourage users from disabling it by moving the option to the new "Legacy" category.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
