### PR TITLE
fix(gog): keep library entries when GamesDB is unavailable

### DIFF
--- a/src/backend/storeManagers/gog/__tests__/unified_info.test.ts
+++ b/src/backend/storeManagers/gog/__tests__/unified_info.test.ts
@@ -1,0 +1,79 @@
+import { ProductsEndpointData } from 'common/types/gog'
+import { productToGameInfo } from '../unified_info'
+
+describe('productToGameInfo', () => {
+  it('maps product API metadata into a usable GOG library entry', () => {
+    const product = {
+      id: 1971477531,
+      title: '  GWENT: The Witcher Card Game  ',
+      game_type: 'game',
+      is_installable: true,
+      images: {
+        background: '//images.example/background.jpg',
+        logo: '//images.example/logo.jpg',
+        icon: '//images.example/icon.png',
+        sidebarIcon: '//images.example/sidebar.png'
+      },
+      content_system_compatibility: {
+        windows: true,
+        osx: false,
+        linux: true
+      },
+      description: {
+        lead: 'Short description',
+        full: 'Full description',
+        whats_cool_about_it: ''
+      }
+    } as ProductsEndpointData
+
+    expect(productToGameInfo(product, '1971477531')).toMatchObject({
+      runner: 'gog',
+      app_name: '1971477531',
+      title: 'GWENT: The Witcher Card Game',
+      art_cover: 'https://images.example/logo.jpg',
+      art_square: 'https://images.example/icon.png',
+      art_background: 'https://images.example/background.jpg',
+      art_icon: 'https://images.example/icon.png',
+      installable: true,
+      is_mac_native: false,
+      is_linux_native: true,
+      extra: {
+        about: {
+          description: 'Full description',
+          shortDescription: 'Short description'
+        }
+      }
+    })
+  })
+
+  it('marks non-game products as DLC and keeps absolute image URLs', () => {
+    const product = {
+      id: 42,
+      title: 'Expansion',
+      game_type: 'dlc',
+      is_installable: false,
+      images: {
+        background: 'https://images.example/background.jpg',
+        logo: 'https://images.example/logo.jpg',
+        icon: 'https://images.example/icon.png',
+        sidebarIcon: 'https://images.example/sidebar.png'
+      },
+      content_system_compatibility: {
+        windows: true,
+        osx: true,
+        linux: false
+      }
+    } as ProductsEndpointData
+
+    expect(productToGameInfo(product)).toMatchObject({
+      app_name: '42',
+      title: 'Expansion',
+      art_cover: 'https://images.example/logo.jpg',
+      art_square: 'https://images.example/icon.png',
+      install: { is_dlc: true },
+      installable: false,
+      is_mac_native: true,
+      is_linux_native: false
+    })
+  })
+})

--- a/src/backend/storeManagers/gog/library.ts
+++ b/src/backend/storeManagers/gog/library.ts
@@ -57,6 +57,7 @@ import { runGogdlCommandStub } from './e2eMock'
 import { gogdlConfigPath } from './constants'
 import { userDataPath } from 'backend/constants/paths'
 import GOGGame from './games'
+import { productToGameInfo } from './unified_info'
 import type { LibraryManager } from 'common/types/game_manager'
 import { libraryManagerMap } from '../index'
 import { readdir } from 'fs/promises'
@@ -491,6 +492,8 @@ export default class GOGLibraryManager implements LibraryManager {
     const gamesObjects: GameInfo[] = [redistGameInfo]
     apiInfoCache.use_in_memory() // Prevent blocking operations
     for (const game of filteredApiArray) {
+      let unifiedObject: GameInfo | undefined
+      let gamesdbUnavailable = false
       let retries = 5
       while (retries > 0) {
         let gdbData
@@ -503,8 +506,10 @@ export default class GOGLibraryManager implements LibraryManager {
             credentials.access_token
           )
           gdbData = data
+          gamesdbUnavailable = !gdbData
         } catch {
           retries -= 1
+          gamesdbUnavailable = true
           logError(
             `Error getting gamesdb data for ${game.external_id} retries: ${retries}/5`,
             LogPrefix.Gog
@@ -513,37 +518,63 @@ export default class GOGLibraryManager implements LibraryManager {
           continue
         }
 
-        const unifiedObject = await this.gogToUnifiedInfo(gdbData)
-        if (unifiedObject.app_name) {
-          const oldData = library.get(unifiedObject.app_name)
-          if (oldData) {
-            unifiedObject.folder_name = oldData.folder_name
-          }
-          gamesObjects.push(unifiedObject)
-
-          const installedInfo = installedGames.get(String(game.external_id))
-          // If game is installed, verify if installed game supports cloud saves
-          if (installedInfo && installedInfo?.platform !== 'linux') {
-            const saveLocations = await this.getSaveSyncLocation(
-              unifiedObject.app_name,
-              installedInfo
-            )
-
-            if (saveLocations) {
-              unifiedObject.cloud_save_enabled = true
-              unifiedObject.gog_save_location = saveLocations
-            }
-          }
-          // Create new object to not write install data into library store
-          const copyObject = Object.assign({}, unifiedObject)
-          if (installedInfo) {
-            copyObject.is_installed = true
-            copyObject.install = installedInfo
-          }
-          library.set(copyObject.app_name, copyObject)
-        }
+        const candidate = await this.gogToUnifiedInfo(gdbData)
+        if (candidate.app_name) unifiedObject = candidate
         break
       }
+
+      if (!unifiedObject && gamesdbUnavailable) {
+        const productResponse = await this.getProductApi(
+          String(game.external_id),
+          ['description'],
+          credentials.access_token
+        )
+        if (productResponse) {
+          logWarning(
+            `Using product API metadata for GOG game ${game.external_id} because GamesDB data is unavailable`,
+            LogPrefix.Gog
+          )
+          unifiedObject = productToGameInfo(
+            productResponse.data,
+            String(game.external_id)
+          )
+        } else {
+          logError(
+            `Unable to load metadata for GOG game ${game.external_id}`,
+            LogPrefix.Gog
+          )
+          continue
+        }
+      }
+
+      if (!unifiedObject) continue
+
+      const oldData = library.get(unifiedObject.app_name)
+      if (oldData) {
+        unifiedObject.folder_name = oldData.folder_name
+      }
+      gamesObjects.push(unifiedObject)
+
+      const installedInfo = installedGames.get(String(game.external_id))
+      // If game is installed, verify if installed game supports cloud saves
+      if (installedInfo && installedInfo?.platform !== 'linux') {
+        const saveLocations = await this.getSaveSyncLocation(
+          unifiedObject.app_name,
+          installedInfo
+        )
+
+        if (saveLocations) {
+          unifiedObject.cloud_save_enabled = true
+          unifiedObject.gog_save_location = saveLocations
+        }
+      }
+      // Create new object to not write install data into library store
+      const copyObject = Object.assign({}, unifiedObject)
+      if (installedInfo) {
+        copyObject.is_installed = true
+        copyObject.install = installedInfo
+      }
+      library.set(copyObject.app_name, copyObject)
     }
 
     apiInfoCache.commit() // Sync cache to drive

--- a/src/backend/storeManagers/gog/unified_info.ts
+++ b/src/backend/storeManagers/gog/unified_info.ts
@@ -1,0 +1,47 @@
+import { GameInfo } from 'common/types'
+import { ProductsEndpointData } from 'common/types/gog'
+
+function normalizeImageUrl(url?: string): string {
+  if (!url) return ''
+  return url.startsWith('//') ? `https:${url}` : url
+}
+
+export function productToGameInfo(
+  info: ProductsEndpointData,
+  appName = String(info.id)
+): GameInfo {
+  const artCover = normalizeImageUrl(info.images.logo || info.images.icon)
+  const artSquare = normalizeImageUrl(
+    info.images.icon || info.images.sidebarIcon || info.images.logo
+  )
+  const description = info.description?.full || info.description?.lead || ''
+
+  return {
+    runner: 'gog',
+    app_name: appName,
+    art_cover: artCover,
+    art_square: artSquare || artCover,
+    art_logo: normalizeImageUrl(info.images.logo),
+    art_background: normalizeImageUrl(info.images.background),
+    art_icon: normalizeImageUrl(info.images.icon),
+    cloud_save_enabled: false,
+    extra: {
+      about: {
+        description,
+        shortDescription: info.description?.lead || ''
+      },
+      reqs: []
+    },
+    folder_name: '',
+    install: {
+      is_dlc: info.game_type !== 'game'
+    },
+    installable: info.is_installable,
+    is_installed: false,
+    save_folder: '',
+    title: info.title.trim(),
+    canRunOffline: true,
+    is_mac_native: info.content_system_compatibility.osx,
+    is_linux_native: info.content_system_compatibility.linux
+  }
+}


### PR DESCRIPTION
## Summary

- keep GOG library entries when GamesDB metadata is unavailable after retries
- fall back to the existing GOG product API for title, artwork, description, installability, and platform metadata
- preserve the existing behavior for GamesDB entries that are not visible library games
- add unit coverage for product metadata conversion

Fixes #5797

## Validation

- pnpm test:ci (22 suites, 136 tests)
- pnpm codecheck
- pnpm exec prettier --check src/backend/storeManagers/gog/library.ts src/backend/storeManagers/gog/unified_info.ts src/backend/storeManagers/gog/__tests__/unified_info.test.ts
- git diff --check