### PR TITLE
[Fix] Validate and normalize gogInfo folder_name

### DIFF
--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -723,6 +723,23 @@ export default class GOGLibraryManager implements LibraryManager {
       )
       return
     }
+    
+    // Validate external data before using it
+    const folderName = gogInfo.folder_name?.trim()
+
+    if (!folderName) {
+      logWarning(
+        [
+          'Invalid GOG install info: missing or empty folder_name',
+          { appName }
+        ],
+        LogPrefix.Gog
+      )
+      return
+    }
+
+    // Normalize data for safe use downstream
+    gogInfo.folder_name = folderName
 
     let libraryArray = libraryStore.get('games', [])
     let gameObjectIndex = libraryArray.findIndex(


### PR DESCRIPTION
Validate external data in gogInfo for folder_name. Assigns the trimmed folder_name for use downstream to prevent storage of undefined / empty values.

If the data validation fails, the function is ended. This prevents invalid data from being cached. The failed function also redirects the user to the Error: Cannot get game info screen. The user can then refresh their library, clear the cache, or reset Heroic.

This should resolve bugs like the ones reported below:

game info folder is undefined
https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2954

When GOG's cached install info is invalid, we should ignore the cache
https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5475

Unable to install The Binding of Isaac: Rebirth 
https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5579

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
