### PR TITLE
Make GE-Proton downloads deterministic

### DIFF
--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -68,6 +68,25 @@ async function fetchReleases({
               release_data.download = stagingAsset.browser_download_url
               release_data.downsize = stagingAsset.size
             }
+          } else if (type === 'GE-Proton') {
+            // GE-Proton includes aarch64 & x86_64 builds. Find the correct one
+            // based on platform
+            for (const asset of release.assets) {
+              const isAarch64 = asset.name.includes('-aarch64')
+              const isShaChecksum = asset.name.endsWith('.sha512sum')
+              const isTar = asset.name.endsWith('.tar.gz')
+              if (
+                (isAarch64 && process.arch === 'arm64') ||
+                (!isAarch64 && process.arch === 'x64')
+              ) {
+                if (isShaChecksum) {
+                  release_data.checksum = asset.browser_download_url
+                } else if (isTar) {
+                  release_data.download = asset.browser_download_url
+                  release_data.downsize = asset.size
+                }
+              }
+            }
           } else if (type === 'Proton-CachyOS') {
             const shaAsset = release.assets.find((asset) =>
               asset.browser_download_url.endsWith('x86_64.sha512sum')


### PR DESCRIPTION
GE-Proton now ships aarch64 builds. Right now, our Wine Manager happens to pick the x86_64 builds by accident (since they're last in the file list). I don't want to depend on that always being the case, so add explicit filtering (assets are now only considered if they match the current process architecture)

If you happen to have an arm64 Linux machine, you can test this PR by trying to download GE-Proton11-1. It should now pull the correct version. Nothing changed for x86_64.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
