### PR TITLE
feat: Use umu to provide the Steam Runtime, and automatically enable it for native GOG games

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -958,7 +958,10 @@
         "showMetalOverlay": "Show Stats Overlay",
         "start-in-console-mode": "Start in Console Mode",
         "start-in-tray": "Start Minimized",
-        "steamruntime": "Use Steam Runtime",
+        "steamRuntime": {
+            "label": "Use Steam Runtime",
+            "noRuntimeOption": "None"
+        },
         "verboseLogs": {
             "description": "Enable verbose logs"
         },

--- a/src/backend/game_config.ts
+++ b/src/backend/game_config.ts
@@ -233,7 +233,6 @@ class GameConfigV0 extends GameConfig {
       winePrefix,
       wineCrossoverBottle,
       wineVersion,
-      useSteamRuntime,
       eacRuntime,
       battlEyeRuntime,
       beforeLaunchScriptPath,
@@ -271,7 +270,6 @@ class GameConfigV0 extends GameConfig {
       showMangohud,
       targetExe,
       useGameMode,
-      useSteamRuntime,
       battlEyeRuntime,
       eacRuntime,
       language: '', // we want to fallback to '' always here, fallback lang for games should be ''
@@ -280,7 +278,8 @@ class GameConfigV0 extends GameConfig {
       gamescope,
       verboseLogs,
       advertiseAvxForRosetta,
-      enableQuickSavesMenu: false
+      enableQuickSavesMenu: false,
+      steamRuntime: false
     } as GameSettings
 
     let gameSettings = {} as GameSettings

--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -10,7 +10,6 @@ import {
   RpcClient,
   WineInstallation,
   WineCommandArgs,
-  SteamRuntime,
   GameSettings,
   KnowFixesInfo,
   LaunchParams,
@@ -24,7 +23,6 @@ import { join, dirname, isAbsolute } from 'path'
 
 import {
   constructAndUpdateRPC,
-  getSteamRuntime,
   isEpicServiceOffline,
   quoteIfNecessary,
   errorHandler,
@@ -55,7 +53,6 @@ import { isOnline } from './online_monitor'
 import { showDialogBoxModalAuto } from './dialog/dialog'
 import { legendarySetup } from './storeManagers/legendary/setup'
 import { libraryManagerMap } from 'backend/storeManagers'
-import * as VDF from '@node-steam/vdf'
 import { readFileSync, writeFileSync } from 'fs'
 import { LegendaryCommand } from './storeManagers/legendary/commands'
 import { searchForExecutableOnPath } from './utils/os/path'
@@ -367,13 +364,12 @@ function filterGameSettingsForLog(
     delete gameSettings.advertiseAvxForRosetta
 
     if (notNative) {
+      delete gameSettings.steamRuntime
       const wineVersion = gameSettings.wineVersion
       if (wineVersion) {
         if (wineVersion.type === 'proton') {
           delete gameSettings.autoInstallDxvk
           delete gameSettings.autoInstallVkd3d
-        } else {
-          delete gameSettings.useSteamRuntime
         }
       }
 
@@ -414,7 +410,7 @@ function filterGameSettingsForLog(
     delete gameSettings.enableWoW64
     delete gameSettings.showMangohud
     delete gameSettings.disableUMU
-    delete gameSettings.useSteamRuntime
+    delete gameSettings.steamRuntime
     delete gameSettings.enableFsync
 
     if (notNative) {
@@ -481,7 +477,7 @@ function filterGameSettingsForLog(
     delete gameSettings.nvidiaPrime
     delete gameSettings.disableUMU
     delete gameSettings.advertiseAvxForRosetta
-    delete gameSettings.useSteamRuntime
+    delete gameSettings.steamRuntime
   }
 
   return gameSettings
@@ -710,61 +706,19 @@ async function prepareLaunch(
     }
   }
 
-  if (
-    (await isUmuSupported(gameSettings, false)) &&
-    isOnline() &&
-    !(await isInstalled('umu')) &&
-    (await getUmuPath()) === defaultUmuPath
-  ) {
+  let steamRuntime = undefined
+  const umuAvailable =
+    (await isInstalled('umu')) || (await getUmuPath()) !== defaultUmuPath
+  const useUmu =
+    (await isUmuSupported(gameSettings, false)) ||
+    (gameSettings.steamRuntime && isNative)
+
+  if (useUmu && !umuAvailable) {
     await download('umu')
   }
 
-  // If the Steam Runtime is enabled, find a valid one
-  let steamRuntime: string[] = []
-  const shouldUseRuntime =
-    gameSettings.useSteamRuntime &&
-    (isNative ||
-      (!(await isUmuSupported(gameSettings)) &&
-        gameSettings.wineVersion.type === 'proton'))
-
-  if (shouldUseRuntime) {
-    // Determine which runtime to use based on toolmanifest.vdf which is shipped with proton
-    let nonNativeRuntime: SteamRuntime['type'] = 'soldier'
-    if (!isNative) {
-      try {
-        const parentPath = dirname(gameSettings.wineVersion.bin)
-        const requiredAppId = VDF.parse(
-          readFileSync(join(parentPath, 'toolmanifest.vdf'), 'utf-8')
-        ).manifest?.require_tool_appid
-        if (requiredAppId === 1628350) nonNativeRuntime = 'sniper'
-      } catch (error) {
-        logError(
-          ['Failed to parse toolmanifest.vdf:', error],
-          LogPrefix.Backend
-        )
-      }
-    }
-
-    const runtimeType = isNative ? 'scout' : nonNativeRuntime
-    const { path, args } = await getSteamRuntime(runtimeType)
-    if (!path) {
-      return {
-        success: false,
-        failureReason:
-          'Steam Runtime is enabled, but no runtimes could be found\n' +
-          `Make sure Steam ${
-            isNative
-              ? 'is'
-              : `and the SteamLinuxRuntime - ${
-                  nonNativeRuntime === 'sniper' ? 'Sniper' : 'Soldier'
-                } are`
-          } installed`
-      }
-    }
-
-    logInfo(`Using Steam ${runtimeType} Runtime`, LogPrefix.Backend)
-
-    steamRuntime = [path, ...args]
+  if (gameSettings.steamRuntime) {
+    steamRuntime = [await getUmuPath()]
   }
 
   return {
@@ -1087,6 +1041,11 @@ function setupEnvVars(gameSettings: GameSettings, installPath?: string) {
   if (isLinux && installPath) {
     // Used by steam runtime to mount the game directory to the container
     ret.STEAM_COMPAT_INSTALL_PATH = installPath
+  }
+
+  if (isLinux && gameSettings.steamRuntime) {
+    // Umu uses "PROTONPATH" to dictate the runtime to use
+    ret.PROTONPATH = gameSettings.steamRuntime
   }
 
   if (gameSettings.enviromentOptions) {

--- a/src/backend/migration/index.ts
+++ b/src/backend/migration/index.ts
@@ -2,6 +2,7 @@ import { TypeCheckedStoreBackend } from '../electron_store'
 import { logError, logInfo } from '../logger'
 
 import { LegendaryGlobalConfigFolderMigration } from './migrations/legendary'
+import { UmuSteamRuntimeMigration } from './migrations/config'
 
 import type { TypeCheckedStore } from 'common/types/electron_store'
 
@@ -70,7 +71,10 @@ export default class MigrationSystem {
   }
 
   private getAllMigrations(): Migration[] {
-    return [new LegendaryGlobalConfigFolderMigration()]
+    return [
+      new LegendaryGlobalConfigFolderMigration(),
+      new UmuSteamRuntimeMigration()
+    ]
   }
 
   private readonly migrationsStore: TypeCheckedStore<'migrationsStore'>

--- a/src/backend/migration/migrations/config.ts
+++ b/src/backend/migration/migrations/config.ts
@@ -1,0 +1,35 @@
+import { readdir } from 'fs/promises'
+import { parse } from 'path'
+
+import { isLinux } from 'backend/constants/environment'
+import { gamesConfigPath } from 'backend/constants/paths'
+import { GameConfig } from 'backend/game_config'
+import { logDebug } from 'backend/logger'
+
+import type { Migration } from '..'
+
+export class UmuSteamRuntimeMigration implements Migration {
+  identifier = 'umu-steam-runtime'
+  async run() {
+    if (!isLinux) return true
+
+    for (const entry of await readdir(gamesConfigPath, {
+      withFileTypes: true
+    })) {
+      const filename = entry.name
+      if (!entry.isFile() || !filename.endsWith('.json')) continue
+      const appName = parse(filename).name
+      const config = GameConfig.get(appName)
+      const settings = (await config.getSettings()) as {
+        useSteamRuntime?: boolean
+      }
+      // NOTE: This will also set the option for non-native games, but the
+      //       option is not actually used for them, so it should be fine
+      if (settings.useSteamRuntime) {
+        config.setSetting('steamRuntime', 'umu-scout')
+        logDebug(['Enabled new Steam Runtime option for', appName])
+      }
+    }
+    return true
+  }
+}

--- a/src/backend/storeManagers/gog/games.ts
+++ b/src/backend/storeManagers/gog/games.ts
@@ -224,6 +224,11 @@ export default class GOGGame implements Game {
         folderPath
       )
       this.addShortcuts()
+
+      if (isLinux && this.isNative()) {
+        const gameConfig = GameConfig.get(this.id)
+        gameConfig.setSetting('steamRuntime', 'umu-scout')
+      }
     } catch (error) {
       logError([`Failed to import ${this.id}:`, error], LogPrefix.Gog)
     }
@@ -472,6 +477,9 @@ export default class GOGGame implements Game {
         )
       }
     } else if (isLinuxNative) {
+      const gameConfig = GameConfig.get(this.id)
+      gameConfig.setSetting('steamRuntime', 'umu-scout')
+
       const installer = join(install_path, 'support/postinst.sh')
       if (existsSync(installer)) {
         logInfo(`Running ${installer}`, LogPrefix.Gog)

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -3,7 +3,6 @@ import {
   Runner,
   WineInstallation,
   RpcClient,
-  SteamRuntime,
   Release,
   GameInfo,
   GameSettings,
@@ -551,55 +550,6 @@ export async function getSteamLibraries(): Promise<string[]> {
     LogPrefix.Backend
   )
   return libraries
-}
-
-async function getSteamRuntime(
-  requestedType: SteamRuntime['type']
-): Promise<SteamRuntime> {
-  const steamLibraries = await getSteamLibraries()
-  const runtimeTypes: SteamRuntime[] = [
-    {
-      path: 'steamapps/common/SteamLinuxRuntime_sniper/_v2-entry-point',
-      type: 'sniper',
-      args: ['--']
-    },
-    {
-      path: 'steamapps/common/SteamLinuxRuntime_soldier/_v2-entry-point',
-      type: 'soldier',
-      args: ['--']
-    },
-    {
-      path: 'ubuntu12_32/steam-runtime/run.sh',
-      type: 'scout',
-      args: []
-    }
-  ]
-  const allAvailableRuntimes: SteamRuntime[] = []
-  steamLibraries.forEach((library) => {
-    runtimeTypes.forEach(({ path, type, args }) => {
-      const fullPath = join(library, path)
-      if (existsSync(fullPath)) {
-        allAvailableRuntimes.push({ path: fullPath, type, args })
-      }
-    })
-  })
-  // Add dummy runtime at the end to not return `undefined`
-  allAvailableRuntimes.push({ path: '', type: 'scout', args: [] })
-  const requestedRuntime = allAvailableRuntimes.find(({ type }) => {
-    return type === requestedType
-  })
-  if (requestedRuntime) {
-    return requestedRuntime
-  }
-  logWarning(
-    [
-      'No runtimes of type',
-      requestedType,
-      'could be found, returning first available one'
-    ],
-    LogPrefix.Backend
-  )
-  return allAvailableRuntimes.pop()!
 }
 
 function constructAndUpdateRPC(gameInfo: GameInfo): RpcClient {
@@ -1687,7 +1637,6 @@ export {
   getCometBin,
   getNileBin,
   formatEpicStoreUrl,
-  getSteamRuntime,
   constructAndUpdateRPC,
   quoteIfNecessary,
   removeQuoteIfNecessary,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -19,6 +19,7 @@ import { ChildProcess } from 'child_process'
 import type { HeroicHowLongToBeatEntry } from 'backend/wiki_game_info/howlongtobeat/utils'
 import type { Path } from 'backend/schemas'
 import type LogWriter from 'backend/logger/log_writer'
+import type { SteamRuntimeName } from './types/umu'
 
 export type Runner = 'legendary' | 'gog' | 'sideload' | 'nile' | 'zoom'
 
@@ -255,7 +256,7 @@ export interface GameSettings {
   showMangohud: boolean
   targetExe: string
   useGameMode: boolean
-  useSteamRuntime: boolean
+  steamRuntime: SteamRuntimeName | false
   wineCrossoverBottle: string
   winePrefix: string
   wineVersion: WineInstallation
@@ -427,12 +428,6 @@ export interface GOGImportData {
   platform: GogInstallPlatform
   versionName: string
   dlcs: string[]
-}
-
-export interface SteamRuntime {
-  path: string
-  type: 'sniper' | 'scout' | 'soldier'
-  args: string[]
 }
 
 export interface LaunchPreperationResult {

--- a/src/common/types/umu.ts
+++ b/src/common/types/umu.ts
@@ -1,0 +1,5 @@
+export type SteamRuntimeName =
+  | 'umu-scout'
+  | 'umu-soldier'
+  | 'umu-sniper'
+  | 'umu-steamrt4'

--- a/src/frontend/screens/Settings/components/SteamRuntime.tsx
+++ b/src/frontend/screens/Settings/components/SteamRuntime.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SelectField } from 'frontend/components/UI'
-import ContextProvider from 'frontend/state/ContextProvider'
 import useSetting from 'frontend/hooks/useSetting'
 import SettingsContext from '../SettingsContext'
 import InfoIcon from 'frontend/components/UI/InfoIcon'
@@ -19,8 +18,6 @@ const RUNTIME_NAMES = {
 function SteamRuntime() {
   const { t } = useTranslation()
   const { isLinuxNative } = useContext(SettingsContext)
-  const { platform } = useContext(ContextProvider)
-  const isLinux = platform === 'linux'
   const [steamRuntime, setSteamRuntime] = useSetting('steamRuntime', false)
 
   const parseAndSet = useCallback(
@@ -39,7 +36,7 @@ function SteamRuntime() {
     [setSteamRuntime]
   )
 
-  if (!(isLinux && isLinuxNative)) return <></>
+  if (!isLinuxNative) return <></>
 
   return (
     <>

--- a/src/frontend/screens/Settings/components/SteamRuntime.tsx
+++ b/src/frontend/screens/Settings/components/SteamRuntime.tsx
@@ -1,48 +1,93 @@
-import { useContext } from 'react'
+import { useCallback, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ToggleSwitch } from 'frontend/components/UI'
+import { SelectField } from 'frontend/components/UI'
 import ContextProvider from 'frontend/state/ContextProvider'
 import useSetting from 'frontend/hooks/useSetting'
-import { defaultWineVersion } from '..'
 import SettingsContext from '../SettingsContext'
 import InfoIcon from 'frontend/components/UI/InfoIcon'
+import { Box, MenuItem, Stack, Typography } from '@mui/material'
+import type { SteamRuntimeName } from 'common/types/umu'
 
-const SteamRuntime = () => {
+// Names as they appear in the Steam client
+const RUNTIME_NAMES = {
+  'umu-scout': 'Steam Linux Runtime 1.0 (scout)',
+  'umu-soldier': 'Steam Linux Runtime 2.0 (soldier)',
+  'umu-sniper': 'Steam Linux Runtime 3.0 (sniper)',
+  'umu-steamrt4': 'Steam Linux Runtime 4.0'
+} as const satisfies Record<SteamRuntimeName, string>
+
+function SteamRuntime() {
   const { t } = useTranslation()
   const { isLinuxNative } = useContext(SettingsContext)
   const { platform } = useContext(ContextProvider)
   const isLinux = platform === 'linux'
-  const isWin = platform === 'win32'
-  const [useSteamRuntime, setUseSteamRuntime] = useSetting(
-    'useSteamRuntime',
-    false
+  const [steamRuntime, setSteamRuntime] = useSetting('steamRuntime', false)
+
+  const parseAndSet = useCallback(
+    (value: string) => {
+      switch (value) {
+        case 'umu-scout':
+        case 'umu-soldier':
+        case 'umu-sniper':
+        case 'umu-steamrt4':
+          setSteamRuntime(value)
+          break
+        case 'none':
+          setSteamRuntime(false)
+      }
+    },
+    [setSteamRuntime]
   )
-  const [wineVersion] = useSetting('wineVersion', defaultWineVersion)
 
-  const isProton = !isWin && wineVersion?.type === 'proton'
-
-  const showSteamRuntime = isLinuxNative || isProton
-
-  if (!isLinux || !showSteamRuntime) {
-    return <></>
-  }
+  if (!(isLinux && isLinuxNative)) return <></>
 
   return (
-    <div className="toggleRow">
-      <ToggleSwitch
-        htmlId="steamruntime"
-        value={useSteamRuntime}
-        handleChange={() => setUseSteamRuntime(!useSteamRuntime)}
-        title={t('setting.steamruntime', 'Use Steam Runtime')}
-      />
-
-      <InfoIcon
-        text={t(
-          'help.steamruntime',
-          'Custom libraries provided by Steam to help run Linux and Windows (Proton) games. Enabling might improve compatibility.'
-        )}
-      />
-    </div>
+    <>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        gap={2}
+      >
+        <Typography>
+          {t('setting.steamRuntime.label', 'Use Steam Runtime')}
+        </Typography>
+        <Box
+          display="flex"
+          flexDirection="row"
+          alignItems="center"
+          gap={2}
+          width="60%"
+          sx={{
+            [`& .selectFieldWrapper`]: {
+              paddingTop: 0,
+              paddingBottom: 0
+            }
+          }}
+        >
+          <SelectField
+            htmlId="steamruntime"
+            onChange={(event) => parseAndSet(event.target.value)}
+            value={steamRuntime || 'none'}
+          >
+            <MenuItem value={'none'}>
+              {t('setting.steamRuntime.noRuntimeOption', 'None')}
+            </MenuItem>
+            {Object.entries(RUNTIME_NAMES).map(([id, name]) => (
+              <MenuItem key={id} value={id}>
+                {name}
+              </MenuItem>
+            ))}
+          </SelectField>
+          <InfoIcon
+            text={t(
+              'help.steamruntime',
+              'Custom libraries provided by Steam to help run Linux and Windows (Proton) games. Enabling might improve compatibility.'
+            )}
+          />
+        </Box>
+      </Stack>
+    </>
   )
 }
 


### PR DESCRIPTION
The Steam Runtime is useful in two cases:
1. Proton is used to run a Windows game
2. A Linux-native game (potentially built for older distros) is ran on a modern distro

We already use umu to cover the first case. Let's also use it for the 2nd.

The existing "Use Steam Runtime" checkbox is replaced by a dropdown to select the Steam Runtime to use for the game:

<img width="1505" height="847" alt="grafik" src="https://github.com/user-attachments/assets/ac157d7d-788f-4110-95ef-48894396f20a" />

> [!NOTE]
> This also removes the "Use Steam Runtime" option completely for non-native games. Using umu is strictly more compatible. We were running Proton in SteamRT3, not 4 (like modern versions expect)

When the game is then launched, umu is used to provide the runtime:

<img width="1170" height="652" alt="grafik" src="https://github.com/user-attachments/assets/964ca687-3550-4ba9-a47e-c264580fde76" />

---

GOG games will also automatically enable `umu-scout` when they are installed/imported. Scout is the default runtime for Linux-native Steam games, and it seems to provide the most period-accurate runtime for most games.  
We may want to expand this to automatically check some heuristics and decide the runtime based on that, but this is fine as a first implementation.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
