### PR TITLE
[Tech] Point Plausible analytics to the self-hosted instance

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -24,7 +24,7 @@
         "enable": "Enable",
         "info": {
             "pt1": "In order to improve the app, Heroic collects 100% anonymous data.",
-            "pt2": "Heroic uses the open-source Plausible Analytics platform to gather basic data: App Version, OS, Stores Connected and Country.",
+            "pt2": "Heroic uses the open-source Plausible Analytics platform, self-hosted by the Heroic team, to gather basic data: App Version, OS, System Architecture, Linux Distribution, Stores Connected and Country.",
             "pt3": "It will never collect any personal information, including your username, IP address or email.",
             "pt4": "This data is used to give us insights on what to focus on next due to our limited resources and user feedback.",
             "pt5": "Plausible Analytics is fully compliant with GDPR, CCPA and PECR.",

--- a/src/backend/utils/plausible.ts
+++ b/src/backend/utils/plausible.ts
@@ -16,11 +16,29 @@ import { app } from 'electron'
 import https from 'https'
 
 const PLAUSIBLE_DOMAIN = 'heroic-games-client.com'
-const PLAUSIBLE_API = 'https://plausible.io/api/event'
+const PLAUSIBLE_API = 'https://analytics.heroicgameslauncher.com/api/event'
 
 interface PlausibleEventProps {
   [key: string]: string | number | boolean
 }
+
+// A browser-like User-Agent lets Plausible parse the OS natively from the
+// request instead of us sending it as a custom property.
+function getUserAgent(): string {
+  const chromeVersion = process.versions.chrome || '120.0.0.0'
+  const engine = `AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`
+
+  switch (process.platform) {
+    case 'win32':
+      return `Mozilla/5.0 (Windows NT 10.0; Win64; x64) ${engine}`
+    case 'darwin':
+      return `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ${engine}`
+    default:
+      return `Mozilla/5.0 (X11; Linux x86_64) ${engine}`
+  }
+}
+
+const USER_AGENT = getUserAgent()
 
 function sendPlausible(payload: object): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -31,7 +49,7 @@ function sendPlausible(payload: object): Promise<void> {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'User-Agent': 'HeroicGamesLauncher/1.0'
+          'User-Agent': USER_AGENT
         }
       },
       (res) => {
@@ -103,6 +121,8 @@ export async function startPlausible() {
     )
   }
 
+  // OS is parsed natively from the User-Agent and Country from the request IP,
+  // so only what Plausible can't derive on its own is sent as custom props.
   const props = {
     version: appVersion,
     gog: providersObject.gog || false,
@@ -110,7 +130,6 @@ export async function startPlausible() {
     amazon: providersObject.amazon || false,
     sideloaded: providersObject.sideloaded || false,
     providers: loggedInProviders.join(', '),
-    OS: process.platform,
     arch: process.arch,
     distro,
     distroVersion,
@@ -121,13 +140,9 @@ export async function startPlausible() {
     isSteamDeck: !!isSteamDeck
   }
 
-  if (process.platform) {
-    logInfo('Starting Plausible Analytics', LogPrefix.Backend)
-    logInfo(`Shared Data: ${JSON.stringify(props)}`, LogPrefix.Backend)
-    plausible.trackEvent('App Loaded', {
-      props
-    })
-  }
+  logInfo('Starting Plausible Analytics', LogPrefix.Backend)
+  logInfo(`Shared Data: ${JSON.stringify(props)}`, LogPrefix.Backend)
+  plausible.trackEvent('App Loaded', { props })
 }
 
 backendEvents.on('settingChanged', ({ key, newValue }) => {

--- a/src/frontend/screens/Settings/components/AnalyticsDialog.tsx
+++ b/src/frontend/screens/Settings/components/AnalyticsDialog.tsx
@@ -30,7 +30,7 @@ export default function AnalyticsDialog() {
               <li>
                 {t(
                   'analyticsModal.info.pt2',
-                  'Heroic uses the open-source Plausible Analytics platform to gather basic data: App Version, OS, System Architecture, Linux Distribution, Stores Connected and Country.'
+                  'Heroic uses the open-source Plausible Analytics platform, self-hosted by the Heroic team, to gather basic data: App Version, OS, System Architecture, Linux Distribution, Stores Connected and Country.'
                 )}
               </li>
               <li>


### PR DESCRIPTION
## What

Moves Plausible Analytics from the public `plausible.io` cloud to the Heroic team's **self-hosted** instance at `analytics.heroicgameslauncher.com`.

## Changes

- **Self-hosted endpoint** — events now POST to `https://analytics.heroicgameslauncher.com/api/event`.
- **Native OS detection** — instead of sending the operating system as a custom property, we now send a browser-like `User-Agent` so Plausible parses the OS natively into its built-in "Operating System" report. Country is likewise derived natively from the request IP (and discarded/anonymized by Plausible).
- **Custom props kept only where necessary** — `arch`, `distro` and `distroVersion` remain custom properties because Plausible has no native dimension for them. All other system info (stores connected, packaging format, Steam Deck, app version) is unchanged.
- **Consent dialog** — updated to state that Plausible is self-hosted by the Heroic team.

## Notes

The integration remains 100% backend-side and opt-in; no browser script tag is used. The site domain stays `heroic-games-client.com` for data continuity.