### PR TITLE
Warn when the Wine prefix folder is empty

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -794,6 +794,7 @@
         "default-install-path": "Default Installation Path",
         "default-steam-path": "Default Steam path",
         "defaultWinePrefix": "Set Folder for new Wine Prefixes",
+        "defaultWinePrefixEmpty": "An empty prefix folder may prevent game installations. Default: {{path}}",
         "disable_controller": "Disable Heroic navigation using controller",
         "disable_gog_presence": "Disable GOG Presence updates",
         "disable_logs": "Disable Logs",
@@ -929,6 +930,7 @@
         "offlinemode": "Run Game Offline",
         "prefered_language": "Prefered Language (Language Code)",
         "preferSystemLibs": "Prefer system libraries",
+        "restoreDefault": "Restore default",
         "runexe": {
             "title": "Run EXE on Prefix"
         },

--- a/src/frontend/screens/Settings/components/WinePrefixesBasePath.tsx
+++ b/src/frontend/screens/Settings/components/WinePrefixesBasePath.tsx
@@ -18,21 +18,21 @@ const WinePrefixesBasePath = () => {
   const { isDefault } = useContext(SettingsContext)
   const isWindows = platform === 'win32'
 
-  const [winePrefixDir, setWinePrefixDir] = useSetting(
+  const [defaultWinePrefixDir, setDefaultWinePrefixDir] = useSetting(
     'defaultWinePrefixDir',
     ''
   )
 
-  const emptyPathWarning = !winePrefixDir ? (
+  const emptyPathWarning = !defaultWinePrefixDir ? (
     <span className="smallInputInfo warning">
       {t(
         'setting.defaultWinePrefixEmpty',
-        'An empty prefix folder may prevent game installations. Default: {{path}}',
+        'An empty prefix folder will prevent games from running. Default: {{path}}',
         { path: factoryDefaultWinePrefixDir }
       )}
       <SvgButton
         title={t('setting.restoreDefault', 'Restore default')}
-        onClick={() => setWinePrefixDir(factoryDefaultWinePrefixDir)}
+        onClick={() => setDefaultWinePrefixDir(factoryDefaultWinePrefixDir)}
       >
         <Undo />
       </SvgButton>
@@ -47,15 +47,17 @@ const WinePrefixesBasePath = () => {
     <PathSelectionBox
       htmlId="selectDefaultWinePrefix"
       label={t('setting.defaultWinePrefix', 'Set Folder for new Wine Prefixes')}
-      path={winePrefixDir}
-      onPathChange={setWinePrefixDir}
+      path={defaultWinePrefixDir}
+      onPathChange={setDefaultWinePrefixDir}
       type="directory"
       pathDialogTitle={t(
         'toolbox.settings.wineprefix',
         'Select a Folder for new Wine Prefixes'
       )}
       noDeleteButton
-      pathDialogDefaultPath={winePrefixDir || factoryDefaultWinePrefixDir}
+      pathDialogDefaultPath={
+        defaultWinePrefixDir || factoryDefaultWinePrefixDir
+      }
       afterInput={emptyPathWarning}
     />
   )

--- a/src/frontend/screens/Settings/components/WinePrefixesBasePath.tsx
+++ b/src/frontend/screens/Settings/components/WinePrefixesBasePath.tsx
@@ -1,9 +1,16 @@
 import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
+import Undo from '@mui/icons-material/Undo'
 import ContextProvider from 'frontend/state/ContextProvider'
 import useSetting from 'frontend/hooks/useSetting'
-import { PathSelectionBox } from 'frontend/components/UI'
+import { PathSelectionBox, SvgButton } from 'frontend/components/UI'
 import SettingsContext from 'frontend/screens/Settings/SettingsContext'
+import { configStore } from 'frontend/helpers/electronStores'
+
+const factoryDefaultWinePrefixDir = `${configStore.get(
+  'userHome',
+  ''
+)}/Games/Heroic/Prefixes`
 
 const WinePrefixesBasePath = () => {
   const { t } = useTranslation()
@@ -11,10 +18,26 @@ const WinePrefixesBasePath = () => {
   const { isDefault } = useContext(SettingsContext)
   const isWindows = platform === 'win32'
 
-  const [defaultWinePrefixDir, setDefaultWinePrefixDir] = useSetting(
+  const [winePrefixDir, setWinePrefixDir] = useSetting(
     'defaultWinePrefixDir',
     ''
   )
+
+  const emptyPathWarning = !winePrefixDir ? (
+    <span className="smallInputInfo warning">
+      {t(
+        'setting.defaultWinePrefixEmpty',
+        'An empty prefix folder may prevent game installations. Default: {{path}}',
+        { path: factoryDefaultWinePrefixDir }
+      )}
+      <SvgButton
+        title={t('setting.restoreDefault', 'Restore default')}
+        onClick={() => setWinePrefixDir(factoryDefaultWinePrefixDir)}
+      >
+        <Undo />
+      </SvgButton>
+    </span>
+  ) : undefined
 
   if (!isDefault || isWindows) {
     return <></>
@@ -24,15 +47,16 @@ const WinePrefixesBasePath = () => {
     <PathSelectionBox
       htmlId="selectDefaultWinePrefix"
       label={t('setting.defaultWinePrefix', 'Set Folder for new Wine Prefixes')}
-      path={defaultWinePrefixDir}
-      onPathChange={setDefaultWinePrefixDir}
+      path={winePrefixDir}
+      onPathChange={setWinePrefixDir}
       type="directory"
       pathDialogTitle={t(
         'toolbox.settings.wineprefix',
         'Select a Folder for new Wine Prefixes'
       )}
       noDeleteButton
-      pathDialogDefaultPath={defaultWinePrefixDir}
+      pathDialogDefaultPath={winePrefixDir || factoryDefaultWinePrefixDir}
+      afterInput={emptyPathWarning}
     />
   )
 }


### PR DESCRIPTION
Fixes #2556.

## What changed

- warn when a custom Wine prefix folder is empty
- offer a one-click restore to Heroic's factory default
- use the factory default as the folder-picker fallback
- add the related English strings

## Verification

- pnpm codecheck
- ESLint and Prettier pre-push checks
- translation validation

OpenAI Codex assisted with implementation and validation; I reviewed the final diff and test output.