### PR TITLE
Fix sideload installer overwriting Wine prefix

### DIFF
--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -252,9 +252,16 @@ export default function SideloadDialog({
         if (!gameSettings) {
           return
         }
+        const selectedWinePrefix =
+          winePrefix === '...' ? gameSettings.winePrefix : winePrefix
+        const selectedWineVersion = wineVersion || gameSettings.wineVersion
         await writeConfig({
           appName: app_name,
-          config: { ...gameSettings, winePrefix, wineVersion }
+          config: {
+            ...gameSettings,
+            winePrefix: selectedWinePrefix,
+            wineVersion: selectedWineVersion
+          }
         })
         await window.api.runWineCommand({
           commandParts: [exeToRun],
@@ -262,8 +269,8 @@ export default function SideloadDialog({
           protonVerb: 'runinprefix',
           gameSettings: {
             ...gameSettings,
-            winePrefix,
-            wineVersion: wineVersion || gameSettings.wineVersion
+            winePrefix: selectedWinePrefix,
+            wineVersion: selectedWineVersion
           }
         })
         setRunningSetup(false)

--- a/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
+++ b/src/frontend/screens/Library/components/InstallModal/SideloadDialog/index.tsx
@@ -252,16 +252,9 @@ export default function SideloadDialog({
         if (!gameSettings) {
           return
         }
-        const selectedWinePrefix =
-          winePrefix === '...' ? gameSettings.winePrefix : winePrefix
-        const selectedWineVersion = wineVersion || gameSettings.wineVersion
         await writeConfig({
           appName: app_name,
-          config: {
-            ...gameSettings,
-            winePrefix: selectedWinePrefix,
-            wineVersion: selectedWineVersion
-          }
+          config: { ...gameSettings, winePrefix, wineVersion }
         })
         await window.api.runWineCommand({
           commandParts: [exeToRun],
@@ -269,8 +262,8 @@ export default function SideloadDialog({
           protonVerb: 'runinprefix',
           gameSettings: {
             ...gameSettings,
-            winePrefix: selectedWinePrefix,
-            wineVersion: selectedWineVersion
+            winePrefix,
+            wineVersion: wineVersion || gameSettings.wineVersion
           }
         })
         setRunningSetup(false)
@@ -306,6 +299,7 @@ export default function SideloadDialog({
   const showSideloadExe = appPlatform !== 'Browser'
 
   const shouldShowRunExe =
+    !editMode &&
     platform !== 'win32' &&
     appPlatform !== 'Mac' &&
     appPlatform !== 'linux' &&


### PR DESCRIPTION
## Summary

- hide **Run Installer First** when editing an existing sideloaded game
- keep the button available while adding a new sideloaded game

The button is intended for initial setup. Existing games can run additional installers through **Run EXE on prefix**, which already uses the configured Wine prefix. Hiding the setup button in edit mode prevents it from persisting the uninitialized `...` prefix value.

Fixes #5551

## Testing

- `pnpm codecheck`
- `pnpm test:ci` (135 tests passed)
- `pnpm exec electron-vite build`
- project pre-push checks