### PR TITLE
Create `compatibilitytools.d` if it does not exist

### DIFF
--- a/src/backend/wine/manager/utils.ts
+++ b/src/backend/wine/manager/utils.ts
@@ -242,18 +242,22 @@ function getInstallDir(release: WineVersionInfo): string {
   } else {
     const config = GlobalConfig.get().getSettings()
     if (config.downloadProtonToSteam && config.defaultSteamPath) {
-      const steamCompatPath = join(
-        config.defaultSteamPath,
-        'compatibilitytools.d'
+      const isValidSteamPath = existsSync(
+        join(config.defaultSteamPath, 'steam.sh')
       )
-      if (existsSync(steamCompatPath)) {
-        return steamCompatPath
+      if (isValidSteamPath) {
+        const compatToolsPath = join(
+          config.defaultSteamPath,
+          'compatibilitytools.d'
+        )
+        mkdirSync(compatToolsPath, { recursive: true })
+        return compatToolsPath
+      } else {
+        logWarning(
+          `Configured Steam path ("${config.defaultSteamPath}") does not appear to be valid, installing into Heroic tools path instead`,
+          LogPrefix.WineDownloader
+        )
       }
-      // If Steam path doesn't exist, fall back to default
-      logWarning(
-        'Steam compatibilitytools.d directory does not exist, defaulting to Heroic tools path',
-        LogPrefix.WineDownloader
-      )
     }
     return `${toolsPath}/proton`
   }


### PR DESCRIPTION
Closes #5684

If "Download GE-Proton to Steam directory" is checked, but `compatibilitytools.d` does not exist, Heroic will always fall back to its own tools path on download. This is a safe fallback, but isn't always necessary.
Instead, we now check whether `steam.sh` exists in the configured Steam path. If it does, the path is deemed "valid", and a missing `compatibilitytools.d` will be auto-created.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
