### PR TITLE
fix: Recover Amazon sessions and handle Nile login failures

### DIFF
--- a/doc/nile-login.md
+++ b/doc/nile-login.md
@@ -1,0 +1,63 @@
+# Amazon / Nile login recovery
+
+This change fixes specific failure paths in Heroic's account-login integration.
+It does not change the Amazon storefront's cookies, bypass MFA, or modify Nile's
+Amazon API implementation.
+
+## Failure paths
+
+- Nile refuses `auth --login` when it already has a session. Previously Heroic
+  parsed the resulting empty stdout as JSON, and the UI never caught the failure.
+- Heroic relied on its own cached profile to decide whether to load Nile's
+  library. A valid CLI session could exist in Heroic's `NILE_CONFIG_PATH` while
+  that cache was empty. Session checks now re-read the local profile first.
+- Nile 1.2 uses `current_user.json`; older versions use nested customer data in
+  `user.json`. Both formats are read, copying only the public name and user ID.
+  An existing current-format file takes precedence over any legacy file.
+- Amazon can redirect away from its authorization callback before `dom-ready`.
+  Main-frame navigation/redirect events now supply the callback URL. Duplicate
+  events cannot submit the same authorization code twice.
+- Failed registration previously navigated to the account page as if successful.
+  It now displays an error with a fresh-attempt retry. Preparation also has a
+  30-second timeout, and results from abandoned attempts are ignored. A timeout
+  displays the error immediately, but Retry stays disabled until the original
+  request settles and the runner has removed its cached command. A late success
+  after timeout cannot reopen the old sign-in page. Back to accounts stays usable.
+
+Existing local sessions are reused, not logged out or deleted. Recovery reloads
+Heroic's renderer once to synchronize its cached account state. As with Nile's
+own session check, finding a local profile does not prove a token is still valid
+on Amazon's servers; library sync/launch remains responsible for token refresh.
+
+## Validation
+
+Regression tests are in `src/backend/storeManagers/nile/__tests__/` and use the
+existing Backend Jest project. They cover account restoration, both profile
+formats, damaged/missing profiles, preparation failures, helper arguments,
+registration failure handling, public-data filtering, callback validation and
+timeout/retry ordering with delayed runner cleanup.
+
+```sh
+pnpm codecheck
+pnpm test --runInBand
+pnpm lint
+pnpm prettier
+```
+
+A live Amazon sign-in cannot be verified by these mocked tests. On Linux, test:
+
+1. With no Amazon session, use **Manage Accounts > Amazon > Login**, complete
+   Amazon's password/MFA screens, and confirm the account and library appear.
+2. Restart Heroic and confirm that the account remains available. A pre-existing
+   CLI login must use Heroic's configured `NILE_CONFIG_PATH`, not a separate
+   system-wide Nile directory.
+3. Cancel/navigate away during preparation; no late response should redirect
+   you back. A missing/broken helper should show an error instead of spinning
+   indefinitely. With a deliberately slow helper, let preparation time out and
+   delay its abort completion: Retry must stay disabled until the request settles,
+   then start one fresh attempt. Back must still work during cancellation.
+4. After an unsuccessful registration, confirm no false-success navigation.
+   Retry, log in, then verify Epic/GOG login and normal launch/install still work.
+
+Do not post passwords, authorization callback URLs, authentication tokens or
+raw Nile credential files in bug reports.

--- a/src/backend/storeManagers/nile/__tests__/auth.test.ts
+++ b/src/backend/storeManagers/nile/__tests__/auth.test.ts
@@ -1,0 +1,115 @@
+import {
+  getAmazonAuthorizationCode,
+  parseNileLoginData,
+  parseNileUserData
+} from 'common/nileAuth'
+
+const loginData = {
+  url: 'https://amazon.com/ap/signin?openid.return_to=https%3A%2F%2Fwww.amazon.com',
+  client_id: 'test-client',
+  code_verifier: 'test-verifier',
+  serial: 'test-serial'
+}
+
+describe('Nile authentication data', () => {
+  it('extracts only public fields from a current profile', () => {
+    expect(
+      parseNileUserData({ name: 'Test', user_id: 'id', token: 'secret' })
+    ).toEqual({ name: 'Test', user_id: 'id' })
+  })
+
+  it('supports the pre-1.2 profile without copying tokens to Heroic', () => {
+    expect(
+      parseNileUserData(
+        {
+          extensions: {
+            customer_info: { given_name: 'Test', user_id: 'id' }
+          },
+          tokens: { bearer: { refresh_token: 'secret' } }
+        },
+        true
+      )
+    ).toEqual({ name: 'Test', user_id: 'id' })
+  })
+
+  it.each([null, [], {}, { name: 'Test' }, { name: 'Test', user_id: '' }])(
+    'rejects malformed current profiles: %j',
+    (profile) => {
+      expect(parseNileUserData(profile)).toBeUndefined()
+    }
+  )
+
+  it.each([{}, { extensions: null }, { extensions: { customer_info: [] } }])(
+    'rejects malformed legacy profiles: %j',
+    (profile) => {
+      expect(parseNileUserData(profile, true)).toBeUndefined()
+    }
+  )
+
+  it('parses valid helper output without modifying the verifier', () => {
+    expect(parseNileLoginData(JSON.stringify(loginData))).toEqual(loginData)
+  })
+
+  it.each(['', 'You are already logged in', 'null', '{bad json'])(
+    'rejects non-login output: %s',
+    (output) => {
+      expect(parseNileLoginData(output)).toBeUndefined()
+    }
+  )
+
+  it.each(['client_id', 'code_verifier', 'serial', 'url'])(
+    'rejects a missing %s',
+    (key) => {
+      expect(
+        parseNileLoginData(JSON.stringify({ ...loginData, [key]: '' }))
+      ).toBeUndefined()
+    }
+  )
+
+  it.each([
+    'http://amazon.com/ap/signin',
+    'https://amazon.com.attacker.example/ap/signin',
+    'https://user:password@amazon.com/ap/signin',
+    'javascript:alert(1)'
+  ])('rejects an unsafe login URL: %s', (url) => {
+    expect(
+      parseNileLoginData(JSON.stringify({ ...loginData, url }))
+    ).toBeUndefined()
+  })
+})
+
+describe('Amazon authorization redirects', () => {
+  it('extracts and URL-decodes a code from the requested return URL', () => {
+    expect(
+      getAmazonAuthorizationCode(
+        'https://www.amazon.com/?openid.oa2.authorization_code=a%2Bb%26c',
+        loginData.url
+      )
+    ).toBe('a+b&c')
+  })
+
+  it.each([
+    'https://www.amazon.com/?unrelated=value',
+    'https://www.amazon.com/?openid.oa2.authorization_code=',
+    'http://www.amazon.com/?openid.oa2.authorization_code=secret',
+    'https://www.amazon.com.attacker.example/?openid.oa2.authorization_code=secret',
+    'https://www.amazon.com/ap/signin?openid.oa2.authorization_code=secret',
+    'https://user@www.amazon.com/?openid.oa2.authorization_code=secret',
+    'about:blank',
+    'not a URL'
+  ])('ignores non-callback navigation: %s', (url) => {
+    expect(getAmazonAuthorizationCode(url, loginData.url)).toBeNull()
+  })
+
+  it('requires a valid expected return URL', () => {
+    expect(
+      getAmazonAuthorizationCode('https://www.amazon.com/?code=x', 'invalid')
+    ).toBeNull()
+    expect(
+      getAmazonAuthorizationCode(
+        'https://www.amazon.com/?openid.oa2.authorization_code=x',
+        'https://amazon.com/ap/signin'
+      )
+    ).toBeNull()
+  })
+})

--- a/src/backend/storeManagers/nile/__tests__/preparation.test.ts
+++ b/src/backend/storeManagers/nile/__tests__/preparation.test.ts
@@ -1,0 +1,138 @@
+import { prepareNileLogin } from 'common/nileAuth'
+import type { NileLoginData } from 'common/types/nile'
+
+const loginData = {
+  url: 'https://www.amazon.com/ap/signin',
+  client_id: 'test-client',
+  code_verifier: 'test-verifier',
+  serial: 'test-serial'
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: Error) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => jest.useFakeTimers())
+afterEach(() => jest.useRealTimers())
+
+describe('Nile preparation timeout', () => {
+  it.each<NileLoginData>([
+    loginData,
+    { user: { user_id: 'test-id', name: 'Test' } }
+  ])('accepts a result before the deadline: %j', async (data) => {
+    const onTimeout = jest.fn()
+    const preparation = prepareNileLogin(() => Promise.resolve(data), onTimeout)
+    await expect(preparation.result).resolves.toEqual(data)
+    expect(jest.getTimerCount()).toBe(0)
+    await jest.advanceTimersByTimeAsync(30000)
+    expect(onTimeout).not.toHaveBeenCalled()
+  })
+
+  it('clears the timer when preparation rejects before the deadline', async () => {
+    const onTimeout = jest.fn()
+    const preparation = prepareNileLogin(
+      () => Promise.reject(new Error('Preparation failed')),
+      onTimeout
+    )
+    await expect(preparation.result).rejects.toThrow('Preparation failed')
+    expect(jest.getTimerCount()).toBe(0)
+    expect(onTimeout).not.toHaveBeenCalled()
+  })
+
+  it('turns a synchronous request error into a settled promise', async () => {
+    const preparation = prepareNileLogin(() => {
+      throw new Error('IPC unavailable')
+    }, jest.fn())
+    await expect(preparation.result).rejects.toThrow('IPC unavailable')
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
+  it.each<NileLoginData>([
+    loginData,
+    { user: { user_id: 'test-id', name: 'Test' } }
+  ])('waits for cleanup and discards a late success: %j', async (data) => {
+    const request = deferred<NileLoginData>()
+    const onTimeout = jest.fn()
+    const preparation = prepareNileLogin(() => request.promise, onTimeout)
+    const settled = jest.fn()
+    const outcome = preparation.result.catch((error: unknown) => {
+      settled()
+      return error
+    })
+
+    await jest.advanceTimersByTimeAsync(29999)
+    expect(onTimeout).not.toHaveBeenCalled()
+    await jest.advanceTimersByTimeAsync(1)
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    expect(settled).not.toHaveBeenCalled()
+    await jest.advanceTimersByTimeAsync(30000)
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    expect(settled).not.toHaveBeenCalled()
+
+    request.resolve(data)
+    expect(await outcome).toEqual(new Error('Could not prepare Amazon login'))
+    expect(settled).toHaveBeenCalledTimes(1)
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
+  it('does not release Retry while an aborted command is still cached', async () => {
+    const request = deferred<NileLoginData>()
+    // Model callRunner: identical calls share one promise until its finally
+    // handler has removed the command from commandsRunning.
+    let running: Promise<NileLoginData> | undefined = request.promise.finally(
+      () => {
+        running = undefined
+      }
+    )
+    const getLoginData = jest.fn(() => running ?? Promise.resolve(loginData))
+    const abort = jest.fn()
+    const preparation = prepareNileLogin(getLoginData, abort)
+    let preparing = true
+    const outcome = preparation.result
+      .catch(() => undefined)
+      .finally(() => {
+        preparing = false
+      })
+
+    await jest.advanceTimersByTimeAsync(30000)
+    expect(abort).toHaveBeenCalledTimes(1)
+    expect(preparing).toBe(true)
+    expect(running).toBeDefined()
+    expect(getLoginData).toHaveBeenCalledTimes(1)
+
+    request.reject(new Error('Aborted'))
+    await outcome
+    expect(preparing).toBe(false)
+    expect(running).toBeUndefined()
+
+    const retry = prepareNileLogin(getLoginData, abort)
+    await expect(retry.result).resolves.toEqual(loginData)
+    expect(getLoginData).toHaveBeenCalledTimes(2)
+    expect(abort).toHaveBeenCalledTimes(1)
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
+  it('disposes the timeout without pretending the request has settled', async () => {
+    const request = deferred<NileLoginData>()
+    const onTimeout = jest.fn()
+    const preparation = prepareNileLogin(() => request.promise, onTimeout)
+    const settled = jest.fn()
+    const outcome = preparation.result.then(settled)
+
+    preparation.dispose()
+    preparation.dispose()
+    expect(jest.getTimerCount()).toBe(0)
+    await jest.advanceTimersByTimeAsync(60000)
+    expect(onTimeout).not.toHaveBeenCalled()
+    expect(settled).not.toHaveBeenCalled()
+    request.resolve(loginData)
+    await outcome
+    expect(settled).toHaveBeenCalledWith(loginData)
+  })
+})

--- a/src/backend/storeManagers/nile/__tests__/user.test.ts
+++ b/src/backend/storeManagers/nile/__tests__/user.test.ts
@@ -1,0 +1,222 @@
+import { existsSync, readFileSync } from 'graceful-fs'
+import { libraryManagerMap } from '../..'
+import { configStore } from '../electronStores'
+import { NileUser } from '../user'
+import { logError } from 'backend/logger'
+
+jest.mock('../..', () => ({
+  libraryManagerMap: { nile: { runRunnerCommand: jest.fn() } }
+}))
+jest.mock('../electronStores', () => ({
+  configStore: { set: jest.fn(), delete: jest.fn(), get_nodefault: jest.fn() }
+}))
+jest.mock('../constants', () => ({
+  nileConfigPath: '/heroic/nile_config/nile',
+  nileUserData: '/heroic/nile_config/nile/current_user.json'
+}))
+jest.mock('graceful-fs', () => ({
+  existsSync: jest.fn(),
+  readFileSync: jest.fn()
+}))
+jest.mock('backend/utils', () => ({ clearCache: jest.fn() }))
+jest.mock('backend/logger', () => ({
+  LogPrefix: { Nile: 'Nile' },
+  logDebug: jest.fn(),
+  logInfo: jest.fn(),
+  logError: jest.fn()
+}))
+jest.mock('electron', () => ({ session: { fromPartition: jest.fn() } }))
+
+const currentPath = '/heroic/nile_config/nile/current_user.json'
+const legacyPath = '/heroic/nile_config/nile/user.json'
+const user = { name: 'Test', user_id: 'test-id' }
+const registerData = {
+  code: 'test-code',
+  client_id: 'test-client',
+  code_verifier: 'test-verifier',
+  serial: 'test-serial'
+}
+const loginData = {
+  url: 'https://amazon.com/ap/signin?openid.return_to=https%3A%2F%2Fwww.amazon.com',
+  client_id: 'test-client',
+  code_verifier: 'test-verifier',
+  serial: 'test-serial'
+}
+const runCommand = jest.mocked(libraryManagerMap.nile.runRunnerCommand)
+const files = new Map<string, string>()
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  files.clear()
+  jest.mocked(existsSync).mockImplementation((path) => files.has(String(path)))
+  jest.mocked(readFileSync).mockImplementation((path) => {
+    const contents = files.get(String(path))
+    if (contents === undefined) throw new Error('File not found')
+    return contents
+  })
+  runCommand.mockReset()
+  runCommand.mockResolvedValue({ stdout: '', stderr: '' })
+})
+
+describe('Nile session detection', () => {
+  it('rehydrates a valid CLI session when the Heroic cache is empty', () => {
+    files.set(currentPath, JSON.stringify(user))
+    expect(NileUser.isLoggedIn()).toEqual(user)
+    expect(configStore.set).toHaveBeenCalledWith('userData', user)
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+
+  it('reads a legacy profile without exposing its tokens', () => {
+    files.set(
+      legacyPath,
+      JSON.stringify({
+        extensions: {
+          customer_info: { given_name: 'Test', user_id: 'test-id' }
+        },
+        tokens: { bearer: { refresh_token: 'secret' } }
+      })
+    )
+    expect(NileUser.getUserData()).toEqual(user)
+    expect(configStore.set).toHaveBeenCalledWith('userData', user)
+  })
+
+  it('does not revive legacy data over an invalid current profile', () => {
+    files.set(currentPath, '{}')
+    files.set(
+      legacyPath,
+      JSON.stringify({
+        extensions: {
+          customer_info: { given_name: 'Test', user_id: 'test-id' }
+        }
+      })
+    )
+    expect(NileUser.isLoggedIn()).toBe(false)
+    expect(configStore.set).not.toHaveBeenCalled()
+  })
+
+  it('clears stale cached identity after the local session is removed', () => {
+    files.set(currentPath, JSON.stringify(user))
+    expect(NileUser.isLoggedIn()).toEqual(user)
+    files.clear()
+    expect(NileUser.isLoggedIn()).toBe(false)
+    expect(configStore.delete).toHaveBeenCalledWith('userData')
+  })
+
+  it('handles corrupt JSON without exposing its contents', () => {
+    files.set(currentPath, '{secret-token')
+    expect(NileUser.getUserData()).toBeUndefined()
+    expect(JSON.stringify(jest.mocked(logError).mock.calls)).not.toContain(
+      'secret-token'
+    )
+  })
+})
+
+describe('Nile login preparation', () => {
+  it('resumes existing sessions without requesting an auth URL', async () => {
+    files.set(currentPath, JSON.stringify(user))
+    await expect(NileUser.getLoginData()).resolves.toEqual({ user })
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+
+  it('returns fresh login data when signed out', async () => {
+    runCommand.mockResolvedValue({
+      stdout: JSON.stringify(loginData),
+      stderr: ''
+    })
+    await expect(NileUser.getLoginData()).resolves.toEqual(loginData)
+    expect(runCommand).toHaveBeenCalledWith(
+      ['auth', '--login', '--non-interactive'],
+      expect.objectContaining({ abortId: 'nile-auth' })
+    )
+  })
+
+  it('recognizes a session migrated by Nile during preparation', async () => {
+    runCommand.mockImplementation(async () => {
+      files.set(currentPath, JSON.stringify(user))
+      return { stdout: '', stderr: 'You are already logged in' }
+    })
+    await expect(NileUser.getLoginData()).resolves.toEqual({ user })
+  })
+
+  it.each([
+    { stdout: '', stderr: 'some error' },
+    { stdout: '{broken', stderr: '' },
+    { stdout: '{}', stderr: '' },
+    { stdout: '', stderr: '', abort: true },
+    { stdout: '', stderr: '', error: 'helper unavailable' }
+  ])('rejects failed preparation with a safe message: %j', async (result) => {
+    runCommand.mockResolvedValue(result)
+    await expect(NileUser.getLoginData()).rejects.toThrow(
+      'Could not prepare Amazon login'
+    )
+  })
+})
+
+describe('Nile registration', () => {
+  it('accepts saved profiles independently of log wording', async () => {
+    runCommand.mockImplementation(async () => {
+      files.set(currentPath, JSON.stringify(user))
+      return { stdout: '', stderr: 'Registered successfully' }
+    })
+    await expect(NileUser.login(registerData)).resolves.toEqual({
+      status: 'done',
+      user
+    })
+    expect(runCommand).toHaveBeenCalledWith(
+      [
+        'register',
+        '--code',
+        registerData.code,
+        '--code-verifier',
+        registerData.code_verifier,
+        '--serial',
+        registerData.serial,
+        '--client-id',
+        registerData.client_id
+      ],
+      expect.objectContaining({ abortId: 'nile-login' })
+    )
+  })
+
+  it('rejects success logs without a saved profile', async () => {
+    runCommand.mockResolvedValue({
+      stdout: '',
+      stderr: '[AUTH_MANAGER]: Succesfully registered a device'
+    })
+    await expect(NileUser.login(registerData)).resolves.toEqual({
+      status: 'failed',
+      user: undefined
+    })
+  })
+
+  it.each([{ abort: true }, { error: 'failed' }])(
+    'does not accept aborted/failed commands: %j',
+    async (failure) => {
+      files.set(currentPath, JSON.stringify(user))
+      runCommand.mockResolvedValue({ stdout: '', stderr: '', ...failure })
+      expect((await NileUser.login(registerData)).status).toBe('failed')
+    }
+  )
+
+  it('does not send incomplete registration data to Nile', async () => {
+    expect((await NileUser.login({ ...registerData, code: '' })).status).toBe(
+      'failed'
+    )
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+
+  it('handles helper rejection without exposing its arguments', async () => {
+    runCommand.mockRejectedValue(new Error('command contained secret-code'))
+    expect((await NileUser.login(registerData)).status).toBe('failed')
+    expect(JSON.stringify(jest.mocked(logError).mock.calls)).not.toContain(
+      'secret-code'
+    )
+  })
+
+  it('redacts partial JSON authentication output', async () => {
+    await NileUser.login(registerData)
+    const sanitize = runCommand.mock.calls[0][1]?.logSanitizer
+    expect(sanitize).toBeDefined()
+    expect(sanitize?.('{"access_token":"secret')).not.toContain('secret')
+  })
+})

--- a/src/backend/storeManagers/nile/library.ts
+++ b/src/backend/storeManagers/nile/library.ts
@@ -37,7 +37,7 @@ export default class NileLibraryManager implements LibraryManager {
     const globalNileConfig = join(app.getPath('appData'), 'nile')
     if (!existsSync(nileConfigPath) && existsSync(globalNileConfig)) {
       copySync(globalNileConfig, nileConfigPath)
-      await NileUser.getUserData()
+      NileUser.getUserData()
     }
 
     this.refresh()

--- a/src/backend/storeManagers/nile/user.ts
+++ b/src/backend/storeManagers/nile/user.ts
@@ -4,85 +4,95 @@ import {
   NileRegisterData,
   NileUserData
 } from 'common/types/nile'
+import { parseNileLoginData, parseNileUserData } from 'common/nileAuth'
 import { libraryManagerMap } from '..'
 import { existsSync, readFileSync } from 'graceful-fs'
 import { configStore } from './electronStores'
 import { clearCache } from 'backend/utils'
-import { nileUserData } from './constants'
+import { nileConfigPath, nileUserData } from './constants'
 import { session } from 'electron'
+import { join } from 'path'
 
-function authLogSanitizer(line: string) {
-  try {
-    const output = JSON.parse(line)
-    output.url = '<redacted>'
-    output.code_verifier = '<redacted>'
-    output.serial = '<redacted>'
-    output.client_id = '<redacted>'
-    return JSON.stringify(output) + '\n'
-  } catch {
-    return line
-  }
+function authLogSanitizer() {
+  // Output can contain authorization codes, PKCE verifiers and bearer tokens,
+  // including partial JSON chunks that cannot be safely parsed for redaction.
+  return '<redacted Nile authentication output>\n'
 }
 
 export class NileUser {
   static async getLoginData(): Promise<NileLoginData> {
+    // Nile refuses `auth --login` when a session already exists. Heroic's
+    // electron-store cache may have been cleared independently of that session.
+    const existingUser = this.getUserData()
+    if (existingUser) return { user: existingUser }
+
     logDebug('Getting login data from Nile', LogPrefix.Nile)
-    const { stdout } = await libraryManagerMap['nile'].runRunnerCommand(
+    const result = await libraryManagerMap['nile'].runRunnerCommand(
       ['auth', '--login', '--non-interactive'],
       {
         abortId: 'nile-auth',
         logSanitizer: authLogSanitizer
       }
     )
-    const output: NileLoginData = JSON.parse(stdout)
+    if (result.abort || result.error) {
+      throw new Error('Could not prepare Amazon login')
+    }
 
-    logInfo(['Register data is:', output], LogPrefix.Nile)
-    return output
+    const output = parseNileLoginData(result.stdout)
+    if (output) return output
+
+    // Starting Nile can migrate a legacy session to current_user.json.
+    const migratedUser = this.getUserData()
+    if (migratedUser) return { user: migratedUser }
+
+    logError('Nile did not return valid Amazon login data', LogPrefix.Nile)
+    throw new Error('Could not prepare Amazon login')
   }
 
   static async login(
     data: NileRegisterData
   ): Promise<{ status: 'done' | 'failed'; user: NileUserData | undefined }> {
-    logDebug(['Got register data:', data], LogPrefix.Nile)
+    const failed = { status: 'failed' as const, user: undefined }
     const { code, code_verifier, serial, client_id } = data
-    // Nile prints output to stderr
-    const { stderr: output } = await libraryManagerMap['nile'].runRunnerCommand(
-      [
-        'register',
-        '--code',
-        code,
-        '--code-verifier',
-        code_verifier,
-        '--serial',
-        serial,
-        '--client-id',
-        client_id
-      ],
-      { abortId: 'nile-login' }
-    )
-
-    const successRegex = /\[AUTH_MANAGER]:.*Succesfully registered a device/
-    if (!successRegex.test(output)) {
-      // Authentication failed
-      logError(['Authentication failed:', output], LogPrefix.Nile)
-      return {
-        status: 'failed',
-        user: undefined
-      }
+    if (
+      ![code, code_verifier, serial, client_id].every(
+        (value) => typeof value === 'string' && value.trim().length > 0
+      )
+    ) {
+      return failed
     }
 
-    logInfo('Authentication successful', LogPrefix.Nile)
-    const user = await this.getUserData()
-    if (!user) {
-      return {
-        status: 'failed',
-        user: undefined
-      }
-    }
+    try {
+      const result = await libraryManagerMap['nile'].runRunnerCommand(
+        [
+          'register',
+          '--code',
+          code,
+          '--code-verifier',
+          code_verifier,
+          '--serial',
+          serial,
+          '--client-id',
+          client_id
+        ],
+        { abortId: 'nile-login', logSanitizer: authLogSanitizer }
+      )
+      if (result.abort || result.error) return failed
 
-    return {
-      status: 'done',
-      user
+      // Human-readable log messages are not an authentication API. A valid
+      // profile written by Nile is required, even when its output says success.
+      const user = this.getUserData()
+      if (!user) {
+        logError('Nile did not save an Amazon user profile', LogPrefix.Nile)
+        return failed
+      }
+
+      logInfo('Authentication successful', LogPrefix.Nile)
+      return { status: 'done', user }
+    } catch {
+      // Helper errors can embed command arguments or token-bearing output.
+      logError('Amazon authentication failed', LogPrefix.Nile)
+      return failed
     }
   }
 
@@ -93,8 +103,8 @@ export class NileUser {
       abortId: 'nile-logout'
     })
 
-    if (res.abort) {
-      logError('Failed to logout: abort by user', LogPrefix.Nile)
+    if (res.abort || res.error) {
+      logError('Failed to logout from Amazon', LogPrefix.Nile)
       return
     }
 
@@ -106,27 +116,37 @@ export class NileUser {
     ses.clearAuthCache().catch(() => {})
   }
 
-  static async getUserData(): Promise<NileUserData | undefined> {
-    if (!existsSync(nileUserData)) {
-      logError('user.json does not exist', LogPrefix.Nile)
+  static getUserData(): NileUserData | undefined {
+    // Nile < 1.2 stores customer_info in user.json. Newer Nile stores only the
+    // public profile in current_user.json; it is authoritative when present.
+    const legacy = !existsSync(nileUserData)
+    const path = legacy ? join(nileConfigPath, 'user.json') : nileUserData
+    if (!existsSync(path)) {
       configStore.delete('userData')
       return
     }
 
-    const user: NileUserData = JSON.parse(readFileSync(nileUserData, 'utf-8'))
-    if (!Object.keys(user).length) {
-      logInfo('user.json is empty', LogPrefix.Nile)
-      configStore.delete('userData')
-      return
+    try {
+      const user = parseNileUserData(
+        JSON.parse(readFileSync(path, 'utf-8')),
+        legacy
+      )
+      if (user) {
+        configStore.set('userData', user)
+        return user
+      }
+    } catch {
+      // A damaged profile should not crash startup or leak its contents.
+      logError('Could not read the Nile user profile', LogPrefix.Nile)
     }
 
-    configStore.set('userData', user)
-    logInfo('Saved user data to config file', LogPrefix.Nile)
-
-    return user
+    configStore.delete('userData')
+    return
   }
 
   public static isLoggedIn() {
-    return configStore.get_nodefault('userData') || false
+    // Rehydrate the cache before the initial library refresh, including when
+    // the user authenticated with the CLI in Heroic's NILE_CONFIG_PATH.
+    return this.getUserData() || false
   }
 }

--- a/src/common/nileAuth.ts
+++ b/src/common/nileAuth.ts
@@ -1,0 +1,112 @@
+import type { NileLoginData, NileLoginUrl, NileUserData } from './types/nile'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+/** Return only public profile fields, never Nile's stored authentication tokens. */
+export function parseNileUserData(
+  value: unknown,
+  legacy = false
+): NileUserData | undefined {
+  if (!isRecord(value)) return
+  if (legacy) {
+    if (!isRecord(value.extensions)) return
+    value = value.extensions.customer_info
+    if (!isRecord(value)) return
+  }
+
+  const name = legacy ? value.given_name : value.name
+  const user_id = value.user_id
+  if (!isNonEmptyString(name) || !isNonEmptyString(user_id)) return
+  return { name, user_id }
+}
+
+/** Invalid/empty helper output must not be used as a webview URL. */
+export function parseNileLoginData(output: string): NileLoginUrl | undefined {
+  try {
+    const data: unknown = JSON.parse(output)
+    if (!isRecord(data)) return
+    const { url, code_verifier, serial, client_id } = data
+    if (
+      !isNonEmptyString(url) ||
+      !isNonEmptyString(code_verifier) ||
+      !isNonEmptyString(serial) ||
+      !isNonEmptyString(client_id)
+    ) {
+      return
+    }
+    const parsed = new URL(url)
+    if (
+      parsed.protocol !== 'https:' ||
+      !['amazon.com', 'www.amazon.com'].includes(parsed.hostname) ||
+      parsed.username ||
+      parsed.password ||
+      parsed.port
+    ) {
+      return
+    }
+    return { url, code_verifier, serial, client_id }
+  } catch {
+    // JSON/URL errors can contain credentials; do not log the input or error.
+    return
+  }
+}
+
+/** Only consume codes from the return URL requested by this login attempt. */
+export function getAmazonAuthorizationCode(
+  pageUrl: string,
+  loginUrl: string
+): string | null {
+  try {
+    const returnTo = new URL(loginUrl).searchParams.get('openid.return_to')
+    if (!returnTo) return null
+    const expected = new URL(returnTo)
+    const actual = new URL(pageUrl)
+    if (
+      expected.protocol !== 'https:' ||
+      !['amazon.com', 'www.amazon.com'].includes(expected.hostname) ||
+      actual.origin !== expected.origin ||
+      actual.pathname !== expected.pathname ||
+      actual.username ||
+      actual.password
+    ) {
+      return null
+    }
+    const code = actual.searchParams.get('openid.oa2.authorization_code')
+    return isNonEmptyString(code) ? code : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Report a timeout immediately, but settle only after the runner request does.
+ * Retrying before then can reuse callRunner's still-cached, aborted command.
+ */
+export function prepareNileLogin(
+  getLoginData: () => Promise<NileLoginData>,
+  onTimeout: () => void
+): { result: Promise<NileLoginData>; dispose: () => void } {
+  let timedOut = false
+  const timeout = setTimeout(() => {
+    timedOut = true
+    onTimeout()
+  }, 30000)
+
+  const result = (async () => {
+    try {
+      const data = await getLoginData()
+      if (timedOut) throw new Error('Could not prepare Amazon login')
+      return data
+    } finally {
+      clearTimeout(timeout)
+    }
+  })()
+
+  return { result, dispose: () => clearTimeout(timeout) }
+}

--- a/src/common/types/nile.ts
+++ b/src/common/types/nile.ts
@@ -106,12 +106,15 @@ export interface NileUserData {
   name: string
 }
 
-export interface NileLoginData {
+export interface NileLoginUrl {
   url: string
   code_verifier: string
   serial: string
   client_id: string
 }
+
+// Login preparation can discover a session already authenticated by Nile.
+export type NileLoginData = NileLoginUrl | { user: NileUserData }
 
 export interface NileRegisterData {
   code: string

--- a/src/frontend/screens/WebView/index.css
+++ b/src/frontend/screens/WebView/index.css
@@ -29,4 +29,12 @@
   &:has(.UpdateComponent) .WebView__webview {
     display: none;
   }
+
+  .WebView__loginError {
+    padding: var(--space-lg);
+
+    button {
+      margin-inline-end: var(--space-sm);
+    }
+  }
 }

--- a/src/frontend/screens/WebView/index.tsx
+++ b/src/frontend/screens/WebView/index.tsx
@@ -3,6 +3,7 @@ import {
   useContext,
   useEffect,
   useLayoutEffect,
+  useRef,
   useState
 } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -18,7 +19,8 @@ import {
 } from 'frontend/helpers/gamepad'
 import './index.css'
 import LoginWarning from '../Login/components/LoginWarning'
-import { NileLoginData } from 'common/types/nile'
+import { NileLoginUrl } from 'common/types/nile'
+import { getAmazonAuthorizationCode, prepareNileLogin } from 'common/nileAuth'
 import {
   Dialog,
   DialogContent,
@@ -52,9 +54,15 @@ export default function WebView() {
     refresh: true,
     message: t('loading.website', 'Loading Website')
   }))
-  const [amazonLoginData, setAmazonLoginData] = useState<NileLoginData | null>(
+  const [amazonLoginData, setAmazonLoginData] = useState<NileLoginUrl | null>(
     null
   )
+  const [amazonLoginError, setAmazonLoginError] = useState<string | null>(null)
+  const [amazonLoginAttempt, setAmazonLoginAttempt] = useState(0)
+  const [amazonLoginPreparing, setAmazonLoginPreparing] = useState(false)
+  const amazonLoginGeneration = useRef(0)
+  const handledAmazonCode = useRef<string | null>(null)
+  const amazonLoginInProgress = useRef(false)
   const navigate = useNavigate()
   // Keep the webview element in state (via a callback ref) instead of a plain
   // ref so that mounting/remounting it — e.g. when switching stores — triggers
@@ -124,40 +132,114 @@ export default function WebView() {
 
   useEffect(() => {
     if (pathname !== '/loginweb/nile') return
-    console.log('Loading amazon login data')
-
+    const generation = ++amazonLoginGeneration.current
+    let active = true
+    handledAmazonCode.current = null
+    amazonLoginInProgress.current = false
+    setAmazonLoginData(null)
+    setAmazonLoginError(null)
+    setAmazonLoginPreparing(true)
     setLoading({
       refresh: true,
       message: t('status.preparing_login', 'Preparing Login...')
     })
-    amazon.getLoginData().then((data) => {
-      setAmazonLoginData(data)
-      setLoading({
-        ...loading,
-        refresh: false
+
+    const fail = () => {
+      setAmazonLoginError(
+        t(
+          'amazon-login.prepare-error',
+          'Could not prepare Amazon login. Check your connection and Nile executable, then retry.'
+        )
+      )
+      setLoading((current) => ({ ...current, refresh: false }))
+    }
+    const preparation = prepareNileLogin(
+      () => amazon.getLoginData(),
+      () => {
+        if (!active || generation !== amazonLoginGeneration.current) return
+        window.api.abort('nile-auth')
+        fail()
+      }
+    )
+
+    void preparation.result
+      .then((data) => {
+        if (!active || generation !== amazonLoginGeneration.current) return
+        if ('user' in data) {
+          // Nile's profile has rehydrated the backend cache. Reload the renderer
+          // so GlobalState also picks up the recovered account and its library.
+          navigate('/login', { replace: true })
+          window.location.reload()
+          return
+        }
+        setAmazonLoginData(data)
+        setLoading({
+          refresh: true,
+          message: t('loading.website', 'Loading Website')
+        })
       })
-    })
-  }, [pathname])
+      .catch(() => {
+        if (active && generation === amazonLoginGeneration.current) fail()
+      })
+      .finally(() => {
+        // Aborting is asynchronous: Retry must wait for runner cleanup even
+        // when the timeout has already displayed its error message.
+        if (active && generation === amazonLoginGeneration.current) {
+          setAmazonLoginPreparing(false)
+        }
+      })
+
+    return () => {
+      active = false
+      amazonLoginGeneration.current++
+      amazonLoginInProgress.current = false
+      preparation.dispose()
+    }
+  }, [pathname, amazonLoginAttempt])
 
   const handleAmazonLogin = (code: string) => {
-    if (!amazonLoginData) {
-      console.error('Could not login to Amazon because login data is missing')
+    if (
+      !amazonLoginData ||
+      amazonLoginInProgress.current ||
+      handledAmazonCode.current === code
+    ) {
       return
     }
-
+    const generation = amazonLoginGeneration.current
+    handledAmazonCode.current = code
+    amazonLoginInProgress.current = true
+    setAmazonLoginError(null)
     setLoading({
       refresh: true,
       message: t('status.logging', 'Logging In...')
     })
-    amazon
+
+    void amazon
       .login({
         client_id: amazonLoginData.client_id,
-        code: code,
+        code,
         code_verifier: amazonLoginData.code_verifier,
         serial: amazonLoginData.serial
       })
-      .then(() => {
+      .then((status) => {
+        if (generation !== amazonLoginGeneration.current) return
+        if (status !== 'done') throw new Error('Amazon login failed')
         handleSuccessfulLogin()
+      })
+      .catch(() => {
+        if (generation !== amazonLoginGeneration.current) return
+        setAmazonLoginError(
+          t(
+            'amazon-login.register-error',
+            'Amazon login could not be completed. Retry to start a new sign-in attempt.'
+          )
+        )
+        setLoading((current) => ({ ...current, refresh: false }))
+      })
+      .finally(() => {
+        if (generation === amazonLoginGeneration.current) {
+          amazonLoginInProgress.current = false
+        }
       })
   }
 
@@ -178,7 +260,9 @@ export default function WebView() {
   useLayoutEffect(() => {
     if (webview) {
       const loadstop = () => {
-        setLoading({ ...loading, refresh: false })
+        if (!amazonLoginInProgress.current) {
+          setLoading((current) => ({ ...current, refresh: false }))
+        }
         const userAgent =
           startUrl === epicLoginUrl
             ? 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) EpicGamesLauncher'
@@ -212,15 +296,12 @@ export default function WebView() {
               gog.login(code).then(() => handleSuccessfulLogin())
             }
           }
-        } else if (runner === 'nile') {
-          const pageURL = webview.getURL()
-          const parsedURL = new URL(pageURL)
-          const code = parsedURL.searchParams.get(
-            'openid.oa2.authorization_code'
+        } else if (runner === 'nile' && amazonLoginData) {
+          const code = getAmazonAuthorizationCode(
+            webview.getURL(),
+            amazonLoginData.url
           )
-          if (code) {
-            handleAmazonLogin(code)
-          }
+          if (code) handleAmazonLogin(code)
         } else if (runner == 'legendary') {
           const pageUrl = webview.getURL()
           const parsedUrl = new URL(pageUrl)
@@ -259,6 +340,27 @@ export default function WebView() {
         }
       }
 
+      const onAmazonNavigate = (event: {
+        url: string
+        isMainFrame?: boolean
+      }) => {
+        if (
+          runner !== 'nile' ||
+          !amazonLoginData ||
+          event.isMainFrame === false
+        ) {
+          return
+        }
+        const code = getAmazonAuthorizationCode(event.url, amazonLoginData.url)
+        if (code) handleAmazonLogin(code)
+      }
+
+      // The landing page can redirect again before dom-ready. Consume the
+      // main-frame callback URL from the navigation event instead of getURL().
+      webview.addEventListener('did-start-navigation', onAmazonNavigate)
+      webview.addEventListener('did-redirect-navigation', onAmazonNavigate)
+      webview.addEventListener('did-navigate', onAmazonNavigate)
+      webview.addEventListener('did-navigate-in-page', onAmazonNavigate)
       webview.addEventListener('dom-ready', loadstop)
       webview.addEventListener('did-fail-load', onerror)
       // if the page title changed it's because the store loaded so there's
@@ -271,6 +373,10 @@ export default function WebView() {
       webview.addEventListener('page-title-updated', updateConnectivity)
 
       return () => {
+        webview.removeEventListener('did-start-navigation', onAmazonNavigate)
+        webview.removeEventListener('did-redirect-navigation', onAmazonNavigate)
+        webview.removeEventListener('did-navigate', onAmazonNavigate)
+        webview.removeEventListener('did-navigate-in-page', onAmazonNavigate)
         webview.removeEventListener('dom-ready', loadstop)
         webview.removeEventListener('did-fail-load', onerror)
         webview.removeEventListener('page-title-updated', updateConnectivity)
@@ -448,15 +554,42 @@ export default function WebView() {
         />
       )}
       {loading.refresh && <UpdateComponent message={loading.message} />}
-      <webview
-        key={store}
-        ref={webviewRef}
-        className="WebView__webview"
-        partition={`persist:${store ?? (runner === 'legendary' ? 'epic' : runner === 'nile' ? 'amazon' : runner)}`}
-        src={startUrl}
-        allowpopups={trueAsStr}
-        preload={webviewPreloadPath}
-      />
+      {runner === 'nile' && amazonLoginError ? (
+        <div className="WebView__loginError" role="alert">
+          <p>{amazonLoginError}</p>
+          <button
+            type="button"
+            className="button"
+            disabled={amazonLoginPreparing}
+            onClick={() => {
+              if (amazonLoginPreparing) return
+              setAmazonLoginPreparing(true)
+              setAmazonLoginAttempt((attempt) => attempt + 1)
+            }}
+          >
+            {t('amazon-login.retry', 'Retry')}
+          </button>
+          <button
+            type="button"
+            className="button outline"
+            onClick={() => navigate('/login')}
+          >
+            {t('amazon-login.cancel', 'Back to accounts')}
+          </button>
+        </div>
+      ) : (
+        startUrl && (
+          <webview
+            key={runner === 'nile' ? `nile-${amazonLoginAttempt}` : store}
+            ref={webviewRef}
+            className="WebView__webview"
+            partition={`persist:${store ?? (runner === 'legendary' ? 'epic' : runner === 'nile' ? 'amazon' : runner)}`}
+            src={startUrl}
+            allowpopups={trueAsStr}
+            preload={webviewPreloadPath}
+          />
+        )
+      )}
       {showLoginWarningFor && (
         <LoginWarning
           warnLoginForStore={showLoginWarningFor}


### PR DESCRIPTION
Nile has been broken in Heroic for me on CachyOS for a while now. Now that Astra is available, I pointed it at fixing this issue, because I want to be able to use Heroic to launch Amazon games. For me, this fix enables proper Amazon games again. Since I am not sure what your stance on AI agents is, I decided that I just propose the fix and disclose the usage. My repo builds a working image for testing. https://github.com/felixfoertsch/HeroicGamesLauncher


**AI disclosure:** I am **Astra, an OpenAI AI assistant**. I implemented this change, its tests and documentation, and prepared the technical sections below at **Felix Förtsch's** direction. The motivation paragraph is Felix's own account; human testing and automated checks are distinguished below.

## Description

Restore Heroic's Amazon account integration when Nile already has a local session, and replace stalled login preparation with actionable error and retry states.

- Read current and legacy Nile profiles, preferring `current_user.json`, without copying authentication tokens into Heroic's identity cache.
- Validate helper output and saved registration profiles rather than parsing success messages; suppress raw authentication output in logs.
- Capture trusted main-frame authorization callbacks and reject untrusted, duplicate or stale responses.
- Add a 30-second preparation timeout and Retry/Back controls. Keep Retry disabled until an aborted preparation request has settled, so it cannot reuse a still-cached command.

Existing credentials, installations and Nile configuration are retained. Nile still handles token refresh; a local profile alone does not prove that Amazon accepts its tokens. This fixes account/library authentication, not embedded storefront cookies.

Related: [Amazon login report #5280](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5280).

## Testing

**Automated checks for this independent PR at `7e3b754`:** [TypeScript](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/actions/runs/34085089179), [Jest](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/actions/runs/34085089240), [Lint](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/actions/runs/34085089272), [platform builds](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/actions/runs/34085089381) and [Flatpak](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/actions/runs/34085089216) passed. These are the upstream PR's checks, not the older combined downstream build.

**Human testing:** Felix reports that Amazon login and the custom application work on CachyOS/Linux. A fresh-profile installation, every MFA variant and the complete login/install/play/uninstall/move regression matrix have not been separately confirmed. The clean-install checklist items therefore remain unchecked. Astra did not use a live Amazon account.

Authentication regressions are in `src/backend/storeManagers/nile/__tests__/`, including timeout/retry ordering. Manual checks and limitations are in `doc/nile-login.md`.

One commit; no game-stacking changes or release automation included.

---

Use the following Checklist if you have changed something on the Backend or Frontend:

- [ ] Tested the feature and it's working on a current and clean install.
- [ ] Tested the main App features and they are still working on a current and clean install. (Login, Install, Play, Uninstall, Move games, etc.)
- [x] Created / Updated Tests (If necessary)
- [x] Created / Updated documentation (If necessary)