### PR TITLE
[Feat] Help user deal with previous download progress

### DIFF
--- a/public/locales/en/gamepage.json
+++ b/public/locales/en/gamepage.json
@@ -74,6 +74,7 @@
         "cancel": "Pause/Cancel",
         "changelog": "Show Changelog",
         "continue": "Continue Downloading",
+        "delete_and_install": "Delete and Install",
         "details": "Details",
         "edit-game": "Edit Game",
         "finish": "Finish",
@@ -82,6 +83,7 @@
         "hide_game": "Hide Game",
         "import": "Import Game",
         "install": "Install",
+        "move_and_continue": "Move and Continue Download",
         "no-path-selected": "No path selected",
         "play": "PLAY",
         "queue": {
@@ -201,6 +203,11 @@
         "not-enough-disk-space": "Not enough disk space",
         "path": "Select Install Path",
         "path-not-writtable": "Warning: path might not be writable.",
+        "previous_progress_strategy_options": {
+            "delete": "Delete and download from scratch",
+            "move": "Move to new path and continue"
+        },
+        "previous_progress_strategy_prompt": "What to do with previous partial download?",
         "space-after-install": "After Install",
         "wineprefix": "WinePrefix",
         "wineversion": "Wine version"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -93,6 +93,10 @@
                 "generic": "An error has occurred! Try to Logout and Login on your Epic account. {{newline}}  {{error}}"
             },
             "moving": "Error Moving Game {{error}}",
+            "previous_progress_move_failure": {
+                "message": "Error: {{error}}\nContinuing without moving previous progress.",
+                "title": "Failed to move previously downloaded files"
+            },
             "title": "Error",
             "uncaught-exception": {
                 "message": "A uncaught exception occured:{{newLine}}{{error}}{{newLine}}{{newLine}} Report the exception on our Github repository.",

--- a/src/backend/downloadmanager/ipc_handler.ts
+++ b/src/backend/downloadmanager/ipc_handler.ts
@@ -7,10 +7,60 @@ import {
   removeFromQueue,
   resumeCurrentDownload
 } from './downloadqueue'
+import { t } from 'i18next'
+import {
+  moveOnWindows,
+  moveOnUnix,
+  removeFolder,
+  sendGameStatusUpdate
+} from 'backend/utils'
+import { isWindows } from 'backend/constants/environment'
+import { showDialogBoxModalAuto } from 'backend/dialog/dialog'
+import { join } from 'path'
 
 import type { DMQueueElement } from 'common/types'
 
 addHandler('install', async (_e, args) => {
+  if (args.previousProgress?.folder && args.gameInfo.folder_name) {
+    if (
+      args.previousProgressStrategy === 'move' &&
+      args.previousProgress.folder !== args.path
+    ) {
+      sendGameStatusUpdate({
+        appName: args.gameInfo.app_name,
+        status: 'moving'
+      })
+
+      const moveImpl = isWindows ? moveOnWindows : moveOnUnix
+      const result = await moveImpl(args.path, {
+        ...args.gameInfo,
+        install: {
+          install_path: join(
+            args.previousProgress.folder,
+            args.gameInfo.folder_name
+          )
+        }
+      })
+
+      if (result.status === 'error') {
+        showDialogBoxModalAuto({
+          title: t(
+            'box.error.previous_progress_move_failure.title',
+            'Failed to move previously downloaded files'
+          ),
+          message: t(
+            'box.error.previous_progress_move_failure.message',
+            `Error: {{error}}\nContinuing without moving previous progress.`,
+            { error: result.error }
+          ),
+          type: 'ERROR'
+        })
+      }
+    } else if (args.previousProgressStrategy === 'delete') {
+      removeFolder(args.previousProgress.folder, args.gameInfo.folder_name)
+    }
+  }
+
   const dmQueueElement: DMQueueElement = {
     params: args,
     type: 'install',

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -379,6 +379,8 @@ export interface InstallArgs {
   branch?: string
   build?: string
   dependencies?: string[]
+  previousProgress?: InstallProgress
+  previousProgressStrategy?: string
 }
 
 export interface InstallParams extends InstallArgs {

--- a/src/frontend/helpers/library.ts
+++ b/src/frontend/helpers/library.ts
@@ -19,6 +19,7 @@ type InstallArgs = {
   installPath: string
   isInstalling: boolean
   previousProgress: InstallProgress | null
+  previousProgressStrategy?: string
   progress: InstallProgress
   installDlcs?: Array<string>
   t: TFunction<'gamepage'>
@@ -38,6 +39,7 @@ async function install({
   progress,
   isInstalling,
   previousProgress,
+  previousProgressStrategy,
   setInstallPath,
   sdlList = [],
   installDlcs = [],
@@ -95,7 +97,9 @@ async function install({
     platformToInstall,
     gameInfo,
     build,
-    branch
+    branch,
+    previousProgress: previousProgress ? previousProgress : undefined,
+    previousProgressStrategy
   })
 }
 

--- a/src/frontend/screens/Library/components/GameCard/constants.ts
+++ b/src/frontend/screens/Library/components/GameCard/constants.ts
@@ -59,6 +59,7 @@ export function getCardStatus(
     isLaunching,
     isInstallingWinetricksPackages,
     isInstallingRedist,
+    isMoving,
     haveStatus
   }
 }

--- a/src/frontend/screens/Library/components/GameCard/index.tsx
+++ b/src/frontend/screens/Library/components/GameCard/index.tsx
@@ -171,6 +171,7 @@ const GameCard = ({
     isPlaying,
     notAvailable,
     isUpdating,
+    isMoving,
     haveStatus
   } = getCardStatus(status, isInstalled, layout)
 
@@ -261,6 +262,13 @@ const GameCard = ({
         >
           {justPlayed ? <span>{t('button.play', 'PLAY')}</span> : <PlayIcon />}
         </SvgButton>
+      )
+    }
+    if (isMoving) {
+      return (
+        <button className="svg-button iconDisabled">
+          <svg />
+        </button>
       )
     } else {
       return (

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -4,6 +4,7 @@ import {
   faSpinner
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { MenuItem } from '@mui/material'
 
 import classNames from 'classnames'
 import {
@@ -26,6 +27,7 @@ import {
   DialogFooter,
   DialogContent
 } from 'frontend/components/UI/Dialog'
+import SelectField from 'frontend/components/UI/SelectField'
 import {
   getProgress,
   size,
@@ -150,6 +152,9 @@ export default function DownloadDialog({
     validFlatpakPath: true,
     spaceLeftAfter: ''
   })
+
+  const [previousProgressStrategy, setPreviousProgressStrategy] =
+    useState<string>('move')
 
   const anticheatInfo = hasAnticheatInfo(gameInfo)
 
@@ -287,7 +292,6 @@ export default function DownloadDialog({
       gameInfo,
       installPath: path || installFolder,
       isInstalling: false,
-      previousProgress,
       progress: previousProgress,
       t,
       sdlList,
@@ -296,7 +300,9 @@ export default function DownloadDialog({
       platformToInstall,
       build: selectedBuild,
       branch,
-      showDialogModal: () => backdropClick()
+      showDialogModal: () => backdropClick(),
+      previousProgressStrategy,
+      previousProgress
     })
   }
 
@@ -570,10 +576,14 @@ export default function DownloadDialog({
     if (installPath) {
       if (notEnoughDiskSpace) {
         return t('button.force-innstall', 'Force Install')
-      } else {
-        return previousProgress.folder === installPath
-          ? t('button.continue', 'Continue Download')
-          : t('button.install')
+      } else if (!previousProgress.folder) {
+        return t('button.install')
+      } else if (previousProgress.folder === installPath) {
+        return t('button.continue', 'Continue Download')
+      } else if (previousProgressStrategy === 'move') {
+        return t('button.move_and_continue', 'Move and Continue Download')
+      } else if (previousProgressStrategy === 'delete') {
+        return t('button.delete_and_install', 'Delete and Install')
       }
     }
     return t('button.no-path-selected', 'No path selected')
@@ -584,6 +594,17 @@ export default function DownloadDialog({
 
   const showDlcSelector =
     ['legendary', 'gog'].includes(runner) && DLCList && DLCList?.length > 0
+
+  const previousProgressStrategyOptions = {
+    move: t(
+      'install.previous_progress_strategy_options.move',
+      'Move to new path and continue'
+    ),
+    delete: t(
+      'install.previous_progress_strategy_options.delete',
+      'Delete and download from scratch'
+    )
+  }
 
   return (
     <>
@@ -636,21 +657,41 @@ export default function DownloadDialog({
               `${t('game.getting-install-size', 'Geting install size')}...`
             )}
           </div>
-          {previousProgress.folder === installPath && (
-            <div className="InstallModal__size">
-              <FontAwesomeIcon
-                className="InstallModal__sizeIcon"
-                icon={faSpinner}
-              />
-              <div className="InstallModal__sizeLabel">
-                {t('status.totalDownloaded', 'Total Downloaded')}:
-              </div>
-              <div className="InstallModal__sizeValue">
-                {getProgress(previousProgress)}%
-              </div>
+          <div className="InstallModal__size">
+            <FontAwesomeIcon
+              className="InstallModal__sizeIcon"
+              icon={faSpinner}
+            />
+            <div className="InstallModal__sizeLabel">
+              {t('status.totalDownloaded', 'Total Downloaded')}:
             </div>
-          )}
+            <div className="InstallModal__sizeValue">
+              {getProgress(previousProgress)}%
+            </div>
+          </div>
         </div>
+
+        {previousProgress.folder && previousProgress.folder !== installPath && (
+          <SelectField
+            htmlId="previousProgressStrategySelect"
+            value={previousProgressStrategy}
+            onChange={(event) =>
+              setPreviousProgressStrategy(event.target.value)
+            }
+            label={t(
+              'install.previous_progress_strategy_prompt',
+              'What to do with previous partial download?'
+            )}
+          >
+            {Object.entries(previousProgressStrategyOptions).map(
+              ([key, value]) => (
+                <MenuItem key={key} value={key}>
+                  {value}
+                </MenuItem>
+              )
+            )}
+          </SelectField>
+        )}
         {installLanguages && installLanguages?.length > 1 && (
           <GameLanguageSelector
             installPlatform={platformToInstall}

--- a/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/DownloadDialog/index.tsx
@@ -521,7 +521,10 @@ export default function DownloadDialog({
       return size(languageSize + universalSize + dlcSize)
     }
     if (gameInstallInfo?.manifest?.download_size) {
-      if (previousProgress.folder === installPath) {
+      if (
+        previousProgress.folder === installPath ||
+        previousProgressStrategy === 'move'
+      ) {
         const progress = 100 - getProgress(previousProgress)
         return size(
           (progress / 100) * Number(gameInstallInfo.manifest.disk_size)
@@ -531,7 +534,13 @@ export default function DownloadDialog({
       return size(Number(gameInstallInfo?.manifest?.download_size))
     }
     return ''
-  }, [installPath, gameInstallInfo, installLanguage, dlcsToInstall])
+  }, [
+    installPath,
+    gameInstallInfo,
+    installLanguage,
+    dlcsToInstall,
+    previousProgressStrategy
+  ])
 
   const installSize = useMemo(() => {
     if (


### PR DESCRIPTION
Addresses #1488

This PR adds a select field to the download dialog that conditionally appears when a user selects a different install path than their previous partial attempt, which allows them to choose a strategy to deal with the previous partial download. The user can choose to move the partial download to their new install path and the download will continue once the move is complete; or they can choose to delete the partial download and start the installation from the beginning.

I'm not sure if my changes are the best way to solve this issue and this PR ended up being a more extensive change than I anticipated, so I'm submitting it as a draft as I expect it may need large changes.

### Screenshots
<img width="1882" height="1029" alt="1" src="https://github.com/user-attachments/assets/ec059d91-d45a-4fba-994c-64d330ccacc8" />
<img width="1882" height="1029" alt="2" src="https://github.com/user-attachments/assets/b41f7f2b-42d7-4c1a-af86-54917a1ad684" />
<img width="1882" height="1029" alt="3" src="https://github.com/user-attachments/assets/a89dc8dd-599d-4299-8002-0eab6fbcf143" />
<img width="1882" height="1029" alt="4" src="https://github.com/user-attachments/assets/4d8ce8c4-65ef-4429-8462-eb9a7f2fe84f" />

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
