### PR TITLE
Remove dead code: unused localStorage key and calculatePercent in hasProgress

### DIFF
--- a/src/frontend/hooks/hasProgress.ts
+++ b/src/frontend/hooks/hasProgress.ts
@@ -1,39 +1,13 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { InstallProgress, Runner } from 'common/types'
 import { useInstallProgress } from 'frontend/state/InstallProgress'
 
-const storage: Storage = window.localStorage
-
 export const hasProgress = (appName: string, runner: Runner) => {
-  const [previousProgress] = useState<InstallProgress>(
-    JSON.parse(
-      storage.getItem(`${appName}_${runner}_progress`) || '{}'
-    ) as InstallProgress
-  )
-
-  const [currentProgress, setProgress] = useState<InstallProgress>(
-    previousProgress ?? {
-      bytes: '0.00MB',
-      eta: '00:00:00',
-      percent: 0
-    }
-  )
-
-  const calculatePercent = useCallback(
-    (newProgress: InstallProgress) => {
-      // current/100 * (100-heroic_stored) + heroic_stored
-      if (newProgress.percent && previousProgress.percent) {
-        const currentPercent = newProgress.percent
-        const storedPercent = previousProgress.percent
-        const newPercent: number = Math.round(
-          (currentPercent / 100) * (100 - storedPercent) + storedPercent
-        )
-        return newPercent
-      }
-      return newProgress.percent
-    },
-    [previousProgress]
-  )
+  const [currentProgress, setProgress] = useState<InstallProgress>({
+    bytes: '0.00MB',
+    eta: '00:00:00',
+    percent: 0
+  })
 
   const installationProgress = useInstallProgress(
     (state) => state[`${appName}_${runner}`]
@@ -42,18 +16,9 @@ export const hasProgress = (appName: string, runner: Runner) => {
   useEffect(() => {
     if (installationProgress) {
       if (currentProgress.percent !== installationProgress.percent)
-        setProgress({
-          ...installationProgress,
-          percent: calculatePercent(installationProgress)
-        })
+        setProgress(installationProgress)
     }
-  }, [
-    installationProgress,
-    appName,
-    runner,
-    calculatePercent,
-    currentProgress.percent
-  ])
+  }, [installationProgress, appName, runner, currentProgress.percent])
 
-  return [currentProgress, previousProgress]
+  return [currentProgress]
 }

--- a/src/frontend/screens/Game/GamePage/index.tsx
+++ b/src/frontend/screens/Game/GamePage/index.tsx
@@ -111,7 +111,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
   const { status, folder, statusContext } = hasStatus(gameInfo)
   const gameAvailable = gameInfo.is_installed && status !== 'notAvailable'
 
-  const [progress, previousProgress] = hasProgress(appName, runner)
+  const [progress] = hasProgress(appName, runner)
 
   const [extraInfo, setExtraInfo] = useState<ExtraInfo | null>(
     gameInfo.extra || null
@@ -621,7 +621,7 @@ export default React.memo(function GamePage(): JSX.Element | null {
       gameInfo,
       installPath: folder,
       isInstalling,
-      previousProgress,
+      previousProgress: null,
       progress,
       t,
       showDialogModal: showDialogModal

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -136,7 +136,7 @@ const GameCard = ({
   const isInstallable =
     gameInfo.installable === undefined || gameInfo.installable // If it's undefined we assume it's installable
 
-  const [progress, previousProgress] = hasProgress(appName, runner)
+  const [progress] = hasProgress(appName, runner)
   const { install_size: size = '0' } = {
     ...gameInstallInfo
   }
@@ -572,7 +572,7 @@ const GameCard = ({
         gameInfo,
         installPath: folder || 'default',
         isInstalling,
-        previousProgress,
+        previousProgress: null,
         progress,
         t,
         showDialogModal


### PR DESCRIPTION
## Summary

- Removed dead `localStorage.getItem` for key `${appName}_${runner}_progress` — this key was **never written** anywhere in the codebase, so `previousProgress` was always `{}`
- Removed `calculatePercent` (`useCallback`) — its condition (`previousProgress.percent`) was never truthy, so it never modified the percent value
- Simplified `hasProgress` hook to return only `[currentProgress]`
- Updated `GameCard` and `GamePage` (the only consumers of the 2nd tuple element) to pass `previousProgress: null` to `install()`, which already accepts `InstallProgress | null`

## What this removes

1. A redundant `localStorage.getItem` + `JSON.parse` on every mount — since `useState` was used in its eager initializer form, this ran on every mount of every component using `hasProgress`
2. ~35 lines of dead code including `calculatePercent` and its `useCallback` wrapper
3. A misleading API where the 2nd return element was always `{}`

## Test plan

- [x] `pnpm run codecheck` (tsc --noEmit) — 0 errors
- [x] `pnpm run lint` — 0 errors (961 pre-existing warnings)
- [x] `pnpm run test` — 134/134 tests passed
- [x] Behavior is functionally identical: `install()` with `previousProgress: null` skips the folder comparison (line 84 of library.ts), same as with `{}` which had no `.folder` property

Closes #5702