### PR TITLE
Fix/discounts page scroll reset + doc typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Run the appropriate command for your OS:
 ### Building with VS Code
 
 Instead of using the above commands to build Heroic, you can also use the Tasks in VSCode to build.
-To do that, open up the command palette (Ctrl + P), type in "task" and press Space. You will then see 3 build tasks, "Build for Linux", "Build for Windows", and "Build for MacOS". Click the one you want to run.
+To do that, open up the command palette (Ctrl + Shift + P), type in "task" and press Space. You will then see 3 build tasks, "Build for Linux", "Build for Windows", and "Build for MacOS". Click the one you want to run.
 
 ### Quickly testing/debugging Heroic on your own system
 

--- a/src/frontend/screens/Discounts/index.tsx
+++ b/src/frontend/screens/Discounts/index.tsx
@@ -160,6 +160,7 @@ export default function Discounts() {
     storedFilters.pageSize ?? DEFAULT_PAGE_SIZE
   )
   const [page, setPage] = useState(1)
+  const topSentinelRef = useRef<HTMLDivElement>(null)
 
   // Track whether we've already completed a load, so locale-change reloads
   // know to clear the data-bound ranges (price/releaseYear), but the very
@@ -612,11 +613,16 @@ export default function Discounts() {
 
   const handlePageChange = (newPage: number) => {
     setPage(newPage)
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+    // window.scrollTo({ top: 0, behavior: 'smooth' })
+    topSentinelRef.current?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start'
+    })
   }
 
   return (
     <div className="discountsScreen">
+      <div ref={topSentinelRef} />
       <div className="discountsScreen__topbar">
         <h2 className="discountsScreen__header">
           {t('discounts.titleMulti', 'Deals')}


### PR DESCRIPTION
Fixes page not scrolling to top when changing pages in the Discounts tab.

`window.scrollTo` had no effect because the scrollable container is not
`window` itself. Replaced it with a sentinel `div` + `scrollIntoView`,
which works regardless of which parent element is actually scrollable.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
