### PR TITLE
fix: Make sure to set Wine-related options when adding a sideloaded game

### DIFF
--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1630,7 +1630,10 @@ const axiosClient = axios.create({
   httpsAgent: new https.Agent({ keepAlive: true })
 })
 
-export const writeConfig = (appName: string, config: Partial<AppSettings>) => {
+export const writeConfig = async (
+  appName: string,
+  config: Partial<AppSettings>
+) => {
   logInfo(
     `Writing config for ${appName === 'default' ? 'Heroic' : appName}`,
     LogPrefix.Backend
@@ -1638,7 +1641,7 @@ export const writeConfig = (appName: string, config: Partial<AppSettings>) => {
   const oldConfig =
     appName === 'default'
       ? GlobalConfig.get().getSettings()
-      : GameConfig.get(appName).config
+      : await GameConfig.get(appName).getSettings()
 
   // log only the changed setting
   const sharedKeys = (

--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -33,6 +33,7 @@ import Folder from '@mui/icons-material/Folder'
 type Props = {
   availablePlatforms: AvailablePlatforms
   winePrefix: string
+  crossoverBottle: string
   wineVersion: WineInstallation | undefined
   children: React.ReactNode
   platformToInstall: InstallPlatform
@@ -46,6 +47,7 @@ export default function SideloadDialog({
   availablePlatforms,
   backdropClick,
   winePrefix,
+  crossoverBottle,
   wineVersion,
   platformToInstall,
   children,
@@ -195,6 +197,17 @@ export default function SideloadDialog({
       customUserAgent,
       launchFullScreen
     })
+
+    if (!editMode) {
+      await window.api.writeConfig({
+        appName: app_name,
+        config: {
+          winePrefix,
+          wineVersion,
+          wineCrossoverBottle: crossoverBottle
+        }
+      })
+    }
 
     await refreshLibrary({
       library: 'sideload',

--- a/src/frontend/screens/Library/components/InstallModal/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/index.tsx
@@ -262,6 +262,7 @@ function InstallModal({ appName, runner, gameInfo = null }: Props) {
             backdropClick={closeModal}
             platformToInstall={platformToInstall}
             appName={appName}
+            crossoverBottle={crossoverBottle}
           >
             {platformSelection()}
             {hasWine ? (


### PR DESCRIPTION
In https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5599, I had assumed that `setWinePrefix`, `setWineVersion` and `setCrossoverBottle` are `useSetting` return values, and thus, setting them will automatically save the set option for the game. However...

https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/34924446b69f14e9ec9cdfcce3ff8c9157e19ed4/src/frontend/screens/Library/components/InstallModal/index.tsx#L49-L52

...they are not. Thus, we have to make sure to save them when the user clicks "Finish" in the dialog.

Closes #5820

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
