### PR TITLE
[Console] Show supported 3rd party apps

### DIFF
--- a/src/frontend/screens/ConsoleMode/index.tsx
+++ b/src/frontend/screens/ConsoleMode/index.tsx
@@ -128,8 +128,10 @@ export default function ConsoleMode() {
     return all.filter(
       (g) =>
         !g.install?.is_dlc &&
-        !g.thirdPartyManagedApp &&
-        !hiddenAppNames.has(g.app_name)
+        !hiddenAppNames.has(g.app_name) &&
+        // Validate it's a supported 3rd party app
+        // TODO: This should probably be abstracted
+        (!g.thirdPartyManagedApp || g.isEAManaged || g.isUbisoftManaged)
     )
   }, [
     epic.library,


### PR DESCRIPTION
Stops filtering out games using supported third party apps from Console Mode. Similar logic appears to be in place in the Library view. It may be good to abstract this logic somewhere so the games list is identical in the main and console views.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [x] Tested the feature and it's working on a current and clean install.
- [x] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
