### PR TITLE
[UX] Fix pausing/canceling a download from game details page

### DIFF
--- a/src/frontend/screens/Game/GamePage/components/MainButton.tsx
+++ b/src/frontend/screens/Game/GamePage/components/MainButton.tsx
@@ -206,7 +206,7 @@ const MainButton = ({ gameInfo, handlePlay, handleInstall }: Props) => {
         <span className="installButtons">
           <button
             onClick={async () => {
-              if (!is_installed && !is.queued) {
+              if (!is_installed && !is.queued && !is.installing) {
                 openInstallGameModal({
                   appName: gameInfo.app_name,
                   runner: gameInfo.runner,


### PR DESCRIPTION
Clicking the Pause/Cancel button while a game is being installed is reopening the install dialog instead of the "Cancel download" confirmation dialog.

This PR fixes that.

Closes https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5846

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
