### PR TITLE
Fix Sorting and Filtering/Search for custom renamed games

### DIFF
--- a/src/frontend/components/UI/LibrarySearchBar/index.tsx
+++ b/src/frontend/components/UI/LibrarySearchBar/index.tsx
@@ -6,6 +6,7 @@ import SearchBar from '../SearchBar'
 import { useTranslation } from 'react-i18next'
 import LibraryContext from 'frontend/screens/Library/LibraryContext'
 import { normalizeTitle } from 'frontend/helpers/library'
+import { getGameDisplayTitle } from 'frontend/helpers/gameOverrides'
 
 function fixFilter(text: string) {
   const regex = new RegExp(/([?\\|*|+|(|)|[|]|])+/, 'g')
@@ -41,12 +42,16 @@ export default function LibrarySearchBar() {
     ]
       .filter(Boolean)
       .filter((el) => {
+        if (el.install.is_dlc) return false
         return (
-          !el.install.is_dlc &&
-          normalizeTitle(el.title).includes(normalizedFilterText)
+          normalizeTitle(getGameDisplayTitle(el)).includes(
+            normalizedFilterText
+          ) || normalizeTitle(el.title).includes(normalizedFilterText)
         )
       })
-      .sort((g1, g2) => (g1.title < g2.title ? -1 : 1))
+      .sort((g1, g2) =>
+        getGameDisplayTitle(g1).localeCompare(getGameDisplayTitle(g2))
+      )
   }, [
     amazon.library,
     epic.library,

--- a/src/frontend/helpers/gameOverrides.ts
+++ b/src/frontend/helpers/gameOverrides.ts
@@ -2,6 +2,9 @@ import type { GameInfo } from 'common/types'
 
 type GameOverride = NonNullable<GameInfo['overrides']>
 
+export const getGameDisplayTitle = (game: GameInfo): string =>
+  game.overrides?.title || game.title
+
 export const attachGameOverrides = (
   games: GameInfo[],
   overrides: Record<string, GameOverride>

--- a/src/frontend/screens/ConsoleMode/index.tsx
+++ b/src/frontend/screens/ConsoleMode/index.tsx
@@ -14,6 +14,7 @@ import classNames from 'classnames'
 
 import ContextProvider from 'frontend/state/ContextProvider'
 import { sendKill, updateGame } from 'frontend/helpers'
+import { getGameDisplayTitle } from 'frontend/helpers/gameOverrides'
 import HeroicIcon from 'frontend/assets/heroic-icon.svg?react'
 
 import ConfirmDialog from './components/ConfirmDialog'
@@ -145,7 +146,7 @@ export default function ConsoleMode() {
     }
 
     return filteredGames.sort((a, b) => {
-      const cmp = a.title.localeCompare(b.title)
+      const cmp = getGameDisplayTitle(a).localeCompare(getGameDisplayTitle(b))
       return ascending ? cmp : -cmp
     })
   }, [allGames, filteringByInstalled, activeStore, ascending])

--- a/src/frontend/screens/Library/index.tsx
+++ b/src/frontend/screens/Library/index.tsx
@@ -37,6 +37,10 @@ import CategoriesManager from './components/CategoriesManager'
 import LibraryTour from './components/LibraryTour'
 import AlphabetFilter from './components/AlphabetFilter'
 import { openInstallGameModal } from 'frontend/state/InstallGameModal'
+import { getGameDisplayTitle } from 'frontend/helpers/gameOverrides'
+
+const titleForSorting = (game: GameInfo) =>
+  getGameDisplayTitle(game).toUpperCase().replace('THE ', '')
 
 const storage = window.localStorage
 
@@ -44,6 +48,8 @@ type SearchableGame = {
   original: GameInfo
   title: string
   normalizedTitle: string
+  storeTitle: string
+  normalizedStoreTitle: string
 }
 
 export default React.memo(function Library(): JSX.Element {
@@ -375,11 +381,9 @@ export default React.memo(function Library(): JSX.Element {
         if (favouriteAppNames.includes(game.app_name)) tempArray.push(game)
       })
     }
-    return tempArray.sort((a, b) => {
-      const gameA = a.title.toUpperCase().replace('THE ', '')
-      const gameB = b.title.toUpperCase().replace('THE ', '')
-      return gameA.localeCompare(gameB)
-    })
+    return tempArray.sort((a, b) =>
+      titleForSorting(a).localeCompare(titleForSorting(b))
+    )
   }, [
     showFavourites,
     showFavouritesLibrary,
@@ -521,11 +525,14 @@ export default React.memo(function Library(): JSX.Element {
       const filteredLibrary = filterByPlatform(library)
       const searchableLibrary: SearchableGame[] = filteredLibrary.map(
         (game) => {
-          const title = game.overrides?.title || game.title
+          const title = getGameDisplayTitle(game)
+          const storeTitle = title === game.title ? '' : game.title
           return {
             original: game,
             title,
-            normalizedTitle: normalizeTitle(title)
+            normalizedTitle: normalizeTitle(title),
+            storeTitle,
+            normalizedStoreTitle: storeTitle ? normalizeTitle(storeTitle) : ''
           }
         }
       )
@@ -534,7 +541,12 @@ export default React.memo(function Library(): JSX.Element {
         minMatchCharLength: 1,
         threshold: 0.4,
         useExtendedSearch: true,
-        keys: ['title', 'normalizedTitle']
+        keys: [
+          { name: 'title', weight: 2 },
+          { name: 'normalizedTitle', weight: 2 },
+          { name: 'storeTitle', weight: 1 },
+          { name: 'normalizedStoreTitle', weight: 1 }
+        ]
       }
       const fuse = new Fuse(searchableLibrary, options)
 
@@ -611,11 +623,8 @@ export default React.memo(function Library(): JSX.Element {
 
     // sort
     library = library.sort((a, b) => {
-      const gameA = a.title.toUpperCase().replace('THE ', '')
-      const gameB = b.title.toUpperCase().replace('THE ', '')
-      return sortDescending
-        ? -gameA.localeCompare(gameB)
-        : gameA.localeCompare(gameB)
+      const cmp = titleForSorting(a).localeCompare(titleForSorting(b))
+      return sortDescending ? -cmp : cmp
     })
     const installed = library.filter((game) => game?.is_installed)
     const notInstalled = library.filter(

--- a/src/frontend/screens/Settings/sections/LogSettings/index.tsx
+++ b/src/frontend/screens/Settings/sections/LogSettings/index.tsx
@@ -8,6 +8,7 @@ import './index.css'
 import ContextProvider from 'frontend/state/ContextProvider'
 import { GameInfo } from 'common/types'
 import { openDiscordLink } from 'frontend/helpers'
+import { getGameDisplayTitle } from 'frontend/helpers/gameOverrides'
 import { faDiscord } from '@fortawesome/free-brands-svg-icons'
 import useGlobalState from 'frontend/state/GlobalStateV2'
 import Upload from '@mui/icons-material/Upload'
@@ -91,7 +92,9 @@ export default function LogSettings() {
     games = games.concat(amazon.library.filter((game) => game.is_installed))
     games = games.concat(zoom.library.filter((game) => game.is_installed))
     games = games.concat(sideloadedLibrary.filter((game) => game.is_installed))
-    games = games.sort((game1, game2) => game1.title.localeCompare(game2.title))
+    games = games.sort((game1, game2) =>
+      getGameDisplayTitle(game1).localeCompare(getGameDisplayTitle(game2))
+    )
 
     setInstalledGames(games)
   }, [
@@ -131,9 +134,10 @@ export default function LogSettings() {
     if (!showLogOf.runner)
       return t('setting.log.descriptiveNames.heroic', 'General Heroic log')
     if (showLogOf.appName) {
-      const gameTitle = installedGames.find(
+      const game = installedGames.find(
         ({ app_name }) => app_name === showLogOf.appName
-      )?.title
+      )
+      const gameTitle = game ? getGameDisplayTitle(game) : undefined
       return t(
         'setting.log.descriptiveNames.game-log',
         'Game log of {{gameTitle}}',


### PR DESCRIPTION
The new feature to rename a game breaks sorting.
Also searching does only work for one of both.

This PR fixes the sorting and also allows searching for the original game name as well as the custom name.

Mentioned issue: #5765
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ X] Tested the feature and it's working on a current and clean install.
- [ X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
