### PR TITLE
[Fix] Make Wine manager CPU architecture aware

### DIFF
--- a/src/backend/constants/environment.ts
+++ b/src/backend/constants/environment.ts
@@ -24,6 +24,7 @@ export const isMac = process.platform === 'darwin'
 export const isIntelMac = isMac && cpus()[0].model.includes('Intel') // so we can have different behavior for Intel Mac
 export const isWindows = process.platform === 'win32'
 export const isLinux = process.platform === 'linux'
+export const cpuArch = process.arch
 export const isSteamDeckGameMode =
   process.env.XDG_CURRENT_DESKTOP === 'gamescope'
 const isSteamDeckDesktopMode =

--- a/src/backend/wine/manager/downloader/utilities.ts
+++ b/src/backend/wine/manager/downloader/utilities.ts
@@ -3,7 +3,7 @@ import { spawnSync } from 'child_process'
 
 import { VersionInfo, Type, type WineManagerStatus } from 'common/types'
 import { axiosClient, extractFiles } from 'backend/utils'
-import { isMac } from 'backend/constants/environment'
+import { isMac, cpuArch } from 'backend/constants/environment'
 
 interface fetchProps {
   url: string
@@ -69,24 +69,26 @@ async function fetchReleases({
               release_data.downsize = stagingAsset.size
             }
           } else if (type === 'Proton-CachyOS') {
+            const archPrefix = cpuArch === 'arm64' ? 'arm64' : 'x86_64'
             const shaAsset = release.assets.find((asset) =>
-              asset.browser_download_url.endsWith('x86_64.sha512sum')
+              asset.browser_download_url.endsWith(`${archPrefix}.sha512sum`)
             )
             if (shaAsset) release_data.checksum = shaAsset.browser_download_url
             const tarAsset = release.assets.find((asset) =>
-              asset.browser_download_url.endsWith('x86_64.tar.xz')
+              asset.browser_download_url.endsWith(`${archPrefix}.tar.xz`)
             )
             if (tarAsset) {
               release_data.download = tarAsset.browser_download_url
               release_data.downsize = tarAsset.size
             }
           } else {
+            const archPrefix = cpuArch === 'arm64' ? 'aarch64' : ''
             for (const asset of release.assets) {
-              if (asset.name.endsWith('sha512sum')) {
+              if (asset.name.endsWith(`${archPrefix}.sha512sum`)) {
                 release_data.checksum = asset.browser_download_url
               } else if (
-                asset.name.endsWith('tar.gz') ||
-                asset.name.endsWith('tar.xz')
+                asset.name.endsWith(`${archPrefix}.tar.gz`) ||
+                asset.name.endsWith(`${archPrefix}.tar.xz`)
               ) {
                 release_data.download = asset.browser_download_url
                 release_data.downsize = asset.size


### PR DESCRIPTION
Now that Proton also runs natively on ARM64, we should take special care in downloading Wine versions depending on the CPU architecture. This commit ensures that running Heroic on ARM64 machines only fetches ARM64 builds of Proton.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
