### PR TITLE
fix: remove unnecessary proton prefix creation

### DIFF
--- a/src/backend/launcher.ts
+++ b/src/backend/launcher.ts
@@ -881,7 +881,6 @@ async function prepareWineLaunch(
     )
   }
 
-  await verifyWinePrefix(gameSettings)
   const experimentalFeatures =
     GlobalConfig.get().getSettings().experimentalFeatures
 


### PR DESCRIPTION
When Heroic launches a game through Proton, it first calls prepareWineLaunch to do some preparation work, and then calls runWineCommand to actually start the game.

https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/37a9bef678a837240477e97b708069dab4517666/src/backend/storeManagers/storeManagerCommon/games.ts#L165-L167

https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/37a9bef678a837240477e97b708069dab4517666/src/backend/storeManagers/storeManagerCommon/games.ts#L254-L265

Looking at the code, prepareWineLaunch unconditionally calls verifyWinePrefix. The literal purpose of this function is to ensure that the Wine prefix exists, but what it actually does is forcibly recreate the Wine prefix, regardless of whether the prefix already exists.

https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/37a9bef678a837240477e97b708069dab4517666/src/backend/launcher.ts#L884

In fact, runWineCommand already checks whether the prefix exists when it runs, and creates it if necessary. Therefore, the verifyWinePrefix call in prepareWineLaunch is completely redundant and should be removed. This can reduce game launch delay by about 1/3 to 1/2.

https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/37a9bef678a837240477e97b708069dab4517666/src/backend/launcher.ts#L1533-L1540


---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
