### PR TITLE
 [Fix] patch extract-zip dependency to mitigate CVE-2026-56876 (Symlink Path Traversal)

### DIFF
--- a/patches/extract-zip@2.0.1.patch
+++ b/patches/extract-zip@2.0.1.patch
@@ -1,0 +1,31 @@
+diff --git a/index.js b/index.js
+index 23384ea16bb848616886f356d8d69f94325535bf..91c4a60e341b5ffb9793f941f9f86c5d303d76d8 100644
+--- a/index.js
++++ b/index.js
+@@ -125,10 +125,22 @@ class Extractor {
+     const readStream = await promisify(this.zipfile.openReadStream.bind(this.zipfile))(entry)
+ 
+     if (symlink) {
+-      const link = await getStream(readStream)
+-      debug('creating symlink', link, dest)
+-      await fs.symlink(link, dest)
+-    } else {
++      let link = await getStream(readStream)
++      link = link.toString().trim()
++
++      // --- CVE-2026-56876 Fix ---
++      const symlinkDir = path.dirname(dest)
++      const absoluteTarget = path.resolve(symlinkDir, link)
++      const safeDir = this.opts.dir
++
++      if (!absoluteTarget.startsWith(safeDir + path.sep) && absoluteTarget !== safeDir) {
++        throw new Error(`Out of bound symlink target "${absoluteTarget}" found while processing symlink ${entry.fileName}`)
++      }
++      // --- END OF FIX ---
++
++       debug('creating symlink', link, dest)
++       await fs.symlink(link, dest)
++     } else {
+       await pipeline(readStream, createWriteStream(dest, { mode: procMode }))
+     }
+   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ patchedDependencies:
   '@types/node@22.19.3':
     hash: 8c1b2354f08e74aa2381e5f6c314a45bb82ae9f8763bf63f0e1b6797e9232831
     path: patches/@types__node@22.19.3.patch
+  extract-zip@2.0.1:
+    hash: 4dfae9c4338fd843cbc6f7dd7d3bd371de07584a152c2c983c2f72ae959c336a
+    path: patches/extract-zip@2.0.1.patch
 
 importers:
 
@@ -9652,7 +9655,7 @@ snapshots:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 16.18.126
-      extract-zip: 2.0.1
+      extract-zip: 2.0.1(patch_hash=4dfae9c4338fd843cbc6f7dd7d3bd371de07584a152c2c983c2f72ae959c336a)
     transitivePeerDependencies:
       - supports-color
 
@@ -10070,7 +10073,7 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extract-zip@2.0.1:
+  extract-zip@2.0.1(patch_hash=4dfae9c4338fd843cbc6f7dd7d3bd371de07584a152c2c983c2f72ae959c336a):
     dependencies:
       debug: 4.4.3
       get-stream: 5.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,3 @@
-patchedDependencies:
-  '@types/node@22.19.3': patches/@types__node@22.19.3.patch
-
 onlyBuiltDependencies:
   - '@fortawesome/fontawesome-common-types'
   - '@fortawesome/fontawesome-svg-core'
@@ -12,3 +9,7 @@ onlyBuiltDependencies:
   - esbuild
   - register-scheme
   - unrs-resolver
+
+patchedDependencies:
+  '@types/node@22.19.3': patches/@types__node@22.19.3.patch
+  extract-zip@2.0.1: patches/extract-zip@2.0.1.patch


### PR DESCRIPTION
This PR introduces a patch to the `extract-zip` dependency to address **CVE-2026-56876**, an arbitrary file write/read vulnerability caused by unvalidated symlink targets during zip extraction.

Upon investigating the upstream extract-zip repository, I noticed it hasn't received any updates in about 6 years and appears to be abandoned. Since an official upstream release fixing this CVE is highly unlikely, applying a local pnpm patch is the safest and most immediate solution to protect Heroic's users.

### The Issue
Currently, `extract-zip` does not validate the target path of symlinks inside zip archives. If a malicious zip file contains a symlink with a relative path (e.g., `../../../../etc/passwd`), `extract-zip` will extract it without validation, allowing the symlink to point outside the intended extraction directory. 

### The Solution
This patch intercepts the symlink creation process and resolves the absolute path of the symlink target. It then verifies if the resolved target stays within the boundaries of the intended extraction directory (`this.opts.dir`). If it attempts to escape the directory, the extraction throws an `Out of bound symlink target` error, successfully blocking the path traversal exploit.

### Security Impact
Since Heroic Games Launcher handles zip extractions (for tools, updates, or game components), mitigating this vulnerability at the dependency level ensures that malicious archives cannot compromise the user's system via directory traversal.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
