### PR TITLE
[Fix] Description of "Game Arguments" option

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -702,7 +702,7 @@
                 "env": "Environment variables must be configured in the table below."
             },
             "placeholder": "Put here the Launcher Arguments",
-            "title": "Game Arguments (To run after the command):"
+            "title": "Game Arguments (appended to game launch command)"
         },
         "gamescope": {
             "additionalOptions": "Additional Options",

--- a/src/frontend/screens/Settings/components/LauncherArgs.tsx
+++ b/src/frontend/screens/Settings/components/LauncherArgs.tsx
@@ -55,7 +55,10 @@ const LauncherArgs = () => {
 
   return (
     <TextInputField
-      label={t('options.gameargs.title')}
+      label={t(
+        'options.gameargs.title',
+        'Game Arguments (appended to game launch command)'
+      )}
       htmlId="launcherArgs"
       placeholder={t('options.gameargs.placeholder')}
       value={launcherArgs}


### PR DESCRIPTION
The description currently says "To run after the command". This is inaccurate, the arguments are not "ran", they are just added to the command

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
