### PR TITLE
[Tech] Update gogdl to 1.2.2

### DIFF
--- a/meta/downloadHelperBinaries.ts
+++ b/meta/downloadHelperBinaries.ts
@@ -16,7 +16,7 @@ type DownloadedBinary =
 
 const RELEASE_TAGS = {
   legendary: '0.20.43',
-  gogdl: 'v1.2.1',
+  gogdl: 'v1.2.2',
   nile: 'v1.2.0',
   comet: 'v0.2.0',
   'epic-integration': 'v0.4'
@@ -129,12 +129,12 @@ async function downloadGogdl() {
     {
       x64: {
         linux: 'gogdl_linux_x86_64',
-        darwin: 'gogdl_macOS_x86_64',
+        darwin: 'gogdl_macos_x86_64',
         win32: 'gogdl_windows_x86_64.exe'
       },
       arm64: {
         linux: 'gogdl_linux_arm64',
-        darwin: 'gogdl_macOS_arm64',
+        darwin: 'gogdl_macos_arm64',
         win32: 'gogdl_windows_arm64.exe'
       }
     }


### PR DESCRIPTION
Updates the bundled gogdl from 1.2.1 to [1.2.2](https://github.com/Heroic-Games-Launcher/heroic-gogdl/releases/tag/v1.2.2).

Fixes #5756

### The bug

gogdl 1.2.1 compares depot language codes case-sensitively, and some GOG game manifests use nonstandard casing (e.g. The Wolf Among Us, id `1432213513`, lists its depot language as `en-us` instead of `en-US`). `Language.parse` then returns `None` and gogdl crashes with an unhandled exception when Heroic runs `gogdl info`:

```
File "gogdl/dl/objects/v2.py", line 102, in list_languages
AttributeError: 'NoneType' object has no attribute 'code'
```

Heroic gets no output from the crashed process and shows **"Error: Cannot get game info"** for the affected game, which also makes it impossible to install (this is the symptom reported in #5756 for Little Nightmares, and reproduces identically with The Wolf Among Us). Fixed upstream in Heroic-Games-Launcher/heroic-gogdl@27d06fd (gogdl issue Heroic-Games-Launcher/heroic-gogdl#81), released in v1.2.2.

The v1.2.2 release also renamed the macOS assets from `gogdl_macOS_*` to `gogdl_macos_*`, so this PR updates the asset names accordingly.

### Verification

- `pnpm download-helper-binaries` fetches all 6 assets for v1.2.2 successfully (including the renamed macOS ones)
- Ran the failing command directly with both versions against a real library:
  - 1.2.1: `gogdl ... info 1432213513 --os windows` → `AttributeError` crash, exit != 0
  - 1.2.2: same command → correct JSON install info, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)