### PR TITLE
Make Proton-CachyOS the default Proton version

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -949,7 +949,7 @@ export async function downloadDefaultWine() {
   const isMacOSUpToDate = await isMacSonomaOrHigher()
   const release = availableWine.find((version) => {
     if (isLinux) {
-      return version.type === 'GE-Proton'
+      return version.type === 'Proton-CachyOS'
     } else if (isMac) {
       if (isIntelMac || !isMacOSUpToDate) {
         return version.type === 'Wine-Crossover'

--- a/src/frontend/assets/cachyos-logo.svg
+++ b/src/frontend/assets/cachyos-logo.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" version="1.1" viewBox="0 0 17.921 17.921" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+   <defs>
+      <linearGradient id="d" x1="237.19" x2="237.07" y1="296.2" y2="304.08" gradientTransform="matrix(.04476 0 0 .044679 -8.5923 -4.6302)" gradientUnits="userSpaceOnUse" xlink:href="#b"/>
+      <linearGradient id="b">
+         <stop stop-color="#001313" offset="0"/>
+         <stop stop-color="#001313" stop-opacity="0" offset="1"/>
+      </linearGradient>
+      <linearGradient id="f" x1="994.81" x2="982.34" y1="1533.3" y2="1556.8" gradientTransform="matrix(.084141 0 0 .083989 -76.331 -126.67)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+      <linearGradient id="a">
+         <stop stop-color="#020202" offset="0"/>
+         <stop stop-color="#020202" stop-opacity="0" offset="1"/>
+      </linearGradient>
+      <linearGradient id="e" x1="1022.5" x2="1018.6" y1="1582.4" y2="1575.6" gradientTransform="matrix(.086381 0 0 .081808 -79.192 -124.97)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+      <linearGradient id="p" x1="940.43" x2="930.59" y1="1612.5" y2="1594.5" gradientTransform="matrix(.084141 0 0 .083989 -76.331 -126.67)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+      <linearGradient id="q" x1="965.6" x2="951.66" y1="1571.4" y2="1571.3" gradientTransform="matrix(.084141 0 0 .083989 -76.331 -126.67)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+      <linearGradient id="l" x1="946.23" x2="961.37" y1="1655.9" y2="1655.8" gradientTransform="matrix(.084141 0 0 .083989 -76.331 -126.67)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+      <linearGradient id="h" x1="366.15" x2="350.92" y1="427.32" y2="419.64" gradientTransform="matrix(.04476 0 0 .044679 -10.921 -4.4349)" gradientUnits="userSpaceOnUse" xlink:href="#b"/>
+      <linearGradient id="o" x1="936.34" x2="933.38" y1="1628.8" y2="1623" gradientTransform="matrix(.084141 0 0 .083989 -76.331 -126.67)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+      <linearGradient id="n" x1="950.33" x2="941.97" y1="1618.6" y2="1645.8" gradientTransform="matrix(.084141 0 0 .083989 -76.331 -126.67)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+      <linearGradient id="m" x1="1008.2" x2="1015.7" y1="1681.3" y2="1668.4" gradientTransform="matrix(.084141 0 0 .083989 -76.331 -126.67)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+      <linearGradient id="k" x1="1148.3" x2="1145.4" y1="1585.5" y2="1630" gradientTransform="matrix(.34992 0 0 .34992 -282.87 -491.67)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+      <linearGradient id="c">
+         <stop stop-color="#008066" stop-opacity="0" offset="0"/>
+         <stop stop-color="#0fc" offset="1"/>
+      </linearGradient>
+      <linearGradient id="j" x1="1148.3" x2="1145.4" y1="1585.5" y2="1630" gradientTransform="matrix(.26565 0 0 .26565 -211.15 -375.49)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+      <linearGradient id="i" x1="1148.3" x2="1145.4" y1="1585.5" y2="1630" gradientTransform="matrix(.13679 0 0 .13679 -53.624 -195.03)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+      <linearGradient id="g" x1="348.05" x2="361.21" y1="194.78" y2="187.24" gradientTransform="matrix(.04476 0 0 .044679 -10.921 -4.4349)" gradientUnits="userSpaceOnUse" xlink:href="#b"/>
+   </defs>
+   <circle cx="64.51" cy="62.02" r="87.45" opacity="0" stroke-width=".27971"/>
+   <path d="m4.3286 1.9244h8.3458l-2.1127 3.6528h-4.526l-1.8859 3.2605 1.9121 3.306h8.8286l-2.1664 3.7456h-8.5747l-4.1369-7.1525 3.9605-6.8475z" fill="#fff"/>
+   <path d="m3.973 1.8893 6.5887 3.6879 2.1127-3.6528z" fill="#0a8"/>
+   <path d="m6.0619 12.144-1.9125 3.7456h8.5747l2.1664-3.7456z" fill="#0a8"/>
+   <path d="m3.973 1.8893 6.5887 3.6879h-4.526l-1.8859 3.2605 1.9121 3.306-1.9125 3.7456-4.1369-7.1525 3.9605-6.8475" fill="#0cf"/>
+   <path d="m0.0125 8.7368 4.1373 0.10091 0.11568 0.19788-4.123-0.082887z" fill="url(#d)"/>
+   <path d="m10.562 5.5772-6.5887-3.6879-0.50106 0.9021 4.9947 2.7648z" fill="url(#f)"/>
+   <path d="m6.0029 5.5427 6.7111-3.7832-2.169 3.5579z" fill="url(#e)"/>
+   <path d="m6.0356 5.5772 6.6388-3.6528-2.1127 3.6528z" fill="#0a8"/>
+   <path d="m0.0125 8.7368 6.0231-3.1596-1.8859 3.2605z" fill="#0a8"/>
+   <path d="m0.0125 8.7368 6.0231-3.1596-0.4069-0.6354-5.1908 3.0036z" fill="url(#p)"/>
+   <path d="m6.0356 5.5772-2.0626-3.6879 0.17673 6.9484z" fill="#0a8"/>
+   <path d="m6.0619 12.144 6.6622 3.7456 2.1664-3.7456z" fill="#0cf"/>
+   <path d="m3.973 1.8893-0.50106 0.9021 0.048066 6.0168 0.62973 0.029556z" fill="url(#q)"/>
+   <path d="m4.1498 8.8377-3.1586 1.5811 3.1583 5.4705z" fill="#0a8"/>
+   <path d="m4.1498 8.8377v7.0516l0.77392-1.5077 0.059767-4.1337z" fill="url(#l)"/>
+   <path d="m4.1494 15.889-0.29801-0.53544 1.9191-3.6995 0.29137 0.48935z" fill="url(#h)"/>
+   <path d="m0.99115 10.419 3.1586-1.5811-0.62972-0.029556-2.7405 1.307z" fill="url(#o)"/>
+   <path d="m0.99115 10.419 5.0708 1.7248-1.9121-3.306z" fill="#0a8"/>
+   <path d="m6.0619 12.144-5.0708-1.7248 0.55061 0.94903 4.1672 1.5109z" fill="url(#n)"/>
+   <path d="m6.0619 12.144 6.6622 3.7456 0.79849-1.4187-4.2878-2.3635z" fill="url(#m)"/>
+   <g transform="matrix(.14699 0 0 .14672 -.84757 -.42617)">
+      <circle cx="117.95" cy="75.441" r="9.6894" fill="#0cf"/>
+      <circle cx="118.08" cy="75.341" r="9.6894" fill="url(#k)"/>
+   </g>
+   <g transform="matrix(.14699 0 0 .14672 -.20056 -.74963)">
+      <circle cx="93.138" cy="55.045" r="7.3559" fill="#0cf"/>
+      <circle cx="93.239" cy="54.969" r="7.3559" fill="url(#j)"/>
+   </g>
+   <g transform="matrix(.14699 0 0 .14672 -.17051 -.32616)">
+      <circle cx="103.06" cy="26.657" r="3.7877" fill="#0cf"/>
+      <circle cx="103.11" cy="26.618" r="3.7877" fill="url(#i)"/>
+   </g>
+   <path d="m6.0356 5.5772-2.0626-3.6879 0.52544-0.00742 1.9387 3.4465z" fill="url(#g)"/>
+</svg>

--- a/src/frontend/screens/Settings/components/WineVersionSelector.tsx
+++ b/src/frontend/screens/Settings/components/WineVersionSelector.tsx
@@ -15,6 +15,7 @@ import { faApple } from '@fortawesome/free-brands-svg-icons'
 import Badge from '@mui/material/Badge'
 import { Autorenew as AutorenewIcon } from '@mui/icons-material'
 import GELogo from 'frontend/assets/ge-logo.svg?react'
+import CachyOSLogo from 'frontend/assets/cachyos-logo.svg?react'
 
 interface ListItemProps {
   version: WineInstallation
@@ -36,6 +37,7 @@ export const WineVersionListItem = React.memo(function WineVersionListItem({
         return <FontAwesomeIcon icon={faWineGlass} />
       case 'proton':
         if (name.includes('GE')) return <GELogo />
+        if (name.includes('CachyOS')) return <CachyOSLogo />
         return <ProtonLogo />
       case 'crossover':
         return <CodeweaversLogo />

--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -49,8 +49,8 @@ export default function WineManager(): JSX.Element | null {
   const repositories: WineManagerUISettings[] = useMemo(() => {
     if (isLinux) {
       return [
-        { type: 'GE-Proton', value: 'protonge' },
         { type: 'Proton-CachyOS', value: 'proton-cachyos' },
+        { type: 'GE-Proton', value: 'protonge' },
         { type: 'Wine-GE', value: 'winege' }
       ]
     }


### PR DESCRIPTION
This PR makes Proton-CachyOS the default version shown when opening the Wine Manager and the default when Heroic auto-downloads a Wine version if none are found.  It also adds a logo for it (to be shown in the Wine Version selector).

Latest GE-Proton has issues with launching the EA app (and I believe Ubisoft Connect too?). I understand GE is still working on getting video playback just right, so a new release may take some more time (and there's no guarantee that those issues are fixed then). Defaulting to a version with shortcomings like that seems irresponsible.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
