### PR TITLE
[Fix] Correct reversed A/B and X/Y buttons on Nintendo controllers

### DIFF
--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -8,7 +8,8 @@ import {
   checkPS3Clone1,
   checkStandard,
   checkN64Clone1,
-  checkGenius1
+  checkGenius1,
+  checkSwitchPro
 } from './gamepad_layouts'
 import { VirtualKeyboardController } from './virtualKeyboard'
 
@@ -493,6 +494,8 @@ export const initGamepad = () => {
           checkN64Clone1(buttons, axes, index, checkAction)
         } else if (controller.id.match(/0583.*a009/i)) {
           checkGenius1(buttons, axes, index, checkAction)
+        } else if (controller.id.match(/057e/i)) {
+          checkSwitchPro(buttons, axes, index, checkAction)
         } else {
           // if not specific, fallback to the standard layout, seems
           // to be the most common for now and if not exact it seems

--- a/src/frontend/helpers/gamepad.ts
+++ b/src/frontend/helpers/gamepad.ts
@@ -9,7 +9,7 @@ import {
   checkStandard,
   checkN64Clone1,
   checkGenius1,
-  checkSwitchPro
+  checkNintendo
 } from './gamepad_layouts'
 import { VirtualKeyboardController } from './virtualKeyboard'
 
@@ -494,8 +494,8 @@ export const initGamepad = () => {
           checkN64Clone1(buttons, axes, index, checkAction)
         } else if (controller.id.match(/0583.*a009/i)) {
           checkGenius1(buttons, axes, index, checkAction)
-        } else if (controller.id.match(/057e/i)) {
-          checkSwitchPro(buttons, axes, index, checkAction)
+        } else if (controller.id.match(/057e.*(2006|2007|2009)/i)) {
+          checkNintendo(buttons, axes, index, checkAction)
         } else {
           // if not specific, fallback to the standard layout, seems
           // to be the most common for now and if not exact it seems

--- a/src/frontend/helpers/gamepad_layouts/nintendo.ts
+++ b/src/frontend/helpers/gamepad_layouts/nintendo.ts
@@ -47,6 +47,54 @@ export function checkGameCube(
   checkAction('rightClick', X.pressed, controllerIndex)
 }
 
+// Nintendo Switch Pro Controller / Joy-Cons (Vendor: 057e)
+// Chromium reports these with the "standard" mapping by physical position,
+// so buttons[0] is the bottom button (labeled B on Switch) and buttons[1] is
+// the right button (labeled A). We swap the face buttons so the A/B and X/Y
+// actions match the Nintendo labels shown in the UI.
+export function checkSwitchPro(
+  buttons: readonly GamepadButton[],
+  axes: readonly number[],
+  controllerIndex: number,
+  checkAction: (
+    action: ValidGamepadAction,
+    pressed: boolean,
+    ctrlIdx: number
+  ) => void
+) {
+  const B = buttons[0], // bottom button
+    A = buttons[1], // right button
+    Y = buttons[2], // left button
+    X = buttons[3], // top button
+    up = buttons[12],
+    down = buttons[13],
+    left = buttons[14],
+    right = buttons[15],
+    guideButton = buttons[16],
+    leftAxisX = axes[0],
+    leftAxisY = axes[1],
+    rightAxisX = axes[2],
+    rightAxisY = axes[3]
+
+  checkAction('mainAction', A?.pressed, controllerIndex)
+  checkAction('back', B?.pressed, controllerIndex)
+  checkAction('altAction', Y?.pressed, controllerIndex)
+  checkAction('rightClick', X?.pressed, controllerIndex)
+  checkAction('leftStickLeft', leftAxisX < -0.5, controllerIndex)
+  checkAction('leftStickRight', leftAxisX > 0.5, controllerIndex)
+  checkAction('leftStickUp', leftAxisY < -0.5, controllerIndex)
+  checkAction('leftStickDown', leftAxisY > 0.5, controllerIndex)
+  checkAction('rightStickLeft', rightAxisX < -0.5, controllerIndex)
+  checkAction('rightStickRight', rightAxisX > 0.5, controllerIndex)
+  checkAction('rightStickUp', rightAxisY < -0.5, controllerIndex)
+  checkAction('rightStickDown', rightAxisY > 0.5, controllerIndex)
+  checkAction('padUp', up?.pressed, controllerIndex)
+  checkAction('padDown', down?.pressed, controllerIndex)
+  checkAction('padLeft', left?.pressed, controllerIndex)
+  checkAction('padRight', right?.pressed, controllerIndex)
+  checkAction('guide', guideButton?.pressed, controllerIndex)
+}
+
 // Generic USB Joystick (Vendor: 0079 Product: 0006)
 export function checkN64Clone1(
   buttons: readonly GamepadButton[],

--- a/src/frontend/helpers/gamepad_layouts/nintendo.ts
+++ b/src/frontend/helpers/gamepad_layouts/nintendo.ts
@@ -52,7 +52,7 @@ export function checkGameCube(
 // so buttons[0] is the bottom button (labeled B on Switch) and buttons[1] is
 // the right button (labeled A). We swap the face buttons so the A/B and X/Y
 // actions match the Nintendo labels shown in the UI.
-export function checkSwitchPro(
+export function checkNintendo(
   buttons: readonly GamepadButton[],
   axes: readonly number[],
   controllerIndex: number,

--- a/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
+++ b/src/frontend/screens/ConsoleMode/InstallOverlay/index.tsx
@@ -10,8 +10,8 @@ import ContextProvider from 'frontend/state/ContextProvider'
 
 import type { GameInfo, InstallPlatform, WineInstallation } from 'common/types'
 
-import { BTN_ACTION, BTN_BACK } from '../controller'
-import { useGamepadButtonPress } from '../hooks'
+import { getActionButtonIndex, getBackButtonIndex } from '../controller'
+import { useGamepadButtonPress, useGamepadInfo } from '../hooks'
 
 type PlatformOption = {
   value: InstallPlatform
@@ -234,11 +234,12 @@ export default function InstallOverlay({
     return () => window.removeEventListener('keydown', onKeyDown, true)
   }, [])
 
-  useGamepadButtonPress(BTN_ACTION, () => {
+  const { layout } = useGamepadInfo()
+  useGamepadButtonPress(getActionButtonIndex(layout), () => {
     if (focused === 'install') void installGame()
     else if (focused === 'cancel') onDismiss()
   })
-  useGamepadButtonPress(BTN_BACK, onDismiss)
+  useGamepadButtonPress(getBackButtonIndex(layout), onDismiss)
 
   const showPlatform = availablePlatforms.length > 1
   const wineLabel =

--- a/src/frontend/screens/ConsoleMode/components/ConfirmDialog/index.tsx
+++ b/src/frontend/screens/ConsoleMode/components/ConfirmDialog/index.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import classNames from 'classnames'
 
-import { BTN_ACTION, BTN_BACK } from '../../controller'
-import { useGamepadButtonPress } from '../../hooks'
+import { getActionButtonIndex, getBackButtonIndex } from '../../controller'
+import { useGamepadButtonPress, useGamepadInfo } from '../../hooks'
 
 type ButtonId = 'confirm' | 'cancel' | 'dismiss'
 
@@ -102,8 +102,9 @@ export default function ConfirmDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focused, buttons, onBackKey, onConfirm, onCancel, onDismiss])
 
-  useGamepadButtonPress(BTN_ACTION, () => handlers[focused]())
-  useGamepadButtonPress(BTN_BACK, () => onBackKey())
+  const { layout } = useGamepadInfo()
+  useGamepadButtonPress(getActionButtonIndex(layout), () => handlers[focused]())
+  useGamepadButtonPress(getBackButtonIndex(layout), () => onBackKey())
 
   const confirmKey = gamepadConnected ? actionButtonLabel : 'Enter'
   const dismissKey = gamepadConnected ? backButtonLabel : 'Esc'

--- a/src/frontend/screens/ConsoleMode/components/LaunchOverlay/index.tsx
+++ b/src/frontend/screens/ConsoleMode/components/LaunchOverlay/index.tsx
@@ -9,8 +9,12 @@ import BackHint from '../BackHint'
 
 import type { GameInfo, Runner } from 'common/types'
 import { useContext, useEffect } from 'react'
-import { useCancelOnHold, useGamepadButtonHold } from '../../hooks'
-import { BTN_BACK } from '../../controller'
+import {
+  useCancelOnHold,
+  useGamepadButtonHold,
+  useGamepadInfo
+} from '../../hooks'
+import { getBackButtonIndex } from '../../controller'
 import { launch, sendKill } from 'frontend/helpers'
 import ContextProvider from 'frontend/state/ContextProvider'
 
@@ -76,8 +80,9 @@ export default function LaunchOverlay({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const { layout } = useGamepadInfo()
   useGamepadButtonHold(
-    BTN_BACK,
+    getBackButtonIndex(layout),
     (held) => (held ? startHold() : stopHold()),
     !!game
   )

--- a/src/frontend/screens/ConsoleMode/controller.ts
+++ b/src/frontend/screens/ConsoleMode/controller.ts
@@ -15,6 +15,14 @@ export const BTN_R2 = 7
 export const getActionButtonLabel = (layout: ControllerLayout) =>
   layout.startsWith('ps') ? '✕' : 'A'
 
+// Nintendo controllers report the same Chromium "standard" positions as Xbox,
+// but their A/B labels sit in swapped physical positions, so confirm/cancel
+// must swap to match the on-screen glyphs.
+export const getActionButtonIndex = (layout: ControllerLayout) =>
+  layout === 'nintendo' ? BTN_BACK : BTN_ACTION
+export const getBackButtonIndex = (layout: ControllerLayout) =>
+  layout === 'nintendo' ? BTN_ACTION : BTN_BACK
+
 export function detectControllerLayout(id: string): ControllerLayout {
   if (/054c|PS3|054c.*09cc|0268|'2563.*0523/i.test(id)) return 'ps4'
   if (/054c.*0ce6/i.test(id)) return 'ps5'

--- a/src/frontend/screens/ConsoleMode/controller.ts
+++ b/src/frontend/screens/ConsoleMode/controller.ts
@@ -6,8 +6,8 @@ export type ControllerLayout =
   | 'steam-deck'
 
 // Standard gamepad button indices (Chromium "standard" mapping).
-export const BTN_ACTION = 0
-export const BTN_BACK = 1
+const BTN_ACTION = 0
+const BTN_BACK = 1
 export const BTN_L1 = 4
 export const BTN_R1 = 5
 export const BTN_R2 = 7


### PR DESCRIPTION
## Fixes #5732

### Problem
On Nintendo Switch Pro Controllers and Joy-Cons, the A/B and X/Y button actions were reversed from what the UI shows: the glyphs indicate **A = select, B = back**, but pressing **A went back** and **B selected**.

### Cause
Nintendo controllers place their face buttons in swapped physical positions compared to Xbox, and Chromium reports them with the "standard" mapping by physical position:

- `buttons[0]` = bottom button → labeled **B** on a Switch
- `buttons[1]` = right button → labeled **A**

Two input paths assumed the Xbox convention (`buttons[0]` = main action, `buttons[1]` = back), so physical **A** fired *back* and **B** fired *select*.

### Fix
- Add a dedicated `checkSwitchPro` layout that swaps the face buttons (and X/Y), routed for Nintendo's vendor id `057e`. GameCube adapters (`057e:0337`) are still handled by the earlier GameCube branch, and Steam-Input-masked controllers (`28de`) are unaffected.
- Make Console Mode's confirm/back button indices layout-aware via `getActionButtonIndex` / `getBackButtonIndex`, so the overlays (ConfirmDialog, InstallOverlay, LaunchOverlay) match the on-screen glyphs.

Pressing the physical **A** button now selects and **B** goes back, matching the labels shown in the UI.