### PR TITLE
refactor: use WEBVIEW_PARTITION constant for all webview partitions

### DIFF
--- a/e2e/webview_controls.spec.ts
+++ b/e2e/webview_controls.spec.ts
@@ -1,51 +1,38 @@
 import { expect, test } from '@playwright/test'
 import { electronTest } from './helpers'
-import { WebviewTag } from 'electron'
+
+const WIKI_URL =
+  'https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki'
+const GOOGLE_URL = 'https://www.google.com/'
 
 electronTest('webview', async (app) => {
   const page = await app.firstWindow()
+  const urlInput = page.locator('.WebviewControls__urlInput')
 
   await test.step('goes back and forth inside webview and also to Heroic screens', async () => {
     // we have to do this or it fails, the icon also has the same text
     await page.locator('span').filter({ hasText: 'Documentation' }).click()
 
-    // we have to wait a bit for the webview to properly load these urls
-    // it's not great to force a sleep, but without these it's too flaky
-    await page.waitForTimeout(600)
+    // wait for the wiki to load in the webview
+    await expect(urlInput).toHaveAttribute('value', WIKI_URL)
 
-    await expect(page.locator('.WebviewControls__urlInput')).toHaveAttribute(
-      'value',
-      'https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki'
-    )
-    await page.waitForTimeout(600)
-
-    // we have to force a src change since we can't really click something reliably
-    // inside the webview programatically
-    await page.$eval(
-      'webview',
-      (el: WebviewTag) => (el.src = 'https://www.google.com/')
-    )
-    await page.waitForTimeout(600)
-
-    await expect(page.locator('.WebviewControls__urlInput')).toHaveAttribute(
-      'value',
-      'https://www.google.com/'
-    )
+    // use evaluate + loadURL so Playwright properly awaits the navigation
+    // promise instead of racing ahead on a src change
+    const webview = await page.$('webview')
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+    await page.evaluate(({ el, url }) => el.loadURL(url), {
+      el: webview,
+      url: GOOGLE_URL
+    })
+    await expect(urlInput).toHaveAttribute('value', GOOGLE_URL)
 
     // go back to previous page in webview's history
     await page.getByTitle('Go back').click()
-    await expect(page.locator('.WebviewControls__urlInput')).toHaveAttribute(
-      'value',
-      'https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki'
-    )
+    await expect(urlInput).toHaveAttribute('value', WIKI_URL)
 
     // go forward again to google.com
     await page.getByTitle('Go forward').click()
-    await expect(page.locator('.WebviewControls__urlInput')).toHaveAttribute(
-      'value',
-      'https://www.google.com/'
-    )
-    await page.waitForTimeout(600)
+    await expect(urlInput).toHaveAttribute('value', GOOGLE_URL)
 
     // simulate mouse back
     await page.dispatchEvent('body', 'mouseup', {
@@ -53,11 +40,7 @@ electronTest('webview', async (app) => {
       bubbles: true,
       cancelable: true
     })
-    await expect(page.locator('.WebviewControls__urlInput')).toHaveAttribute(
-      'value',
-      'https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/wiki'
-    )
-    await page.waitForTimeout(600)
+    await expect(urlInput).toHaveAttribute('value', WIKI_URL)
 
     // simulate mouse forward
     await page.dispatchEvent('webview', 'mouseup', {
@@ -65,11 +48,7 @@ electronTest('webview', async (app) => {
       bubbles: true,
       cancelable: true
     })
-    await expect(page.locator('.WebviewControls__urlInput')).toHaveAttribute(
-      'value',
-      'https://www.google.com/'
-    )
-    await page.waitForTimeout(600)
+    await expect(urlInput).toHaveAttribute('value', GOOGLE_URL)
 
     // it looks like we can't simulate mouse buttons INSIDE the webview to also test those
 

--- a/src/backend/storeManagers/gog/user.ts
+++ b/src/backend/storeManagers/gog/user.ts
@@ -9,6 +9,7 @@ import { libraryManagerMap } from '../index'
 import { clearCache } from 'backend/utils'
 import { app, session } from 'electron'
 import { gogdlAuthConfig } from './constants'
+import { WEBVIEW_PARTITION } from 'common/constants/webview'
 
 function authLogSanitizer(line: string) {
   try {
@@ -130,7 +131,7 @@ export class GOGUser {
     if (existsSync(gogdlAuthConfig)) {
       unlinkSync(gogdlAuthConfig)
     }
-    const ses = session.fromPartition('persist:gog')
+    const ses = session.fromPartition(WEBVIEW_PARTITION.gog)
     ses.clearStorageData().catch(() => {})
     ses.clearCache().catch(() => {})
     ses.clearAuthCache().catch(() => {})

--- a/src/backend/storeManagers/legendary/user.ts
+++ b/src/backend/storeManagers/legendary/user.ts
@@ -10,6 +10,7 @@ import { LegendaryCommand } from './commands'
 import { NonEmptyString } from './commands/base'
 import { configStore } from 'backend/constants/key_value_stores'
 import { legendaryUserInfo } from './constants'
+import { WEBVIEW_PARTITION } from 'common/constants/webview'
 
 export class LegendaryUser {
   public static async login(
@@ -68,7 +69,7 @@ export class LegendaryUser {
       return
     }
 
-    const ses = session.fromPartition('persist:epic')
+    const ses = session.fromPartition(WEBVIEW_PARTITION.epic)
     await ses.clearStorageData()
     await ses.clearCache()
     await ses.clearAuthCache()

--- a/src/backend/storeManagers/nile/user.ts
+++ b/src/backend/storeManagers/nile/user.ts
@@ -10,6 +10,7 @@ import { configStore } from './electronStores'
 import { clearCache } from 'backend/utils'
 import { nileUserData } from './constants'
 import { session } from 'electron'
+import { WEBVIEW_PARTITION } from 'common/constants/webview'
 
 function authLogSanitizer(line: string) {
   try {
@@ -100,7 +101,7 @@ export class NileUser {
 
     configStore.delete('userData')
     clearCache('nile')
-    const ses = session.fromPartition('persist:amazon')
+    const ses = session.fromPartition(WEBVIEW_PARTITION.amazon)
     ses.clearStorageData().catch(() => {})
     ses.clearCache().catch(() => {})
     ses.clearAuthCache().catch(() => {})

--- a/src/backend/storeManagers/zoom/user.ts
+++ b/src/backend/storeManagers/zoom/user.ts
@@ -12,6 +12,7 @@ import { ZoomCredentials } from 'common/types/zoom'
 import { clearCache } from 'backend/utils'
 import { tokenPath, embedUrl, apiUrl } from './constants'
 import { session } from 'electron'
+import { WEBVIEW_PARTITION } from 'common/constants/webview'
 
 export class ZoomUser {
   static async login(url: string): Promise<{
@@ -94,7 +95,7 @@ export class ZoomUser {
     if (existsSync(tokenPath)) {
       unlinkSync(tokenPath)
     }
-    const ses = session.fromPartition('persist:zoom')
+    const ses = session.fromPartition(WEBVIEW_PARTITION.zoom)
     ses.clearStorageData().catch(() => {})
     ses.clearCache().catch(() => {})
     ses.clearAuthCache().catch(() => {})

--- a/src/common/constants/webview.ts
+++ b/src/common/constants/webview.ts
@@ -1,0 +1,35 @@
+/**
+ * Electron session partition names used by store webviews.
+ * Keeping them here prevents naming mismatches between the login
+ * flow (WebView) and the cleanup code (logout handlers).
+ */
+export const WEBVIEW_PARTITION = {
+  epic: 'persist:epic',
+  gog: 'persist:gog',
+  amazon: 'persist:amazon',
+  zoom: 'persist:zoom'
+} as const
+
+/** Maps runner names to their WEBVIEW_PARTITION key. */
+const RUNNER_TO_PARTITION_KEY: Record<string, keyof typeof WEBVIEW_PARTITION> =
+  {
+    legendary: 'epic',
+    gog: 'gog',
+    nile: 'amazon',
+    zoom: 'zoom'
+  }
+
+/**
+ * Returns the Electron session partition for the given store/runner.
+ * Falls back to `persist:<key>` for unrecognised values.
+ */
+export function getWebviewPartition(
+  store: string | undefined,
+  runner: string | undefined
+): string {
+  const key = store ?? (runner ? RUNNER_TO_PARTITION_KEY[runner] : undefined)
+  if (key && key in WEBVIEW_PARTITION) {
+    return WEBVIEW_PARTITION[key as keyof typeof WEBVIEW_PARTITION]
+  }
+  return `persist:${store ?? runner}`
+}

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -1,4 +1,10 @@
-import { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useState
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useLocation, useParams } from 'react-router-dom'
 
@@ -8,6 +14,7 @@ import ContextProvider from 'frontend/state/ContextProvider'
 import './index.css'
 import LoginWarning from '../Login/components/LoginWarning'
 import { NileLoginData } from 'common/types/nile'
+import { getWebviewPartition } from 'common/constants/webview'
 import {
   Dialog,
   DialogContent,
@@ -45,7 +52,14 @@ export default function WebView() {
     null
   )
   const navigate = useNavigate()
-  const webviewRef = useRef<Electron.WebviewTag>(null)
+  // Keep the webview element in state (via a callback ref) instead of a plain
+  // ref so that mounting/remounting it — e.g. when switching stores — triggers
+  // a re-render and propagates the live element to children like
+  // WebviewControls. A mutable ref wouldn't, leaving them with a stale webview.
+  const [webview, setWebview] = useState<Electron.WebviewTag | null>(null)
+  const webviewRef = useCallback((node: Electron.WebviewTag | null) => {
+    setWebview(node)
+  }, [])
 
   // `store` is set to epic/gog/amazon depending on which storefront we're
   // supposed to show, `runner` is set to a runner if we're supposed to show its
@@ -158,9 +172,8 @@ export default function WebView() {
   }, [])
 
   useLayoutEffect(() => {
-    const webview = webviewRef.current
     if (webview) {
-      const loadstop = async () => {
+      const loadstop = () => {
         setLoading({ ...loading, refresh: false })
         const userAgent =
           startUrl === epicLoginUrl
@@ -250,10 +263,9 @@ export default function WebView() {
       }
     }
     return
-  }, [webviewRef.current, amazonLoginData, runner, webviewPreloadPath])
+  }, [webview, amazonLoginData, runner, webviewPreloadPath])
 
   useEffect(() => {
-    const webview = webviewRef.current
     if (webview) {
       const onNavigate = () => {
         if (store) {
@@ -293,7 +305,7 @@ export default function WebView() {
     }
 
     return
-  }, [webviewRef.current, store, runner])
+  }, [webview, store, runner])
 
   const [showLoginWarningFor, setShowLoginWarningFor] = useState<
     null | 'epic' | 'gog' | 'amazon' | 'zoom'
@@ -333,9 +345,7 @@ export default function WebView() {
 
   // Handle back/forward mouse buttons to navigate inside webview
   useEffect(() => {
-    if (!webviewRef.current) return
-
-    const webview = webviewRef.current
+    if (!webview) return
 
     const handleMouseBackForward = (ev: MouseEvent) => {
       // 3 and 4 are the typical `button` value for mouse back/forward buttons on mouseup events
@@ -360,7 +370,7 @@ export default function WebView() {
     return () => {
       document.removeEventListener('mouseup', handleMouseBackForward)
     }
-  }, [webviewRef.current])
+  }, [webview])
 
   if (!webviewPreloadPath) {
     return <></>
@@ -368,9 +378,10 @@ export default function WebView() {
 
   return (
     <div className="WebView">
-      {webviewRef.current && (
+      {webview && (
         <WebviewControls
-          webview={webviewRef.current}
+          key={`controls-${store}`}
+          webview={webview}
           initURL={startUrl}
           openInBrowser={!startUrl.startsWith('login')}
         />
@@ -380,7 +391,7 @@ export default function WebView() {
         key={store}
         ref={webviewRef}
         className="WebView__webview"
-        partition={`persist:${store ?? (runner === 'legendary' ? 'epic' : runner === 'nile' ? 'amazon' : runner)}`}
+        partition={getWebviewPartition(store, runner)}
         src={startUrl}
         allowpopups={trueAsStr}
         preload={webviewPreloadPath}


### PR DESCRIPTION
Refactored webview partitions to use a constant to avoid typos as discussed in PR #5752.