### PR TITLE
[Fix] Prevent install if the lockfile is out of sync with the manifest

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -14,7 +14,7 @@ runs:
       run: pnpm add --global node-gyp
       shell: bash
     - name: Install modules
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
       shell: bash
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'


### PR DESCRIPTION
Add a flag ([https://pnpm.io/cli/install#--frozen-lockfile](https://pnpm.io/cli/install#--frozen-lockfile)) to prevent silent regressions such as [https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5583/changes/6896595cd305e523e0e001374e2fab90d3154ce1
](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5583/changes/6896595cd305e523e0e001374e2fab90d3154ce1
)
