### PR TITLE
update Spanish language code to es-ES for Epic API requests

### DIFF
--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -168,6 +168,9 @@ export default class LegendaryGame implements Game {
     if (lang === 'zh_Hans') {
       lang = 'zh-CN'
     }
+    if (lang === 'es') {
+      lang = 'es-ES'
+    }
 
     const epicUrl = `https://store-content.ak.epicgames.com/api/${lang}/content/products/${slug}`
 


### PR DESCRIPTION
The Spanish language (es) wasn't being formatted correctly for the Legendary API. This caused it to return English text (en) instead of Spanish.

This PR simply adds the mapping following the format used for other languages.


## HOW TO TEST

Go to the library
Enter a game's page
The description should be in Spanish

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
