### PR TITLE
[UX] Don't show Wine Manager settings on Mac

### DIFF
--- a/src/frontend/screens/WineManager/index.tsx
+++ b/src/frontend/screens/WineManager/index.tsx
@@ -186,13 +186,15 @@ export default function WineManager(): JSX.Element | null {
               icon={faSyncAlt}
             />
           </button>
-          <button
-            className="toolbarBtn"
-            title={t('wine.manager.settings', 'Settings')}
-            onClick={() => setShowSettingsModal(true)}
-          >
-            <FontAwesomeIcon icon={faCog} />
-          </button>
+          {isLinux && (
+            <button
+              className="toolbarBtn"
+              title={t('wine.manager.settings', 'Settings')}
+              onClick={() => setShowSettingsModal(true)}
+            >
+              <FontAwesomeIcon icon={faCog} />
+            </button>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
The Wine Manager's settings dialog shows the option to add custom paths for wine/proton.

These custom paths were only used on Linux, so showing it on Mac makes it confusing for users expecting to add custom wines on Mac that then don't show up.

I also tried changing the code for mac to actually use this config, but I don't really know how custom "wines" should be handled (like... Sikarugir, CrossOver, or WineForge include a `wine` inside their .app, but it doesn't look like we can simply use them without the they provide wrapper).

So, to avoid confusion, I think it's better to just not show the option (at least until someone figures out how to handle custom wine paths on mac).

It kinda closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5845 (it doesn't make the feature work on mac, but it solved the confusing non-working option).

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
