### PR TITLE
Respect "device sleep time" when calculating playtime

### DIFF
--- a/flatpak/templates/com.heroicgameslauncher.hgl.yml.template
+++ b/flatpak/templates/com.heroicgameslauncher.hgl.yml.template
@@ -64,6 +64,7 @@ finish-args:
   - --system-talk-name=org.freedesktop.UDisks2
   - --talk-name=org.kde.StatusNotifierWatcher
   - --system-talk-name=org.freedesktop.UPower
+  - --system-talk-name=org.freedesktop.login1
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.freedesktop.Notifications
   - --env=TZ=

--- a/src/backend/__tests__/playtime_recovery.test.ts
+++ b/src/backend/__tests__/playtime_recovery.test.ts
@@ -34,7 +34,8 @@ const mockActiveStore = activeSessionsStore as unknown as {
 const mockTsStoreSet = tsStore.set as unknown as jest.Mock
 const mockTsStoreGet = tsStore.get as unknown as jest.Mock
 const mockGogGetGame = libraryManagerMap.gog.getGame as unknown as jest.Mock
-const mockLegendaryGetGame = libraryManagerMap.legendary.getGame as unknown as jest.Mock
+const mockLegendaryGetGame = libraryManagerMap.legendary
+  .getGame as unknown as jest.Mock
 const mockLogError = logError as unknown as jest.Mock
 
 const mockGogGame = { updatePlaytime: jest.fn() }
@@ -83,9 +84,15 @@ describe('recoverOrphanedSessions', () => {
 
     await recoverOrphanedSessions()
 
-    expect(mockTsStoreSet).toHaveBeenCalledWith('1511366207.lastPlayed', checkpointAt)
+    expect(mockTsStoreSet).toHaveBeenCalledWith(
+      '1511366207.lastPlayed',
+      checkpointAt
+    )
     expect(mockTsStoreSet).toHaveBeenCalledWith('1511366207.totalPlayed', 15)
-    expect(mockGogGame.updatePlaytime).toHaveBeenCalledWith(new Date(ISO_START), 5)
+    expect(mockGogGame.updatePlaytime).toHaveBeenCalledWith(
+      new Date(ISO_START),
+      5
+    )
     expect(mockActiveStore.delete).toHaveBeenCalledWith('1511366207')
   })
 
@@ -147,7 +154,10 @@ describe('recoverOrphanedSessions', () => {
 
     // active = 10 - 4 = 6m
     expect(mockTsStoreSet).toHaveBeenCalledWith('1511366207.totalPlayed', 6)
-    expect(mockGogGame.updatePlaytime).toHaveBeenCalledWith(new Date(ISO_START), 6)
+    expect(mockGogGame.updatePlaytime).toHaveBeenCalledWith(
+      new Date(ISO_START),
+      6
+    )
   })
 
   test('unknown runner: outer catch fires, activeSessionsStore.delete still runs', async () => {
@@ -168,7 +178,9 @@ describe('recoverOrphanedSessions', () => {
 
     expect(mockActiveStore.delete).toHaveBeenCalledWith('weird-game')
     expect(mockLogError).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to finalize orphaned session for weird-game'),
+      expect.stringContaining(
+        'Failed to finalize orphaned session for weird-game'
+      ),
       'Backend'
     )
   })
@@ -232,7 +244,9 @@ describe('recoverOrphanedSessions', () => {
     expect(mockActiveStore.delete).toHaveBeenCalledWith('game-b')
     expect(mockGogGame.updatePlaytime).toHaveBeenCalledTimes(2)
     expect(mockLogError).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to enqueue orphaned gog session for game-a'),
+      expect.stringContaining(
+        'Failed to enqueue orphaned gog session for game-a'
+      ),
       'Backend'
     )
   })

--- a/src/backend/__tests__/playtime_recovery.test.ts
+++ b/src/backend/__tests__/playtime_recovery.test.ts
@@ -1,0 +1,239 @@
+jest.mock('../constants/key_value_stores', () => ({
+  activeSessionsStore: {
+    raw_store: {},
+    delete: jest.fn()
+  },
+  tsStore: {
+    set: jest.fn(),
+    get: jest.fn()
+  }
+}))
+
+jest.mock('../storeManagers', () => ({
+  libraryManagerMap: {
+    gog: { getGame: jest.fn() },
+    legendary: { getGame: jest.fn() }
+  }
+}))
+
+jest.mock('../logger', () => ({
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+  LogPrefix: { Backend: 'Backend' }
+}))
+
+import { activeSessionsStore, tsStore } from '../constants/key_value_stores'
+import { libraryManagerMap } from '../storeManagers'
+import { logError } from '../logger'
+import { recoverOrphanedSessions } from '../playtime_recovery'
+
+const mockActiveStore = activeSessionsStore as unknown as {
+  raw_store: Record<string, unknown>
+  delete: jest.Mock
+}
+const mockTsStoreSet = tsStore.set as unknown as jest.Mock
+const mockTsStoreGet = tsStore.get as unknown as jest.Mock
+const mockGogGetGame = libraryManagerMap.gog.getGame as unknown as jest.Mock
+const mockLegendaryGetGame = libraryManagerMap.legendary.getGame as unknown as jest.Mock
+const mockLogError = logError as unknown as jest.Mock
+
+const mockGogGame = { updatePlaytime: jest.fn() }
+const mockLegendaryGame = {}
+
+const ISO_START = '2026-07-06T14:00:00.000Z'
+
+const makeCheckpointAt = (minutesAfterStart: number): string =>
+  new Date(Date.parse(ISO_START) + minutesAfterStart * 60_000).toISOString()
+
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve))
+
+describe('recoverOrphanedSessions', () => {
+  beforeEach(() => {
+    mockActiveStore.raw_store = {}
+    mockActiveStore.delete.mockClear()
+    mockTsStoreSet.mockClear()
+    mockTsStoreGet.mockClear().mockReturnValue(0)
+    mockGogGetGame.mockClear().mockReturnValue(mockGogGame)
+    mockLegendaryGetGame.mockClear().mockReturnValue(mockLegendaryGame)
+    mockGogGame.updatePlaytime.mockClear().mockResolvedValue(undefined)
+    mockLogError.mockClear()
+  })
+
+  test('empty store: no writes, no deletes, returns without error', async () => {
+    await recoverOrphanedSessions()
+    expect(mockTsStoreSet).not.toHaveBeenCalled()
+    expect(mockActiveStore.delete).not.toHaveBeenCalled()
+    expect(mockGogGame.updatePlaytime).not.toHaveBeenCalled()
+  })
+
+  test('single GOG orphan: tsStore updated with adjusted minutes and updatePlaytime called', async () => {
+    // wall = 8m, suspend = 3m, active = 5m
+    const checkpointAt = makeCheckpointAt(8)
+    mockActiveStore.raw_store = {
+      '1511366207': {
+        runner: 'gog',
+        title: 'Showgunners',
+        startedAt: ISO_START,
+        checkpointAt,
+        totalSuspendMs: 3 * 60_000,
+        suspendedAt: null
+      }
+    }
+    mockTsStoreGet.mockReturnValue(10)
+
+    await recoverOrphanedSessions()
+
+    expect(mockTsStoreSet).toHaveBeenCalledWith('1511366207.lastPlayed', checkpointAt)
+    expect(mockTsStoreSet).toHaveBeenCalledWith('1511366207.totalPlayed', 15)
+    expect(mockGogGame.updatePlaytime).toHaveBeenCalledWith(new Date(ISO_START), 5)
+    expect(mockActiveStore.delete).toHaveBeenCalledWith('1511366207')
+  })
+
+  test('non-GOG runner (no updatePlaytime method): tsStore updated, no sync call', async () => {
+    const checkpointAt = makeCheckpointAt(5)
+    mockActiveStore.raw_store = {
+      'epic-game': {
+        runner: 'legendary',
+        title: 'Some Epic Game',
+        startedAt: ISO_START,
+        checkpointAt,
+        totalSuspendMs: 0,
+        suspendedAt: null
+      }
+    }
+
+    await recoverOrphanedSessions()
+
+    expect(mockTsStoreSet).toHaveBeenCalledWith('epic-game.totalPlayed', 5)
+    expect(mockGogGame.updatePlaytime).not.toHaveBeenCalled()
+    expect(mockActiveStore.delete).toHaveBeenCalledWith('epic-game')
+  })
+
+  test('short session (< 1 min): tsStore updated with floor, updatePlaytime skipped', async () => {
+    const checkpointAt = new Date(Date.parse(ISO_START) + 30_000).toISOString()
+    mockActiveStore.raw_store = {
+      '1511366207': {
+        runner: 'gog',
+        title: 'Short',
+        startedAt: ISO_START,
+        checkpointAt,
+        totalSuspendMs: 0,
+        suspendedAt: null
+      }
+    }
+
+    await recoverOrphanedSessions()
+
+    expect(mockTsStoreSet).toHaveBeenCalledWith('1511366207.totalPlayed', 0)
+    expect(mockGogGame.updatePlaytime).not.toHaveBeenCalled()
+    expect(mockActiveStore.delete).toHaveBeenCalledWith('1511366207')
+  })
+
+  test('persisted totalSuspendMs used as-is (fold already applied at persist time)', async () => {
+    // wall = 10m, persisted totalSuspendMs = 4m. Recovery trusts the snapshot — no double-fold.
+    const checkpointAt = makeCheckpointAt(10)
+    mockActiveStore.raw_store = {
+      '1511366207': {
+        runner: 'gog',
+        title: 'Showgunners',
+        startedAt: ISO_START,
+        checkpointAt,
+        totalSuspendMs: 4 * 60_000,
+        suspendedAt: Date.parse(ISO_START) + 6 * 60_000
+      }
+    }
+
+    await recoverOrphanedSessions()
+
+    // active = 10 - 4 = 6m
+    expect(mockTsStoreSet).toHaveBeenCalledWith('1511366207.totalPlayed', 6)
+    expect(mockGogGame.updatePlaytime).toHaveBeenCalledWith(new Date(ISO_START), 6)
+  })
+
+  test('unknown runner: outer catch fires, activeSessionsStore.delete still runs', async () => {
+    // runner is not in libraryManagerMap → libraryManagerMap[runner] is undefined
+    // → undefined.getGame() throws TypeError → outer catch → logError → finally deletes.
+    mockActiveStore.raw_store = {
+      'weird-game': {
+        runner: 'unknown-runner',
+        title: 'Weird Game',
+        startedAt: ISO_START,
+        checkpointAt: makeCheckpointAt(5),
+        totalSuspendMs: 0,
+        suspendedAt: null
+      }
+    }
+
+    await recoverOrphanedSessions()
+
+    expect(mockActiveStore.delete).toHaveBeenCalledWith('weird-game')
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to finalize orphaned session for weird-game'),
+      'Backend'
+    )
+  })
+
+  test('multiple orphans: each processed independently', async () => {
+    mockActiveStore.raw_store = {
+      'game-a': {
+        runner: 'gog',
+        title: 'Game A',
+        startedAt: ISO_START,
+        checkpointAt: makeCheckpointAt(3),
+        totalSuspendMs: 0,
+        suspendedAt: null
+      },
+      'game-b': {
+        runner: 'gog',
+        title: 'Game B',
+        startedAt: ISO_START,
+        checkpointAt: makeCheckpointAt(6),
+        totalSuspendMs: 0,
+        suspendedAt: null
+      }
+    }
+
+    await recoverOrphanedSessions()
+
+    expect(mockTsStoreSet).toHaveBeenCalledWith('game-a.totalPlayed', 3)
+    expect(mockTsStoreSet).toHaveBeenCalledWith('game-b.totalPlayed', 6)
+    expect(mockActiveStore.delete).toHaveBeenCalledWith('game-a')
+    expect(mockActiveStore.delete).toHaveBeenCalledWith('game-b')
+    expect(mockGogGame.updatePlaytime).toHaveBeenCalledTimes(2)
+  })
+
+  test('updatePlaytime rejection: .catch logs error, does not block loop', async () => {
+    mockActiveStore.raw_store = {
+      'game-a': {
+        runner: 'gog',
+        title: 'Game A',
+        startedAt: ISO_START,
+        checkpointAt: makeCheckpointAt(3),
+        totalSuspendMs: 0,
+        suspendedAt: null
+      },
+      'game-b': {
+        runner: 'gog',
+        title: 'Game B',
+        startedAt: ISO_START,
+        checkpointAt: makeCheckpointAt(4),
+        totalSuspendMs: 0,
+        suspendedAt: null
+      }
+    }
+    mockGogGame.updatePlaytime
+      .mockRejectedValueOnce(new Error('POST failed'))
+      .mockResolvedValueOnce(undefined)
+
+    await recoverOrphanedSessions()
+    await flushMicrotasks()
+
+    expect(mockActiveStore.delete).toHaveBeenCalledWith('game-a')
+    expect(mockActiveStore.delete).toHaveBeenCalledWith('game-b')
+    expect(mockGogGame.updatePlaytime).toHaveBeenCalledTimes(2)
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to enqueue orphaned gog session for game-a'),
+      'Backend'
+    )
+  })
+})

--- a/src/backend/constants/key_value_stores.ts
+++ b/src/backend/constants/key_value_stores.ts
@@ -8,3 +8,11 @@ export const tsStore = new TypeCheckedStoreBackend('timestampStore', {
   cwd: 'store',
   name: 'timestamp'
 })
+
+export const activeSessionsStore = new TypeCheckedStoreBackend(
+  'activeSessionsStore',
+  {
+    cwd: 'store',
+    name: 'active-sessions'
+  }
+)

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -72,7 +72,7 @@ import { copyFile } from 'fs/promises'
 import { app, powerMonitor, powerSaveBlocker } from 'electron'
 import gogPresence from './storeManagers/gog/presence'
 import { addRecentGame } from './recent_games/recent_games'
-import { tsStore } from './constants/key_value_stores'
+import { activeSessionsStore, tsStore } from './constants/key_value_stores'
 import {
   defaultUmuPath,
   sharedWinePrefix,
@@ -145,22 +145,48 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   // Note that on Linux, Chromium is double-firing `PrepareForSleep`
   let totalSuspendMs = 0
   let suspendedAt: number | null = null
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null
   const onSuspend = () => {
     if (suspendedAt !== null) return
     suspendedAt = Date.now()
+    logInfo(`[Playtime] Suspend detected for ${appName}`, LogPrefix.Backend)
   }
   const onResume = () => {
     if (suspendedAt === null) return
-    totalSuspendMs += Date.now() - suspendedAt
+    const delta = Date.now() - suspendedAt
+    totalSuspendMs += delta
     suspendedAt = null
+    logInfo(
+      `[Playtime] Resume after ${Math.floor(delta / 1000)}s for ${appName}`,
+      LogPrefix.Backend
+    )
   }
-  const unregisterPowerListeners = () => {
+  const persistSessionCheckpoint = () => {
+    // Snapshot for recovery from session loss
+    const suspendSoFar =
+      totalSuspendMs +
+      (suspendedAt !== null ? Date.now() - suspendedAt : 0)
+    activeSessionsStore.set(appName, {
+      runner,
+      title,
+      startedAt: startPlayingDate.toISOString(),
+      checkpointAt: new Date().toISOString(),
+      totalSuspendMs: suspendSoFar,
+      suspendedAt
+    })
+  }
+  const finalizeSession = () => {
     powerMonitor.off('suspend', onSuspend)
     powerMonitor.off('resume', onResume)
     if (suspendedAt !== null) {
       totalSuspendMs += Date.now() - suspendedAt
       suspendedAt = null
     }
+    if (heartbeatTimer !== null) {
+      clearInterval(heartbeatTimer)
+      heartbeatTimer = null
+    }
+    activeSessionsStore.delete(appName)
   }
   powerMonitor.on('suspend', onSuspend)
   powerMonitor.on('resume', onResume)
@@ -241,7 +267,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
       })
 
       await logWriter.close()
-      unregisterPowerListeners()
+      finalizeSession()
 
       return { status: 'error' }
     }
@@ -261,6 +287,10 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     args,
     skipVersionCheck
   )
+
+  // Start 60s heartbeat for playtime
+  persistSessionCheckpoint()
+  heartbeatTimer = setInterval(persistSessionCheckpoint, 60_000)
 
   if (runner === 'gog') {
     gogPresence.setCurrentGame(appName)
@@ -292,7 +322,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     powerSaveBlocker.stop(powerDisplayId)
   }
 
-  unregisterPowerListeners()
+  finalizeSession()
 
   // Update playtime and last played date
   const finishedPlayingDate = new Date()
@@ -301,6 +331,15 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   const wallMs = finishedPlayingDate.getTime() - startPlayingDate.getTime()
   const activeMs = Math.max(0, wallMs - totalSuspendMs)
   const sessionPlaytime = activeMs / 1000 / 60
+  if (totalSuspendMs > 0) {
+    logInfo(
+      `[Playtime] Session for ${appName}: 
+      wall=${Math.floor(wallMs / 60000)}m 
+      active=${Math.floor(activeMs / 60000)}m 
+      (subtracted ${Math.floor(totalSuspendMs / 60000)}m of suspend)`,
+      LogPrefix.Backend
+    )
+  }
   const totalPlaytime =
     sessionPlaytime + tsStore.get(`${appName}.totalPlayed`, 0)
   tsStore.set(`${appName}.totalPlayed`, Math.floor(totalPlaytime))

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -165,8 +165,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   const persistSessionCheckpoint = () => {
     // Snapshot for recovery from session loss
     const suspendSoFar =
-      totalSuspendMs +
-      (suspendedAt !== null ? Date.now() - suspendedAt : 0)
+      totalSuspendMs + (suspendedAt !== null ? Date.now() - suspendedAt : 0)
     activeSessionsStore.set(appName, {
       runner,
       title,
@@ -197,138 +196,140 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   powerMonitor.on('suspend', onSuspend)
   powerMonitor.on('resume', onResume)
 
-  if (!tsStore.has(appName)) {
-    tsStore.set(`${appName}.firstPlayed`, startPlayingDate.toISOString())
-  }
-
-  logInfo(`Launching ${title} (${appName})`, LogPrefix.Backend)
-
-  if (autoSyncSaves && isOnline()) {
-    sendGameStatusUpdate({
-      appName,
-      runner,
-      status: 'syncing-saves'
-    })
-    logInfo(`Downloading saves for ${title}`, LogPrefix.Backend)
-    try {
-      await game.syncSaves('--skip-upload', savesPath, gogSaves)
-      logInfo(`Saves for ${title} downloaded`, LogPrefix.Backend)
-    } catch (error) {
-      logError(
-        `Error while downloading saves for ${title}. ${error}`,
-        LogPrefix.Backend
-      )
+  let launchResult: boolean | undefined
+  try {
+    if (!tsStore.has(appName)) {
+      tsStore.set(`${appName}.firstPlayed`, startPlayingDate.toISOString())
     }
-  }
 
-  sendGameStatusUpdate({
-    appName,
-    runner,
-    status: 'launching'
-  })
+    logInfo(`Launching ${title} (${appName})`, LogPrefix.Backend)
 
-  const mainWindow = getMainWindow()
-  if (minimizeOnLaunch && !noTrayIcon) {
-    mainWindow?.hide()
-  }
-
-  // Prevent display from sleep
-  if (!powerDisplayId) {
-    logInfo('Preventing display from sleep', LogPrefix.Backend)
-    powerDisplayId = powerSaveBlocker.start('prevent-display-sleep')
-  }
-
-  const logWriter = await createGameLogWriter(appName, runner)
-
-  if (!gameSettings.verboseLogs) {
-    await logWriter.logWarning('IMPORTANT: Logs are disabled', {
-      forceLog: true
-    })
-    await logWriter.logWarning(
-      "Enable verbose logs in Game's settings > Advanced tab > 'Enable verbose logs' before reporting an issue.",
-      { forceLog: true }
-    )
-  }
-
-  const isNative = game.isNative()
-
-  // check if isNative, if not, check if wine is valid
-  if (!isNative) {
-    const isWineOkToLaunch = await checkWineBeforeLaunch(
-      gameInfo,
-      gameSettings,
-      logWriter
-    )
-
-    if (!isWineOkToLaunch) {
-      logError(
-        `Was not possible to launch using ${gameSettings.wineVersion.name}`,
-        LogPrefix.Backend
-      )
-
+    if (autoSyncSaves && isOnline()) {
       sendGameStatusUpdate({
         appName,
         runner,
-        status: 'done'
+        status: 'syncing-saves'
+      })
+      logInfo(`Downloading saves for ${title}`, LogPrefix.Backend)
+      try {
+        await game.syncSaves('--skip-upload', savesPath, gogSaves)
+        logInfo(`Saves for ${title} downloaded`, LogPrefix.Backend)
+      } catch (error) {
+        logError(
+          `Error while downloading saves for ${title}. ${error}`,
+          LogPrefix.Backend
+        )
+      }
+    }
+
+    sendGameStatusUpdate({
+      appName,
+      runner,
+      status: 'launching'
+    })
+
+    const mainWindow = getMainWindow()
+    if (minimizeOnLaunch && !noTrayIcon) {
+      mainWindow?.hide()
+    }
+
+    // Prevent display from sleep
+    if (!powerDisplayId) {
+      logInfo('Preventing display from sleep', LogPrefix.Backend)
+      powerDisplayId = powerSaveBlocker.start('prevent-display-sleep')
+    }
+
+    const logWriter = await createGameLogWriter(appName, runner)
+
+    if (!gameSettings.verboseLogs) {
+      await logWriter.logWarning('IMPORTANT: Logs are disabled', {
+        forceLog: true
+      })
+      await logWriter.logWarning(
+        "Enable verbose logs in Game's settings > Advanced tab > 'Enable verbose logs' before reporting an issue.",
+        { forceLog: true }
+      )
+    }
+
+    const isNative = game.isNative()
+
+    // check if isNative, if not, check if wine is valid
+    if (!isNative) {
+      const isWineOkToLaunch = await checkWineBeforeLaunch(
+        gameInfo,
+        gameSettings,
+        logWriter
+      )
+
+      if (!isWineOkToLaunch) {
+        logError(
+          `Was not possible to launch using ${gameSettings.wineVersion.name}`,
+          LogPrefix.Backend
+        )
+
+        sendGameStatusUpdate({
+          appName,
+          runner,
+          status: 'done'
+        })
+
+        await logWriter.close()
+
+        return { status: 'error' }
+      }
+    }
+
+    await runBeforeLaunchScript(gameInfo, gameSettings, logWriter)
+
+    sendGameStatusUpdate({
+      appName,
+      runner,
+      status: 'launching'
+    })
+
+    const command = game.launch(
+      logWriter,
+      launchArguments,
+      args,
+      skipVersionCheck
+    )
+
+    // Start 60s heartbeat for playtime
+    persistSessionCheckpoint()
+    heartbeatTimer = setInterval(persistSessionCheckpoint, 60_000)
+
+    if (runner === 'gog') {
+      gogPresence.setCurrentGame(appName)
+      await gogPresence.setPresence()
+    }
+
+    launchResult = await command
+      .catch(async (exception) => {
+        logError(exception, LogPrefix.Backend)
+        await logWriter.logError([
+          `An exception occurred when launching the game:`
+        ])
+        await logWriter.logError(exception)
+
+        return false
+      })
+      .finally(async () => {
+        await runAfterLaunchScript(gameInfo, gameSettings, logWriter)
+        await logWriter.close()
       })
 
-      await logWriter.close()
-      finalizeSession()
-
-      return { status: 'error' }
+    if (runner === 'gog') {
+      gogPresence.setCurrentGame('')
+      await gogPresence.setPresence()
     }
+    // Stop display sleep blocker
+    if (powerDisplayId !== null) {
+      logInfo('Stopping Display Power Saver Blocker', LogPrefix.Backend)
+      powerSaveBlocker.stop(powerDisplayId)
+    }
+  } finally {
+    finalizeSession()
   }
-
-  await runBeforeLaunchScript(gameInfo, gameSettings, logWriter)
-
-  sendGameStatusUpdate({
-    appName,
-    runner,
-    status: 'launching'
-  })
-
-  const command = game.launch(
-    logWriter,
-    launchArguments,
-    args,
-    skipVersionCheck
-  )
-
-  // Start 60s heartbeat for playtime
-  persistSessionCheckpoint()
-  heartbeatTimer = setInterval(persistSessionCheckpoint, 60_000)
-
-  if (runner === 'gog') {
-    gogPresence.setCurrentGame(appName)
-    await gogPresence.setPresence()
-  }
-
-  const launchResult = await command
-    .catch(async (exception) => {
-      logError(exception, LogPrefix.Backend)
-      await logWriter.logError([
-        `An exception occurred when launching the game:`
-      ])
-      await logWriter.logError(exception)
-
-      return false
-    })
-    .finally(async () => {
-      await runAfterLaunchScript(gameInfo, gameSettings, logWriter)
-      await logWriter.close()
-    })
-
-  if (runner === 'gog') {
-    gogPresence.setCurrentGame('')
-    await gogPresence.setPresence()
-  }
-  // Stop display sleep blocker
-  if (powerDisplayId !== null) {
-    logInfo('Stopping Display Power Saver Blocker', LogPrefix.Backend)
-    powerSaveBlocker.stop(powerDisplayId)
-  }
-
-  finalizeSession()
 
   // Update playtime and last played date
   const finishedPlayingDate = new Date()
@@ -339,10 +340,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   const sessionPlaytime = activeMs / 1000 / 60
   if (totalSuspendMs > 0) {
     logInfo(
-      `[Playtime] Session for ${appName}: 
-      wall=${Math.floor(wallMs / 60000)}m 
-      active=${Math.floor(activeMs / 60000)}m 
-      (subtracted ${Math.floor(totalSuspendMs / 60000)}m of suspend)`,
+      `[Playtime] Session for ${appName}: wall=${Math.floor(wallMs / 60000)}m active=${Math.floor(activeMs / 60000)}m (subtracted ${Math.floor(totalSuspendMs / 60000)}m of suspend)`,
       LogPrefix.Backend
     )
   }

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -151,6 +151,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     if (suspendedAt !== null) return
     suspendedAt = Date.now()
     logInfo(`[Playtime] Suspend detected for ${appName}`, LogPrefix.Backend)
+    persistSessionCheckpoint()
   }
   const onResume = () => {
     if (suspendedAt === null) return
@@ -161,6 +162,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
       `[Playtime] Resume after ${Math.floor(delta / 1000)}s for ${appName}`,
       LogPrefix.Backend
     )
+    persistSessionCheckpoint()
   }
   const persistSessionCheckpoint = () => {
     // Snapshot for recovery from session loss
@@ -294,9 +296,9 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
       skipVersionCheck
     )
 
-    // Start 60s heartbeat for playtime
+    // Heartbeat to recover session state on crash
     persistSessionCheckpoint()
-    heartbeatTimer = setInterval(persistSessionCheckpoint, 60_000)
+    heartbeatTimer = setInterval(persistSessionCheckpoint, 5 * 60 * 1000)
 
     if (runner === 'gog') {
       gogPresence.setCurrentGame(appName)

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -351,18 +351,10 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   tsStore.set(`${appName}.totalPlayed`, Math.floor(totalPlaytime))
   clearPersistedSession()
 
-  const { disablePlaytimeSync } = GlobalConfig.get().getSettings()
   if (runner === 'gog') {
-    if (!disablePlaytimeSync) {
-      await libraryManagerMap['gog']
-        .getGame(appName)
-        .updateGOGPlaytime(startPlayingDate, sessionPlaytime)
-    } else {
-      logWarning(
-        'Posting playtime session to server skipped - playtime sync disabled',
-        { prefix: LogPrefix.Backend }
-      )
-    }
+    await libraryManagerMap['gog']
+      .getGame(appName)
+      .updateGOGPlaytime(startPlayingDate, sessionPlaytime)
   }
   await addRecentGame(gameInfo)
 

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -69,7 +69,7 @@ import { getMainWindow } from './main_window'
 import { sendFrontendMessage } from './ipc'
 import { getUmuPath, isUmuSupported } from './utils/compatibility_layers'
 import { copyFile } from 'fs/promises'
-import { app, powerSaveBlocker } from 'electron'
+import { app, powerMonitor, powerSaveBlocker } from 'electron'
 import gogPresence from './storeManagers/gog/presence'
 import { addRecentGame } from './recent_games/recent_games'
 import { tsStore } from './constants/key_value_stores'
@@ -141,6 +141,29 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   const { minimizeOnLaunch, noTrayIcon } = GlobalConfig.get().getSettings()
 
   const startPlayingDate = new Date()
+
+  // Note that on Linux, Chromium is double-firing `PrepareForSleep`
+  let totalSuspendMs = 0
+  let suspendedAt: number | null = null
+  const onSuspend = () => {
+    if (suspendedAt !== null) return
+    suspendedAt = Date.now()
+  }
+  const onResume = () => {
+    if (suspendedAt === null) return
+    totalSuspendMs += Date.now() - suspendedAt
+    suspendedAt = null
+  }
+  const unregisterPowerListeners = () => {
+    powerMonitor.off('suspend', onSuspend)
+    powerMonitor.off('resume', onResume)
+    if (suspendedAt !== null) {
+      totalSuspendMs += Date.now() - suspendedAt
+      suspendedAt = null
+    }
+  }
+  powerMonitor.on('suspend', onSuspend)
+  powerMonitor.on('resume', onResume)
 
   if (!tsStore.has(appName)) {
     tsStore.set(`${appName}.firstPlayed`, startPlayingDate.toISOString())
@@ -218,6 +241,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
       })
 
       await logWriter.close()
+      unregisterPowerListeners()
 
       return { status: 'error' }
     }
@@ -268,12 +292,15 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     powerSaveBlocker.stop(powerDisplayId)
   }
 
+  unregisterPowerListeners()
+
   // Update playtime and last played date
   const finishedPlayingDate = new Date()
   tsStore.set(`${appName}.lastPlayed`, finishedPlayingDate.toISOString())
-  // Playtime of this session in minutes
-  const sessionPlaytime =
-    (finishedPlayingDate.getTime() - startPlayingDate.getTime()) / 1000 / 60
+  // Playtime of this session in minutes, excluding system-suspend time.
+  const wallMs = finishedPlayingDate.getTime() - startPlayingDate.getTime()
+  const activeMs = Math.max(0, wallMs - totalSuspendMs)
+  const sessionPlaytime = activeMs / 1000 / 60
   const totalPlaytime =
     sessionPlaytime + tsStore.get(`${appName}.totalPlayed`, 0)
   tsStore.set(`${appName}.totalPlayed`, Math.floor(totalPlaytime))
@@ -283,7 +310,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
     if (!disablePlaytimeSync) {
       await libraryManagerMap['gog']
         .getGame(appName)
-        .updateGOGPlaytime(startPlayingDate, finishedPlayingDate)
+        .updateGOGPlaytime(startPlayingDate, sessionPlaytime)
     } else {
       logWarning(
         'Posting playtime session to server skipped - playtime sync disabled',

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -111,7 +111,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   skipVersionCheck,
   args
 }) => {
-  const game = libraryManagerMap[runner].getGame(appName)
+  const game: Game = libraryManagerMap[runner].getGame(appName)
   const gameInfo = game.getGameInfo()
 
   if (
@@ -351,11 +351,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   tsStore.set(`${appName}.totalPlayed`, Math.floor(totalPlaytime))
   clearPersistedSession()
 
-  if (runner === 'gog') {
-    await libraryManagerMap['gog']
-      .getGame(appName)
-      .updateGOGPlaytime(startPlayingDate, sessionPlaytime)
-  }
+  await game.updatePlaytime?.(startPlayingDate, sessionPlaytime)
   await addRecentGame(gameInfo)
 
   if (autoSyncSaves && isOnline()) {

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -146,6 +146,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   let totalSuspendMs = 0
   let suspendedAt: number | null = null
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  let sessionPersisted = false
   const onSuspend = () => {
     if (suspendedAt !== null) return
     suspendedAt = Date.now()
@@ -174,6 +175,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
       totalSuspendMs: suspendSoFar,
       suspendedAt
     })
+    sessionPersisted = true
   }
   const finalizeSession = () => {
     powerMonitor.off('suspend', onSuspend)
@@ -186,7 +188,11 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
       clearInterval(heartbeatTimer)
       heartbeatTimer = null
     }
+  }
+  const clearPersistedSession = () => {
+    if (!sessionPersisted) return
     activeSessionsStore.delete(appName)
+    sessionPersisted = false
   }
   powerMonitor.on('suspend', onSuspend)
   powerMonitor.on('resume', onResume)
@@ -343,6 +349,7 @@ const launchEventCallback: (args: LaunchParams) => StatusPromise = async ({
   const totalPlaytime =
     sessionPlaytime + tsStore.get(`${appName}.totalPlayed`, 0)
   tsStore.set(`${appName}.totalPlayed`, Math.floor(totalPlaytime))
+  clearPersistedSession()
 
   const { disablePlaytimeSync } = GlobalConfig.get().getSettings()
   if (runner === 'gog') {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -375,14 +375,17 @@ if (!gotTheLock) {
 
     // Make sure lock is not present when starting up
     playtimeSyncQueue.delete('lock')
-    await recoverOrphanedSessions()
-    if (!settings.disablePlaytimeSync) {
-      runOnceWhenOnline(() => libraryManagerMap['gog'].syncQueuedPlaytime())
-    } else {
-      logDebug('Skipping playtime sync queue upload - playtime sync disabled', {
-        prefix: LogPrefix.Backend
-      })
-    }
+    runOnceWhenOnline(async () => {
+      await recoverOrphanedSessions()
+      if (!settings.disablePlaytimeSync) {
+        await libraryManagerMap['gog'].syncQueuedPlaytime()
+      } else {
+        logDebug(
+          'Skipping playtime sync queue upload - playtime sync disabled',
+          { prefix: LogPrefix.Backend }
+        )
+      }
+    })
     runOnceWhenOnline(gogPresence.setPresence)
     await i18next.use(Backend).init({
       backend: {

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -92,6 +92,7 @@ import {
   isOnline,
   runOnceWhenOnline
 } from './online_monitor'
+import { recoverOrphanedSessions } from './playtime_recovery'
 import { notify, showDialogBoxModalAuto } from './dialog/dialog'
 import { callAbortController } from './utils/aborthandler/aborthandler'
 import { getDefaultSavePath } from './save_sync'
@@ -374,6 +375,7 @@ if (!gotTheLock) {
 
     // Make sure lock is not present when starting up
     playtimeSyncQueue.delete('lock')
+    await recoverOrphanedSessions()
     if (!settings.disablePlaytimeSync) {
       runOnceWhenOnline(() => libraryManagerMap['gog'].syncQueuedPlaytime())
     } else {

--- a/src/backend/playtime_recovery.ts
+++ b/src/backend/playtime_recovery.ts
@@ -1,0 +1,55 @@
+import { activeSessionsStore, tsStore } from './constants/key_value_stores'
+import { libraryManagerMap } from './storeManagers'
+import { logError, logInfo, LogPrefix } from './logger'
+
+/// Recovers playtime in the event of any crash(es)
+export async function recoverOrphanedSessions(): Promise<void> {
+  const orphans = activeSessionsStore.raw_store
+  const entries = Object.entries(orphans)
+  if (entries.length === 0) return
+
+  logInfo(
+    `[Playtime] Recovering ${entries.length} orphaned session(s) from previous run`,
+    LogPrefix.Backend
+  )
+
+  for (const [appName, state] of entries) {
+    try {
+      const startedAt = new Date(state.startedAt)
+      const wallMs = Date.parse(state.checkpointAt) - startedAt.getTime()
+      const activeMs = Math.max(0, wallMs - state.totalSuspendMs)
+      const minutes = activeMs / 60000
+
+      tsStore.set(`${appName}.lastPlayed`, state.checkpointAt)
+      const totalPlaytime = minutes + tsStore.get(`${appName}.totalPlayed`, 0)
+      tsStore.set(`${appName}.totalPlayed`, Math.floor(totalPlaytime))
+
+      logInfo(
+        `[Playtime] Recovered ${state.title || appName}: ${Math.floor(
+          minutes
+        )}m (checkpoint ${state.checkpointAt})`,
+        LogPrefix.Backend
+      )
+
+      if (state.runner === 'gog' && minutes >= 1) {
+        try {
+          await libraryManagerMap['gog']
+            .getGame(appName)
+            .updateGOGPlaytime(startedAt, minutes)
+        } catch (e) {
+          logError(
+            `[Playtime] Failed to enqueue orphaned GOG session for ${appName}: ${e}`,
+            LogPrefix.Gog
+          )
+        }
+      }
+    } catch (e) {
+      logError(
+        `[Playtime] Failed to finalize orphaned session for ${appName}: ${e}`,
+        LogPrefix.Backend
+      )
+    } finally {
+      activeSessionsStore.delete(appName)
+    }
+  }
+}

--- a/src/backend/playtime_recovery.ts
+++ b/src/backend/playtime_recovery.ts
@@ -32,16 +32,15 @@ export async function recoverOrphanedSessions(): Promise<void> {
       )
 
       if (state.runner === 'gog' && minutes >= 1) {
-        try {
-          await libraryManagerMap['gog']
-            .getGame(appName)
-            .updateGOGPlaytime(startedAt, minutes)
-        } catch (e) {
-          logError(
-            `[Playtime] Failed to enqueue orphaned GOG session for ${appName}: ${e}`,
-            LogPrefix.Gog
-          )
-        }
+        libraryManagerMap['gog']
+          .getGame(appName)
+          .updateGOGPlaytime(startedAt, minutes)
+          .catch((e) => {
+            logError(
+              `[Playtime] Failed to enqueue orphaned GOG session for ${appName}: ${e}`,
+              LogPrefix.Gog
+            )
+          })
       }
     } catch (e) {
       logError(

--- a/src/backend/playtime_recovery.ts
+++ b/src/backend/playtime_recovery.ts
@@ -1,3 +1,4 @@
+import type { Game } from 'common/types/game_manager'
 import { activeSessionsStore, tsStore } from './constants/key_value_stores'
 import { libraryManagerMap } from './storeManagers'
 import { logError, logInfo, LogPrefix } from './logger'
@@ -31,16 +32,14 @@ export async function recoverOrphanedSessions(): Promise<void> {
         LogPrefix.Backend
       )
 
-      if (state.runner === 'gog' && minutes >= 1) {
-        libraryManagerMap['gog']
-          .getGame(appName)
-          .updateGOGPlaytime(startedAt, minutes)
-          .catch((e) => {
-            logError(
-              `[Playtime] Failed to enqueue orphaned GOG session for ${appName}: ${e}`,
-              LogPrefix.Gog
-            )
-          })
+      if (minutes >= 1) {
+        const game: Game = libraryManagerMap[state.runner].getGame(appName)
+        game.updatePlaytime?.(startedAt, minutes)?.catch((e: unknown) => {
+          logError(
+            `[Playtime] Failed to enqueue orphaned ${state.runner} session for ${appName}: ${e}`,
+            LogPrefix.Backend
+          )
+        })
       }
     } catch (e) {
       logError(

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -1312,7 +1312,7 @@ export default class GOGGame implements Game {
     })
   }
 
-  async updateGOGPlaytime(startPlayingDate: Date, minutesPlayed: number) {
+  async updatePlaytime(startPlayingDate: Date, minutesPlayed: number) {
     const { disablePlaytimeSync } = GlobalConfig.get().getSettings()
     if (disablePlaytimeSync) {
       logWarning(

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -1312,12 +1312,10 @@ export default class GOGGame implements Game {
     })
   }
 
-  async updateGOGPlaytime(startPlayingDate: Date, finishedPlayingDate: Date) {
+  async updateGOGPlaytime(startPlayingDate: Date, minutesPlayed: number) {
     // Let server know about new session
     const sessionDate = Math.floor(startPlayingDate.getTime() / 1000) // In seconds
-    const time = Math.floor(
-      (finishedPlayingDate.getTime() - startPlayingDate.getTime()) / 1000 / 60
-    ) // In minutes
+    const time = Math.floor(minutesPlayed)
 
     // It makes no sense to post 0 minutes of playtime
     if (time < 1) {

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -1313,6 +1313,15 @@ export default class GOGGame implements Game {
   }
 
   async updateGOGPlaytime(startPlayingDate: Date, minutesPlayed: number) {
+    const { disablePlaytimeSync } = GlobalConfig.get().getSettings()
+    if (disablePlaytimeSync) {
+      logWarning(
+        'Posting playtime session to server skipped - playtime sync disabled',
+        { prefix: LogPrefix.Gog }
+      )
+      return
+    }
+
     // Let server know about new session
     const sessionDate = Math.floor(startPlayingDate.getTime() / 1000) // In seconds
     const time = Math.floor(minutesPlayed)

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -14,7 +14,8 @@ import {
   WikiInfo,
   GameInfo,
   WindowProps,
-  UploadedLogData
+  UploadedLogData,
+  Runner
 } from 'common/types'
 import { UserData } from 'common/types/gog'
 import { NileUserData } from './nile'
@@ -69,7 +70,7 @@ export interface StoreStructure {
   }
   activeSessionsStore: {
     [appName: string]: {
-      runner: string
+      runner: Runner
       title: string
       startedAt: string
       checkpointAt: string

--- a/src/common/types/electron_store.ts
+++ b/src/common/types/electron_store.ts
@@ -67,6 +67,16 @@ export interface StoreStructure {
       totalPlayed: number
     }
   }
+  activeSessionsStore: {
+    [appName: string]: {
+      runner: string
+      title: string
+      startedAt: string
+      checkpointAt: string
+      totalSuspendMs: number
+      suspendedAt: number | null
+    }
+  }
   fontsStore: {
     fonts: string[]
   }

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -61,6 +61,7 @@ export interface Game {
   stop: (stopWine?: boolean) => Promise<void>
   isGameAvailable: () => Promise<boolean>
   getAchievements?: (lang: string) => Promise<GOGAchievement[]>
+  updatePlaytime?: (startDate: Date, minutesPlayed: number) => Promise<void>
 }
 
 export interface LibraryManager {


### PR DESCRIPTION
Respect "device sleep time" when calculating playtime:

###  Respect sleep time
Calculating playtime does not take into account any time difference when the device (ex. Steam Deck) is slept.

Use case:
- User plays 1 hour
- User puts device to sleep for 24 hours
- User plays 1 hour again
- Playtime is recorded as 26 hours (1 + 24 + 1), instead of 2 hours

### Restore playtime on crash

If Heroic crashes mid-session, the playtime recorded is lost.



#### AI disclosure
- Only used AI for final code review and writing tests



## Notes
- This uses Electron's `powerMonitor` to determine sleep/resume events. I have not tested this on all systems (just Linux/Deck)
  - Updated manifest to include `--system-talk-name=org.freedesktop.login1` to get this working (ok, I admit AI helped find this out too bc of the flatpak sandbox)
- The `launcher.ts diff` looks large, but I'm just wrapping a part of it in `try/catch` because of the suspend/resume events
- Works as things did before without `powerMonitor` events firing, nothing changed there
- Small refactor for `updatePlaytime` (from `updateGOGPlaytime`) in case you ever support updating playtimes for other stores
- Heartbeat interval of 5min, for if Heroic crashes during play





---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install (**On Steam Deck only**)
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
