### PR TITLE
Switch GOG user APIs

### DIFF
--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -1328,10 +1328,10 @@ export default class GOGGame implements Game {
       session_date: sessionDate,
       time
     }
-    const userData: UserData | undefined = configStore.get_nodefault('userData')
+    const credentials = await GOGUser.getCredentials()
 
-    if (!userData) {
-      logWarning(['Unable to post session, userData not present'], {
+    if (!credentials) {
+      logWarning(['Unable to post session, credentials not present'], {
         prefix: LogPrefix.Gog
       })
       return
@@ -1341,9 +1341,9 @@ export default class GOGGame implements Game {
       logWarning(['App offline, unable to post new session at this time'], {
         prefix: LogPrefix.Gog
       })
-      const alreadySetData = playtimeSyncQueue.get(userData.galaxyUserId, [])
+      const alreadySetData = playtimeSyncQueue.get(credentials.user_id, [])
       alreadySetData.push({ ...data, appName: this.id })
-      playtimeSyncQueue.set(userData.galaxyUserId, alreadySetData)
+      playtimeSyncQueue.set(credentials.user_id, alreadySetData)
       runOnceWhenOnline(() => libraryManagerMap['gog'].syncQueuedPlaytime())
       return
     }
@@ -1357,9 +1357,9 @@ export default class GOGGame implements Game {
 
     if (!response || response.status !== 201) {
       logError('Failed to post session', { prefix: LogPrefix.Gog })
-      const alreadySetData = playtimeSyncQueue.get(userData.galaxyUserId, [])
+      const alreadySetData = playtimeSyncQueue.get(credentials.user_id, [])
       alreadySetData.push({ ...data, appName: this.id })
-      playtimeSyncQueue.set(userData.galaxyUserId, alreadySetData)
+      playtimeSyncQueue.set(credentials.user_id, alreadySetData)
       return
     }
 
@@ -1371,14 +1371,13 @@ export default class GOGGame implements Game {
       return
     }
     const credentials = await GOGUser.getCredentials()
-    const userData: UserData | undefined = configStore.get_nodefault('userData')
 
-    if (!credentials || !userData) {
+    if (!credentials) {
       return
     }
     const response = await axios
       .get(
-        `https://gameplay.gog.com/games/${this.id}/users/${userData?.galaxyUserId}/sessions`,
+        `https://gameplay.gog.com/games/${this.id}/users/${credentials.user_id}/sessions`,
         {
           headers: {
             Authorization: `Bearer ${credentials.access_token}`

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -24,7 +24,6 @@ import {
   GOGCredentials,
   GOGv1Manifest,
   GOGv2Manifest,
-  UserData,
   GOGSessionSyncQueueItem
 } from 'common/types/gog'
 import { dirname, join } from 'node:path'
@@ -45,7 +44,6 @@ import {
   installInfoStore,
   apiInfoCache,
   privateBranchesStore,
-  configStore,
   playtimeSyncQueue
 } from './electronStores'
 import { callRunner } from '../../launcher'
@@ -170,14 +168,14 @@ export default class GOGLibraryManager implements LibraryManager {
     if (playtimeSyncQueue.has('lock')) {
       return
     }
-    const userData: UserData | undefined = configStore.get_nodefault('userData')
-    if (!userData) {
-      logError('Unable to syncQueued playtime, userData not present', {
+    const credentials = await GOGUser.getCredentials()
+    if (!credentials) {
+      logError('Unable to syncQueued playtime, credentials not present', {
         prefix: LogPrefix.Gog
       })
       return
     }
-    const queue = playtimeSyncQueue.get(userData.galaxyUserId, [])
+    const queue = playtimeSyncQueue.get(credentials.user_id, [])
     if (queue.length === 0) {
       return
     }
@@ -195,7 +193,7 @@ export default class GOGLibraryManager implements LibraryManager {
         failed.push(session)
       }
     }
-    playtimeSyncQueue.set(userData.galaxyUserId, failed)
+    playtimeSyncQueue.set(credentials.user_id, failed)
     playtimeSyncQueue.delete('lock')
     logInfo(
       [
@@ -214,13 +212,6 @@ export default class GOGLibraryManager implements LibraryManager {
     time,
     appName
   }: GOGSessionSyncQueueItem) {
-    const userData: UserData | undefined = configStore.get_nodefault('userData')
-    if (!userData) {
-      logError('No userData, unable to post new session', {
-        prefix: LogPrefix.Gog
-      })
-      return null
-    }
     const credentials = await GOGUser.getCredentials().catch(() => null)
 
     if (!credentials) {
@@ -232,7 +223,7 @@ export default class GOGLibraryManager implements LibraryManager {
 
     return axios
       .post(
-        `https://gameplay.gog.com/games/${appName}/users/${userData?.galaxyUserId}/sessions`,
+        `https://gameplay.gog.com/games/${appName}/users/${credentials.user_id}/sessions`,
         { session_date, time },
         {
           headers: {

--- a/src/backend/storeManagers/gog/user.ts
+++ b/src/backend/storeManagers/gog/user.ts
@@ -60,7 +60,7 @@ export class GOGUser {
     return { status: 'done', data: userDetails }
   }
 
-  public static async getUserDetails() {
+  public static async getUserDetails(): Promise<UserData | undefined> {
     if (!isOnline()) {
       logError('Unable to login information, Heroic offline', LogPrefix.Gog)
       return
@@ -76,7 +76,7 @@ export class GOGUser {
       return
     }
     const response = await axios
-      .get(`https://embed.gog.com/userData.json`, {
+      .get(`https://users.gog.com/users/${user.user_id}`, {
         headers: {
           Authorization: `Bearer ${user.access_token}`,
           'User-Agent': `HeroicGamesLauncher/${app.getVersion()}`
@@ -91,9 +91,6 @@ export class GOGUser {
     }
 
     const data: UserData = response.data
-
-    //Exclude email, it won't be needed
-    delete data.email
 
     configStore.set('userData', data)
     logInfo('Saved username to config file', LogPrefix.Gog)

--- a/src/common/types/gog.ts
+++ b/src/common/types/gog.ts
@@ -149,61 +149,47 @@ export type SaveFolderVariable =
   | 'DOCUMENTS'
   | 'APPLICATION_SUPPORT'
 
-// Data returned from https://embed.gog.com/userData.json
+// Data returned from https://users.gog.com/users/${user_id}
 export interface UserData {
-  country: string
-  currencies: Currency[]
-  selectedCurrency: Currency
-  preferredLanguage: {
-    code: string
-    name: string
-  }
-  ratingBrand: string
-  isLoggedIn: true
-  checksum: {
-    cart: string | null
-    games: string | null
-    wishlist: string | null
-    reviews_votes: string | null
-    games_rating: string | null
-  }
-  updates: {
-    messages: number
-    pendingFriendRequests: number
-    unreadChatMessages: number
-    products: number
-    total: number
-  }
-  userId: string
+  id: string
   username: string
-  galaxyUserId: string
-  email?: string
-  // NOTE: This URL doesn't seem to work?
-  avatar: string
-  walletBalancy: {
-    currency: string
-    amount: number
-  }
-  purchasedItems: {
-    games: number
-    movies: number
-  }
-  whishlistedItems: number
-  friends: Friend[]
-  personalizedProductPrices: []
-  personalizedSeriesPrices: []
+  // ISO 8601 date and time with offset
+  created_date: string
+  avatar: UserAvatar
+  is_employee: boolean
+  tags: string[]
+  email: string
+  email_sha256_hash: string
+  roles: string[]
+  status: number
+  checksum: string
+  settings: UserSettings
+  password_set: boolean
+  marketing_consent: boolean
 }
 
-interface Currency {
-  code: string
-  symbol: string
+interface UserAvatar {
+  gog_image_id: string
+  small: string
+  small_2x: string
+  medium: string
+  medium_2x: string
+  large: string
+  large_2x: string
+  sdk_img_32: string
+  sdk_img_64: string
+  sdk_img_184: string
+  menu_small: string
+  menu_small_2: string
+  menu_big: string
+  menu_big_2: string
 }
 
-interface Friend {
-  username: string
-  userSince: number
-  galaxyId: string
-  avatar: string
+interface UserSettings {
+  allow_to_be_invited_by: 'anyone' | 'friend' | 'nobody'
+  allow_to_be_searched: boolean
+  use_two_step_authentication: boolean
+  use_two_factor_authentication: boolean
 }
 
 // Data returned by https://gamesdb.gog.com/platforms/$PLATFORM/external_releases/$APP_ID


### PR DESCRIPTION
Use `https://users.gog.com/users/<user id>` instead of `https://embed.gog.com/userData.json`

This is the API GOG Galaxy uses, and it includes very little data we don't need (userData was failing for one user with a very large wishlist)

We used to use two properties of `UserData`:
- `galaxyUserId`: This is just `GOGCredentials.user_id`, so usage was switched to that
- `username`: Included with the new data, no change necessary

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
