### PR TITLE
[Fix] Respect hidden games in Console mode

### DIFF
--- a/src/frontend/screens/ConsoleMode/index.tsx
+++ b/src/frontend/screens/ConsoleMode/index.tsx
@@ -117,9 +117,7 @@ export default function ConsoleMode() {
   const allGames = useMemo<GameInfo[]>(() => {
     // Match normal library: respect games hidden from the library view.
     // See https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5783
-    const hiddenAppNames = new Set(
-      hiddenGames.list.map((game) => game.appName)
-    )
+    const hiddenAppNames = new Set(hiddenGames.list.map((game) => game.appName))
     const all: GameInfo[] = [
       ...epic.library,
       ...gog.library,

--- a/src/frontend/screens/ConsoleMode/index.tsx
+++ b/src/frontend/screens/ConsoleMode/index.tsx
@@ -67,7 +67,8 @@ export default function ConsoleMode() {
     sideloadedLibrary,
     refreshLibrary,
     refreshing,
-    gameUpdates
+    gameUpdates,
+    hiddenGames
   } = useContext(ContextProvider)
 
   const [activeStore, setActiveStore] = useState<StoreKey>('all')
@@ -114,6 +115,11 @@ export default function ConsoleMode() {
   }, [])
 
   const allGames = useMemo<GameInfo[]>(() => {
+    // Match normal library: respect games hidden from the library view.
+    // See https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5783
+    const hiddenAppNames = new Set(
+      hiddenGames.list.map((game) => game.appName)
+    )
     const all: GameInfo[] = [
       ...epic.library,
       ...gog.library,
@@ -121,13 +127,19 @@ export default function ConsoleMode() {
       ...zoom.library,
       ...sideloadedLibrary
     ]
-    return all.filter((g) => !g.install?.is_dlc && !g.thirdPartyManagedApp)
+    return all.filter(
+      (g) =>
+        !g.install?.is_dlc &&
+        !g.thirdPartyManagedApp &&
+        !hiddenAppNames.has(g.app_name)
+    )
   }, [
     epic.library,
     gog.library,
     amazon.library,
     zoom.library,
-    sideloadedLibrary
+    sideloadedLibrary,
+    hiddenGames
   ])
 
   const visibleGames = useMemo(() => {


### PR DESCRIPTION
## Description

Console mode currently ignores the library "hidden games" list. Hiding a title in the normal library still leaves it visible on the console grid (#5783).

This change filters `hiddenGames` out of the console mode library the same way the normal library does.

## Related issue

Fixes #5783

## Scope

- File: `src/frontend/screens/ConsoleMode/index.tsx`
- Pull `hiddenGames` from `ContextProvider`
- Exclude `hiddenGames.list[].appName` from `allGames`
- No new UI; hide/unhide remains in normal library mode (as today)

## Test plan

1. In normal library, hide a game (right-click / game page → Hide).
2. Open Console mode (`--console` or Settings → Start in console mode).
3. Confirm the hidden game is **not** listed.
4. Unhide the game in normal library.
5. Return to console mode and confirm it reappears.
6. Confirm Installed / store chips still work.
7. Confirm DLC / third-party-managed titles remain excluded.

## Notes

- Console mode still has no in-console "Hide" action; this only makes the existing hidden flag apply there.
- A follow-up could add hide from the console game menu and/or persist the Installed chip.