### PR TITLE
[Tech] Don't minify main, and add source maps

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -21,8 +21,8 @@ export default defineConfig(({ mode }) => ({
         input: 'src/backend/main.ts'
       },
       outDir: 'build/main',
-      minify: true,
-      sourcemap: mode === 'development' ? 'inline' : false
+      minify: false,
+      sourcemap: 'inline'
     },
     resolve: { alias: srcAliases },
     plugins: [externalizeDepsPlugin({ exclude: dependenciesToNotExternalize })]


### PR DESCRIPTION
This increases our build size slightly (~500KB of main -> 3.5MB), but gives us much more readable error messages. Since the main factor in our final build size is Electron (and it is sitting at ~250MB), I think we can spare the extra 3MB to give us the comfort.

Before:
```
(node:3997101) UnhandledPromiseRejectionWarning: Error: A scary error
    at Object.vd [as getInstalledGames] (.../resources/app.asar/build/main/main.js:124:12768)
    at Pd.refreshInstalled (.../resources/app.asar/build/main/main.js:157:11721)
    at Pd.init (.../resources/app.asar/build/main/main.js:157:10750)
    at .../resources/app.asar/build/main/main.js:169:5405
    at Array.map (<anonymous>)
    at Md (.../resources/app.asar/build/main/main.js:169:5396)
    at .../resources/app.asar/build/main/main.js:185:38956
```
After:
```
(node:4007946) UnhandledPromiseRejectionWarning: Error: A scary error
    at Object.getInstalledGames (.../resources/app.asar/src/backend/storeManagers/legendary/thirdParty.ts:8:9)
    at LegendaryLibraryManager.refreshInstalled (.../resources/app.asar/src/backend/storeManagers/legendary/library.ts:152:40)
    at LegendaryLibraryManager.init (.../resources/app.asar/src/backend/storeManagers/legendary/library.ts:66:10)
    at .../resources/app.asar/src/backend/storeManagers/index.ts:64:63
    at Array.map (<anonymous>)
    at initStoreManagers (.../resources/app.asar/src/backend/storeManagers/index.ts:64:38)
    at .../resources/app.asar/src/backend/main.ts:335:5
```
Note: I've replaced the path to the install/build directory with `...` to aid readability.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
