### PR TITLE
fix(backend): flush session cookies to prevent store disconnects on kill

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -321,6 +321,23 @@ if (!gotTheLock) {
 
     handleProtocol(argv)
   })
+
+  // Proactively save session cookies to prevent store disconnects on hard crash or ungraceful shutdown
+  app.on('session-created', (ses) => {
+    let timeout: NodeJS.Timeout | null = null
+    ses.cookies.on('changed', () => {
+      if (timeout) clearTimeout(timeout)
+      timeout = setTimeout(() => {
+        ses.cookies.flushStore().catch((err: unknown) => {
+          logError(`Failed to flush session cookies: ${err}`, {
+            prefix: LogPrefix.Backend
+          })
+        })
+        ses.flushStorageData()
+      }, 1000)
+    })
+  })
+
   app.whenReady().then(async () => {
     initLogger()
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -330,6 +330,10 @@ if (!gotTheLock) {
     initStoreManagers()
     initImagesCache()
 
+    // Gracefully handle termination signals to ensure Electron natively flushes session data
+    process.on('SIGTERM', () => app.quit())
+    process.on('SIGINT', () => app.quit())
+
     // Add User-Agent Client hints to behave like Windows
     if (process.argv.includes('--spoof-windows')) {
       session.defaultSession.webRequest.onBeforeSendHeaders(


### PR DESCRIPTION
This pull request ensures that Electron session cookies and DOM storage data are immediately written to disk upon any change. This prevents store credentials from being lost when the process is forcefully killed on Flatpak or during scheduled token refreshes on Windows. Closes #5753.