### PR TITLE
5738 shortcuts

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -354,7 +354,8 @@
                 "TR": "Turkey",
                 "TW": "Taiwan",
                 "UA": "Ukraine",
-                "US": "United States"
+                "US": "United States",
+                "ZA": "South Africa"
             },
             "label": "Store region"
         },

--- a/src/backend/shortcuts/nonesteamgame/steamhelper.ts
+++ b/src/backend/shortcuts/nonesteamgame/steamhelper.ts
@@ -113,7 +113,7 @@ async function prepareImagesForSteam(props: {
   for (const [key, imgUrl] of images) {
     if (!checkImageExistsAlready(key) && imgUrl) {
       if (imgUrl.startsWith('http')) {
-        const error = downloadImage(imgUrl, key)
+        const error = await downloadImage(imgUrl, key)
         if (error) {
           errors.push(error)
         }

--- a/src/backend/shortcuts/shortcuts/shortcuts.ts
+++ b/src/backend/shortcuts/shortcuts/shortcuts.ts
@@ -10,7 +10,7 @@ import {
   writeFile,
   writeFileSync
 } from 'graceful-fs'
-import { IconIcns } from '@shockpkg/icon-encoder'
+import { IconIcns, IconIco } from '@shockpkg/icon-encoder'
 import { join } from 'path'
 import { logError, logInfo, LogPrefix } from 'backend/logger'
 import { GlobalConfig } from '../../config'
@@ -20,7 +20,11 @@ import { addNonSteamGame } from '../nonesteamgame/nonesteamgame'
 import sanitize from 'sanitize-filename'
 import { libraryManagerMap } from 'backend/storeManagers'
 import { isMac } from 'backend/constants/environment'
-import { userHome } from 'backend/constants/paths'
+import {
+  userHome,
+  heroicIconFolder as iconsFolder
+} from 'backend/constants/paths'
+import { getGameOverrides } from 'backend/game_overrides'
 import type { Game } from 'common/types/game_manager'
 
 /**
@@ -83,7 +87,17 @@ Categories=Game;
       if (gameInfo.runner === 'gog') {
         executable = libraryManagerMap['gog'].getExecutable(gameInfo.app_name)
       }
-      if (executable) {
+
+      // Prefer the custom user picked cover over the executable's embedded icon
+      const customArt = getGameOverrides(gameInfo.app_name)?.art_square
+      const icoPath = customArt
+        ? await convertPngToICO(gameInfo.app_name, gameInfo, iconsFolder)
+        : undefined
+
+      if (icoPath) {
+        shortcutOptions.icon = icoPath
+        shortcutOptions.iconIndex = 0
+      } else if (executable) {
         let icon: string
         if (
           'install_path' in gameInfo.install &&
@@ -274,6 +288,36 @@ async function convertPngToICNS(
   } catch (error) {
     logError(['Error converting icon to icns:', error], LogPrefix.Backend)
     return false
+  }
+}
+
+async function convertPngToICO(
+  app_name: string,
+  gameInfo: GameInfo,
+  dest: string
+): Promise<string | undefined> {
+  try {
+    const iconPath = await getIcon(app_name, gameInfo)
+    const iconBuffer = readFileSync(iconPath)
+    const pngTemp = join(dest, `${app_name}-shortcut-temp.png`)
+    const resized = nativeImage
+      .createFromBuffer(iconBuffer)
+      .resize({ width: 256 })
+      .crop({ x: 0, y: 0, width: 256, height: 256 })
+      .toPNG()
+
+    writeFileSync(pngTemp, resized)
+
+    const icoPath = join(dest, `${app_name}-shortcut.ico`)
+    const ico = new IconIco()
+    ico.addFromPng(readFileSync(pngTemp), null, false)
+    writeFileSync(icoPath, ico.encode())
+    unlinkSync(pngTemp)
+
+    return icoPath
+  } catch (error) {
+    logError(['Error converting icon to ico:', error], LogPrefix.Backend)
+    return undefined
   }
 }
 

--- a/src/backend/shortcuts/utils.ts
+++ b/src/backend/shortcuts/utils.ts
@@ -5,6 +5,7 @@ import { libraryManagerMap } from '../storeManagers'
 import { downloadFile } from 'backend/utils'
 import { createAbortController } from 'backend/utils/aborthandler/aborthandler'
 import { heroicIconFolder as iconsFolder } from 'backend/constants/paths'
+import { getGameOverrides } from 'backend/game_overrides'
 
 function createImage(
   buffer: Buffer,
@@ -20,12 +21,12 @@ function createImage(
   return
 }
 
-function downloadImage(
+async function downloadImage(
   imageURL: string,
   outputFilePath: string
-): string | undefined {
+): Promise<string | undefined> {
   try {
-    downloadFile({
+    await downloadFile({
       url: imageURL,
       dest: outputFilePath,
       abortSignal: createAbortController(imageURL).signal
@@ -63,8 +64,13 @@ async function getIcon(appName: string, gameInfo: GameInfo) {
     mkdirSync(iconsFolder)
   }
 
+  // Prefer the custom user picked cover over the store one
+  const customArt = getGameOverrides(appName)?.art_square
+
   // By default use vertical image - art_square in jpg format
-  let image = gameInfo.art_square.replaceAll(' ', '%20').replace('{ext}', 'jpg')
+  let image = (customArt || gameInfo.art_square)
+    .replaceAll(' ', '%20')
+    .replace('{ext}', 'jpg')
   let icon = `${iconsFolder}/${appName}.jpg`
 
   if (gameInfo.runner === 'gog') {
@@ -89,8 +95,8 @@ async function getIcon(appName: string, gameInfo: GameInfo) {
     }
   }
 
-  if (!checkImageExistsAlready(icon)) {
-    downloadImage(image, icon)
+  if (customArt || !checkImageExistsAlready(icon)) {
+    await downloadImage(image, icon)
   }
   return icon
 }

--- a/src/backend/shortcuts/utils.ts
+++ b/src/backend/shortcuts/utils.ts
@@ -73,7 +73,8 @@ async function getIcon(appName: string, gameInfo: GameInfo) {
     .replace('{ext}', 'jpg')
   let icon = `${iconsFolder}/${appName}.jpg`
 
-  if (gameInfo.runner === 'gog') {
+  // Only fall back to GOG icons when the user hasn't picked a custom one
+  if (gameInfo.runner === 'gog' && !customArt) {
     const icoPath = join(
       gameInfo.install.install_path!,
       `goggame-${appName}.ico`


### PR DESCRIPTION
Allow custom images to be used as desktop icons.

this will fix #5738 
---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
