### PR TITLE
Auto Sync Cloud Saves when launched from steam

### DIFF
--- a/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
+++ b/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
@@ -19,7 +19,7 @@ let tmpSteamUserConfigDir = ''
 function makeGameMock(title: string = 'MyGame', id: string = 'Game'): Game {
   return {
     getGameInfo: () => ({ title, app_name: id }),
-    getSettings: async () => ({ autoSyncSaves: true})
+    getSettings: async () => ({ autoSyncSaves: true })
   } as Game
 }
 

--- a/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
+++ b/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
@@ -18,7 +18,8 @@ let tmpSteamUserConfigDir = ''
 
 function makeGameMock(title: string = 'MyGame', id: string = 'Game'): Game {
   return {
-    getGameInfo: () => ({ title, app_name: id })
+    getGameInfo: () => ({ title, app_name: id }),
+    getSettings: async () => ({ autoSyncSaves: true})
   } as Game
 }
 

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -296,6 +296,20 @@ async function addNonSteamGame(game: Game): Promise<boolean> {
 
     const { runner, app_name } = gameInfo
 
+    await game.getSettings()
+      .then((settings) => {
+        if (settings?.autoSyncSaves) {
+          args.push('--download')
+          args.push('--upload')
+        }
+      })
+      .catch((error) =>
+        logWarning(
+          [`Couldn't retrieve game settings for ${gameInfo.title} with:`, error],
+          LogPrefix.Shortcuts
+        )
+      )
+
     args.push(`"heroic://launch?appName=${app_name}&runner=${runner}"`)
     newEntry.LaunchOptions = args.join(' ')
     if (isFlatpak) {

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -296,7 +296,8 @@ async function addNonSteamGame(game: Game): Promise<boolean> {
 
     const { runner, app_name } = gameInfo
 
-    await game.getSettings()
+    await game
+      .getSettings()
       .then((settings) => {
         if (settings?.autoSyncSaves) {
           args.push('--download')
@@ -305,7 +306,10 @@ async function addNonSteamGame(game: Game): Promise<boolean> {
       })
       .catch((error) =>
         logWarning(
-          [`Couldn't retrieve game settings for ${gameInfo.title} with:`, error],
+          [
+            `Couldn't retrieve game settings for ${gameInfo.title} with:`,
+            error
+          ],
           LogPrefix.Shortcuts
         )
       )


### PR DESCRIPTION
Adds `--download --upload` to the steam launch arguments if the user has the game set to auto sync saves.
This ensures that if the user launches the game from steam it actually performs the cloud sync.

Note that this only applies **when** the user hits the add to steam button. This could lead to the following confusions:

- If the user doesn't have autosync enabled when they add to steam, it won't have these arguments.
- If the user later unchecks autosync after they've added to steam, it will still have these arguments.

For that reason I can see why this might not be desired. Maybe this should just be a docs update?

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ x] Tested the feature and it's working on a current and clean install.
- [ x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ x] Created / Updated Tests (If necessary)
- [ x] Created / Updated documentation (If necessary)
