### PR TITLE
fix: unify webview session partitions so login credentials carry over to stores

### DIFF
--- a/src/backend/storeManagers/gog/user.ts
+++ b/src/backend/storeManagers/gog/user.ts
@@ -7,7 +7,7 @@ import { isOnline } from '../../online_monitor'
 import { GOGCredentials, UserData } from 'common/types/gog'
 import { libraryManagerMap } from '../index'
 import { clearCache } from 'backend/utils'
-import { app } from 'electron'
+import { app, session } from 'electron'
 import { gogdlAuthConfig } from './constants'
 
 function authLogSanitizer(line: string) {
@@ -130,6 +130,10 @@ export class GOGUser {
     if (existsSync(gogdlAuthConfig)) {
       unlinkSync(gogdlAuthConfig)
     }
+    const ses = session.fromPartition('persist:gog')
+    ses.clearStorageData().catch(() => {})
+    ses.clearCache().catch(() => {})
+    ses.clearAuthCache().catch(() => {})
     logInfo('Logging user out', LogPrefix.Gog)
   }
 

--- a/src/backend/storeManagers/legendary/user.ts
+++ b/src/backend/storeManagers/legendary/user.ts
@@ -68,7 +68,7 @@ export class LegendaryUser {
       return
     }
 
-    const ses = session.fromPartition('persist:epicstore')
+    const ses = session.fromPartition('persist:epic')
     await ses.clearStorageData()
     await ses.clearCache()
     await ses.clearAuthCache()

--- a/src/backend/storeManagers/nile/user.ts
+++ b/src/backend/storeManagers/nile/user.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync } from 'graceful-fs'
 import { configStore } from './electronStores'
 import { clearCache } from 'backend/utils'
 import { nileUserData } from './constants'
+import { session } from 'electron'
 
 function authLogSanitizer(line: string) {
   try {
@@ -99,6 +100,10 @@ export class NileUser {
 
     configStore.delete('userData')
     clearCache('nile')
+    const ses = session.fromPartition('persist:amazon')
+    ses.clearStorageData().catch(() => {})
+    ses.clearCache().catch(() => {})
+    ses.clearAuthCache().catch(() => {})
   }
 
   static async getUserData(): Promise<NileUserData | undefined> {

--- a/src/backend/storeManagers/zoom/user.ts
+++ b/src/backend/storeManagers/zoom/user.ts
@@ -11,6 +11,7 @@ import { isOnline } from '../../online_monitor'
 import { ZoomCredentials } from 'common/types/zoom'
 import { clearCache } from 'backend/utils'
 import { tokenPath, embedUrl, apiUrl } from './constants'
+import { session } from 'electron'
 
 export class ZoomUser {
   static async login(url: string): Promise<{
@@ -93,6 +94,10 @@ export class ZoomUser {
     if (existsSync(tokenPath)) {
       unlinkSync(tokenPath)
     }
+    const ses = session.fromPartition('persist:zoom')
+    ses.clearStorageData().catch(() => {})
+    ses.clearCache().catch(() => {})
+    ses.clearAuthCache().catch(() => {})
     logInfo('Logging user out from Zoom', LogPrefix.Zoom)
   }
 

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -380,7 +380,7 @@ export default function WebView() {
         key={store}
         ref={webviewRef}
         className="WebView__webview"
-        partition={`persist:${startUrl === epicLoginUrl ? 'epicstore' : store}`}
+        partition={`persist:${store ?? (runner === 'legendary' ? 'epic' : runner === 'nile' ? 'amazon' : runner)}`}
         src={startUrl}
         allowpopups={trueAsStr}
         preload={webviewPreloadPath}


### PR DESCRIPTION
Store webviews (Epic, GOG, Amazon, Zoom) do not share the authentication session with the login flow. A user logging in through "Manage Accounts" is prompted to log in again when opening any store page.

The root cause was a partition mismatch in Electron:
- Epic login used `persist:epicstore` while the store webview used `persist:epic`, two completely isolated sessions.
- For GOG, Amazon and Zoom the login page used `persist:undefined` while the store used their own partition, again isolated.

This fix unifies the login and store partitions per runner so the cookies set during the OAuth flow are available when the store webview loads, and makes session cleanup on logout consistent across all runners.

- [x] Tested the feature and it is working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)