### PR TITLE
[Tech] Slim down `Game`

### DIFF
--- a/src/backend/__tests__/protocol.test.ts
+++ b/src/backend/__tests__/protocol.test.ts
@@ -30,6 +30,14 @@ jest.mock('../config', () => ({
   }
 }))
 
+const mockGameSettings = {
+  ignoreGameUpdates: false
+}
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  getSettings: () => mockGameSettings
+}))
+
 import { handleProtocol, shouldHideWindowForProtocolArgs } from '../protocol'
 import { app, dialog } from 'electron'
 import { libraryManagerMap } from '../storeManagers'
@@ -122,15 +130,11 @@ describe('protocol.ts --no-gui behavior', () => {
     is_installed: false
   }
 
-  const mockGameSettings = {
-    ignoreGameUpdates: false
-  }
   const emptyGameInfoMock = { getGameInfo: () => ({}) }
 
   beforeEach(() => {
     jest.clearAllMocks()
     fakeGame.getGameInfo.mockReturnValue(mockGameInfo)
-    fakeGame.getSettings.mockReturnValue(mockGameSettings)
     mockHideWindowOnProtocolLaunch.mockReturnValue(false)
     mockMainWindow.isVisible.mockReturnValue(true)
     ;(getMainWindow as jest.Mock).mockReturnValue(mockMainWindow)

--- a/src/backend/__tests__/util.ts
+++ b/src/backend/__tests__/util.ts
@@ -15,8 +15,6 @@ export class FakeGame extends Game {
     return `FakeGame(id=${this.id}, runner=${this.runner})`
   }
 
-  getSettings = jest.fn()
-  addShortcuts = jest.fn()
   forceUninstall = jest.fn()
   getExtraInfo = jest.fn()
   getGameInfo = jest.fn()
@@ -26,8 +24,6 @@ export class FakeGame extends Game {
   isNative = jest.fn()
   launch = jest.fn()
   moveInstall = jest.fn()
-  onInstallOrUpdateOutput = jest.fn()
-  removeShortcuts = jest.fn()
   repair = jest.fn()
   stop = jest.fn()
   syncSaves = jest.fn()

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -31,7 +31,8 @@ import {
   sendGameStatusUpdate,
   checkWineBeforeLaunch,
   isMacSonomaOrHigher,
-  askForceUninstall
+  askForceUninstall,
+  getSettings
 } from './utils'
 import {
   createGameLogWriter,
@@ -118,7 +119,7 @@ async function launchEventCallback(
     return { status: 'abort' }
   }
 
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
   const { autoSyncSaves, savesPath, gogSaves = [] } = gameSettings
 
   if (!launchArguments && gameSettings.lastUsedLaunchOption) {
@@ -446,7 +447,7 @@ async function prepareLaunch(
   logWriter: LogWriter
 ): Promise<LaunchPreperationResult> {
   const gameInfo = game.getGameInfo()
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
   const isNative = game.isNative()
 
   const globalSettings = GlobalConfig.get().getSettings()
@@ -733,7 +734,7 @@ async function prepareLaunch(
 
 // Use Crossover's verbose output to extract the path of the game's configured bottle
 async function getCrossoverBottleFolder(game: Game) {
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
   const command = runWineCommand(game, {
     commandParts: [
       '--bottle',
@@ -768,7 +769,7 @@ async function prepareWineLaunch(
 }> {
   const gameInfo = game.getGameInfo()
 
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
 
   if (!(await validWine(gameSettings.wineVersion))) {
     const defaultWine = GlobalConfig.get().getSettings().wineVersion
@@ -1376,8 +1377,7 @@ export async function validWine(
 export async function verifyWinePrefix(
   game: Game
 ): Promise<{ res: ExecResult }> {
-  const { winePrefix = sharedWinePrefix, wineVersion } =
-    await game.getSettings()
+  const { winePrefix = sharedWinePrefix, wineVersion } = await getSettings(game)
 
   const isValidWine = await validWine(wineVersion)
 
@@ -1444,7 +1444,7 @@ async function runWineCommand(
     ignoreLogging = false
   } = args
 
-  const settings = await game.getSettings()
+  const settings = await getSettings(game)
   const { wineVersion, winePrefix } = settings
 
   if (!skipPrefixCheckIKnowWhatImDoing && wineVersion.type !== 'crossover') {
@@ -1866,7 +1866,7 @@ async function getWinePath(
 }
 
 async function runBeforeLaunchScript(game: Game, logWriter: LogWriter) {
-  const { beforeLaunchScriptPath } = await game.getSettings()
+  const { beforeLaunchScriptPath } = await getSettings(game)
   if (!beforeLaunchScriptPath) {
     return true
   }
@@ -1879,7 +1879,7 @@ async function runBeforeLaunchScript(game: Game, logWriter: LogWriter) {
 }
 
 async function runAfterLaunchScript(game: Game, logWriter: LogWriter) {
-  const { afterLaunchScriptPath } = await game.getSettings()
+  const { afterLaunchScriptPath } = await getSettings(game)
   if (!afterLaunchScriptPath) {
     return true
   }
@@ -1917,7 +1917,7 @@ async function runScriptForGame(
   scriptStage: 'before' | 'after',
   logWriter: LogWriter
 ): Promise<boolean | string> {
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
   const gameInfo = game.getGameInfo()
   return new Promise((resolve, reject) => {
     const scriptPath = gameSettings[`${scriptStage}LaunchScriptPath`]

--- a/src/backend/logger/index.ts
+++ b/src/backend/logger/index.ts
@@ -8,6 +8,7 @@ import { GameLogType, getLogFilePath } from './paths'
 
 import type { Game } from 'common/types/game_manager'
 import type { RunnerOrComet } from './types'
+import { getSettings } from '../utils'
 
 let heroicLogWriter: LogWriter
 const runnerLogWriters = new Map<RunnerOrComet, LogWriter>()
@@ -45,7 +46,7 @@ async function createGameLogWriter(
 ): Promise<LogWriter> {
   const logsDisabledGlobally = GlobalConfig.get().getSettings().disableLogs
   const logsDisabledPerGame =
-    type === 'launch' ? !(await game.getSettings()).verboseLogs : false
+    type === 'launch' ? !(await getSettings(game)).verboseLogs : false
 
   return new LogWriter(
     getLogFilePath({ appName: game.id, runner: game.runner, type }),

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -56,7 +56,8 @@ import {
   checkRosettaInstall,
   writeConfig,
   createNecessaryFolders,
-  clearAchievementCache
+  clearAchievementCache,
+  getSettings
 } from './utils'
 import { startPlausible } from './utils/plausible'
 
@@ -747,7 +748,7 @@ addHandler('getAchievements', async (event, game, lang = 'en-US') => {
   return game.getAchievements?.(lang) ?? []
 })
 
-addHandler('getGameSettings', async (event, game) => game.getSettings())
+addHandler('getGameSettings', async (event, game) => getSettings(game))
 
 addHandler('getGOGLinuxInstallersLangs', async (event, game) =>
   libraryManagerMap['gog'].getLinuxInstallersLanguages(game.id)
@@ -805,7 +806,7 @@ addHandler('readConfig', async (event, configClass) => {
 })
 
 addHandler('requestAppSettings', () => GlobalConfig.get().getSettings())
-addHandler('requestGameSettings', async (_e, game) => game.getSettings())
+addHandler('requestGameSettings', async (_e, game) => getSettings(game))
 
 addHandler('toggleDXVK', async (event, game, action) =>
   DXVK.installRemove(game, 'dxvk', action)

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -10,7 +10,7 @@ import { Path } from './schemas'
 import { isCLINoGui } from './constants/environment'
 import { GlobalConfig } from './config'
 import { Runner } from 'common/schemas'
-import { getGame } from './utils'
+import { getGame, getSettings } from './utils'
 import { Game } from '../common/types/game_manager'
 
 function parseHeroicUrl(args: string[]): URL | undefined {
@@ -109,7 +109,7 @@ async function handleLaunch(url: URL) {
   }
 
   const { is_installed, title } = game.getGameInfo()
-  const settings = await game.getSettings()
+  const settings = await getSettings(game)
   const hideForThisLaunch =
     urlRequestsNoGui(url) ||
     GlobalConfig.get().getSettings().hideWindowOnProtocolLaunch === true

--- a/src/backend/save_sync.ts
+++ b/src/backend/save_sync.ts
@@ -2,7 +2,7 @@ import { InstalledInfo } from 'common/types'
 import { GOGCloudSavesLocation, SaveFolderVariable } from 'common/types/gog'
 import { getWinePath, setupWineEnvVars, verifyWinePrefix } from './launcher'
 import { logDebug, LogPrefix, logInfo, logError, logWarning } from './logger'
-import { getShellPath } from './utils'
+import { getSettings, getShellPath } from './utils'
 import {
   existsSync,
   readFileSync,
@@ -77,7 +77,7 @@ async function getDefaultLegendarySavePath(game: Game): Promise<string> {
     {
       abortId: game.id + '-savePath',
       logMessagePrefix: 'Getting default save path',
-      env: game.isNative() ? {} : setupWineEnvVars(await game.getSettings()),
+      env: game.isNative() ? {} : setupWineEnvVars(await getSettings(game)),
       game
     }
   )

--- a/src/backend/shortcuts/ipc_handler.ts
+++ b/src/backend/shortcuts/ipc_handler.ts
@@ -6,12 +6,16 @@ import {
   isAddedToSteam,
   removeNonSteamGame
 } from './nonesteamgame/nonesteamgame'
-import { shortcutFiles } from './shortcuts/shortcuts'
+import {
+  addShortcuts,
+  removeShortcuts,
+  shortcutFiles
+} from './shortcuts/shortcuts'
 import { notify } from 'backend/dialog/dialog'
 import { isMac } from 'backend/constants/environment'
 
 addListener('addShortcut', async (event, game, fromMenu) => {
-  game.addShortcuts(fromMenu)
+  await addShortcuts(game, fromMenu)
 
   const body = i18next.t(
     'box.shortcuts.message',
@@ -38,7 +42,7 @@ addHandler('shortcutsExists', (event, game) => {
 })
 
 addListener('removeShortcut', async (event, game) => {
-  game.removeShortcuts()
+  await removeShortcuts(game)
 
   const body = i18next.t(
     'box.shortcuts.message-remove',

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -197,12 +197,7 @@ export default class GOGGame extends Game {
   })
   private tmpProgress: InstallProgress | undefined
 
-  onInstallOrUpdateOutput(
-    action: 'installing' | 'updating',
-    data: string,
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    totalDownloadSize = -1
-  ) {
+  onInstallOrUpdateOutput(action: 'installing' | 'updating', data: string) {
     if (!this.tmpProgress) {
       this.tmpProgress = this.defaultTmpProgress()
     }

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -56,8 +56,8 @@ import {
   setupWrappers
 } from '../../launcher'
 import {
-  addShortcuts as addShortcutsUtil,
-  removeShortcuts as removeShortcutsUtil
+  addShortcuts,
+  removeShortcuts
 } from '../../shortcuts/shortcuts/shortcuts'
 import setup from './setup'
 import { removeNonSteamGame } from '../../shortcuts/nonesteamgame/nonesteamgame'
@@ -180,7 +180,7 @@ export default class GOGGame extends Game {
         JSON.parse(res.stdout),
         folderPath
       )
-      this.addShortcuts()
+      addShortcuts(this)
     } catch (error) {
       logError([`Failed to import ${this.id}:`, error], LogPrefix.Gog)
     }
@@ -435,7 +435,7 @@ export default class GOGGame extends Game {
         )
       }
     }
-    this.addShortcuts()
+    addShortcuts(this)
     return { status: 'done' }
   }
 
@@ -454,14 +454,6 @@ export default class GOGGame extends Game {
     }
 
     return false
-  }
-
-  async addShortcuts(fromMenu?: boolean) {
-    return addShortcutsUtil(this, fromMenu)
-  }
-
-  async removeShortcuts() {
-    return removeShortcutsUtil(this)
   }
 
   async launch(
@@ -932,7 +924,7 @@ export default class GOGGame extends Game {
     const gameInfo = this.getGameInfo()
     gameInfo.is_installed = false
     gameInfo.install = { is_dlc: false }
-    await removeShortcutsUtil(this)
+    await removeShortcuts(this)
     syncStore.delete(this.id)
     await removeNonSteamGame(this)
     sendFrontendMessage('pushGameToLibrary', gameInfo)

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -1,6 +1,5 @@
 import { libraryManagerMap } from '..'
 import { join } from 'path'
-import { GameConfig } from '../../game_config'
 import { GlobalConfig } from '../../config'
 import {
   errorHandler,
@@ -13,11 +12,11 @@ import {
   sendGameStatusUpdate,
   getPathDiskSize,
   getCometBin,
-  axiosClient
+  axiosClient,
+  getSettings
 } from '../../utils'
 import {
   GameInfo,
-  GameSettings,
   ExecResult,
   InstallArgs,
   InstalledInfo,
@@ -155,13 +154,6 @@ export default class GOGGame extends Game {
       }
     }
     return info
-  }
-
-  async getSettings(): Promise<GameSettings> {
-    return (
-      GameConfig.get(this.id).config ||
-      (await GameConfig.get(this.id).getSettings())
-    )
   }
 
   async importGame(folderPath: string): Promise<ExecResult> {
@@ -477,7 +469,7 @@ export default class GOGGame extends Game {
     launchArguments?: LaunchOption,
     args: string[] = []
   ): Promise<boolean> {
-    const gameSettings = await this.getSettings()
+    const gameSettings = await getSettings(this)
     const gameInfo = this.getGameInfo()
 
     if (
@@ -729,7 +721,7 @@ export default class GOGGame extends Game {
     newInstallPath: string
   ): Promise<{ status: 'done' } | { status: 'error'; error: string }> {
     const gameInfo = this.getGameInfo()
-    const gameConfig = await this.getSettings()
+    const gameConfig = await getSettings(this)
     logInfo(`Moving ${gameInfo.title} to ${newInstallPath}`, LogPrefix.Gog)
 
     const moveImpl = isWindows ? moveOnWindows : moveOnUnix
@@ -882,7 +874,7 @@ export default class GOGGame extends Game {
 
     const res: ExecResult = { stdout: '', stderr: '' }
     if (existsSync(uninstallerPath)) {
-      const gameSettings = await this.getSettings()
+      const gameSettings = await getSettings(this)
 
       const installDirectory = isWindows
         ? object.install_path
@@ -979,7 +971,7 @@ export default class GOGGame extends Game {
       return { status: 'error' }
     }
 
-    const gameConfig = await this.getSettings()
+    const gameConfig = await getSettings(this)
     const installedDlcs = gameData.install.installedDLCs || []
 
     if (updateOverwrites?.dlcs) {
@@ -1156,7 +1148,7 @@ export default class GOGGame extends Game {
     gameObject.install_size = getFileSize(sizeOnDisk)
     installedGamesStore.set('installed', installedArray)
     libraryManagerMap['gog'].refreshInstalled()
-    const gameSettings = await this.getSettings()
+    const gameSettings = await getSettings(this)
     // Simple check if wine prefix exists and setup can be performed because of an
     // update
     if (

--- a/src/backend/storeManagers/gog/setup.ts
+++ b/src/backend/storeManagers/gog/setup.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { InstalledInfo, WineCommandArgs } from 'common/types'
 import {
   checkWineBeforeLaunch,
+  getSettings,
   sendGameStatusUpdate,
   spawnAsync
 } from '../../utils'
@@ -85,7 +86,7 @@ async function setup(
     return
   }
 
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
   if (!isWindows) {
     const logWriter = getRunnerLogWriter('gog')
     const isWineOkToLaunch = await checkWineBeforeLaunch(game, logWriter)

--- a/src/backend/storeManagers/index.ts
+++ b/src/backend/storeManagers/index.ts
@@ -9,7 +9,7 @@ import { addToQueue } from 'backend/downloadmanager/downloadqueue'
 
 import type { DMQueueElement, Runner } from 'common/types'
 import { Game, LibraryManager } from 'common/types/game_manager'
-import { getGame } from '../utils'
+import { getGame, getSettings } from '../utils'
 
 export const libraryManagerMap = {
   sideload: new SideloadLibraryManager(),
@@ -44,7 +44,7 @@ export function autoUpdate(runner: Runner, gamesToUpdate: string[]) {
   const logPrefix = RunnerToLogPrefixMap[runner]
   gamesToUpdate.forEach(async (appName) => {
     const game = getGame(appName, runner)
-    const { ignoreGameUpdates } = await game.getSettings()
+    const { ignoreGameUpdates } = await getSettings(game)
     const gameInfo = game.getGameInfo()
     const gameIsAvailable = await game.isGameAvailable()
     if (!ignoreGameUpdates && gameIsAvailable) {

--- a/src/backend/storeManagers/legendary/eos_overlay/eos_overlay.ts
+++ b/src/backend/storeManagers/legendary/eos_overlay/eos_overlay.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 
 import { logError, LogPrefix, logWarning } from 'backend/logger'
 import { callAbortController } from 'backend/utils/aborthandler/aborthandler'
-import { sendGameStatusUpdate } from 'backend/utils'
+import { getSettings, sendGameStatusUpdate } from 'backend/utils'
 import { libraryManagerMap } from '../..'
 import { LegendaryCommand } from '../commands'
 import { ValidWinePrefix } from '../commands/base'
@@ -274,7 +274,7 @@ async function getWinePrefixFolder(
 ): Promise<ValidWinePrefix | null | false> {
   if (!isLinux || !game) return null
 
-  const { winePrefix, wineVersion } = await game.getSettings()
+  const { winePrefix, wineVersion } = await getSettings(game)
   const prefixPath =
     wineVersion.type === 'proton' ? join(winePrefix, 'pfx') : winePrefix
   const maybePrefix = ValidWinePrefix.safeParse(prefixPath)

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -10,11 +10,11 @@ import {
   LaunchOption,
   Reqs
 } from 'common/types'
-import { GameConfig } from '../../game_config'
 import { GlobalConfig } from '../../config'
 import { libraryManagerMap } from '..'
 import {
   downloadFile,
+  getSettings,
   killPattern,
   moveOnUnix,
   moveOnWindows,
@@ -255,19 +255,6 @@ export default class LegendaryGame extends Game {
       .toLowerCase()
       .replace(/[^a-z ]/g, '')
       .replaceAll(' ', '-')
-  }
-
-  /**
-   * Alias for `GameConfig.get(appName).config`
-   * If it doesn't exist, uses getSettings() instead.
-   *
-   * @returns GameConfig
-   */
-  async getSettings() {
-    return (
-      GameConfig.get(this.appName).config ||
-      (await GameConfig.get(this.appName).getSettings())
-    )
   }
 
   /**
@@ -781,7 +768,7 @@ export default class LegendaryGame extends Game {
     args: string[] = [],
     skipVersionCheck = false
   ): Promise<boolean> {
-    const gameSettings = await this.getSettings()
+    const gameSettings = await getSettings(this)
     const gameInfo = this.getGameInfo()
 
     const {

--- a/src/backend/storeManagers/legendary/games.ts
+++ b/src/backend/storeManagers/legendary/games.ts
@@ -40,8 +40,8 @@ import {
   getWinePath
 } from '../../launcher'
 import {
-  addShortcuts as addShortcutsUtil,
-  removeShortcuts as removeShortcutsUtil
+  addShortcuts,
+  removeShortcuts
 } from '../../shortcuts/shortcuts/shortcuts'
 import { join } from 'path'
 import { removeNonSteamGame } from '../../shortcuts/nonesteamgame/nonesteamgame'
@@ -446,26 +446,6 @@ export default class LegendaryGame extends Game {
   }
 
   /**
-   * Adds a desktop shortcut to $HOME/Desktop and to /usr/share/applications
-   * so that the game can be opened from the start menu and the desktop folder.
-   * Both can be disabled with addDesktopShortcuts and addStartMenuShortcuts
-   * @async
-   * @public
-   */
-  async addShortcuts(fromMenu?: boolean) {
-    return addShortcutsUtil(this, fromMenu)
-  }
-
-  /**
-   * Removes a desktop shortcut from $HOME/Desktop and to $HOME/.local/share/applications
-   * @async
-   * @public
-   */
-  async removeShortcuts() {
-    return removeShortcutsUtil(this)
-  }
-
-  /**
    * Install game.
    * Does NOT check for online connectivity.
    */
@@ -548,7 +528,7 @@ export default class LegendaryGame extends Game {
       }
       return { status: 'error', error: res.error }
     }
-    this.addShortcuts()
+    addShortcuts(this)
 
     return { status: 'done' }
   }
@@ -652,7 +632,7 @@ export default class LegendaryGame extends Game {
       )
     } else if (!res.abort) {
       libraryManagerMap['legendary'].installState(this.appName, false)
-      await removeShortcutsUtil(this)
+      await removeShortcuts(this)
       await removeNonSteamGame(this)
     }
     sendFrontendMessage('refreshLibrary', 'legendary')
@@ -712,7 +692,7 @@ export default class LegendaryGame extends Game {
       logWriters: [logWriter],
       game: this
     })
-    this.addShortcuts()
+    addShortcuts(this)
     const errorMatch = res.stderr.match(/^.*ERROR:.*$/gm)?.join('') ?? ''
     res.error = (res.error ?? '') + errorMatch
     if (res.error) {

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -42,8 +42,8 @@ import {
 } from 'backend/utils'
 import { GlobalConfig } from 'backend/config'
 import {
-  addShortcuts as addShortcutsUtil,
-  removeShortcuts as removeShortcutsUtil
+  addShortcuts,
+  removeShortcuts
 } from '../../shortcuts/shortcuts/shortcuts'
 import { removeNonSteamGame } from 'backend/shortcuts/nonesteamgame/nonesteamgame'
 import { sendFrontendMessage } from '../../ipc'
@@ -125,7 +125,7 @@ export default class NileGame extends Game {
     }
 
     try {
-      this.addShortcuts()
+      addShortcuts(this)
       libraryManagerMap['nile'].installState(this.id, true)
     } catch (error) {
       logError(['Failed to import', `${this.id}:`, error], LogPrefix.Nile)
@@ -241,7 +241,7 @@ export default class NileGame extends Game {
       }
       return { status: 'error', error: res.error }
     }
-    this.addShortcuts()
+    addShortcuts(this)
     libraryManagerMap['nile'].installState(this.id, true)
     const metadata = libraryManagerMap['nile'].getInstallMetadata(this.id)
 
@@ -254,26 +254,6 @@ export default class NileGame extends Game {
 
   isNative(): boolean {
     return isWindows
-  }
-
-  /**
-   * Adds a desktop shortcut to $HOME/Desktop and to /usr/share/applications
-   * so that the game can be opened from the start menu and the desktop folder.
-   * Both can be disabled with addDesktopShortcuts and addStartMenuShortcuts
-   * @async
-   * @public
-   */
-  async addShortcuts(fromMenu?: boolean) {
-    return addShortcutsUtil(this, fromMenu)
-  }
-
-  /**
-   * Removes a desktop shortcut from $HOME/Desktop and to $HOME/.local/share/applications
-   * @async
-   * @public
-   */
-  async removeShortcuts() {
-    return removeShortcutsUtil(this)
   }
 
   async launch(
@@ -487,7 +467,7 @@ export default class NileGame extends Game {
         LogPrefix.Nile
       )
     } else if (!res.abort) {
-      await removeShortcutsUtil(this)
+      await removeShortcuts(this)
       await removeNonSteamGame(this)
       libraryManagerMap['nile'].installState(this.id, false)
     }

--- a/src/backend/storeManagers/nile/games.ts
+++ b/src/backend/storeManagers/nile/games.ts
@@ -1,7 +1,6 @@
 import {
   ExecResult,
   GameInfo,
-  GameSettings,
   InstallArgs,
   InstallProgress,
   LaunchOption
@@ -15,7 +14,6 @@ import {
   logInfo,
   createGameLogWriter
 } from 'backend/logger'
-import { GameConfig } from 'backend/game_config'
 import {
   getKnownFixesEnvVariables,
   launchCleanup,
@@ -34,6 +32,7 @@ import {
 } from 'backend/utils/compatibility_layers'
 import shlex from 'shlex'
 import {
+  getSettings,
   killPattern,
   moveOnUnix,
   moveOnWindows,
@@ -65,11 +64,6 @@ export default class NileGame extends Game {
 
   toString(): string {
     return `NileGame(id=${this.id})`
-  }
-
-  async getSettings(): Promise<GameSettings> {
-    const gameConfig = GameConfig.get(this.id)
-    return gameConfig.config || (await gameConfig.getSettings())
   }
 
   getGameInfo(): GameInfo {
@@ -287,7 +281,7 @@ export default class NileGame extends Game {
     launchArguments?: LaunchOption,
     args: string[] = []
   ): Promise<boolean> {
-    const gameSettings = await this.getSettings()
+    const gameSettings = await getSettings(this)
     const gameInfo = this.getGameInfo()
 
     const {

--- a/src/backend/storeManagers/nile/setup.ts
+++ b/src/backend/storeManagers/nile/setup.ts
@@ -9,6 +9,7 @@ import {
 import { libraryManagerMap } from '..'
 import {
   checkWineBeforeLaunch,
+  getSettings,
   sendGameStatusUpdate,
   spawnAsync
 } from 'backend/utils'
@@ -60,7 +61,7 @@ export default async function setup(
     LogPrefix.Nile
   )
 
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
   if (!isWindows) {
     const logWriter = getRunnerLogWriter('nile')
     const isWineOkToLaunch = await checkWineBeforeLaunch(game, logWriter)

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -5,10 +5,7 @@ import { logInfo, LogPrefix, logWarning } from 'backend/logger'
 import { dirname } from 'path'
 import { existsSync, rmSync } from 'graceful-fs'
 import i18next from 'i18next'
-import {
-  addShortcuts as addShortcutsUtil,
-  removeShortcuts as removeShortcutsUtil
-} from '../../shortcuts/shortcuts/shortcuts'
+import { removeShortcuts } from '../../shortcuts/shortcuts/shortcuts'
 import { notify } from '../../dialog/dialog'
 import { launchGame } from 'backend/storeManagers/storeManagerCommon/games'
 import { Game, InstallResult, RemoveArgs } from 'common/types/game_manager'
@@ -40,14 +37,6 @@ export default class SideloadGame extends Game {
       return {}
     }
     return info
-  }
-
-  async addShortcuts(fromMenu?: boolean): Promise<void> {
-    return addShortcutsUtil(this, fromMenu)
-  }
-
-  async removeShortcuts(): Promise<void> {
-    return removeShortcutsUtil(this)
   }
 
   async isGameAvailable(): Promise<boolean> {
@@ -114,7 +103,7 @@ export default class SideloadGame extends Game {
 
     notify({ title, body: i18next.t('notify.uninstalled') })
 
-    removeShortcutsUtil(this)
+    removeShortcuts(this)
     removeRecentGame(this)
     removeNonSteamGame(this)
 

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -140,12 +140,6 @@ export default class SideloadGame extends Game {
     return false
   }
 
-  onInstallOrUpdateOutput() {
-    logWarning(
-      `onInstallOrUpdateOutput not implemented on Sideload Game Manager. called for ID = ${this.id}`
-    )
-  }
-
   async moveInstall(): Promise<InstallResult> {
     logWarning(
       `moveInstall not implemented on Sideload Game Manager. called for ID = ${this.id}`

--- a/src/backend/storeManagers/sideload/games.ts
+++ b/src/backend/storeManagers/sideload/games.ts
@@ -1,6 +1,5 @@
-import { ExecResult, GameInfo, GameSettings, LaunchOption } from 'common/types'
+import { ExecResult, GameInfo, LaunchOption } from 'common/types'
 import { libraryStore } from './electronStores'
-import { GameConfig } from '../../game_config'
 import { killPattern, sendGameStatusUpdate, shutdownWine } from '../../utils'
 import { logInfo, LogPrefix, logWarning } from 'backend/logger'
 import { dirname } from 'path'
@@ -41,13 +40,6 @@ export default class SideloadGame extends Game {
       return {}
     }
     return info
-  }
-
-  async getSettings(): Promise<GameSettings> {
-    return (
-      GameConfig.get(this.id).config ||
-      (await GameConfig.get(this.id).getSettings())
-    )
   }
 
   async addShortcuts(fromMenu?: boolean): Promise<void> {

--- a/src/backend/storeManagers/storeManagerCommon/games.ts
+++ b/src/backend/storeManagers/storeManagerCommon/games.ts
@@ -21,7 +21,7 @@ import {
   deleteAbortController
 } from '../../utils/aborthandler/aborthandler'
 import { BrowserWindow, dialog, Menu } from 'electron'
-import { sendGameStatusUpdate } from 'backend/utils'
+import { getSettings, sendGameStatusUpdate } from 'backend/utils'
 import { isLinux, isMac } from 'backend/constants/environment'
 import { windowIcon } from 'backend/constants/paths'
 
@@ -117,7 +117,7 @@ export async function launchGame(
 
   const { browserUrl, customUserAgent, launchFullScreen } = gameInfo
 
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
   if (gameSettings.targetExe !== undefined && gameSettings.targetExe !== '') {
     executable = gameSettings.targetExe
   }

--- a/src/backend/storeManagers/zoom/games.ts
+++ b/src/backend/storeManagers/zoom/games.ts
@@ -1,11 +1,11 @@
-import { GameConfig } from '../../game_config'
 import {
   errorHandler,
   getFileSize,
   parseSize,
   spawnAsync,
   sendGameStatusUpdate,
-  sendProgressUpdate
+  sendProgressUpdate,
+  getSettings
 } from '../../utils'
 import { join, relative, dirname, basename, isAbsolute } from 'node:path'
 import * as fs from 'fs'
@@ -14,7 +14,6 @@ import { createWriteStream } from 'node:fs'
 import { pipeline } from 'node:stream/promises'
 import {
   GameInfo,
-  GameSettings,
   ExecResult,
   InstallArgs,
   InstalledInfo,
@@ -141,13 +140,6 @@ export default class ZoomGame extends Game {
       }
     }
     return info
-  }
-
-  async getSettings(): Promise<GameSettings> {
-    return (
-      GameConfig.get(this.id).config ||
-      (await GameConfig.get(this.id).getSettings())
-    )
   }
 
   async importGame(): Promise<ExecResult> {
@@ -567,7 +559,7 @@ export default class ZoomGame extends Game {
     launchArguments?: LaunchOption,
     args: string[] = []
   ): Promise<boolean> {
-    const gameSettings = await this.getSettings()
+    const gameSettings = await getSettings(this)
     const gameInfo = this.getGameInfo()
 
     if (

--- a/src/backend/storeManagers/zoom/games.ts
+++ b/src/backend/storeManagers/zoom/games.ts
@@ -40,10 +40,7 @@ import {
   prepareWineLaunch,
   runWineCommand
 } from '../../launcher'
-import {
-  addShortcuts as addShortcutsUtil,
-  removeShortcuts as removeShortcutsUtil
-} from '../../shortcuts/shortcuts/shortcuts'
+import { removeShortcuts } from '../../shortcuts/shortcuts/shortcuts'
 import { removeNonSteamGame } from '../../shortcuts/nonesteamgame/nonesteamgame'
 import shlex from 'shlex'
 import { ZoomInstallPlatform, ZoomDownloadFile } from 'common/types/zoom'
@@ -546,14 +543,6 @@ export default class ZoomGame extends Game {
     return false
   }
 
-  async addShortcuts(fromMenu?: boolean) {
-    return addShortcutsUtil(this, fromMenu)
-  }
-
-  async removeShortcuts() {
-    return removeShortcutsUtil(this)
-  }
-
   async launch(
     logWriter: LogWriter,
     launchArguments?: LaunchOption,
@@ -755,7 +744,7 @@ export default class ZoomGame extends Game {
     const gameInfo = this.getGameInfo()
     gameInfo.is_installed = false
     gameInfo.install = { is_dlc: false }
-    await removeShortcutsUtil(this)
+    await removeShortcuts(this)
     await removeNonSteamGame(this)
     sendFrontendMessage('pushGameToLibrary', gameInfo)
     return { stdout: 'Uninstalled', stderr: '' }

--- a/src/backend/tools/index.ts
+++ b/src/backend/tools/index.ts
@@ -18,6 +18,7 @@ import {
   downloadFile,
   execAsync,
   extractFiles,
+  getSettings,
   getWineFromProton
 } from '../utils'
 import { execOptions } from 'backend/constants/others'
@@ -201,7 +202,7 @@ export const DXVK = {
     tool: 'dxvk' | 'dxvk-nvapi' | 'vkd3d' | 'dxvk-macOS',
     action: 'backup' | 'restore'
   ): Promise<boolean> => {
-    const gameSettings = await game.getSettings()
+    const gameSettings = await getSettings(game)
     if (gameSettings.wineVersion.bin.includes('toolkit')) {
       // we don't want to install dxvk on the toolkit prefix since it breaks Apple's implementation
       logWarning(
@@ -545,7 +546,7 @@ export const Winetricks = {
     }
   },
   runWithArgs: async (game: Game, args: string[], returnOutput = false) => {
-    const gameSettings = await game.getSettings()
+    const gameSettings = await getSettings(game)
     const { wineVersion } = gameSettings
 
     if (!(await validWine(wineVersion))) {

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -6,7 +6,8 @@ import {
   SteamRuntime,
   Release,
   GameInfo,
-  GameStatus
+  GameStatus,
+  GameSettings
 } from 'common/types'
 import axios from 'axios'
 import https from 'node:https'
@@ -99,6 +100,13 @@ function getGame(id: string, runner: Runner): Game {
   return game
 }
 
+async function getSettings(game: Game): Promise<GameSettings> {
+  return (
+    GameConfig.get(game.id).config ||
+    (await GameConfig.get(game.id).getSettings())
+  )
+}
+
 /**
  * Compares 2 SemVer strings following "major.minor.patch".
  * Checks if target is newer than base.
@@ -151,7 +159,7 @@ const getFileSize = fileSize.partial({ base: 2 }) as (arg: unknown) => string
 async function getWineFromProton(
   game: Game
 ): Promise<{ winePrefix: string; wineVersion: WineInstallation }> {
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
   const wineVersion = gameSettings.wineVersion
   let winePrefix = gameSettings.winePrefix
 
@@ -855,7 +863,7 @@ function killPattern(pattern: string) {
 }
 
 async function shutdownWine(game: Game) {
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
   if (gameSettings.wineVersion.wineserver) {
     spawnSync(gameSettings.wineVersion.wineserver, ['-k'], {
       env: { WINEPREFIX: gameSettings.winePrefix }
@@ -985,7 +993,7 @@ export async function checkWineBeforeLaunch(
   game: Game,
   logWriter: LogWriter
 ): Promise<boolean> {
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
   const wineIsValid = await validWine(gameSettings.wineVersion)
 
   if (wineIsValid) {
@@ -1699,7 +1707,8 @@ export {
   extractFiles,
   axiosClient,
   parseSize,
-  getGame
+  getGame,
+  getSettings
 }
 
 // Exported only for testing purpose

--- a/src/backend/utils/compatibility_layers.ts
+++ b/src/backend/utils/compatibility_layers.ts
@@ -1,6 +1,6 @@
 import { GlobalConfig } from 'backend/config'
 import { logError, LogPrefix, logInfo } from 'backend/logger'
-import { execAsync, getSteamLibraries } from 'backend/utils'
+import { execAsync, getSettings, getSteamLibraries } from 'backend/utils'
 import { execSync } from 'child_process'
 import { WineInstallation } from 'common/types'
 import { existsSync, mkdirSync, readFileSync, readdirSync } from 'graceful-fs'
@@ -507,7 +507,7 @@ export async function getWineFlags(
   wrapper: string
 ): Promise<AllowedWineFlags> {
   let partialCommand: AllowedWineFlags = {}
-  const { wineVersion } = await game.getSettings()
+  const { wineVersion } = await getSettings(game)
   const { type: wineType, bin: wineExec } = wineVersion
 
   // Fix for people with old config
@@ -571,7 +571,7 @@ export async function isUmuSupported(
   game: Game,
   checkUmuInstalled = true
 ): Promise<boolean> {
-  const gameSettings = await game.getSettings()
+  const gameSettings = await getSettings(game)
   if (!isLinux) return false
   if (gameSettings.wineVersion.type !== 'proton') return false
   if (gameSettings.disableUMU === true) {

--- a/src/backend/utils/uninstaller.ts
+++ b/src/backend/utils/uninstaller.ts
@@ -6,7 +6,7 @@ import {
 } from 'backend/constants/paths'
 import { notify } from 'backend/dialog/dialog'
 import { logError, logInfo, LogPrefix } from 'backend/logger'
-import { sendGameStatusUpdate } from 'backend/utils'
+import { sendGameStatusUpdate, getSettings } from 'backend/utils'
 import { storeMap } from 'common/utils'
 import { Event } from 'electron'
 import { existsSync, readdirSync, rmSync } from 'graceful-fs'
@@ -15,7 +15,7 @@ import { join } from 'path'
 import type { Game } from 'common/types/game_manager'
 
 export const removePrefix = async (game: Game) => {
-  const { winePrefix } = await game.getSettings()
+  const { winePrefix } = await getSettings(game)
   logInfo(`Removing prefix ${winePrefix}`, LogPrefix.Backend)
 
   if (!existsSync(winePrefix)) {

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -39,8 +39,6 @@ export abstract class Game {
   ): void
   abstract install(args: InstallArgs): Promise<InstallResult>
   abstract isNative(): boolean
-  abstract addShortcuts(fromMenu?: boolean): Promise<void>
-  abstract removeShortcuts(): Promise<void>
   abstract launch(
     logWriter: LogWriter,
     launchArguments?: LaunchOption,

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -32,11 +32,6 @@ export abstract class Game {
     path: string,
     platform: InstallPlatform
   ): Promise<ExecResult>
-  abstract onInstallOrUpdateOutput(
-    action: 'installing' | 'updating',
-    data: string,
-    totalDownloadSize: number
-  ): void
   abstract install(args: InstallArgs): Promise<InstallResult>
   abstract isNative(): boolean
   abstract launch(

--- a/src/common/types/game_manager.ts
+++ b/src/common/types/game_manager.ts
@@ -1,7 +1,6 @@
 import type {
   GameInfo,
   InstallPlatform,
-  GameSettings,
   ExecResult,
   InstallArgs,
   InstallInfo,
@@ -28,8 +27,6 @@ export abstract class Game {
   abstract readonly runner: Runner
 
   abstract toString(): string
-
-  abstract getSettings(): Promise<GameSettings>
   abstract getGameInfo(): GameInfo
   abstract importGame(
     path: string,


### PR DESCRIPTION
Removes some methods from `Game` that only ever ended up calling out to other parts of Heroic - instead of implementing them for each game, consumers can just call the actual functions instead

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [X] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
