### PR TITLE
fix: Don't change main window visibility state when launching a game

### DIFF
--- a/src/backend/__tests__/protocol.test.ts
+++ b/src/backend/__tests__/protocol.test.ts
@@ -25,7 +25,11 @@ jest.mock('../config', () => ({
   }
 }))
 
-import { handleProtocol, shouldHideWindowForProtocolArgs } from '../protocol'
+import {
+  handleProtocol,
+  isGameLaunchArgs,
+  shouldHideWindowForProtocolArgs
+} from '../protocol'
 import { app, dialog } from 'electron'
 import { libraryManagerMap } from '../storeManagers'
 import { getMainWindow } from '../main_window'
@@ -361,6 +365,26 @@ describe('protocol.ts --no-gui behavior', () => {
       expect(
         shouldHideWindowForProtocolArgs(['/path/to/heroic', '--some-flag'])
       ).toBe(false)
+    })
+  })
+
+  describe('isGameLaunchArgs', () => {
+    test('returns true for old-style launch URLs', () => {
+      expect(isGameLaunchArgs(['heroic://launch/test-game'])).toBe(true)
+    })
+
+    test('returns true for new-style launch URLs', () => {
+      expect(
+        isGameLaunchArgs(['heroic://launch?appName=test-game&runner=legendary'])
+      ).toBe(true)
+    })
+
+    test('returns false for non-launch protocol URLs', () => {
+      expect(isGameLaunchArgs(['heroic://ping'])).toBe(false)
+    })
+
+    test('returns false when no heroic URL is present', () => {
+      expect(isGameLaunchArgs(['/path/to/heroic', '--some-flag'])).toBe(false)
     })
   })
 })

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -70,7 +70,11 @@ import {
 import { Path } from './schemas'
 
 import { uninstallGameCallback } from './utils/uninstaller'
-import { handleProtocol, shouldHideWindowForProtocolArgs } from './protocol'
+import {
+  handleProtocol,
+  isGameLaunchArgs,
+  shouldHideWindowForProtocolArgs
+} from './protocol'
 import {
   init as initLogger,
   logDebug,
@@ -317,9 +321,12 @@ if (!gotTheLock) {
   app.quit()
 } else {
   app.on('second-instance', (event, argv) => {
-    // Someone tried to run a second instance, we should focus our window.
+    // Someone tried to run a second instance, we should focus our window,
+    // unless this is a game launch: starting a game should never change the
+    // main window's current visibility state (open, minimized, or hidden),
+    // it should just be left as it is.
     const mainWindow = getMainWindow()
-    if (!shouldHideWindowForProtocolArgs(argv)) {
+    if (!isGameLaunchArgs(argv)) {
       mainWindow?.show()
     }
 

--- a/src/backend/protocol.ts
+++ b/src/backend/protocol.ts
@@ -43,6 +43,16 @@ export function shouldHideWindowForProtocolArgs(args: string[]): boolean {
   }
 }
 
+// Returns true when `args` represent a `heroic://launch/...` request, i.e.
+// starting a game rather than just reopening the app. Used so that starting
+// a game never forces the main window to show: whatever state the window
+// was already in (open, minimized, or hidden) is left untouched, unless the
+// user explicitly opted into hiding it (see `shouldHideWindowForProtocolArgs`).
+export function isGameLaunchArgs(args: string[]): boolean {
+  const url = parseHeroicUrl(args)
+  return url?.hostname === 'launch'
+}
+
 export function handleProtocol(args: string[]) {
   const url = parseHeroicUrl(args)
   if (!url) return


### PR DESCRIPTION
## Summary

Launching a game via a `heroic://launch/...` request while Heroic is already running (e.g. a desktop shortcut, or Steam's "Add to Steam" integration) goes through the `second-instance` handler, which called `mainWindow.show()` whenever `hideWindowOnProtocolLaunch` was off — which is the default (#5154 / #5501). This forced the main window open, and un-minimized it, even if the user had left it minimized or hidden by some other means. The only way to avoid that was enabling `hideWindowOnProtocolLaunch`, but that setting does the opposite extreme: it always *hides* the window on launch, even if it was open — there was no way to just leave the window's current state alone.

Concretely, with `minimizeOnLaunch` enabled but `hideWindowOnProtocolLaunch` left off (a common combination, since these are two independent settings), launching a game from a shortcut caused the window to visibly flash open and then immediately hide again:
1. `second-instance` forces `mainWindow.show()`
2. moments later, `launcher.ts`'s `minimizeOnLaunch` handling calls `mainWindow.hide()`

## What changed

Added `isGameLaunchArgs()` to detect that a `second-instance` event is specifically a game-launch request (`heroic://launch/...`), and skip the forced `show()` in that case instead of gating it on `hideWindowOnProtocolLaunch`. Starting a game via a protocol/shortcut launch now never changes the main window's current visibility state — open stays open, minimized stays minimized, hidden stays hidden.

The existing opt-in "force hide" behavior (`hideWindowOnProtocolLaunch` setting / `gui=false` URL param) is untouched and still works as before, for anyone who wants the window to always hide on a protocol launch even if it happened to be open.

### Scope

This only touches the `second-instance`/protocol-launch path. Launching a game from inside the already-open Heroic UI (clicking Play) goes through a separate IPC path (`window.api.launch` → `launcher.ts`) that never calls `mainWindow.show()` in the first place — it already left the window's state alone by default, and is unaffected by this change.

## Test plan

- [x] Added unit tests for `isGameLaunchArgs` in `src/backend/__tests__/protocol.test.ts`
- [x] `pnpm codecheck` passes
- [x] `pnpm test:ci` passes (139 tests)
- [ ] Manually verified: with Heroic running and minimized, launching a game via a `heroic://launch` shortcut keeps the window minimized instead of flashing open
- [ ] Manually verified: with Heroic running and visible, launching a game via a shortcut leaves the window open (no unexpected hide)
- [ ] Manually verified: default second-instance behavior (reopening the app, no game-launch URL) still shows/focuses the window as before
