### PR TITLE
fix: Search for a `heroic` executable on PATH if our executable is not called "heroic"

### DIFF
--- a/src/backend/__mocks__/electron.ts
+++ b/src/backend/__mocks__/electron.ts
@@ -15,9 +15,10 @@ const dialog = {
 
 const app = {
   // app override
-  getPath: jest.fn().mockImplementation((path: string) => {
+  getPath: (path: string) => {
+    if (path === 'exe') return join(appBasePath, 'heroic')
     return join(appBasePath, path)
-  }),
+  },
   getVersion(): string {
     // TODO: What should we return here?
     return '1.0.0'

--- a/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
+++ b/src/backend/shortcuts/nonesteamgame/__tests__/nonesteamgame.test.ts
@@ -5,8 +5,11 @@ import { addNonSteamGame, removeNonSteamGame } from '../nonesteamgame'
 import { showDialogBoxModalAuto } from 'backend/dialog/dialog'
 import { GlobalConfig } from 'backend/config'
 import { logInfo, logError, logWarning } from 'backend/logger'
+import { app } from 'electron'
+import * as pathUtils from 'backend/utils/os/path'
 import type { Game } from 'common/types/game_manager'
 
+jest.mock('electron')
 jest.mock('backend/logger')
 jest.mock('backend/dialog/dialog')
 jest.mock('backend/utils')
@@ -231,5 +234,19 @@ describe('NonSteamGame', () => {
       expect(logError).not.toBeCalled()
       expect(showDialogBoxModalAuto).not.toBeCalled()
     }
+  })
+
+  test('Searches for Heroic wrapper if executable is not `heroic`', async () => {
+    const game = makeGameMock()
+
+    const getPathSpy = jest
+      .spyOn(app, 'getPath')
+      .mockImplementation(() => '/usr/bin/electron43')
+    const searchExeSpy = jest.spyOn(pathUtils, 'searchForExecutableOnPath')
+
+    await addNonSteamGame(game)
+
+    expect(getPathSpy).toHaveBeenCalled()
+    expect(searchExeSpy).toHaveBeenCalledWith('heroic')
   })
 })

--- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
+++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
@@ -23,7 +23,13 @@ import { notify, showDialogBoxModalAuto } from '../../dialog/dialog'
 import { GlobalConfig } from '../../config'
 import { getWikiGameInfo } from 'backend/wiki_game_info/wiki_game_info'
 import { tsStore } from 'backend/constants/key_value_stores'
-import { isAppImage, isFlatpak, isWindows } from 'backend/constants/environment'
+import {
+  isAppImage,
+  isFlatpak,
+  isLinux,
+  isWindows
+} from 'backend/constants/environment'
+import { searchForExecutableOnPath } from 'backend/utils/os/path'
 import type { Game } from 'common/types/game_manager'
 
 const getSteamUserdataDir = async () => {
@@ -255,7 +261,23 @@ async function addNonSteamGame(game: Game): Promise<boolean> {
     // add new Entry
     const newEntry = {} as ShortcutEntry
     newEntry.AppName = gameInfo.title
-    newEntry.Exe = `"${app.getPath('exe')}"`
+
+    const ourExePath = app.getPath('exe')
+    newEntry.Exe = `"${ourExePath}"`
+    if (isLinux && !ourExePath.toLowerCase().endsWith('heroic')) {
+      // If we are on Linux and our executable path does not end with "heroic",
+      // we are running on a distribution packaging Electron and Heroic
+      // separately (e.g. Arch Linux). Launching our executable alone will only
+      // launch Electron, it will not know what to do (running Heroic).
+      // A proper workaround for this is not easy (we would have to pull out
+      // launch-relevant parameters from our argv while also leaving temporary
+      // parameters out). The best we can do here is search for an
+      // `heroic` wrapper executable (which these types of packages make
+      // available) and launch it
+      const heroicWrapper = await searchForExecutableOnPath('heroic')
+      if (heroicWrapper) newEntry.Exe = `"${heroicWrapper}"`
+    }
+
     newEntry.StartDir = `"${process.cwd()}"`
 
     if (isFlatpak) {


### PR DESCRIPTION
Details are in the comment at

https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/7da85bc52f70f59671913b1b48a7984e0a12b1c3/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts#L268-L276

This is preparation for a potential official `heroic-games-launcher` package for Arch Linux

Testing this isn't really practical. The added test verifies that (1) the old behaviour is still there and (2) the new behaviour is working though.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [X] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
