### PR TITLE
Move `sanitize-html` import into the backend

### DIFF
--- a/src/backend/utils/ipc_handler.ts
+++ b/src/backend/utils/ipc_handler.ts
@@ -11,6 +11,7 @@ import {
 import { hasExecutable } from './os/path'
 import { formatSystemInfo, getSystemInfo } from './systeminfo'
 import { isIntelMac } from 'backend/constants/environment'
+import sanitizeHtml from 'sanitize-html'
 
 addListener('abort', (event, id) => {
   callAbortController(id)
@@ -32,3 +33,12 @@ addHandler('hasExecutable', async (event, executable) => {
 addHandler('isIntelMac', () => {
   return isIntelMac
 })
+
+addHandler('sanitizeHtml', (_e, input, options) =>
+  sanitizeHtml(
+    input,
+    options ?? {
+      disallowedTagsMode: 'discard'
+    }
+  )
+)

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -50,6 +50,7 @@ import type { GOGCloudSavesLocation, UserData } from './gog'
 import type { NileLoginData, NileRegisterData, NileUserData } from './nile'
 import type { GameOverride, SelectiveDownload } from './legendary'
 import type { GetLogFileArgs } from 'backend/logger/paths'
+import type { IOptions as SanitizeHtmlOptions } from 'sanitize-html'
 
 // ts-prune-ignore-next
 interface SyncIPCFunctions {
@@ -351,6 +352,7 @@ interface AsyncIPCFunctions {
   ) => Promise<CatalogProduct[]>
   getGmgDiscounts: (currencyCode?: string) => Promise<CatalogProduct[]>
   getHumbleDiscounts: (currencyCode?: string) => Promise<CatalogProduct[]>
+  sanitizeHtml: (input: string, options?: SanitizeHtmlOptions) => string
   'steamgriddb.hasApiKey': () => Promise<boolean>
   'steamgriddb.setApiKey': (key: string) => Promise<void>
   'steamgriddb.searchGame': (

--- a/src/frontend/screens/Game/GameChangeLog/index.tsx
+++ b/src/frontend/screens/Game/GameChangeLog/index.tsx
@@ -1,10 +1,9 @@
-import { useMemo } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Dialog,
   DialogContent,
   DialogHeader
 } from 'frontend/components/UI/Dialog'
-import sanitizeHtml from 'sanitize-html'
 import { useTranslation } from 'react-i18next'
 
 interface GameChangeLogProps {
@@ -19,12 +18,17 @@ export default function GameChangeLog({
   backdropClick
 }: GameChangeLogProps) {
   const { t } = useTranslation('gamepage')
-  const santiziedChangeLog = useMemo(() => {
-    const sanitized = sanitizeHtml(changelog, {
-      disallowedTagsMode: 'discard'
-    })
-    return { __html: sanitized }
+  const [sanitizedChangelog, setSanitizedChangelog] = useState<{
+    __html: string
+  } | null>(null)
+
+  useEffect(() => {
+    void window.api
+      .sanitizeHtml(changelog)
+      .then((output) => setSanitizedChangelog({ __html: output }))
   }, [changelog])
+
+  if (!sanitizedChangelog) return <></>
 
   return (
     <Dialog showCloseButton onClose={backdropClick}>
@@ -35,7 +39,7 @@ export default function GameChangeLog({
       </DialogHeader>
       <DialogContent className="changelogModalContent">
         <div
-          dangerouslySetInnerHTML={santiziedChangeLog}
+          dangerouslySetInnerHTML={sanitizedChangelog}
           className={'gameChangeLog'}
         />
       </DialogContent>

--- a/src/preload/api/misc.ts
+++ b/src/preload/api/misc.ts
@@ -112,3 +112,4 @@ export const steamgriddb = {
   getGrids: makeHandlerInvoker('steamgriddb.getGrids'),
   getHeroes: makeHandlerInvoker('steamgriddb.getHeroes')
 }
+export const sanitizeHtml = makeHandlerInvoker('sanitizeHtml')


### PR DESCRIPTION
To quote [their README](https://github.com/apostrophecms/apostrophe/tree/main/packages/sanitize-html#requirements)

> sanitize-html is intended for use with Node.js

Importing it in the Frontend lead to a lot of warnings about unavailable modules. It still *worked*, but it might not continue to work, and those warnings were just rather annoying

The Frontend part of this is a little messy. I would've loved to use `useAwaited` here, but that'd need the same changes I made in 0bd1edd9362f666cdcf03723acc34aed16ec281c, and I didn't want to unleash that merge conflict onto future me

---

To test:

Open Heroic with the dev console enabled. On `main`: Observe a lot of warnings about modules being externalized. On this branch: Observe the warnings no longer appearing.

Open the changelog for any GOG game. Observe the changelog still appearing like before (that was the one use we had of this dependency).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
