### PR TITLE
Fix: show Rosetta warning when Rosetta is not installed

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1325,11 +1325,15 @@ export async function checkRosettaInstall() {
     return
   }
 
-  const { stdout: rosettaCheck } = await execAsync(
-    'arch -x86_64 /usr/sbin/sysctl sysctl.proc_translated'
-  )
-
-  const result = rosettaCheck.split(':')[1].trim() === '1'
+  let result = false
+  try {
+    const { stdout: rosettaCheck } = await execAsync(
+      'arch -x86_64 /usr/sbin/sysctl sysctl.proc_translated'
+    )
+    result = rosettaCheck.split(':')[1].trim() === '1'
+  } catch {
+    // the spawn itself fails when Rosetta is not installed
+  }
 
   logInfo(
     `Rosetta is ${result ? 'available' : 'not available'} on this system.`,

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1325,15 +1325,12 @@ export async function checkRosettaInstall() {
     return
   }
 
-  let result = false
-  try {
-    const { stdout: rosettaCheck } = await execAsync(
-      'arch -x86_64 /usr/sbin/sysctl sysctl.proc_translated'
-    )
-    result = rosettaCheck.split(':')[1].trim() === '1'
-  } catch {
-    // the spawn itself fails when Rosetta is not installed
-  }
+  // the spawn itself fails when Rosetta is not installed
+  const result = await execAsync(
+    'arch -x86_64 /usr/sbin/sysctl sysctl.proc_translated'
+  )
+    .then(() => true)
+    .catch(() => false)
 
   logInfo(
     `Rosetta is ${result ? 'available' : 'not available'} on this system.`,


### PR DESCRIPTION
We had the code to check for if rosetta was installed or not on macOS but its was not working anymore after some regression, I am not sure, maybe never worked. I tested this one now and it works fine. I got the issue when updated to macOS 27 beta.