### PR TITLE
Harden GitHub Actions and add a continuous check

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -30,7 +30,7 @@ jobs:
             arch: x64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/install-deps
       - name: Build Windows x64 Portable version
         run: pnpm dist:win portable --x64
@@ -56,7 +56,7 @@ jobs:
         run: pnpm dist:linux AppImage --x64 --arm64 --publish=never
         if: runner.os == 'Linux'
       - name: Upload built version
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ (matrix.os == 'windows-2025'  && 'win-x64-portable'  ) ||
                     (matrix.os == 'windows-11-arm' && 'win-arm64-portable') ||
@@ -70,7 +70,7 @@ jobs:
           if-no-files-found: error
           compression-level: 3
       - name: Upload linux ARM version
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: linux-AppImage-arm64
           path: dist/Heroic*arm64.AppImage
@@ -79,7 +79,7 @@ jobs:
           compression-level: 3
         if: runner.os == 'Linux'
       - name: Upload macOS ARM version
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: mac-arm64
           path: dist/Heroic*arm64.dmg

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -11,7 +11,7 @@ jobs:
   codecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/install-deps
       - name: Check Typescript syntax
         run: pnpm codecheck

--- a/.github/workflows/create-pr-from-stable.yml
+++ b/.github/workflows/create-pr-from-stable.yml
@@ -7,7 +7,7 @@ jobs:
   stableToMain:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: main
       - name: Reset stable branch
@@ -15,7 +15,7 @@ jobs:
           git fetch origin stable:stable
           git reset --hard stable
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: stable_to_main
           commit-message: Sync latest stable changes with main

--- a/.github/workflows/create-pr-from-stable.yml
+++ b/.github/workflows/create-pr-from-stable.yml
@@ -3,6 +3,12 @@ on:
   push:
     branches:
       - stable
+# create-pull-request pushes a branch and opens the PR with the
+# default token.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   stableToMain:
     runs-on: ubuntu-latest

--- a/.github/workflows/draft-release-linux.yml
+++ b/.github/workflows/draft-release-linux.yml
@@ -6,6 +6,11 @@ on:
       - 'v*'
   workflow_dispatch:
 
+# Releases are drafted with the dedicated WORKFLOW_TOKEN, the default
+# token is unused.
+permissions:
+  contents: read
+
 jobs:
   draft-releases:
     runs-on: ubuntu-24.04

--- a/.github/workflows/draft-release-linux.yml
+++ b/.github/workflows/draft-release-linux.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - run: sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/install-deps
       - run: pnpm release:linux
         env:

--- a/.github/workflows/draft-release-mac.yml
+++ b/.github/workflows/draft-release-mac.yml
@@ -18,6 +18,11 @@ env:
   EVS_ACCOUNT_NAME: ${{ secrets.EVS_ACCOUNT_NAME }}
   EVS_PASSWD: ${{ secrets.EVS_PASSWD }}
 
+# Releases are drafted with the dedicated WORKFLOW_TOKEN, the default
+# token is unused.
+permissions:
+  contents: read
+
 jobs:
   draft-releases:
     runs-on: macos-15

--- a/.github/workflows/draft-release-mac.yml
+++ b/.github/workflows/draft-release-mac.yml
@@ -22,9 +22,9 @@ jobs:
   draft-releases:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/install-deps
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
       - run: python3 -m pip install castlabs-evs

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -20,7 +20,7 @@ jobs:
       options: --privileged
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/install-deps
       - name: Build artifacts.
         run: pnpm dist:linux appimage --publish=never
@@ -33,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Flatpak
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        uses: flatpak/flatpak-github-actions/flatpak-builder@401fe28a8384095fc1531b9d320b292f0ee45adb # v6
         with:
           bundle: heroicgameslauncher.flatpak
           manifest-path: flatpak-build/com.heroicgameslauncher.hgl.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/install-deps
       - name: Lint code.
         run: pnpm lint

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,34 @@
+name: Plumber
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - uses: getplumber/plumber@7ad9d267ee5a00163cec9e5c749a088d5f565167 # v0.4.26
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.github/workflows/release_aur.yml
+++ b/.github/workflows/release_aur.yml
@@ -77,7 +77,7 @@ jobs:
         if: ${{ success() }}
 
       - name: Publish AUR package
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
+        uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3
         with:
           pkgname: heroic-games-launcher-bin
           pkgbuild: ./PKGBUILD

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -30,7 +30,7 @@ jobs:
       - name: echo ref name.
         run: echo "tag name ${{ github.ref_name }}"
       - name: Checkout repository.
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/install-deps
       - name: Reconfigure git to use HTTP authentication
         run: >
@@ -50,7 +50,7 @@ jobs:
           git commit -a -m "changes for ${{ github.ref_name }}"
         working-directory: ./com.heroicgameslauncher.hgl
       - name: Push updated flathub branch
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           branch: ${{ github.ref_name }}

--- a/.github/workflows/release_flathub.yml
+++ b/.github/workflows/release_flathub.yml
@@ -23,6 +23,11 @@ env:
   RELEASE_VERSION: ${{ github.ref_name }}
   IS_PRERELEASE: ${{ github.event.release.prerelease || github.event.inputs.is_prerelease || 'false' }}
 
+# The push and PR steps use the dedicated WORKFLOW_TOKEN, the default
+# token is unused.
+permissions:
+  contents: read
+
 jobs:
   draft-releases:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository.
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/install-deps
       - name: Test CI
         run: pnpm test:ci
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository.
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/install-deps
       - name: Fix ownership and mode
         run: sudo chown root /home/runner/work/HeroicGamesLauncher/HeroicGamesLauncher/node_modules/electron/dist/chrome-sandbox && sudo chmod 4755 /home/runner/work/HeroicGamesLauncher/HeroicGamesLauncher/node_modules/electron/dist/chrome-sandbox

--- a/.github/workflows/update-bug-template-on-release.yml
+++ b/.github/workflows/update-bug-template-on-release.yml
@@ -5,6 +5,12 @@ on:
     types:
       - published
 
+# The workflow pushes the template branch and opens a PR with the
+# default token.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update_version_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-bug-template-on-release.yml
+++ b/.github/workflows/update-bug-template-on-release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Get Latest Release Version
         id: get_latest_release

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,30 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: '2.0'
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the actions this repo
+      # already uses on top of it.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - peter-evans/create-pull-request
+        - flatpak/flatpak-github-actions
+        - KSXGitHub/github-actions-deploy-aur
+        - ad-m/github-push-action
+        - contributor-assistant/github-action
+
+    # Off for now: the CLA workflow depends on contributor-assistant,
+    # archived upstream. It is pinned to a commit in the meantime;
+    # enable this once the CLA flow moves to a maintained action.
+    actionsMustNotBeArchived:
+      enabled: false
+
+    # Off for now: the flatpak build and AUR release containers track
+    # distro tags (gnome-48, archlinux) by design. Worth revisiting if
+    # those move to digest pins.
+    containerImageMustNotUseForbiddenTags:
+      enabled: false

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/Heroic-Games-Launcher/HeroicGamesLauncher?style=for-the-badge)](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/latest)
 [![GitHub all releases](https://img.shields.io/github/downloads/Heroic-Games-Launcher/HeroicGamesLauncher/total?style=for-the-badge&color=00B000)](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/)
 [![Flathub](https://img.shields.io/flathub/downloads/com.heroicgameslauncher.hgl?label=flathub&logo=flathub&logoColor=white&style=for-the-badge&color=00B000)](https://flathub.org/apps/details/com.heroicgameslauncher.hgl)
+[![Plumber Score](https://score.getplumber.io/github.com/Heroic-Games-Launcher/HeroicGamesLauncher.svg)](https://score.getplumber.io/github.com/Heroic-Games-Launcher/HeroicGamesLauncher)
 [![GPLv3 license](https://img.shields.io/github/license/Heroic-Games-Launcher/HeroicGamesLauncher?style=for-the-badge&color=blue)](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/main/COPYING)  
 [![Discord](https://img.shields.io/discord/812703221789097985?label=Discord%20Server&logo=discord&color=5865F2&style=for-the-badge)](https://discord.gg/rHJ2uqdquK)
 [![Patreon](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fshieldsio-patreon.vercel.app%2Fapi%3Fusername%3Dheroicgameslauncher%26type%3Dpatrons&style=for-the-badge)](https://patreon.com/heroicgameslauncher)


### PR DESCRIPTION
Hi, drive-by CI hardening in three commits, one logical change each.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v8` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token. The exposed spots here are the release paths: the AUR deploy, the flathub release (which used `ad-m/github-push-action@master`, a moving branch), and the CLA workflow. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). All shas were resolved from the upstream repos and cross checked against their release tags. Two things worth knowing: `ad-m`'s master is currently exactly its v1.3.0 release commit, so behavior is unchanged, and `contributor-assistant/github-action` is archived upstream, pinning contains the risk but replacing it at some point would be better still, that call is yours. The pins stay maintainable: a dependabot config with the `github-actions` ecosystem bumps them automatically, one small block.

**Commit 2 adds `permissions:` blocks to the five workflows that had none.** The scopes are derived from what each workflow does with the token, not guessed: the draft-release and flathub workflows do all their writing through your dedicated WORKFLOW_TOKEN secret, so their default token drops to `contents: read`; create-pr-from-stable and update-bug-template push branches and open PRs with the default token, so they get `contents: write` and `pull-requests: write`. The rest already declare scoped permissions.

**Commit 3 adds [Plumber](https://github.com/getplumber/plumber) to CI**, the tool I used to find the issues in the first place, so none of this quietly drifts back:

- Scans the workflows on each push to main and on each PR, fails when something regresses: an unpinned action, a job without permissions, a known CVE. The gate passes at 85 points, so one small finding does not block your PRs.
- The config is a small overlay inheriting the CLI's built-in baseline: it trusts the actions you already use and turns off two controls with a comment saying why (the archived CLA action until you replace it, and the flatpak and archlinux build containers that track distro tags by design). Findings land in the security tab as SARIF.
- Adds a score badge to the README. It works like OpenSSF Scorecard's published results: runs publish the score to score.getplumber.io, the badge shows the state of main, a failed publish never fails your CI, and it reads UNKNOWN in gray until the first run.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v6`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, say so and I remove that commit from the PR, the two hardening commits are the part that matters and they stand entirely on their own.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [X] Created / Updated Tests (If necessary)
- [X] Created / Updated documentation (If necessary)
