### PR TITLE
[Docs] Fix incorrect command palette shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Run the appropriate command for your OS:
 ### Building with VS Code
 
 Instead of using the above commands to build Heroic, you can also use the Tasks in VSCode to build.
-To do that, open up the command palette (Ctrl + P), type in "task" and press Space. You will then see 3 build tasks, "Build for Linux", "Build for Windows", and "Build for MacOS". Click the one you want to run.
+To do that, open up the command palette (Ctrl + Shift + P), type in "task" and press Space. You will then see 3 build tasks, "Build for Linux", "Build for Windows", and "Build for MacOS". Click the one you want to run.
 
 ### Quickly testing/debugging Heroic on your own system
 


### PR DESCRIPTION
Fixed an incorrect keyboard shortcut in the README. The command palette
shortcut was documented as Ctrl+P, but it's actually Ctrl+Shift+P.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
