### PR TITLE
fix: Set `LEGENDARY_CONFIG_PATH` again

### DIFF
--- a/src/backend/storeManagers/legendary/library.ts
+++ b/src/backend/storeManagers/legendary/library.ts
@@ -693,12 +693,9 @@ export default class LegendaryLibraryManager implements LibraryManager {
 
     // Set LEGENDARY_CONFIG_PATH to a custom, Heroic-specific location so user-made
     // changes to Legendary's main config file don't affect us
-    if (!options) {
-      options = {}
-    }
-    if (!options.env) {
-      options.env = {}
-    }
+    options ??= {}
+    options.env ??= {}
+    options.env['LEGENDARY_CONFIG_PATH'] = legendaryConfigPath
 
     const commandParts = this.commandToArgsArray(command)
 


### PR DESCRIPTION
Accidentally removed this in <https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5814>.

To test (for example): Try to launch an already-installed Epic game, see "[cli] ERROR: Game ... is not currently installed!" error.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [X] Tested the feature and it's working on a current and clean install.
- [X] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [ ] Created / Updated Tests (If necessary)
- [ ] Created / Updated documentation (If necessary)
