### PR TITLE
Hide `ProgressDialog`'s indeterminate progress bar if it does not make sense

### DIFF
--- a/src/frontend/components/UI/ProgressDialog/index.tsx
+++ b/src/frontend/components/UI/ProgressDialog/index.tsx
@@ -17,6 +17,7 @@ export function ProgressDialog(props: {
   onClose: () => void
   children?: JSX.Element
   className?: string
+  hideProgress?: boolean
 }) {
   const { t } = useTranslation()
   const winetricksOutputBottomRef = useRef<HTMLDivElement>(null)
@@ -88,7 +89,9 @@ export function ProgressDialog(props: {
             })}
             <div ref={winetricksOutputBottomRef} />
           </div>
-          <LinearProgress className="progressDialog linearProgress" />
+          {!props.hideProgress && (
+            <LinearProgress className="progressDialog linearProgress" />
+          )}
         </DialogContent>
       </Dialog>
     </>

--- a/src/frontend/components/UI/Winetricks/index.tsx
+++ b/src/frontend/components/UI/Winetricks/index.tsx
@@ -111,7 +111,7 @@ export default function Winetricks({ onClose, runner }: Props) {
         appName,
         runner
       })
-      .then(() => setGuiOpen(false))
+      .finally(() => setGuiOpen(false))
   }
 
   const dialogContent = (

--- a/src/frontend/components/UI/Winetricks/index.tsx
+++ b/src/frontend/components/UI/Winetricks/index.tsx
@@ -102,12 +102,16 @@ export default function Winetricks({ onClose, runner }: Props) {
     }
   }, [])
 
+  const [guiOpen, setGuiOpen] = useState<boolean>(false)
   function launchWinetricks() {
-    window.api.callTool({
-      tool: 'winetricks',
-      appName,
-      runner
-    })
+    setGuiOpen(true)
+    window.api
+      .callTool({
+        tool: 'winetricks',
+        appName,
+        runner
+      })
+      .then(() => setGuiOpen(false))
   }
 
   const dialogContent = (
@@ -178,6 +182,9 @@ export default function Winetricks({ onClose, runner }: Props) {
       showCloseButton={true}
       onClose={onClose}
       className="winetricksDialog"
+      hideProgress={
+        !guiOpen && !installing && !loadingInstalled && !loadingAvailable
+      }
     >
       {dialogContent}
     </ProgressDialog>

--- a/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/gog.tsx
@@ -123,6 +123,7 @@ export default function GOGSyncSaves({
           onClose={() => {
             setManuallyOutputShow(false)
           }}
+          hideProgress
         />
       )}
       <div className="defaults-hint">

--- a/src/frontend/screens/Settings/sections/SyncSaves/legendary.tsx
+++ b/src/frontend/screens/Settings/sections/SyncSaves/legendary.tsx
@@ -103,6 +103,7 @@ export default function LegendarySyncSaves({
           onClose={() => {
             setManuallyOutputShow(false)
           }}
+          hideProgress
         />
       )}
       <div className="defaults-hint">


### PR DESCRIPTION
ProgressDialog used to have a fixed `LinearProgress` at its end. This led to a few confusing situations, since there was not necessarily something running in the background if it was shown (making the user think something is happening even though it is not).

This component was used in 3 places:
- the Epic & GOG save sync screen, to show the output of Legendary/GOGDL
- the Winetricks dialog

For the save sync screens, the dialog was only shown after the tool already quit, so showing a progress bar did not make sense at all there. For Winetricks, the progress is now only shown while we're loading available verbs, installing one, or the GUI is open

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
